### PR TITLE
feat(update): surface IJFW update status

### DIFF
--- a/src/common/update/updateTypes.ts
+++ b/src/common/update/updateTypes.ts
@@ -31,6 +31,21 @@ export interface UpdateCheckResult {
   currentVersion: string;
   updateAvailable: boolean;
   latest?: UpdateReleaseInfo;
+  ijfw?: IjfwUpdateStatus;
+}
+
+export interface IjfwUpdateStatus {
+  installed: boolean;
+  currentVersion?: string;
+  latestVersion?: string | null;
+  updateAvailable: boolean;
+  offline?: boolean;
+  detectedVia: 'directory' | 'symlink' | 'cli' | 'none';
+  cliOnPath?: boolean;
+  mcpServerPath?: string;
+  commandPath?: string;
+  pathHealthy: boolean;
+  error?: string;
 }
 
 export interface UpdateCheckRequest {

--- a/src/process/bridge/updateBridge.ts
+++ b/src/process/bridge/updateBridge.ts
@@ -21,6 +21,7 @@ import * as path from 'path';
 import yaml from 'js-yaml';
 import semver from 'semver';
 import { autoUpdaterService } from '../services/autoUpdaterService';
+import { ijfwSystemService } from '../services/ijfwSystemService';
 
 /** Lazily loads i18n to avoid pulling in initStorage chain at module load time */
 let _i18nCache: Promise<typeof import('../services/i18n')> | null = null;
@@ -66,6 +67,11 @@ const ALLOWED_DOWNLOAD_HOSTS = new Set<string>([
   'release-assets.githubusercontent.com',
 ]);
 const MAX_REDIRECTS = 8;
+
+const getIjfwCommandPath = (mcpServerPath?: string): string | undefined => {
+  if (!mcpServerPath) return undefined;
+  return path.join(path.dirname(mcpServerPath), 'mcp-server', 'bin', process.platform === 'win32' ? 'ijfw.cmd' : 'ijfw');
+};
 
 const isAllowedAssetName = (name: string) => {
   const ext = path.extname(name);
@@ -438,6 +444,46 @@ const mapRelease = (rel: GitHubReleaseApi): UpdateReleaseInfo | null => {
   };
 };
 
+const getIjfwUpdateStatus = async (): Promise<UpdateCheckResult['ijfw']> => {
+  try {
+    const [local, latest] = await Promise.all([
+      ijfwSystemService.detectLocalInstall(),
+      ijfwSystemService.getLatestPublished(),
+    ]);
+    const updateAvailable = Boolean(
+      local.installed &&
+        local.version &&
+        latest &&
+        semver.valid(local.version) &&
+        semver.valid(latest) &&
+        semver.lt(local.version, latest)
+    );
+    const commandPath = getIjfwCommandPath(local.mcpServerPath);
+
+    return {
+      installed: local.installed,
+      currentVersion: local.version,
+      latestVersion: latest,
+      updateAvailable,
+      offline: local.installed && !latest,
+      detectedVia: local.detectedVia,
+      cliOnPath: local.cliOnPath,
+      mcpServerPath: local.mcpServerPath,
+      commandPath,
+      pathHealthy: Boolean(local.cliOnPath),
+    };
+  } catch (err) {
+    return {
+      installed: false,
+      updateAvailable: false,
+      latestVersion: null,
+      detectedVia: 'none',
+      pathHealthy: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+};
+
 type DownloadState = {
   abortController: AbortController;
   filePath: string;
@@ -710,6 +756,7 @@ export function initUpdateBridge(): void {
         // If you want dev/prerelease updates to work reliably, CI must inject a prerelease semver into
         // `package.json#version` for dev builds (e.g. `1.7.2-dev.1234+sha.abcdef0`) so semver ordering holds.
         // We intentionally avoid heuristics based on tag strings when the app version is a stable semver.
+        const ijfw = await getIjfwUpdateStatus();
 
         const releases = await fetchGitHubReleases(repo);
         const candidates = releases
@@ -720,7 +767,7 @@ export function initUpdateBridge(): void {
 
         const currentSemver = semver.valid(currentVersion) || semver.coerce(currentVersion)?.version;
         if (!currentSemver) {
-          return { success: true, data: { currentVersion, updateAvailable: false } };
+          return { success: true, data: { currentVersion, updateAvailable: false, ijfw } };
         }
 
         const latest = candidates
@@ -728,7 +775,7 @@ export function initUpdateBridge(): void {
           .toSorted((a, b) => semver.rcompare(a.version, b.version))[0];
 
         if (!latest) {
-          return { success: true, data: { currentVersion, updateAvailable: false } };
+          return { success: true, data: { currentVersion, updateAvailable: false, ijfw } };
         }
 
         const updateAvailable = semver.gt(latest.version, currentSemver);
@@ -738,6 +785,7 @@ export function initUpdateBridge(): void {
             currentVersion,
             updateAvailable,
             latest,
+            ijfw,
           },
         };
       } catch (err: unknown) {

--- a/src/renderer/components/settings/UpdateModal.tsx
+++ b/src/renderer/components/settings/UpdateModal.tsx
@@ -10,7 +10,12 @@ import { Button, Progress, Message } from '@arco-design/web-react';
 import { ipcBridge } from '@/common';
 import WaylandModal from '@/renderer/components/base/WaylandModal';
 import MarkdownView from '@/renderer/components/Markdown';
-import type { UpdateDownloadProgressEvent, UpdateReleaseInfo, AutoUpdateStatus } from '@/common/update/updateTypes';
+import type {
+  UpdateDownloadProgressEvent,
+  UpdateReleaseInfo,
+  AutoUpdateStatus,
+  IjfwUpdateStatus,
+} from '@/common/update/updateTypes';
 import { useTranslation } from 'react-i18next';
 
 type UpdateStatus = 'checking' | 'upToDate' | 'available' | 'downloading' | 'downloaded' | 'success' | 'error';
@@ -28,6 +33,8 @@ const UpdateModal: React.FC = () => {
   const [errorMsg, setErrorMsg] = useState('');
   const [downloadPath, setDownloadPath] = useState('');
   const [releasePageUrl, setReleasePageUrl] = useState('');
+  const [ijfwStatus, setIjfwStatus] = useState<IjfwUpdateStatus | null>(null);
+  const [ijfwActionPending, setIjfwActionPending] = useState(false);
   // Whether electron-updater auto-update is available (determined automatically, not user-controllable)
   const [autoUpdateAvailable, setAutoUpdateAvailable] = useState(false);
   const [autoUpdateInfo, setAutoUpdateInfo] = useState<{ version: string; releaseNotes?: string } | null>(null);
@@ -41,12 +48,17 @@ const UpdateModal: React.FC = () => {
     setErrorMsg('');
     setDownloadPath('');
     setReleasePageUrl('');
+    setIjfwStatus(null);
+    setIjfwActionPending(false);
     setAutoUpdateAvailable(false);
     setAutoUpdateInfo(null);
   };
 
   const includePrerelease = useMemo(() => localStorage.getItem('update.includePrerelease') === 'true', [visible]);
   const hasCompatibleManualAsset = Boolean(updateInfo?.recommendedAsset);
+  const hasIjfwUpdate = Boolean(ijfwStatus?.installed && ijfwStatus.updateAvailable);
+  const hasIjfwPathIssue = Boolean(ijfwStatus?.installed && !ijfwStatus.pathHealthy);
+  const hasWaylandUpdate = Boolean(updateInfo || autoUpdateInfo || autoUpdateAvailable);
 
   const openReleasePage = () => {
     if (!releasePageUrl) return;
@@ -82,6 +94,7 @@ const UpdateModal: React.FC = () => {
         throw new Error(res?.msg || t('update.checkFailed'));
       }
       setCurrentVersion(res.data?.currentVersion || '');
+      setIjfwStatus(res.data?.ijfw || null);
 
       if (autoUpdateOk) {
         // Auto-update available - use manual check data for display only
@@ -100,6 +113,13 @@ const UpdateModal: React.FC = () => {
         if (!res.data.latest.recommendedAsset) {
           setErrorMsg(t('update.noCompatibleAssetManual'));
         }
+        setStatus('available');
+        return;
+      }
+
+      if (res.data?.ijfw?.updateAvailable || (res.data?.ijfw?.installed && !res.data.ijfw.pathHealthy)) {
+        setUpdateInfo(res.data?.latest || null);
+        setReleasePageUrl(res.data?.latest?.htmlUrl || '');
         setStatus('available');
         return;
       }
@@ -166,6 +186,77 @@ const UpdateModal: React.FC = () => {
       console.error('Install failed:', err);
       Message.error(msg);
     }
+  };
+
+  const startIjfwUpdate = async () => {
+    setIjfwActionPending(true);
+    try {
+      const res = await ipcBridge.ijfw.triggerInstall.invoke();
+      if (!res?.ok) {
+        const detail = res && 'error' in res ? res.error : undefined;
+        throw new Error(detail || 'Failed to start IJFW update');
+      }
+      Message.success(
+        t('update.ijfw.updateStarted', {
+          defaultValue: 'IJFW update started. Restart Wayland after it stages the new version.',
+        })
+      );
+      void checkForUpdates();
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      Message.error(msg);
+    } finally {
+      setIjfwActionPending(false);
+    }
+  };
+
+  const renderIjfwUpdatePanel = () => {
+    if (!ijfwStatus?.installed) return null;
+    if (!hasIjfwUpdate && !hasIjfwPathIssue) return null;
+
+    return (
+      <div className='mx-24px mt-12px px-14px py-12px rounded-8px bg-fill-1 border border-border-2'>
+        <div className='flex items-start justify-between gap-16px'>
+          <div className='min-w-0'>
+            <div className='text-13px font-600 text-t-primary'>
+              {hasIjfwUpdate
+                ? t('update.ijfw.availableTitle', { defaultValue: 'IJFW update available' })
+                : t('update.ijfw.pathIssueTitle', { defaultValue: 'IJFW command path needs attention' })}
+            </div>
+            <div className='text-12px text-t-tertiary mt-4px break-words'>
+              {hasIjfwUpdate
+                ? t('update.ijfw.versionLine', {
+                    defaultValue: 'IJFW {{current}} → {{latest}}',
+                    current: ijfwStatus.currentVersion || '-',
+                    latest: ijfwStatus.latestVersion || '-',
+                  })
+                : t('update.ijfw.pathIssueBody', {
+                    defaultValue:
+                      'IJFW is installed, but the ijfw command is not on PATH. Wayland can still use the local install.',
+                  })}
+            </div>
+            {ijfwStatus.commandPath && (
+              <code className='inline-block mt-6px max-w-full truncate text-11px text-t-tertiary'>
+                {ijfwStatus.commandPath}
+              </code>
+            )}
+          </div>
+          {hasIjfwUpdate && (
+            <Button
+              type='primary'
+              size='small'
+              loading={ijfwActionPending}
+              onClick={() => {
+                void startIjfwUpdate();
+              }}
+              className='!px-14px shrink-0'
+            >
+              {t('update.ijfw.updateButton', { defaultValue: 'Update IJFW' })}
+            </Button>
+          )}
+        </div>
+      </div>
+    );
   };
 
   const formatSpeed = (bytesPerSecond: number) => {
@@ -312,6 +403,7 @@ const UpdateModal: React.FC = () => {
             <div className='text-13px text-t-tertiary'>
               {t('update.currentVersion', { version: currentVersion || '-' })}
             </div>
+            {renderIjfwUpdatePanel()}
           </div>
         );
 
@@ -325,17 +417,44 @@ const UpdateModal: React.FC = () => {
                   <Download size={20} color='rgb(var(--primary-6))' />
                 </div>
                 <div>
-                  <div className='text-15px font-600 text-t-primary'>{t('update.availableTitle')}</div>
+                  <div className='text-15px font-600 text-t-primary'>
+                    {hasWaylandUpdate
+                      ? t('update.availableTitle')
+                      : t('update.ijfw.availableTitle', { defaultValue: 'IJFW update available' })}
+                  </div>
                   <div className='text-12px text-t-tertiary mt-2px'>
-                    {currentVersion} →{' '}
-                    <span className='text-[rgb(var(--primary-6))] font-500'>
-                      {updateInfo?.version || autoUpdateInfo?.version}
-                    </span>
+                    {hasWaylandUpdate ? (
+                      <>
+                        {currentVersion} →{' '}
+                        <span className='text-[rgb(var(--primary-6))] font-500'>
+                          {updateInfo?.version || autoUpdateInfo?.version}
+                        </span>
+                      </>
+                    ) : (
+                      <>
+                        IJFW {ijfwStatus?.currentVersion || '-'} →{' '}
+                        <span className='text-[rgb(var(--primary-6))] font-500'>
+                          {ijfwStatus?.latestVersion || '-'}
+                        </span>
+                      </>
+                    )}
                   </div>
                 </div>
               </div>
               <div className='flex items-center gap-12px'>
-                {!hasCompatibleManualAsset && !autoUpdateAvailable && releasePageUrl ? (
+                {!hasWaylandUpdate && hasIjfwUpdate ? (
+                  <Button
+                    type='primary'
+                    size='small'
+                    loading={ijfwActionPending}
+                    onClick={() => {
+                      void startIjfwUpdate();
+                    }}
+                    className='!px-16px'
+                  >
+                    {t('update.ijfw.updateButton', { defaultValue: 'Update IJFW' })}
+                  </Button>
+                ) : !hasCompatibleManualAsset && !autoUpdateAvailable && releasePageUrl ? (
                   <Button type='primary' size='small' onClick={openReleasePage} className='!px-16px'>
                     {t('update.goToRelease')}
                   </Button>
@@ -351,7 +470,9 @@ const UpdateModal: React.FC = () => {
               </div>
             </div>
 
-            {!hasCompatibleManualAsset && !autoUpdateAvailable && (
+            {renderIjfwUpdatePanel()}
+
+            {hasWaylandUpdate && !hasCompatibleManualAsset && !autoUpdateAvailable && (
               <div className='mx-24px mt-12px px-12px py-10px text-12px rounded-8px bg-[rgb(var(--warning-6))]/10 text-[rgb(var(--warning-6))]'>
                 {t('update.noCompatibleAssetManual')}
               </div>

--- a/src/renderer/services/i18n/locales/en-US/update.json
+++ b/src/renderer/services/i18n/locales/en-US/update.json
@@ -19,6 +19,14 @@
   "readyToInstallDesc": "Update has been downloaded. Click the button below to restart and install the update.",
   "installNow": "Install and restart",
   "autoUpdateMode": "Auto-update mode",
+  "ijfw": {
+    "availableTitle": "IJFW update available",
+    "pathIssueTitle": "IJFW command path needs attention",
+    "pathIssueBody": "IJFW is installed, but the ijfw command is not on PATH. Wayland can still use the local install.",
+    "updateButton": "Update IJFW",
+    "updateStarted": "IJFW update started. Restart Wayland after it stages the new version.",
+    "versionLine": "IJFW {{current}} → {{latest}}"
+  },
   "showInFolder": "Show in folder",
   "openFile": "Open file",
   "errorTitle": "Update failed",

--- a/tests/unit/updateBridgeCdnRewrite.test.ts
+++ b/tests/unit/updateBridgeCdnRewrite.test.ts
@@ -67,6 +67,19 @@ vi.mock('electron-log', () => ({
   },
 }));
 
+vi.mock('@/process/services/ijfwSystemService', () => ({
+  ijfwSystemService: {
+    detectLocalInstall: vi.fn(async () => ({
+      installed: true,
+      version: '1.5.6',
+      mcpServerPath: '/Users/test/.ijfw/mcp-server',
+      detectedVia: 'directory',
+      pathProbe: { homebrew: false, usrLocal: false, standardPath: false },
+    })),
+    getLatestPublished: vi.fn(async () => '1.6.0'),
+  },
+}));
+
 const makeGitHubReleaseResponse = () => [
   {
     tag_name: 'v1.9.22',
@@ -131,6 +144,13 @@ describe('updateBridge GitHub asset URLs', () => {
       const result = await handler({ repo: 'FerroxLabs/wayland' });
 
       expect(result.success).toBe(true);
+      expect(result.data?.ijfw).toMatchObject({
+        installed: true,
+        currentVersion: '1.5.6',
+        latestVersion: '1.6.0',
+        updateAvailable: true,
+        pathHealthy: false,
+      });
       const assets = result.data?.latest?.assets ?? [];
       expect(assets.length).toBe(3);
 

--- a/tests/unit/updateBridgeI18n.test.ts
+++ b/tests/unit/updateBridgeI18n.test.ts
@@ -67,6 +67,17 @@ vi.mock('electron-log', () => ({
   },
 }));
 
+vi.mock('@/process/services/ijfwSystemService', () => ({
+  ijfwSystemService: {
+    detectLocalInstall: vi.fn(async () => ({
+      installed: false,
+      detectedVia: 'none',
+      pathProbe: { homebrew: false, usrLocal: false, standardPath: false },
+    })),
+    getLatestPublished: vi.fn(async () => null),
+  },
+}));
+
 describe('updateBridge lazy i18n', () => {
   beforeEach(() => {
     vi.resetModules();

--- a/tests/unit/updateBridgeRepoPinning.test.ts
+++ b/tests/unit/updateBridgeRepoPinning.test.ts
@@ -72,6 +72,17 @@ vi.mock('electron-log', () => ({
   },
 }));
 
+vi.mock('@/process/services/ijfwSystemService', () => ({
+  ijfwSystemService: {
+    detectLocalInstall: vi.fn(async () => ({
+      installed: false,
+      detectedVia: 'none',
+      pathProbe: { homebrew: false, usrLocal: false, standardPath: false },
+    })),
+    getLatestPublished: vi.fn(async () => '1.6.0'),
+  },
+}));
+
 const CANONICAL_REPO = 'FerroxLabs/wayland';
 
 const getCheckHandler = async () => {


### PR DESCRIPTION
## Summary

- surface IJFW install/update status in Wayland update checks
- show IJFW update/path-health details in the update modal
- let users trigger the IJFW install/update path from the updater UI
- add tests for update bridge version/repo handling around the new status payload

## Testing

- `bunx tsc --noEmit`
- `bun run build:renderer:web`
- `git diff --check`
