### PR TITLE
fix(projects): hide assigned chats from global recents

### DIFF
--- a/src/process/bridge/projectBridge.ts
+++ b/src/process/bridge/projectBridge.ts
@@ -147,6 +147,11 @@ export function initProjectBridge(): void {
     // payload so the renderer can patch that single row instead of re-listing.
     const count = (await projectService.getProjectConversations(projectId)).length;
     ipcBridge.project.changed.emit({ id: projectId, count });
+    ipcBridge.conversation.listChanged.emit({
+      conversationId,
+      action: 'updated',
+      source: 'project-assignment',
+    });
   });
 
   ipcBridge.project.removeConversation.provider(async ({ conversationId }) => {
@@ -156,6 +161,11 @@ export function initProjectBridge(): void {
     // (unchanged behavior). assignConversation above carries the targeted payload
     // since it already knows the destination projectId (PERF-IPC-01).
     ipcBridge.project.changed.emit(undefined);
+    ipcBridge.conversation.listChanged.emit({
+      conversationId,
+      action: 'updated',
+      source: 'project-assignment',
+    });
   });
 
   ipcBridge.project.readKnowledge.provider(async ({ id }) => {

--- a/src/renderer/components/layout/Sider/SiderAccordion/SiderRecentChatsSection.tsx
+++ b/src/renderer/components/layout/Sider/SiderAccordion/SiderRecentChatsSection.tsx
@@ -38,10 +38,10 @@ export const SiderRecentChatsSection: React.FC<SiderRecentChatsSectionProps> = (
           .then((list) => {
             if (!alive) return;
             if (Array.isArray(list)) {
-              // Match WorkspaceGroupedHistory's visible-set filter: drop health-checks and team-attached.
+              // Match WorkspaceGroupedHistory's visible-set filter: drop health-checks and scoped chats.
               const visible = list.filter((conv) => {
-                const extra = conv.extra as { isHealthCheck?: boolean; teamId?: string } | undefined;
-                return extra?.isHealthCheck !== true && !extra?.teamId;
+                const extra = conv.extra as { isHealthCheck?: boolean; teamId?: string; projectId?: string } | undefined;
+                return extra?.isHealthCheck !== true && !extra?.teamId && !extra?.projectId;
               });
               setCount(visible.length);
             } else {

--- a/src/renderer/pages/conversation/GroupedHistory/hooks/useConversationListSync.ts
+++ b/src/renderer/pages/conversation/GroupedHistory/hooks/useConversationListSync.ts
@@ -94,8 +94,8 @@ const refreshConversations = () => {
     .then((data) => {
       if (data && Array.isArray(data)) {
         const filteredData = data.filter((conv) => {
-          const extra = conv.extra as { isHealthCheck?: boolean; teamId?: string } | undefined;
-          return extra?.isHealthCheck !== true && !extra?.teamId;
+          const extra = conv.extra as { isHealthCheck?: boolean; teamId?: string; projectId?: string } | undefined;
+          return extra?.isHealthCheck !== true && !extra?.teamId && !extra?.projectId;
         });
         conversationsState = filteredData;
         // Use ALL conversation IDs (including team/healthCheck) so the

--- a/src/renderer/pages/conversation/GroupedHistory/utils/groupingHelpers.ts
+++ b/src/renderer/pages/conversation/GroupedHistory/utils/groupingHelpers.ts
@@ -89,18 +89,18 @@ export const groupConversationsByWorkspace = (
   ];
 };
 
-/** Check whether a conversation belongs to a team (should be hidden from sidebar). */
-const isTeamConversation = (conversation: TChatConversation): boolean => {
-  const extra = conversation.extra as { teamId?: string } | undefined;
-  return Boolean(extra?.teamId);
+/** Check whether a conversation belongs to a scoped surface (should be hidden from global sidebar). */
+const isScopedConversation = (conversation: TChatConversation): boolean => {
+  const extra = conversation.extra as { teamId?: string; projectId?: string } | undefined;
+  return Boolean(extra?.teamId || extra?.projectId);
 };
 
 export const buildGroupedHistory = (
   conversations: TChatConversation[],
   t: (key: string) => string
 ): GroupedHistoryResult => {
-  // Filter out team-owned conversations; they are only visible via the Teams panel
-  const visibleConversations = conversations.filter((conv) => !isTeamConversation(conv));
+  // Filter out scoped conversations; they are only visible via their owning surface.
+  const visibleConversations = conversations.filter((conv) => !isScopedConversation(conv));
 
   const pinnedConversations = visibleConversations
     .filter((conversation) => isConversationPinned(conversation))

--- a/tests/unit/renderer/components/layout/Sider/SiderAccordion/SiderRecentChatsSection.dom.test.tsx
+++ b/tests/unit/renderer/components/layout/Sider/SiderAccordion/SiderRecentChatsSection.dom.test.tsx
@@ -99,6 +99,7 @@ describe('SiderRecentChatsSection', () => {
       { id: 'c2', extra: {} },
       { id: 'c3', extra: { isHealthCheck: true } }, // filtered out
       { id: 'c4', extra: { teamId: 't1' } }, // filtered out
+      { id: 'c5', extra: { projectId: 'proj-fintrakd' } }, // filtered out
     ]);
     renderSection();
     const badge = await screen.findByTestId('recent-chats-badge', undefined, { timeout: 2000 });

--- a/tests/unit/renderer/groupingHelpers.test.ts
+++ b/tests/unit/renderer/groupingHelpers.test.ts
@@ -421,6 +421,41 @@ describe('buildGroupedHistory', () => {
     expect(result.timelineSections[0].items[0].conversation?.id).toBe('conv-1');
   });
 
+  it('excludes team and project scoped conversations from global history', () => {
+    const conversations: TChatConversation[] = [
+      {
+        id: 'conv-1',
+        title: 'Normal',
+        createdAt: 1000,
+        updatedAt: 1000,
+        extra: {},
+        userMsgCount: 0,
+      },
+      {
+        id: 'conv-2',
+        title: 'Team',
+        createdAt: 2000,
+        updatedAt: 2000,
+        extra: { teamId: 'team-1' },
+        userMsgCount: 0,
+      },
+      {
+        id: 'conv-3',
+        title: 'Project',
+        createdAt: 3000,
+        updatedAt: 3000,
+        extra: { projectId: 'proj-fintrakd' },
+        userMsgCount: 0,
+      },
+    ];
+
+    const result = buildGroupedHistory(conversations, mockT);
+
+    expect(result.pinnedConversations).toHaveLength(0);
+    expect(result.timelineSections[0].items).toHaveLength(1);
+    expect(result.timelineSections[0].items[0].conversation?.id).toBe('conv-1');
+  });
+
   it('sorts pinned conversations by sortOrder first', () => {
     const conversations: TChatConversation[] = [
       {


### PR DESCRIPTION
## Summary
- hide project-owned conversations from the global Recent Chats sidebar count and grouped history list
- emit `conversation.listChanged` after project assign/remove so global recents refresh immediately
- add regression coverage for project-scoped conversations

## Verification
- `bunx vitest run tests/unit/renderer/components/layout/Sider/SiderAccordion/SiderRecentChatsSection.dom.test.tsx tests/unit/renderer/groupingHelpers.test.ts`
- `git diff --check`

Fixes project-assigned chats remaining visible in global Recent Chats after moving them into a Project.