### PR TITLE
fix(standalone): wire missing project/team/skills bridge inits

### DIFF
--- a/src/process/utils/initBridgeStandalone.ts
+++ b/src/process/utils/initBridgeStandalone.ts
@@ -43,6 +43,11 @@ import { initSystemSettingsBridge } from '@process/bridge/systemSettingsBridge';
 import { initTaskBridge } from '@process/bridge/taskBridge';
 import { initSpeechToTextBridge } from '@process/bridge/speechToTextBridge';
 import { initHubBridge } from '@process/bridge/hubBridge';
+import { initProjectBridge } from '@process/bridge/projectBridge';
+import { initTeamBridge } from '@process/bridge/teamBridge';
+import { initSkillsBridge } from '@process/bridge/skillsBridge';
+import { SqliteTeamRepository } from '@process/team/repository/SqliteTeamRepository';
+import { TeamSessionService } from '@process/team/TeamSessionService';
 
 logger.config({ print: true });
 
@@ -80,6 +85,16 @@ export async function initBridgeStandalone(): Promise<void> {
   initStarOfficeBridge();
   initSpeechToTextBridge();
   initHubBridge();
+  initProjectBridge();
+
+  // Team session service: pass the three required deps; ritualScheduler is
+  // optional (Standing-Company rituals are a no-op without it, which is fine
+  // for headless mode — users aren't installing cron-driven rituals here).
+  const teamRepo = new SqliteTeamRepository();
+  const teamSessionService = new TeamSessionService(teamRepo, workerTaskManager, conversationService);
+  initTeamBridge(teamSessionService);
+
+  initSkillsBridge();
 
   // Initialize ACP detector to scan for installed CLI agents (claude, codex, etc.)
   // Must mirror Electron's initializeAcpDetector() call in src/index.ts


### PR DESCRIPTION
## Summary

`initBridgeStandalone` was missing calls to `initProjectBridge`, `initTeamBridge`, and `initSkillsBridge` that the Electron-mode init in `src/process/bridge/index.ts` always makes. On a headless (`getwayland` npm) install, this means the project / team / skills WebSocket providers are never registered, so subscriptions like `subscribe-project.create` reach the bridge emitter via `src/common/adapter/standalone.ts` but have **no listener** — the UI spinner hangs forever with zero log output.

## Repro on `0.9.6-rc.2`

1. `npm i -g getwayland && wayland setup && wayland start`
2. Sign in to the WebUI, click **New Project**
3. Spinner runs indefinitely. No error in `journalctl -u wayland.service` or stdout.

## Root cause

The standalone adapter (`src/common/adapter/standalone.ts`) routes inbound WS messages into `bridge.adapter`'s emitter. When a provider isn't registered for the key, the emit completes silently — there's no listener to call back, so the renderer never gets `subscribe.callback-project.create<id>` and the awaiting Promise on the renderer side never resolves.

In Electron mode `initAllBridges()` in `src/process/bridge/index.ts:108` calls `initProjectBridge()` (and team/skills). In standalone mode, these calls were never added.

## Fix

`src/process/utils/initBridgeStandalone.ts`:

- Import `initProjectBridge`, `initTeamBridge`, `initSkillsBridge` and the deps `TeamSessionService` needs
- Call all three at the end of `initBridgeStandalone()`
- Construct `TeamSessionService` with the three required deps; leave the optional `ritualScheduler` undefined — Standing-Company cron rituals are a no-op without it, which matches the JSDoc on the constructor parameter and is fine for headless use (users self-hosting via `getwayland` aren't installing cron-driven rituals)

## Test plan

- [x] `bun run lint:fix src/process/utils/initBridgeStandalone.ts` — 0 warnings, 0 errors
- [x] `bun run format src/process/utils/initBridgeStandalone.ts` — applied
- [x] `bunx tsc --noEmit` — no new errors
- [x] Manual verification on a local install of `0.9.6-rc.2` with this build's `dist-server/server.mjs` deployed: Create Project completes end-to-end, project list renders, existing rows surface in the UI
- [ ] CI green

## Notes

There are ~28 other bridges in Electron-mode init that aren't in standalone-mode init (e.g. `onboardingBridge`, `memoryArchiveBridge`, `missionControlBridge`, `wcoreConfigBridge`, etc.). Some appear deliberately omitted (e.g. anything calling `ipcMain.handle()` directly), but others may share this same silent-hang failure mode if their WS subscriptions ever get exercised. Happy to do a follow-up sweep — kept this PR focused on the three bridges the WebUI hits on first use, but flag if you'd like the broader audit done in the same PR.