### PR TITLE
fix(guid): prevent main page flashing loop (#8)

### DIFF
--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -214,7 +214,7 @@ export const useGuidAgentSelection = ({
   // Fetch remote agents from DB and merge into available agents
   const { data: remoteAgentsData } = useSWR('remote-agents.list', () => ipcBridge.remoteAgent.list.invoke());
 
-  useEffect(() => {
+ useEffect(() => {
     if (!availableAgentsData) return;
     const remoteAsAvailable: AvailableAgent[] = (remoteAgentsData || []).map((ra) => ({
       backend: 'remote',
@@ -222,7 +222,23 @@ export const useGuidAgentSelection = ({
       customAgentId: ra.id,
       avatar: ra.avatar,
     }));
-    setAvailableAgents([...availableAgentsData, ...remoteAsAvailable]);
+    const next = [...availableAgentsData, ...remoteAsAvailable];
+    setAvailableAgents((prev) => {
+      if (
+        prev &&
+        prev.length === next.length &&
+        prev.every(
+          (p, i) =>
+            p.backend === next[i].backend &&
+            p.customAgentId === next[i].customAgentId &&
+            p.name === next[i].name &&
+            p.avatar === next[i].avatar
+        )
+      ) {
+        return prev;
+      }
+      return next;
+    });
   }, [availableAgentsData, remoteAgentsData]);
 
   // Track whether the resetAssistant flag has been consumed so it only fires once


### PR DESCRIPTION
Fixes #8

## Root cause
`setAvailableAgents` created a new array reference on every SWR refresh of
`availableAgentsData`/`remoteAgentsData`, even when the content was unchanged.
This re-triggered the "restore saved selection" effect (which depends on
`availableAgents`), causing `selectedAgentKey`/`isPresetAgent` to be
re-applied repeatedly. This toggled `showPresetHero`, remounting `Greeting`
on the main page and re-rolling its random greeting variant each time —
producing the rapid welcome-message flashing/looping reported in #8.

## Fix
Only update `availableAgents` state when the resolved list actually differs
in content (by backend, customAgentId, name, avatar), preserving the previous
reference otherwise. This stops the downstream effect from re-firing
spuriously.

## Testing
Could not run the full app locally (Node 22+ / native build toolchain
required for better-sqlite3), but the change is a minimal, isolated bail-out
in a single effect with no behavioral change when content actually differs.