### PR TITLE
fix(platform): improve macOS detection

### DIFF
--- a/src/renderer/utils/platform.ts
+++ b/src/renderer/utils/platform.ts
@@ -21,7 +21,10 @@ export const isElectronDesktop = (): boolean => {
  * Check if running on macOS
  */
 export const isMacOS = (): boolean => {
-  return typeof navigator !== 'undefined' && /mac/i.test(navigator.userAgent);
+  if (typeof navigator === 'undefined') return false;
+  const nav = navigator as Navigator & { userAgentData?: { platform?: string } };
+  const platform = nav.userAgentData?.platform || nav.platform || nav.userAgent;
+  return /mac|iphone|ipad|ipod/i.test(platform);
 };
 
 /**


### PR DESCRIPTION
## Summary

Improve macOS detection to prefer `navigator.userAgentData.platform`, then `navigator.platform`, then the user agent string. This keeps platform-aware behavior working when browser user-agent strings are reduced, and it also recognizes iPhone/iPad/iPod platform values as Apple clients.

This is the focused follow-up requested on #41; it intentionally leaves out the shortcut-label and GUID/memory UI hunks from the superseded PR.

## Testing

- `bun run lint src/renderer/utils/platform.ts`
- `bunx tsc --noEmit --pretty false`
- `bun run build:renderer:web`
