### PR TITLE
fix(wiki): route settings gear to IJFW settings

### DIFF
--- a/src/renderer/pages/wiki/WikiDetailPage.tsx
+++ b/src/renderer/pages/wiki/WikiDetailPage.tsx
@@ -28,6 +28,7 @@ export type WikiDetailPageProps = {
   slug: string;
   onBack?: () => void;
   onNavigate?: (slug: string) => void;
+  onSettings?: () => void;
 };
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -95,6 +96,7 @@ export function WikiDetailPageRoute(): React.ReactElement {
       slug={slug}
       onBack={() => navigate('/wiki')}
       onNavigate={(s) => navigate(`/wiki/${s}`)}
+      onSettings={() => navigate('/settings/ijfw')}
     />
   );
 }
@@ -105,6 +107,7 @@ export function WikiDetailPage({
   slug,
   onBack,
   onNavigate,
+  onSettings,
 }: WikiDetailPageProps): React.ReactElement {
   const { t } = useTranslation('memory');
   const [concept, setConcept] = useState<WikiConcept | null>(null);
@@ -238,7 +241,12 @@ export function WikiDetailPage({
           <Button className={styles.updateBtn} size='small'>
             {t('wiki.detail.updateFromSources', 'Update from sources')}
           </Button>
-          <button className={styles.iconBtn} title={t('wiki.detail.settings', 'Settings')} aria-label={t('wiki.detail.settings', 'Settings')}>
+          <button
+            className={styles.iconBtn}
+            title={t('wiki.detail.settings', 'Settings')}
+            aria-label={t('wiki.detail.settings', 'Settings')}
+            onClick={onSettings}
+          >
             <Settings size={14} />
           </button>
         </div>

--- a/src/renderer/pages/wiki/WikiHomePage.tsx
+++ b/src/renderer/pages/wiki/WikiHomePage.tsx
@@ -188,6 +188,10 @@ export function WikiHomePage(): React.ReactElement {
     navigate(`/wiki/${slug}`);
   };
 
+  const handleOpenSettings = (): void => {
+    navigate('/settings/ijfw');
+  };
+
   return (
     <div className={styles.page}>
       {/* Topbar */}
@@ -247,7 +251,12 @@ export function WikiHomePage(): React.ReactElement {
         <Button type='primary' size='small' className={styles.newBtn}>
           {t('wiki.home.newConcept', '+ New concept')}
         </Button>
-        <button className={styles.iconBtn} title={t('wiki.home.settings', 'Settings')} aria-label={t('wiki.home.settings', 'Settings')}>
+        <button
+          className={styles.iconBtn}
+          title={t('wiki.home.settings', 'Settings')}
+          aria-label={t('wiki.home.settings', 'Settings')}
+          onClick={handleOpenSettings}
+        >
           <Settings size={15} />
         </button>
       </header>


### PR DESCRIPTION
## Summary

- wire Wiki home settings gear to the IJFW settings route
- pass a settings handler through the Wiki detail route/page so the detail gear works too

## Testing

- `bunx tsc --noEmit`
- `bun run build:renderer:web`
- `git diff --check`
