### PR TITLE
fix(ui): use platform-aware shortcut labels

### DIFF
--- a/src/renderer/pages/guid/components/GuidModelSelector.tsx
+++ b/src/renderer/pages/guid/components/GuidModelSelector.tsx
@@ -23,6 +23,7 @@ import { iconColors } from '@/renderer/styles/colors';
 import FluxRouterMark from '@/renderer/components/icons/FluxRouterMark';
 import { getModelDisplayLabel } from '@/renderer/utils/model/agentLogo';
 import { formatAcpModelDisplayLabel, getAcpModelSourceLabel } from '@/renderer/utils/model/modelSource';
+import { formatModifierShortcut } from '@/renderer/utils/platform';
 import type { AcpModelInfo } from '../types';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -707,6 +708,7 @@ export const ModelSelectorPanel: React.FC<ModelSelectorPanelProps> = ({
 }) => {
   const { t } = useTranslation();
   const [query, setQuery] = React.useState('');
+  const searchShortcut = formatModifierShortcut('K');
   // Wraps the search input - used to locate the underlying `<input>` for ⌘K
   // focus without depending on Arco's internal ref shape.
   const searchWrapRef = React.useRef<HTMLDivElement | null>(null);
@@ -915,7 +917,7 @@ export const ModelSelectorPanel: React.FC<ModelSelectorPanelProps> = ({
             size='small'
           />
         </div>
-        {!searching && <span className={styles.kbdHint}>⌘K</span>}
+        {!searching && <span className={styles.kbdHint}>{searchShortcut}</span>}
       </div>
 
       <div className={styles.scrollArea}>

--- a/src/renderer/pages/guid/components/HomeHintBar.tsx
+++ b/src/renderer/pages/guid/components/HomeHintBar.tsx
@@ -6,6 +6,7 @@
 
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { formatModifierShortcut } from '@/renderer/utils/platform';
 import styles from './HomeHintBar.module.css';
 
 const HIDE_AFTER_CHATS = 5;
@@ -23,12 +24,14 @@ export const HomeHintBar: React.FC<HomeHintBarProps> = ({ chatStartedCount }) =>
   const searchLabel = stripKeyToken(t('guid.hint.search', { key: '' }));
   const backendLabel = stripKeyToken(t('guid.hint.backend', { key: '' }));
   const newChatLabel = stripKeyToken(t('guid.hint.newChat', { key: '' }));
+  const searchShortcut = formatModifierShortcut('K');
+  const newChatShortcut = formatModifierShortcut('N');
 
   return (
     <div className={styles.bar} data-testid='home-hint-bar'>
       <span className={styles.hint}>
         {searchLabel}
-        <kbd className={styles.kbd}>⌘K</kbd>
+        <kbd className={styles.kbd}>{searchShortcut}</kbd>
       </span>
       <span className={styles.sep}>·</span>
       <span className={styles.hint}>
@@ -37,7 +40,7 @@ export const HomeHintBar: React.FC<HomeHintBarProps> = ({ chatStartedCount }) =>
       </span>
       <span className={styles.sep}>·</span>
       <span className={styles.hint}>
-        <kbd className={styles.kbd}>⌘N</kbd>
+        <kbd className={styles.kbd}>{newChatShortcut}</kbd>
         {newChatLabel}
       </span>
     </div>

--- a/src/renderer/pages/memory/components/MemoryStatusBar.tsx
+++ b/src/renderer/pages/memory/components/MemoryStatusBar.tsx
@@ -17,6 +17,7 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ipcBridge } from '@/common';
+import { formatModifierShortcut } from '@/renderer/utils/platform';
 import styles from './MemoryStatusBar.module.css';
 
 // ---------------------------------------------------------------------------
@@ -85,6 +86,7 @@ const MemoryStatusBar: React.FC<MemoryStatusBarProps> = ({
   const { t } = useTranslation('memory');
   const [dropStatus, setDropStatus] = useState<DropFolderStatus | null>(null);
   const [openPathError, setOpenPathError] = useState<string | null>(null);
+  const searchShortcut = formatModifierShortcut('K');
 
   useEffect(() => {
     let cancelled = false;
@@ -187,14 +189,14 @@ const MemoryStatusBar: React.FC<MemoryStatusBarProps> = ({
 
       {/* Right: kbd hints (K9) */}
       <div className={styles.right}>
-        <span className={styles.kbd} data-testid='status-kbd-search'>⌘K</span>
+        <span className={styles.kbd} data-testid='status-kbd-search'>{searchShortcut}</span>
         <span className={styles.kbdLabel}>{t('archive.status.kbd.search', 'search')}</span>
         <span className={styles.kbdSep} aria-hidden>·</span>
         <span className={styles.kbd} data-testid='status-kbd-nav-j'>J</span>
         <span className={styles.kbd} data-testid='status-kbd-nav-k'>K</span>
         <span className={styles.kbdLabel}>{t('archive.status.kbd.navigate', 'navigate')}</span>
         <span className={styles.kbdSep} aria-hidden>·</span>
-        <span className={styles.kbd} data-testid='status-kbd-focus'>⌘K</span>
+        <span className={styles.kbd} data-testid='status-kbd-focus'>{searchShortcut}</span>
         <span className={styles.kbdLabel}>/</span>
         <span className={styles.kbdSep} aria-hidden>·</span>
         <span className={styles.kbd} data-testid='status-kbd-close'>Esc</span>

--- a/src/renderer/pages/memory/state-branches/FullPanelShell.tsx
+++ b/src/renderer/pages/memory/state-branches/FullPanelShell.tsx
@@ -35,6 +35,7 @@ import { ipcBridge } from '@/common';
 import { memory as memoryBridge, ijfw as ijfwBridge } from '@/common/adapter/ipcBridge';
 import type { IjfwStatusPayload } from '@/common/adapter/ipcBridge';
 import type { LastDream, ListFilter, MemoryType } from '@/common/types/memory';
+import { formatModifierShortcut } from '@/renderer/utils/platform';
 import { useTranslation } from 'react-i18next';
 import MemoryList from '../components/MemoryList';
 import RightDrawer from '../components/RightDrawer';
@@ -102,6 +103,7 @@ const DEFAULT_THRESHOLD = 90;
 
 const FullPanelShell: React.FC = () => {
   const { t } = useTranslation('memory');
+  const searchShortcut = formatModifierShortcut('K');
 
   const [filter, setFilter] = useState<ListFilter>(DEFAULT_FILTER);
   const [timeWindow, setTimeWindow] = useState<TimeWindow>('all');
@@ -451,7 +453,7 @@ const FullPanelShell: React.FC = () => {
             prefix={<Search size={14} />}
             suffix={
               <kbd className={styles.searchKbd} data-testid='memory-search-kbd'>
-                ⌘K
+                {searchShortcut}
               </kbd>
             }
             placeholder={t('archive.filter.searchPlaceholder', 'Search memories… (type:decision tag:design)')}

--- a/src/renderer/utils/platform.ts
+++ b/src/renderer/utils/platform.ts
@@ -21,7 +21,14 @@ export const isElectronDesktop = (): boolean => {
  * Check if running on macOS
  */
 export const isMacOS = (): boolean => {
-  return typeof navigator !== 'undefined' && /mac/i.test(navigator.userAgent);
+  if (typeof navigator === 'undefined') return false;
+  const userAgentDataPlatform = (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData?.platform;
+  const platform = userAgentDataPlatform || navigator.platform || navigator.userAgent;
+  return /mac|iphone|ipad|ipod/i.test(platform);
+};
+
+export const formatModifierShortcut = (key: string): string => {
+  return isMacOS() ? `⌘${key}` : `Ctrl+${key}`;
 };
 
 /**


### PR DESCRIPTION
## Summary

- add a reusable platform-aware modifier shortcut formatter
- use `navigator.userAgentData.platform` / `navigator.platform` fallback for OS detection
- replace hardcoded `⌘K` / `⌘N` labels in GUID and Memory UI with Mac vs Windows/Linux labels

## Testing

- `bunx tsc --noEmit`
- `bun run build:renderer:web`
- `git diff --check`
