### PR TITLE
Fix local Ollama chat and model refresh

### DIFF
--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -1797,6 +1797,28 @@ export type IModelRegistryRefreshState = {
   refreshing: boolean;
 };
 
+/** Live runtime state for locally-connected Ollama models. */
+export type IOllamaRuntimeState = {
+  reachable: boolean;
+  models: Record<
+    string,
+    {
+      loaded: boolean;
+      expiresAt?: string;
+      sizeVram?: number;
+      contextLength?: number;
+    }
+  >;
+  error?: string;
+};
+
+/** Result of asking the local Ollama daemon to warm a model into memory. */
+export type IOllamaWarmResult = {
+  ok: boolean;
+  loaded: boolean;
+  error?: string;
+};
+
 export const modelRegistry = {
   // Auto-discover provider keys from the environment / credential stores.
   detectKeys: buildProvider<IModelRegistryDetectedKey[], void>('modelRegistry.detectKeys'),
@@ -1843,6 +1865,12 @@ export const modelRegistry = {
   refreshAll: buildProvider<IModelRegistryRefreshSummary, { reason?: 'manual' }>('modelRegistry.refreshAll'),
   // Current freshness + in-flight state for the Models settings header.
   getRefreshState: buildProvider<IModelRegistryRefreshState, void>('modelRegistry.getRefreshState'),
+  // Live runtime state for the local Ollama daemon (`/api/ps`), separate from
+  // the persisted installed-model catalog (`/api/tags` / registry mirror).
+  getOllamaRuntimeState: buildProvider<IOllamaRuntimeState, void>('modelRegistry.getOllamaRuntimeState'),
+  // Ask the native Ollama daemon to warm a model into memory so the next chat
+  // turn can avoid a cold-start load penalty.
+  warmOllamaModel: buildProvider<IOllamaWarmResult, { modelId: string }>('modelRegistry.warmOllamaModel'),
   // The auto-refresh toggle (persisted `models.autoRefresh`, default on).
   getAutoRefresh: buildProvider<boolean, void>('modelRegistry.getAutoRefresh'),
   setAutoRefresh: buildProvider<{ ok: boolean }, { value: boolean }>('modelRegistry.setAutoRefresh'),

--- a/src/process/agent/wcore/envBuilder.ts
+++ b/src/process/agent/wcore/envBuilder.ts
@@ -5,7 +5,7 @@
  */
 
 import type { TProviderWithModel } from '@/common/config/storage';
-import { isOpenAIHost } from '@/common/utils/urlValidation';
+import { isLocalBaseUrl, isOpenAIHost } from '@/common/utils/urlValidation';
 import { loadBaselineProviderCatalog } from '@process/providers/catalog/providerCatalogStore';
 import { getEnhancedEnv } from '@process/utils/shellEnv';
 
@@ -117,6 +117,13 @@ function mapProvider(model: TProviderWithModel): WCoreProvider {
 }
 
 const GEMINI_OPENAI_COMPAT_PATH = '/v1beta/openai';
+/**
+ * wayland-core currently refuses to start an OpenAI-protocol session without a
+ * non-empty key, even when the target is a local keyless daemon like Ollama.
+ * For loopback/private base URLs only, inject a harmless sentinel so the engine
+ * can bootstrap; the local backend ignores the bearer token.
+ */
+const LOCAL_OPENAI_COMPAT_API_KEY = 'local';
 
 /**
  * Default `--max-tokens` budget for reasoning-tier models when the caller
@@ -277,8 +284,12 @@ export function buildSpawnConfig(
       break;
 
     case 'openai': {
-      if (model.apiKey) env.OPENAI_API_KEY = model.apiKey;
       const baseUrl = resolveOpenAIBaseUrl(model);
+      if (model.apiKey) {
+        env.OPENAI_API_KEY = model.apiKey;
+      } else if (isLocalBaseUrl(baseUrl)) {
+        env.OPENAI_API_KEY = LOCAL_OPENAI_COMPAT_API_KEY;
+      }
       if (baseUrl) args.push('--base-url', stripTrailingV1(baseUrl));
       break;
     }

--- a/src/process/onboarding/autoRegisterOllama.ts
+++ b/src/process/onboarding/autoRegisterOllama.ts
@@ -55,19 +55,35 @@ export type AutoRegisterOutcome =
   | { action: 'refreshed'; models: number }
   | { action: 'skipped' };
 
+function inferOllamaKind(name: string): CatalogModel['kind'] {
+  const id = name.toLowerCase();
+  if (id.includes('embed') || id.includes('embedding')) return 'embedding';
+  return 'text';
+}
+
+function inferOllamaTags(name: string, kind: CatalogModel['kind']): CatalogModel['tags'] {
+  if (kind === 'embedding') return ['embeddings'];
+
+  const id = name.toLowerCase();
+  const tags: CatalogModel['tags'] = ['chat'];
+  if (id.includes('vision') || id.includes('vl')) tags.push('vision');
+  return tags;
+}
+
 /**
  * Build a minimal `CatalogModel` for a model name reported by `/api/tags`. The
  * name is the id verbatim (e.g. `llama3:latest`); no enrichment is fabricated.
  */
 function toCatalogModel(name: string): CatalogModel {
+  const kind = inferOllamaKind(name);
   return {
     id: name,
     providerId: OLLAMA_LOCAL_ID,
     displayName: name,
     family: name.split(':')[0] || name,
-    kind: 'text',
+    kind,
     enriched: false,
-    tags: ['chat'],
+    tags: inferOllamaTags(name, kind),
   };
 }
 

--- a/src/process/onboarding/autoRegisterOllama.ts
+++ b/src/process/onboarding/autoRegisterOllama.ts
@@ -27,6 +27,7 @@
  */
 
 import type { CatalogModel, ProviderId } from '@process/providers/types';
+import { isUnsupportedLocalVisionModel } from '@process/providers/catalog/localVisionModelFilter';
 
 /** The fixed native provider id for the local Ollama daemon. */
 const OLLAMA_LOCAL_ID: ProviderId = 'ollama-local';
@@ -63,11 +64,7 @@ function inferOllamaKind(name: string): CatalogModel['kind'] {
 
 function inferOllamaTags(name: string, kind: CatalogModel['kind']): CatalogModel['tags'] {
   if (kind === 'embedding') return ['embeddings'];
-
-  const id = name.toLowerCase();
-  const tags: CatalogModel['tags'] = ['chat'];
-  if (id.includes('vision') || id.includes('vl')) tags.push('vision');
-  return tags;
+  return ['chat'];
 }
 
 /**
@@ -114,7 +111,9 @@ export function autoRegisterOllamaInRepo(repo: OllamaRegistryRepo, probe: Ollama
   try {
     if (!probe.running) return { action: 'skipped' };
 
-    const models = normalizeModelNames(probe.models).map(toCatalogModel);
+    const models = normalizeModelNames(probe.models)
+      .filter((name) => !isUnsupportedLocalVisionModel(OLLAMA_LOCAL_ID, name))
+      .map(toCatalogModel);
     const existing = repo.getRegistryProvider(OLLAMA_LOCAL_ID);
 
     if (existing) {

--- a/src/process/providers/catalog/CatalogAssembler.ts
+++ b/src/process/providers/catalog/CatalogAssembler.ts
@@ -35,6 +35,7 @@ import type { ModelsDevModel, ModelsDevRegistry } from '../enrichment/modelsDevS
 import type { CatalogModel, ModelKind, ProviderId, RawModel, UsageTag } from '../types';
 import { ModelDisplayNames } from './ModelDisplayNames';
 import { isUnsupportedLocalVisionModel } from './localVisionModelFilter';
+import { isLocalBaseUrl } from '@/common/utils/urlValidation';
 
 /**
  * Maps our `ProviderId` to the provider key models.dev uses in its registry.
@@ -103,7 +104,8 @@ export class CatalogAssembler {
 
     const models: CatalogModel[] = [];
     let sourceErrors = 0;
-    for (const result of settled) {
+    for (let sourceIndex = 0; sourceIndex < settled.length; sourceIndex++) {
+      const result = settled[sourceIndex];
       // A rejected source contributes nothing - degrade per-source, never
       // abort - but the failure is reported so the caller can tell a degraded
       // empty result apart from a genuinely empty one.
@@ -111,8 +113,11 @@ export class CatalogAssembler {
         sourceErrors++;
         continue;
       }
+      const isLocalOpenAICompatibleSource =
+        result.value.some((raw) => raw.providerId === 'openai-compatible') &&
+        isLocalBaseUrl(sources[sourceIndex]?.baseUrl);
       for (const raw of result.value) {
-        if (isUnsupportedLocalVisionModel(raw.providerId, raw.id)) continue;
+        if (isUnsupportedLocalVisionModel(raw.providerId, raw.id, isLocalOpenAICompatibleSource)) continue;
         models.push(this.toCatalogModel(raw, registry));
       }
     }

--- a/src/process/providers/catalog/CatalogAssembler.ts
+++ b/src/process/providers/catalog/CatalogAssembler.ts
@@ -34,6 +34,7 @@ import type { CatalogSource } from '../sources/CatalogSource';
 import type { ModelsDevModel, ModelsDevRegistry } from '../enrichment/modelsDevSchema';
 import type { CatalogModel, ModelKind, ProviderId, RawModel, UsageTag } from '../types';
 import { ModelDisplayNames } from './ModelDisplayNames';
+import { isUnsupportedLocalVisionModel } from './localVisionModelFilter';
 
 /**
  * Maps our `ProviderId` to the provider key models.dev uses in its registry.
@@ -111,6 +112,7 @@ export class CatalogAssembler {
         continue;
       }
       for (const raw of result.value) {
+        if (isUnsupportedLocalVisionModel(raw.providerId, raw.id)) continue;
         models.push(this.toCatalogModel(raw, registry));
       }
     }

--- a/src/process/providers/catalog/localVisionModelFilter.ts
+++ b/src/process/providers/catalog/localVisionModelFilter.ts
@@ -10,7 +10,7 @@ const LOCAL_MODEL_PROVIDERS = new Set<ProviderId>(['ollama-local', 'openai-compa
 
 const VISION_MODEL_PATTERNS: RegExp[] = [
   /(?:^|[-_.:/])vision(?:$|[-_.:/])/i,
-  /(?:^|[-_.:/])vl(?:$|[-_.:/])/i,
+  /(?:^|[-_.:/])vlm?(?:$|[-_.:/])/i,
   /llava/i,
   /bakllava/i,
   /moondream/i,

--- a/src/process/providers/catalog/localVisionModelFilter.ts
+++ b/src/process/providers/catalog/localVisionModelFilter.ts
@@ -6,8 +6,6 @@
 
 import type { ProviderId } from '../types';
 
-const LOCAL_MODEL_PROVIDERS = new Set<ProviderId>(['ollama-local', 'openai-compatible']);
-
 const VISION_MODEL_PATTERNS: RegExp[] = [
   /(?:^|[-_.:/])vision(?:$|[-_.:/])/i,
   /(?:^|[-_.:/])vlm?(?:$|[-_.:/])/i,
@@ -25,7 +23,11 @@ const VISION_MODEL_PATTERNS: RegExp[] = [
   /qwen[\w.-]*vl/i,
 ];
 
-export function isUnsupportedLocalVisionModel(providerId: ProviderId, modelId: string): boolean {
-  if (!LOCAL_MODEL_PROVIDERS.has(providerId)) return false;
+export function isUnsupportedLocalVisionModel(
+  providerId: ProviderId,
+  modelId: string,
+  isLocalEndpoint = false
+): boolean {
+  if (providerId !== 'ollama-local' && !(providerId === 'openai-compatible' && isLocalEndpoint)) return false;
   return VISION_MODEL_PATTERNS.some((pattern) => pattern.test(modelId));
 }

--- a/src/process/providers/catalog/localVisionModelFilter.ts
+++ b/src/process/providers/catalog/localVisionModelFilter.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ProviderId } from '../types';
+
+const LOCAL_MODEL_PROVIDERS = new Set<ProviderId>(['ollama-local', 'openai-compatible']);
+
+const VISION_MODEL_PATTERNS: RegExp[] = [
+  /(?:^|[-_.:/])vision(?:$|[-_.:/])/i,
+  /(?:^|[-_.:/])vl(?:$|[-_.:/])/i,
+  /llava/i,
+  /bakllava/i,
+  /moondream/i,
+  /minicpm[-_.:/]?v/i,
+  /internvl/i,
+  /idefics/i,
+  /pixtral/i,
+  /paligemma/i,
+  /cogvlm/i,
+  /deepseek[-_.:/]?vl/i,
+  /glm[-_.:/]?4v/i,
+  /qwen[\w.-]*vl/i,
+];
+
+export function isUnsupportedLocalVisionModel(providerId: ProviderId, modelId: string): boolean {
+  if (!LOCAL_MODEL_PROVIDERS.has(providerId)) return false;
+  return VISION_MODEL_PATTERNS.some((pattern) => pattern.test(modelId));
+}

--- a/src/process/providers/ipc/modelRegistryIpc.ts
+++ b/src/process/providers/ipc/modelRegistryIpc.ts
@@ -1612,7 +1612,14 @@ export async function initModelRegistryIpc(): Promise<void> {
   ipcBridge.modelRegistry.testConnection.provider((payload) => h.testConnection(payload));
   ipcBridge.modelRegistry.list.provider(() => h.list());
   ipcBridge.modelRegistry.getCatalog.provider((payload) => h.getCatalog(payload));
-  ipcBridge.modelRegistry.toggleModel.provider((payload) => h.toggleModel(payload));
+  ipcBridge.modelRegistry.toggleModel.provider(async (payload) => {
+    const result = await h.toggleModel(payload);
+    if (result.ok && _repo) {
+      void mirrorConnectOrRekey(_repo, payload.providerId);
+      ipcBridge.modelRegistry.listChanged.emit();
+    }
+    return result;
+  });
   ipcBridge.modelRegistry.refresh.provider(async (payload) => {
     const result = await h.refresh(payload);
     if (result.ok && _repo) void mirrorConnectOrRekey(_repo, payload.providerId);

--- a/src/process/providers/ipc/modelRegistryIpc.ts
+++ b/src/process/providers/ipc/modelRegistryIpc.ts
@@ -211,7 +211,7 @@ export type ModelRegistryDeps = {
    * `initModelRegistryIpc`. A `null`/unreachable result must leave the existing
    * catalog untouched rather than emptying it.
    */
-  probeOllama?: () => Promise<OllamaProbe>;
+  probeOllama?: (baseUrl?: string) => Promise<OllamaProbe>;
   ollamaRuntime?: {
     getState: () => Promise<IOllamaRuntimeState>;
     warmModel: (modelId: string) => Promise<IOllamaWarmResult>;
@@ -419,11 +419,11 @@ export function createModelRegistryHandlers(deps: ModelRegistryDeps): ModelRegis
    * `autoRegisterOllamaInRepo` preserves a user-changed `state` (e.g. disabled)
    * and only refreshes the catalog for an already-registered provider.
    */
-  async function refreshOllamaLocal(): Promise<'ok' | 'unreachable' | 'failed'> {
+  async function refreshOllamaLocal(baseUrl: string): Promise<'ok' | 'unreachable' | 'failed'> {
     if (!deps.probeOllama) return 'unreachable';
     let probe: OllamaProbe;
     try {
-      probe = await deps.probeOllama();
+      probe = await deps.probeOllama(baseUrl);
     } catch {
       return 'unreachable';
     }
@@ -716,12 +716,10 @@ export function createModelRegistryHandlers(deps: ModelRegistryDeps): ModelRegis
         // generic catalog builder would assemble zero sources and replace the
         // saved model list with `[]`. Re-probe the local daemon instead, and
         // leave the existing catalog untouched if the daemon is unreachable.
-        const storedBaseUrl = stored.creds.baseUrl;
-        if (
-          providerId === OLLAMA_LOCAL_ID &&
-          isLoopbackBaseUrl(typeof storedBaseUrl === 'string' ? storedBaseUrl : '')
-        ) {
-          return { ok: (await refreshOllamaLocal()) === 'ok' };
+        if (providerId === OLLAMA_LOCAL_ID) {
+          const configuredBaseUrl = configuredOllamaBaseUrl(repo);
+          if (configuredBaseUrl.ok === false) return { ok: false };
+          return { ok: (await refreshOllamaLocal(configuredBaseUrl.baseUrl)) === 'ok' };
         }
 
         const creds = toTestCreds(stored.creds);
@@ -767,12 +765,14 @@ export function createModelRegistryHandlers(deps: ModelRegistryDeps): ModelRegis
           // 5): a row whose stored host is not loopback is treated like any
           // other custom provider (validated below), so the keyless+SSRF-exempt
           // allowance can never be hijacked onto a remote host.
-          if (
-            providerId === OLLAMA_LOCAL_ID &&
-            isLoopbackBaseUrl(typeof storedBaseUrl === 'string' ? storedBaseUrl : '')
-          ) {
+          if (providerId === OLLAMA_LOCAL_ID) {
+            const configuredBaseUrl = configuredOllamaBaseUrl(repo);
+            if (configuredBaseUrl.ok === false) {
+              failed.push(providerId);
+              continue;
+            }
             const ollamaBefore = new Set(repo.getRegistryCatalog(providerId).map((m) => m.id));
-            const outcome = await refreshOllamaLocal();
+            const outcome = await refreshOllamaLocal(configuredBaseUrl.baseUrl);
             if (outcome !== 'ok') {
               failed.push(providerId);
               continue;
@@ -1405,7 +1405,7 @@ async function buildProductionDeps(): Promise<ModelRegistryDeps> {
     // `buildAndPersistCatalog` (Finding 1). A down/unreachable daemon resolves
     // to `{ running:false }`, which the refresh path treats as "leave the
     // existing catalog untouched" rather than wiping it.
-    probeOllama: () => probeOllamaDaemon(),
+    probeOllama: (baseUrl) => probeOllamaDaemon(baseUrl),
     ollamaRuntime: {
       getState: () => {
         const configuredBaseUrl = configuredOllamaBaseUrl(_repo);
@@ -1424,7 +1424,7 @@ async function buildProductionDeps(): Promise<ModelRegistryDeps> {
 }
 
 function configuredOllamaBaseUrl(
-  repo?: ProviderRepository
+  repo?: Pick<ProviderRepository, 'getRegistryProvider' | 'getRegistryProviderCreds'>
 ): { ok: true; baseUrl: string } | { ok: false; error: string } {
   const provider = repo?.getRegistryProvider(OLLAMA_LOCAL_ID);
   if (!provider) return { ok: false, error: 'Ollama is not connected.' };
@@ -1446,11 +1446,11 @@ function configuredOllamaBaseUrl(
  * `{ running:false, models:[] }`. Never throws. Mirror of `detect.probeOllama`
  * but kept here to avoid a `detect -> modelRegistryIpc` import cycle.
  */
-async function probeOllamaDaemon(): Promise<OllamaProbe> {
+async function probeOllamaDaemon(baseUrl = OLLAMA_LOCAL_BASE_URL): Promise<OllamaProbe> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 2000);
   try {
-    const res = await fetch(`${OLLAMA_LOCAL_BASE_URL.replace(/\/v1$/, '')}/api/tags`, { signal: controller.signal });
+    const res = await fetch(`${normalizeOllamaApiBaseUrl(baseUrl)}/api/tags`, { signal: controller.signal });
     if (!res.ok) return { running: false, models: [] };
     const body = (await res.json()) as unknown;
     if (!body || typeof body !== 'object') return { running: false, models: [] };

--- a/src/process/providers/ipc/modelRegistryIpc.ts
+++ b/src/process/providers/ipc/modelRegistryIpc.ts
@@ -1615,7 +1615,7 @@ export async function initModelRegistryIpc(): Promise<void> {
   ipcBridge.modelRegistry.toggleModel.provider(async (payload) => {
     const result = await h.toggleModel(payload);
     if (result.ok && _repo) {
-      void mirrorConnectOrRekey(_repo, payload.providerId);
+      await mirrorConnectOrRekey(_repo, payload.providerId);
       ipcBridge.modelRegistry.listChanged.emit();
     }
     return result;

--- a/src/process/providers/ipc/modelRegistryIpc.ts
+++ b/src/process/providers/ipc/modelRegistryIpc.ts
@@ -703,6 +703,19 @@ export function createModelRegistryHandlers(deps: ModelRegistryDeps): ModelRegis
         }
         // `not-found` - nothing to refresh.
         if (stored.status !== 'ok') return { ok: false };
+
+        // `ollama-local` is intentionally keyless. Refreshing it through the
+        // generic catalog builder would assemble zero sources and replace the
+        // saved model list with `[]`. Re-probe the local daemon instead, and
+        // leave the existing catalog untouched if the daemon is unreachable.
+        const storedBaseUrl = stored.creds.baseUrl;
+        if (
+          providerId === OLLAMA_LOCAL_ID &&
+          isLoopbackBaseUrl(typeof storedBaseUrl === 'string' ? storedBaseUrl : '')
+        ) {
+          return { ok: (await refreshOllamaLocal()) === 'ok' };
+        }
+
         const creds = toTestCreds(stored.creds);
         const built = await buildAndPersistCatalog(providerId, creds);
         return { ok: built.ok };

--- a/src/process/providers/ipc/modelRegistryIpc.ts
+++ b/src/process/providers/ipc/modelRegistryIpc.ts
@@ -46,6 +46,8 @@ import type {
   IModelRegistryConnectResult,
   IModelRegistryCreds,
   IModelRegistryDetectedKey,
+  IOllamaRuntimeState,
+  IOllamaWarmResult,
   IModelRegistryProviderView,
   IModelRegistryRefreshState,
   IModelRegistryRefreshSummary,
@@ -210,6 +212,10 @@ export type ModelRegistryDeps = {
    * catalog untouched rather than emptying it.
    */
   probeOllama?: () => Promise<OllamaProbe>;
+  ollamaRuntime?: {
+    getState: () => Promise<IOllamaRuntimeState>;
+    warmModel: (modelId: string) => Promise<IOllamaWarmResult>;
+  };
 };
 
 /** The fixed native provider id for the local Ollama daemon. */
@@ -265,6 +271,8 @@ export type ModelRegistryHandlers = {
    * emitted once. Returns the genuinely-new model ids for the toast.
    */
   refreshAllOnce: () => Promise<IModelRegistryRefreshSummary>;
+  getOllamaRuntimeState: () => Promise<IOllamaRuntimeState>;
+  warmOllamaModel: (p: { modelId: string }) => Promise<IOllamaWarmResult>;
 };
 
 // ─── Handler factory ──────────────────────────────────────────────────────────
@@ -933,6 +941,35 @@ export function createModelRegistryHandlers(deps: ModelRegistryDeps): ModelRegis
         return [];
       }
     },
+
+    async getOllamaRuntimeState(): Promise<IOllamaRuntimeState> {
+      try {
+        return (await deps.ollamaRuntime?.getState()) ?? { reachable: false, models: {} };
+      } catch (error) {
+        return {
+          reachable: false,
+          models: {},
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+
+    async warmOllamaModel({ modelId }): Promise<IOllamaWarmResult> {
+      try {
+        if (!modelId || typeof modelId !== 'string') return { ok: false, loaded: false, error: 'Model id is required.' };
+        return (await deps.ollamaRuntime?.warmModel(modelId)) ?? {
+          ok: false,
+          loaded: false,
+          error: 'Ollama runtime integration is unavailable.',
+        };
+      } catch (error) {
+        return {
+          ok: false,
+          loaded: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
   };
 }
 
@@ -1366,6 +1403,23 @@ async function buildProductionDeps(): Promise<ModelRegistryDeps> {
     // to `{ running:false }`, which the refresh path treats as "leave the
     // existing catalog untouched" rather than wiping it.
     probeOllama: () => probeOllamaDaemon(),
+    ollamaRuntime: {
+      getState: () => readOllamaRuntimeState(OLLAMA_LOCAL_BASE_URL),
+      warmModel: async (modelId: string) => {
+        const provider = _repo?.getRegistryProvider(OLLAMA_LOCAL_ID);
+        if (!provider) return { ok: false, loaded: false, error: 'Ollama is not connected.' };
+        const stored = _repo?.getRegistryProviderCreds(OLLAMA_LOCAL_ID);
+        if (stored?.status !== 'ok') return { ok: false, loaded: false, error: 'Ollama credentials are unavailable.' };
+        const configuredBaseUrl =
+          typeof stored.creds.baseUrl === 'string' && stored.creds.baseUrl.trim().length > 0
+            ? stored.creds.baseUrl.trim()
+            : OLLAMA_LOCAL_BASE_URL;
+        if (!isLoopbackBaseUrl(configuredBaseUrl)) {
+          return { ok: false, loaded: false, error: 'Refusing to warm a non-loopback Ollama endpoint.' };
+        }
+        return warmOllamaRuntimeModel(modelId, configuredBaseUrl);
+      },
+    },
   };
 }
 
@@ -1391,6 +1445,81 @@ async function probeOllamaDaemon(): Promise<OllamaProbe> {
     return { running: true, models };
   } catch {
     return { running: false, models: [] };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function normalizeOllamaApiBaseUrl(baseUrl?: string): string {
+  const raw = typeof baseUrl === 'string' && baseUrl.trim().length > 0 ? baseUrl.trim() : OLLAMA_LOCAL_BASE_URL;
+  return raw.replace(/\/v1\/?$/, '');
+}
+
+async function readOllamaRuntimeState(baseUrl = OLLAMA_LOCAL_BASE_URL): Promise<IOllamaRuntimeState> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 2000);
+  try {
+    const res = await fetch(`${normalizeOllamaApiBaseUrl(baseUrl)}/api/ps`, { signal: controller.signal });
+    if (!res.ok) {
+      return { reachable: false, models: {}, error: `Ollama runtime returned HTTP ${res.status}.` };
+    }
+    const body = (await res.json()) as unknown;
+    const rawModels = body && typeof body === 'object' ? (body as { models?: unknown }).models : undefined;
+    if (!Array.isArray(rawModels)) return { reachable: true, models: {} };
+    const models: IOllamaRuntimeState['models'] = {};
+    for (const entry of rawModels) {
+      if (!entry || typeof entry !== 'object') continue;
+      const row = entry as {
+        model?: unknown;
+        name?: unknown;
+        expires_at?: unknown;
+        size_vram?: unknown;
+        context_length?: unknown;
+      };
+      const modelId = typeof row.model === 'string' ? row.model : typeof row.name === 'string' ? row.name : '';
+      if (!modelId) continue;
+      models[modelId] = {
+        loaded: true,
+        ...(typeof row.expires_at === 'string' ? { expiresAt: row.expires_at } : {}),
+        ...(typeof row.size_vram === 'number' ? { sizeVram: row.size_vram } : {}),
+        ...(typeof row.context_length === 'number' ? { contextLength: row.context_length } : {}),
+      };
+    }
+    return { reachable: true, models };
+  } catch (error) {
+    return {
+      reachable: false,
+      models: {},
+      error: error instanceof Error ? error.message : String(error),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function warmOllamaRuntimeModel(modelId: string, baseUrl = OLLAMA_LOCAL_BASE_URL): Promise<IOllamaWarmResult> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 15000);
+  try {
+    const res = await fetch(`${normalizeOllamaApiBaseUrl(baseUrl)}/api/generate`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ model: modelId, keep_alive: '10m' }),
+      signal: controller.signal,
+    });
+    if (!res.ok) return { ok: false, loaded: false, error: `Ollama warm request returned HTTP ${res.status}.` };
+    const body = (await res.json()) as unknown;
+    const doneReason =
+      body && typeof body === 'object' && typeof (body as { done_reason?: unknown }).done_reason === 'string'
+        ? (body as { done_reason: string }).done_reason
+        : undefined;
+    return { ok: true, loaded: doneReason === 'load' || doneReason === 'stop' || doneReason === undefined };
+  } catch (error) {
+    return {
+      ok: false,
+      loaded: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
   } finally {
     clearTimeout(timer);
   }
@@ -1506,6 +1635,8 @@ export async function initModelRegistryIpc(): Promise<void> {
   });
   ipcBridge.modelRegistry.curatedForAgent.provider((payload) => h.curatedForAgent(payload));
   ipcBridge.modelRegistry.resolveForChatStart.provider((payload) => h.resolveForChatStart(payload));
+  ipcBridge.modelRegistry.getOllamaRuntimeState.provider(() => h.getOllamaRuntimeState());
+  ipcBridge.modelRegistry.warmOllamaModel.provider((payload) => h.warmOllamaModel(payload));
 
   // ── Provider catalog (T3.3): the ~100 connectable catalog PROVIDERS ─────────
   // A separate concept from the per-provider model registry above. The vendored

--- a/src/process/providers/ipc/modelRegistryIpc.ts
+++ b/src/process/providers/ipc/modelRegistryIpc.ts
@@ -222,6 +222,7 @@ export type ModelRegistryDeps = {
 const OLLAMA_LOCAL_ID: ProviderId = 'ollama-local';
 /** The hardcoded loopback OpenAI-compatible endpoint the local Ollama provider is pinned to. */
 const OLLAMA_LOCAL_BASE_URL = 'http://127.0.0.1:11434/v1';
+const OLLAMA_WARM_TIMEOUT_MS = 5 * 60 * 1000;
 
 /**
  * True only when `baseUrl` parses and its host is a LOOPBACK literal
@@ -1516,7 +1517,9 @@ async function readOllamaRuntimeState(baseUrl = OLLAMA_LOCAL_BASE_URL): Promise<
 
 async function warmOllamaRuntimeModel(modelId: string, baseUrl = OLLAMA_LOCAL_BASE_URL): Promise<IOllamaWarmResult> {
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 15000);
+  // Cold-starting large local models can take minutes; keep the UI in Warming
+  // rather than racing the daemon and reporting a false failure.
+  const timer = setTimeout(() => controller.abort(), OLLAMA_WARM_TIMEOUT_MS);
   try {
     const res = await fetch(`${normalizeOllamaApiBaseUrl(baseUrl)}/api/generate`, {
       method: 'POST',

--- a/src/process/providers/ipc/modelRegistryIpc.ts
+++ b/src/process/providers/ipc/modelRegistryIpc.ts
@@ -1407,23 +1407,37 @@ async function buildProductionDeps(): Promise<ModelRegistryDeps> {
     // existing catalog untouched" rather than wiping it.
     probeOllama: () => probeOllamaDaemon(),
     ollamaRuntime: {
-      getState: () => readOllamaRuntimeState(OLLAMA_LOCAL_BASE_URL),
-      warmModel: async (modelId: string) => {
-        const provider = _repo?.getRegistryProvider(OLLAMA_LOCAL_ID);
-        if (!provider) return { ok: false, loaded: false, error: 'Ollama is not connected.' };
-        const stored = _repo?.getRegistryProviderCreds(OLLAMA_LOCAL_ID);
-        if (stored?.status !== 'ok') return { ok: false, loaded: false, error: 'Ollama credentials are unavailable.' };
-        const configuredBaseUrl =
-          typeof stored.creds.baseUrl === 'string' && stored.creds.baseUrl.trim().length > 0
-            ? stored.creds.baseUrl.trim()
-            : OLLAMA_LOCAL_BASE_URL;
-        if (!isLoopbackBaseUrl(configuredBaseUrl)) {
-          return { ok: false, loaded: false, error: 'Refusing to warm a non-loopback Ollama endpoint.' };
+      getState: () => {
+        const configuredBaseUrl = configuredOllamaBaseUrl(_repo);
+        if (configuredBaseUrl.ok === false) {
+          return Promise.resolve({ reachable: false, models: {}, error: configuredBaseUrl.error });
         }
-        return warmOllamaRuntimeModel(modelId, configuredBaseUrl);
+        return readOllamaRuntimeState(configuredBaseUrl.baseUrl);
+      },
+      warmModel: async (modelId: string) => {
+        const configuredBaseUrl = configuredOllamaBaseUrl(_repo);
+        if (configuredBaseUrl.ok === false) return { ok: false, loaded: false, error: configuredBaseUrl.error };
+        return warmOllamaRuntimeModel(modelId, configuredBaseUrl.baseUrl);
       },
     },
   };
+}
+
+function configuredOllamaBaseUrl(
+  repo?: ProviderRepository
+): { ok: true; baseUrl: string } | { ok: false; error: string } {
+  const provider = repo?.getRegistryProvider(OLLAMA_LOCAL_ID);
+  if (!provider) return { ok: false, error: 'Ollama is not connected.' };
+  const stored = repo?.getRegistryProviderCreds(OLLAMA_LOCAL_ID);
+  if (stored?.status !== 'ok') return { ok: false, error: 'Ollama credentials are unavailable.' };
+  const configuredBaseUrl =
+    typeof stored.creds.baseUrl === 'string' && stored.creds.baseUrl.trim().length > 0
+      ? stored.creds.baseUrl.trim()
+      : OLLAMA_LOCAL_BASE_URL;
+  if (!isLoopbackBaseUrl(configuredBaseUrl)) {
+    return { ok: false, error: 'Refusing to use a non-loopback Ollama endpoint.' };
+  }
+  return { ok: true, baseUrl: configuredBaseUrl };
 }
 
 /**
@@ -1512,11 +1526,21 @@ async function warmOllamaRuntimeModel(modelId: string, baseUrl = OLLAMA_LOCAL_BA
     });
     if (!res.ok) return { ok: false, loaded: false, error: `Ollama warm request returned HTTP ${res.status}.` };
     const body = parseOllamaGenerateResponse(await res.text());
+    if (!body || typeof body !== 'object') {
+      return { ok: false, loaded: false, error: 'Ollama warm response was empty or malformed.' };
+    }
     const doneReason =
-      body && typeof body === 'object' && typeof (body as { done_reason?: unknown }).done_reason === 'string'
+      typeof (body as { done_reason?: unknown }).done_reason === 'string'
         ? (body as { done_reason: string }).done_reason
         : undefined;
-    return { ok: true, loaded: doneReason === 'load' || doneReason === 'stop' || doneReason === undefined };
+    const loaded = doneReason === 'load' || doneReason === 'stop';
+    return loaded
+      ? { ok: true, loaded: true }
+      : {
+          ok: false,
+          loaded: false,
+          error: doneReason ? `Ollama warm ended with "${doneReason}".` : 'Ollama warm response did not confirm load.',
+        };
   } catch (error) {
     return {
       ok: false,

--- a/src/process/providers/ipc/modelRegistryIpc.ts
+++ b/src/process/providers/ipc/modelRegistryIpc.ts
@@ -956,12 +956,15 @@ export function createModelRegistryHandlers(deps: ModelRegistryDeps): ModelRegis
 
     async warmOllamaModel({ modelId }): Promise<IOllamaWarmResult> {
       try {
-        if (!modelId || typeof modelId !== 'string') return { ok: false, loaded: false, error: 'Model id is required.' };
-        return (await deps.ollamaRuntime?.warmModel(modelId)) ?? {
-          ok: false,
-          loaded: false,
-          error: 'Ollama runtime integration is unavailable.',
-        };
+        if (!modelId || typeof modelId !== 'string')
+          return { ok: false, loaded: false, error: 'Model id is required.' };
+        return (
+          (await deps.ollamaRuntime?.warmModel(modelId)) ?? {
+            ok: false,
+            loaded: false,
+            error: 'Ollama runtime integration is unavailable.',
+          }
+        );
       } catch (error) {
         return {
           ok: false,
@@ -1504,7 +1507,7 @@ async function warmOllamaRuntimeModel(modelId: string, baseUrl = OLLAMA_LOCAL_BA
     const res = await fetch(`${normalizeOllamaApiBaseUrl(baseUrl)}/api/generate`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ model: modelId, keep_alive: '10m' }),
+      body: JSON.stringify({ model: modelId, keep_alive: '10m', stream: false }),
       signal: controller.signal,
     });
     if (!res.ok) return { ok: false, loaded: false, error: `Ollama warm request returned HTTP ${res.status}.` };
@@ -1951,4 +1954,8 @@ export async function connectModelRegistryProvider(
  */
 export async function _runStartupMigrationForTests(repo: ProviderRepository): Promise<void> {
   await runStartupMigration(repo);
+}
+
+export async function _warmOllamaRuntimeModelForTests(modelId: string, baseUrl?: string): Promise<IOllamaWarmResult> {
+  return warmOllamaRuntimeModel(modelId, baseUrl);
 }

--- a/src/process/providers/ipc/modelRegistryIpc.ts
+++ b/src/process/providers/ipc/modelRegistryIpc.ts
@@ -1511,7 +1511,7 @@ async function warmOllamaRuntimeModel(modelId: string, baseUrl = OLLAMA_LOCAL_BA
       signal: controller.signal,
     });
     if (!res.ok) return { ok: false, loaded: false, error: `Ollama warm request returned HTTP ${res.status}.` };
-    const body = (await res.json()) as unknown;
+    const body = parseOllamaGenerateResponse(await res.text());
     const doneReason =
       body && typeof body === 'object' && typeof (body as { done_reason?: unknown }).done_reason === 'string'
         ? (body as { done_reason: string }).done_reason
@@ -1525,6 +1525,26 @@ async function warmOllamaRuntimeModel(modelId: string, baseUrl = OLLAMA_LOCAL_BA
     };
   } finally {
     clearTimeout(timer);
+  }
+}
+
+function parseOllamaGenerateResponse(text: string): unknown {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    // Ollama streams NDJSON by default. `stream: false` should return one JSON
+    // object, but tolerate streamed/proxied responses and use the final event.
+    const lines = trimmed.split(/\r?\n/).filter(Boolean);
+    for (let i = lines.length - 1; i >= 0; i--) {
+      try {
+        return JSON.parse(lines[i]);
+      } catch {
+        // Keep walking backward until we find a parseable event.
+      }
+    }
+    return null;
   }
 }
 

--- a/src/process/providers/sources/ApiProviderSource.ts
+++ b/src/process/providers/sources/ApiProviderSource.ts
@@ -69,12 +69,12 @@ export class ApiProviderSource implements CatalogSource {
    * through `refresh`. Wave 3 Fix 10 - without this, every refresh on a
    * custom-base provider silently re-targets the canonical default.
    */
-  private readonly customBaseUrl: string | undefined;
+  readonly baseUrl: string | undefined;
 
   constructor(providerId: ProviderId, apiKey: string, customBaseUrl?: string) {
     this.providerId = providerId;
     this.apiKey = apiKey;
-    this.customBaseUrl =
+    this.baseUrl =
       typeof customBaseUrl === 'string' && customBaseUrl.trim().length > 0 ? customBaseUrl.trim() : undefined;
   }
 
@@ -132,13 +132,13 @@ export class ApiProviderSource implements CatalogSource {
    * segment. Falls back to the canonical `PROVIDER_ENDPOINTS` entry otherwise.
    */
   private resolveEndpoint(): string | undefined {
-    if (!this.customBaseUrl) return PROVIDER_ENDPOINTS[this.providerId];
+    if (!this.baseUrl) return PROVIDER_ENDPOINTS[this.providerId];
 
     // Anthropic + Gemini have non-standard `/v1/models` paths but the auth
     // module already encodes the per-provider differences; we just need to
     // append `/models` on the user's base. The base usually ends in `/v1`,
     // but some users save without it - handle both.
-    const base = this.customBaseUrl.replace(/\/+$/, '');
+    const base = this.baseUrl.replace(/\/+$/, '');
     if (this.providerId === 'google-gemini') {
       // Gemini uses `/v1beta/models?key=...`; if the user's base already
       // includes /v1beta, append `/models`; else append `/v1beta/models`.

--- a/src/process/providers/sources/CatalogSource.ts
+++ b/src/process/providers/sources/CatalogSource.ts
@@ -29,5 +29,6 @@ import type { RawModel } from '../types';
 export type CatalogSource = {
   readonly kind: 'api' | 'wcore' | 'cli';
   readonly providerId: string;
+  readonly baseUrl?: string;
   listModels(): Promise<RawModel[]>;
 };

--- a/src/renderer/pages/conversation/components/ChatConversation.tsx
+++ b/src/renderer/pages/conversation/components/ChatConversation.tsx
@@ -52,6 +52,8 @@ const WORKFLOW_WCORE_MODEL_SELECTION: WCoreModelSelection = {
   getAvailableModels: () => [],
   handleSelectModel: async () => {},
   getDisplayModelName: () => '',
+  warmingModelId: null,
+  runtimeRefreshNonce: 0,
 };
 
 const WORKFLOW_GEMINI_MODEL_SELECTION: GeminiModelSelection = {

--- a/src/renderer/pages/conversation/platforms/wcore/WCoreModelSelector.tsx
+++ b/src/renderer/pages/conversation/platforms/wcore/WCoreModelSelector.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { WCoreModelSelection } from './useWCoreModelSelection';
+import { registryProviderIdFor, type WCoreModelSelection } from './useWCoreModelSelection';
 import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
 import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import { getModelDisplayLabel } from '@/renderer/utils/model/agentLogo';
@@ -42,6 +42,14 @@ function getModelStatusView(args: {
       };
     }
     if (!ollamaRuntimeState?.reachable) {
+      if (!ollamaRuntimeState) {
+        return {
+          status: 'unknown',
+          color: 'bg-gray-400',
+          label: 'Checking',
+          tooltip: 'Wayland is checking the local Ollama runtime.',
+        };
+      }
       return {
         status: 'unhealthy',
         color: 'bg-red-500',
@@ -95,7 +103,9 @@ const WCoreModelSelector: React.FC<{
     });
   }, [mutateModelConfig]);
 
-  const hasOllamaProvider = Boolean(selection?.providers.some((provider) => provider.id === 'ollama-local'));
+  const hasOllamaProvider = Boolean(
+    selection?.providers.some((provider) => registryProviderIdFor(provider) === 'ollama-local')
+  );
   const { data: ollamaRuntimeState, mutate: mutateOllamaRuntimeState } = useSWR<IOllamaRuntimeState | null>(
     hasOllamaProvider ? 'modelRegistry.ollama.runtime' : null,
     () => ipcBridge.modelRegistry.getOllamaRuntimeState.invoke()
@@ -104,14 +114,20 @@ const WCoreModelSelector: React.FC<{
   useEffect(() => {
     if (!hasOllamaProvider) return;
     void mutateOllamaRuntimeState();
-  }, [hasOllamaProvider, mutateOllamaRuntimeState, selection?.currentModel?.id, selection?.currentModel?.useModel, selection?.runtimeRefreshNonce]);
+  }, [
+    hasOllamaProvider,
+    mutateOllamaRuntimeState,
+    selection?.currentModel?.id,
+    selection?.currentModel?.useModel,
+    selection?.runtimeRefreshNonce,
+  ]);
 
   const currentModel = selection?.currentModel;
   const currentModelHealth = useMemo(() => {
     if (!currentModel || !modelConfig) return { status: 'unknown', color: 'bg-gray-400' } as ModelStatusView;
     const matchedProvider = modelConfig.find((p) => p.id === currentModel.id);
     return getModelStatusView({
-      providerId: currentModel.id,
+      providerId: registryProviderIdFor(currentModel),
       modelName: currentModel.useModel,
       modelHealthStatus: matchedProvider?.modelHealth?.[currentModel.useModel]?.status || 'unknown',
       ollamaRuntimeState: ollamaRuntimeState ?? undefined,
@@ -162,8 +178,9 @@ const WCoreModelSelector: React.FC<{
               <Menu.ItemGroup title={provider.name} key={provider.id}>
                 {models.map((modelName) => {
                   const matchedProvider = modelConfig?.find((p) => p.id === provider.id);
+                  const providerRegistryId = registryProviderIdFor(provider);
                   const statusView = getModelStatusView({
-                    providerId: provider.id,
+                    providerId: providerRegistryId,
                     modelName,
                     modelHealthStatus: matchedProvider?.modelHealth?.[modelName]?.status || 'unknown',
                     ollamaRuntimeState: ollamaRuntimeState ?? undefined,
@@ -210,7 +227,9 @@ const WCoreModelSelector: React.FC<{
             <div className={`w-6px h-6px rounded-full shrink-0 ${currentModelHealth.color}`} />
           )}
           <span className={compact ? 'block truncate' : undefined}>{label}</span>
-          {!compact && currentModelHealth.label && <span className='text-12px opacity-60 shrink-0'>{currentModelHealth.label}</span>}
+          {!compact && currentModelHealth.label && (
+            <span className='text-12px opacity-60 shrink-0'>{currentModelHealth.label}</span>
+          )}
         </span>
       </Button>
     </Dropdown>

--- a/src/renderer/pages/conversation/platforms/wcore/WCoreModelSelector.tsx
+++ b/src/renderer/pages/conversation/platforms/wcore/WCoreModelSelector.tsx
@@ -15,6 +15,60 @@ import classNames from 'classnames';
 import useSWR from 'swr';
 import { ipcBridge } from '@/common';
 import type { IProvider } from '@/common/config/storage';
+import type { IOllamaRuntimeState } from '@/common/adapter/ipcBridge';
+
+type ModelStatusView = {
+  status: 'healthy' | 'unhealthy' | 'unknown' | 'warming';
+  color: string;
+  label?: string;
+  tooltip?: string;
+};
+
+function getModelStatusView(args: {
+  providerId?: string;
+  modelName?: string;
+  modelHealthStatus?: 'unknown' | 'healthy' | 'unhealthy';
+  ollamaRuntimeState?: IOllamaRuntimeState;
+  warmingModelId?: string | null;
+}): ModelStatusView {
+  const { providerId, modelName, modelHealthStatus = 'unknown', ollamaRuntimeState, warmingModelId } = args;
+  if (providerId === 'ollama-local' && modelName) {
+    if (warmingModelId === modelName) {
+      return {
+        status: 'warming',
+        color: 'bg-orange-400',
+        label: 'Warming',
+        tooltip: 'Wayland is asking Ollama to load this model into memory.',
+      };
+    }
+    if (!ollamaRuntimeState?.reachable) {
+      return {
+        status: 'unhealthy',
+        color: 'bg-red-500',
+        label: 'Unavailable',
+        tooltip: ollamaRuntimeState?.error || 'Wayland cannot reach the local Ollama runtime.',
+      };
+    }
+    if (ollamaRuntimeState.models[modelName]?.loaded) {
+      return {
+        status: 'healthy',
+        color: 'bg-green-500',
+        label: 'Loaded',
+        tooltip: 'This model is currently loaded in Ollama memory.',
+      };
+    }
+    return {
+      status: 'unknown',
+      color: 'bg-gray-400',
+      label: 'Cold',
+      tooltip: 'This model is installed in Ollama but not currently loaded.',
+    };
+  }
+
+  const healthColor =
+    modelHealthStatus === 'healthy' ? 'bg-green-500' : modelHealthStatus === 'unhealthy' ? 'bg-red-500' : 'bg-gray-400';
+  return { status: modelHealthStatus, color: healthColor };
+}
 
 const WCoreModelSelector: React.FC<{
   selection?: WCoreModelSelection;
@@ -41,15 +95,29 @@ const WCoreModelSelector: React.FC<{
     });
   }, [mutateModelConfig]);
 
+  const hasOllamaProvider = Boolean(selection?.providers.some((provider) => provider.id === 'ollama-local'));
+  const { data: ollamaRuntimeState, mutate: mutateOllamaRuntimeState } = useSWR<IOllamaRuntimeState | null>(
+    hasOllamaProvider ? 'modelRegistry.ollama.runtime' : null,
+    () => ipcBridge.modelRegistry.getOllamaRuntimeState.invoke()
+  );
+
+  useEffect(() => {
+    if (!hasOllamaProvider) return;
+    void mutateOllamaRuntimeState();
+  }, [hasOllamaProvider, mutateOllamaRuntimeState, selection?.currentModel?.id, selection?.currentModel?.useModel, selection?.runtimeRefreshNonce]);
+
   const currentModel = selection?.currentModel;
   const currentModelHealth = useMemo(() => {
-    if (!currentModel || !modelConfig) return { status: 'unknown', color: 'bg-gray-400' };
+    if (!currentModel || !modelConfig) return { status: 'unknown', color: 'bg-gray-400' } as ModelStatusView;
     const matchedProvider = modelConfig.find((p) => p.id === currentModel.id);
-    const healthStatus = matchedProvider?.modelHealth?.[currentModel.useModel]?.status || 'unknown';
-    const healthColor =
-      healthStatus === 'healthy' ? 'bg-green-500' : healthStatus === 'unhealthy' ? 'bg-red-500' : 'bg-gray-400';
-    return { status: healthStatus, color: healthColor };
-  }, [currentModel, modelConfig]);
+    return getModelStatusView({
+      providerId: currentModel.id,
+      modelName: currentModel.useModel,
+      modelHealthStatus: matchedProvider?.modelHealth?.[currentModel.useModel]?.status || 'unknown',
+      ollamaRuntimeState: ollamaRuntimeState ?? undefined,
+      warmingModelId: selection?.warmingModelId,
+    });
+  }, [currentModel, modelConfig, ollamaRuntimeState, selection?.warmingModelId]);
 
   if (disabled || !selection) {
     return (
@@ -94,13 +162,13 @@ const WCoreModelSelector: React.FC<{
               <Menu.ItemGroup title={provider.name} key={provider.id}>
                 {models.map((modelName) => {
                   const matchedProvider = modelConfig?.find((p) => p.id === provider.id);
-                  const healthStatus = matchedProvider?.modelHealth?.[modelName]?.status || 'unknown';
-                  const healthColor =
-                    healthStatus === 'healthy'
-                      ? 'bg-green-500'
-                      : healthStatus === 'unhealthy'
-                        ? 'bg-red-500'
-                        : 'bg-gray-400';
+                  const statusView = getModelStatusView({
+                    providerId: provider.id,
+                    modelName,
+                    modelHealthStatus: matchedProvider?.modelHealth?.[modelName]?.status || 'unknown',
+                    ollamaRuntimeState: ollamaRuntimeState ?? undefined,
+                    warmingModelId: selection.warmingModelId,
+                  });
 
                   return (
                     <Menu.Item
@@ -109,10 +177,15 @@ const WCoreModelSelector: React.FC<{
                       onClick={() => void handleSelectModel(provider, modelName)}
                     >
                       <div className='flex items-center gap-8px w-full'>
-                        {healthStatus !== 'unknown' && (
-                          <div className={`w-6px h-6px rounded-full shrink-0 ${healthColor}`} />
+                        {statusView.status !== 'unknown' && (
+                          <div className={`w-6px h-6px rounded-full shrink-0 ${statusView.color}`} />
                         )}
-                        <span>{modelName}</span>
+                        <span className='flex-1 min-w-0 truncate'>{modelName}</span>
+                        {statusView.label && (
+                          <span className='text-12px opacity-60 shrink-0' title={statusView.tooltip}>
+                            {statusView.label}
+                          </span>
+                        )}
                       </div>
                     </Menu.Item>
                   );
@@ -137,6 +210,7 @@ const WCoreModelSelector: React.FC<{
             <div className={`w-6px h-6px rounded-full shrink-0 ${currentModelHealth.color}`} />
           )}
           <span className={compact ? 'block truncate' : undefined}>{label}</span>
+          {!compact && currentModelHealth.label && <span className='text-12px opacity-60 shrink-0'>{currentModelHealth.label}</span>}
         </span>
       </Button>
     </Dropdown>

--- a/src/renderer/pages/conversation/platforms/wcore/useWCoreModelSelection.ts
+++ b/src/renderer/pages/conversation/platforms/wcore/useWCoreModelSelection.ts
@@ -24,6 +24,16 @@ export type UseAionrsModelSelectionOptions = {
   onSelectModel: (provider: IProvider, modelName: string) => Promise<boolean>;
 };
 
+export function registryProviderIdFor(provider?: Pick<IProvider, 'id' | 'platform'>): string | undefined {
+  if (!provider) return undefined;
+  const tag = (provider as unknown as Record<string, unknown>).__waylandModelRegistryBridge;
+  if (typeof tag === 'string' && tag.startsWith('v2:')) {
+    const providerId = tag.slice('v2:'.length);
+    if (providerId) return providerId;
+  }
+  return provider.id;
+}
+
 export const useWCoreModelSelection = ({
   initialModel,
   onSelectModel,
@@ -54,10 +64,10 @@ export const useWCoreModelSelection = ({
       if (ok) {
         setCurrentModel(selected);
         setRuntimeRefreshNonce((n) => n + 1);
-        if (provider.id === 'ollama-local') {
+        if (registryProviderIdFor(provider) === 'ollama-local') {
           setWarmingModelId(modelName);
-          void ipcBridge.modelRegistry
-            .warmOllamaModel.invoke({ modelId: modelName })
+          void ipcBridge.modelRegistry.warmOllamaModel
+            .invoke({ modelId: modelName })
             .catch((error) => {
               console.warn('[WCoreModelSelection] Failed to warm Ollama model:', error);
             })

--- a/src/renderer/pages/conversation/platforms/wcore/useWCoreModelSelection.ts
+++ b/src/renderer/pages/conversation/platforms/wcore/useWCoreModelSelection.ts
@@ -5,6 +5,7 @@
  */
 
 import type { IProvider, TProviderWithModel } from '@/common/config/storage';
+import { ipcBridge } from '@/common';
 import { useModelProviderList } from '@/renderer/hooks/agent/useModelProviderList';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -14,6 +15,8 @@ export type WCoreModelSelection = {
   getAvailableModels: (provider: IProvider) => string[];
   handleSelectModel: (provider: IProvider, modelName: string) => Promise<void>;
   getDisplayModelName: (modelName?: string) => string;
+  warmingModelId: string | null;
+  runtimeRefreshNonce: number;
 };
 
 export type UseAionrsModelSelectionOptions = {
@@ -26,6 +29,8 @@ export const useWCoreModelSelection = ({
   onSelectModel,
 }: UseAionrsModelSelectionOptions): WCoreModelSelection => {
   const [currentModel, setCurrentModel] = useState<TProviderWithModel | undefined>(initialModel);
+  const [warmingModelId, setWarmingModelId] = useState<string | null>(null);
+  const [runtimeRefreshNonce, setRuntimeRefreshNonce] = useState(0);
 
   useEffect(() => {
     setCurrentModel(initialModel);
@@ -48,6 +53,19 @@ export const useWCoreModelSelection = ({
       const ok = await onSelectModel(provider, modelName);
       if (ok) {
         setCurrentModel(selected);
+        setRuntimeRefreshNonce((n) => n + 1);
+        if (provider.id === 'ollama-local') {
+          setWarmingModelId(modelName);
+          void ipcBridge.modelRegistry
+            .warmOllamaModel.invoke({ modelId: modelName })
+            .catch((error) => {
+              console.warn('[WCoreModelSelection] Failed to warm Ollama model:', error);
+            })
+            .finally(() => {
+              setWarmingModelId((current) => (current === modelName ? null : current));
+              setRuntimeRefreshNonce((n) => n + 1);
+            });
+        }
       }
     },
     [onSelectModel]
@@ -69,5 +87,7 @@ export const useWCoreModelSelection = ({
     getAvailableModels,
     handleSelectModel,
     getDisplayModelName,
+    warmingModelId,
+    runtimeRefreshNonce,
   };
 };

--- a/tests/unit/process/onboarding/autoRegisterOllama.test.ts
+++ b/tests/unit/process/onboarding/autoRegisterOllama.test.ts
@@ -95,7 +95,7 @@ describe('autoRegisterOllamaInRepo', () => {
     const repo = makeRepo();
     autoRegisterOllamaInRepo(repo, {
       running: true,
-      models: ['nomic-embed-text:latest', 'llama3.2-vision:11b', 'qwen2.5vl:7b', 'qwen3-coder:30b'],
+      models: ['nomic-embed-text:latest', 'llama3.2-vision:11b', 'qwen2.5vl:7b', 'foo-vlm-7b', 'qwen3-coder:30b'],
     });
 
     const catalog = repo.catalogs.get('ollama-local') ?? [];

--- a/tests/unit/process/onboarding/autoRegisterOllama.test.ts
+++ b/tests/unit/process/onboarding/autoRegisterOllama.test.ts
@@ -91,21 +91,18 @@ describe('autoRegisterOllamaInRepo', () => {
     expect(repo.catalogs.get('ollama-local')?.map((m) => m.id)).toEqual(['llama3:latest', 'phi3:mini']);
   });
 
-  it('classifies embedding and vision models so non-chat Ollama entries do not masquerade as chat', () => {
+  it('keeps embedding models but drops unsupported vision models from the Ollama catalog', () => {
     const repo = makeRepo();
     autoRegisterOllamaInRepo(repo, {
       running: true,
-      models: ['nomic-embed-text:latest', 'llama3.2-vision:11b', 'qwen3-coder:30b'],
+      models: ['nomic-embed-text:latest', 'llama3.2-vision:11b', 'qwen2.5vl:7b', 'qwen3-coder:30b'],
     });
 
     const catalog = repo.catalogs.get('ollama-local') ?? [];
+    expect(catalog.map((m) => m.id)).toEqual(['nomic-embed-text:latest', 'qwen3-coder:30b']);
     expect(catalog.find((m) => m.id === 'nomic-embed-text:latest')).toMatchObject({
       kind: 'embedding',
       tags: ['embeddings'],
-    });
-    expect(catalog.find((m) => m.id === 'llama3.2-vision:11b')).toMatchObject({
-      kind: 'text',
-      tags: ['chat', 'vision'],
     });
     expect(catalog.find((m) => m.id === 'qwen3-coder:30b')).toMatchObject({
       kind: 'text',

--- a/tests/unit/process/onboarding/autoRegisterOllama.test.ts
+++ b/tests/unit/process/onboarding/autoRegisterOllama.test.ts
@@ -91,6 +91,28 @@ describe('autoRegisterOllamaInRepo', () => {
     expect(repo.catalogs.get('ollama-local')?.map((m) => m.id)).toEqual(['llama3:latest', 'phi3:mini']);
   });
 
+  it('classifies embedding and vision models so non-chat Ollama entries do not masquerade as chat', () => {
+    const repo = makeRepo();
+    autoRegisterOllamaInRepo(repo, {
+      running: true,
+      models: ['nomic-embed-text:latest', 'llama3.2-vision:11b', 'qwen3-coder:30b'],
+    });
+
+    const catalog = repo.catalogs.get('ollama-local') ?? [];
+    expect(catalog.find((m) => m.id === 'nomic-embed-text:latest')).toMatchObject({
+      kind: 'embedding',
+      tags: ['embeddings'],
+    });
+    expect(catalog.find((m) => m.id === 'llama3.2-vision:11b')).toMatchObject({
+      kind: 'text',
+      tags: ['chat', 'vision'],
+    });
+    expect(catalog.find((m) => m.id === 'qwen3-coder:30b')).toMatchObject({
+      kind: 'text',
+      tags: ['chat'],
+    });
+  });
+
   it('degrades to skipped (never throws) when the repo throws', () => {
     const repo = makeRepo();
     vi.spyOn(repo, 'getRegistryProvider').mockImplementation(() => {

--- a/tests/unit/process/providers/catalogAssembler.test.ts
+++ b/tests/unit/process/providers/catalogAssembler.test.ts
@@ -207,6 +207,18 @@ describe('CatalogAssembler', () => {
     expect(catalog[0].costInPerM).toBeUndefined();
   });
 
+  it('drops unsupported vision models from local OpenAI-compatible catalogs', async () => {
+    const source = fixedSource('api', 'openai-compatible', [
+      { id: 'qwen3-coder:30b', providerId: 'openai-compatible' },
+      { id: 'llama3.2-vision:11b', providerId: 'openai-compatible' },
+      { id: 'qwen2.5vl:7b', providerId: 'openai-compatible' },
+      { id: 'llava:latest', providerId: 'openai-compatible' },
+    ]);
+    const { models: catalog } = await assembler.assemble([source], buildRegistry());
+
+    expect(catalog.map((m) => m.id)).toEqual(['qwen3-coder:30b']);
+  });
+
   it('does not borrow a colliding model id from another provider', async () => {
     // Both `openai` and `anthropic` could carry an id; enrichment is scoped to
     // the model's OWN provider entry only. `gpt-image-1` lives under `openai`

--- a/tests/unit/process/providers/catalogAssembler.test.ts
+++ b/tests/unit/process/providers/catalogAssembler.test.ts
@@ -13,8 +13,13 @@ import type { RawModel } from '@process/providers/types';
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
 /** A `CatalogSource` that returns a fixed `RawModel[]`. */
-function fixedSource(kind: CatalogSource['kind'], providerId: string, models: RawModel[]): CatalogSource {
-  return { kind, providerId, listModels: async () => models };
+function fixedSource(
+  kind: CatalogSource['kind'],
+  providerId: string,
+  models: RawModel[],
+  baseUrl?: string
+): CatalogSource {
+  return { kind, providerId, ...(baseUrl ? { baseUrl } : {}), listModels: async () => models };
 }
 
 /** A `CatalogSource` whose `listModels()` rejects. */
@@ -208,16 +213,36 @@ describe('CatalogAssembler', () => {
   });
 
   it('drops unsupported vision models from local OpenAI-compatible catalogs', async () => {
-    const source = fixedSource('api', 'openai-compatible', [
-      { id: 'qwen3-coder:30b', providerId: 'openai-compatible' },
-      { id: 'llama3.2-vision:11b', providerId: 'openai-compatible' },
-      { id: 'qwen2.5vl:7b', providerId: 'openai-compatible' },
-      { id: 'foo-vlm-7b', providerId: 'openai-compatible' },
-      { id: 'llava:latest', providerId: 'openai-compatible' },
-    ]);
+    const source = fixedSource(
+      'api',
+      'openai-compatible',
+      [
+        { id: 'qwen3-coder:30b', providerId: 'openai-compatible' },
+        { id: 'llama3.2-vision:11b', providerId: 'openai-compatible' },
+        { id: 'qwen2.5vl:7b', providerId: 'openai-compatible' },
+        { id: 'foo-vlm-7b', providerId: 'openai-compatible' },
+        { id: 'llava:latest', providerId: 'openai-compatible' },
+      ],
+      'http://127.0.0.1:1234/v1'
+    );
     const { models: catalog } = await assembler.assemble([source], buildRegistry());
 
     expect(catalog.map((m) => m.id)).toEqual(['qwen3-coder:30b']);
+  });
+
+  it('keeps vision models from remote OpenAI-compatible catalogs', async () => {
+    const source = fixedSource(
+      'api',
+      'openai-compatible',
+      [
+        { id: 'qwen3-coder:30b', providerId: 'openai-compatible' },
+        { id: 'llama3.2-vision:11b', providerId: 'openai-compatible' },
+      ],
+      'https://remote.example.com/v1'
+    );
+    const { models: catalog } = await assembler.assemble([source], buildRegistry());
+
+    expect(catalog.map((m) => m.id)).toEqual(['qwen3-coder:30b', 'llama3.2-vision:11b']);
   });
 
   it('does not borrow a colliding model id from another provider', async () => {

--- a/tests/unit/process/providers/catalogAssembler.test.ts
+++ b/tests/unit/process/providers/catalogAssembler.test.ts
@@ -212,6 +212,7 @@ describe('CatalogAssembler', () => {
       { id: 'qwen3-coder:30b', providerId: 'openai-compatible' },
       { id: 'llama3.2-vision:11b', providerId: 'openai-compatible' },
       { id: 'qwen2.5vl:7b', providerId: 'openai-compatible' },
+      { id: 'foo-vlm-7b', providerId: 'openai-compatible' },
       { id: 'llava:latest', providerId: 'openai-compatible' },
     ]);
     const { models: catalog } = await assembler.assemble([source], buildRegistry());

--- a/tests/unit/process/providers/modelRegistryIpc.test.ts
+++ b/tests/unit/process/providers/modelRegistryIpc.test.ts
@@ -768,8 +768,28 @@ describe('modelRegistry IPC - refresh', () => {
     const result = await h.refresh({ providerId: 'ollama-local' });
 
     expect(result).toEqual({ ok: true });
+    expect(deps.probeOllama).toHaveBeenCalledWith('http://127.0.0.1:11434/v1');
     expect(apiListModels).not.toHaveBeenCalled();
     expect(repo.getRegistryCatalog('ollama-local').map((m) => m.id)).toEqual(['llama3:latest', 'mistral:latest']);
+  });
+
+  it('uses the default loopback URL when refreshing ollama-local with no stored baseUrl', async () => {
+    const { deps, repo, apiListModels } = makeFakes();
+    repo.upsertRegistryProvider({
+      providerId: 'ollama-local',
+      connectedVia: 'auto-local',
+      state: 'connected',
+      creds: { key: '' },
+    });
+    deps.probeOllama = vi.fn().mockResolvedValue({ running: true, models: ['llama3:latest'] });
+    const h = createModelRegistryHandlers(deps);
+
+    const result = await h.refresh({ providerId: 'ollama-local' });
+
+    expect(result).toEqual({ ok: true });
+    expect(deps.probeOllama).toHaveBeenCalledWith('http://127.0.0.1:11434/v1');
+    expect(apiListModels).not.toHaveBeenCalled();
+    expect(repo.getRegistryCatalog('ollama-local').map((m) => m.id)).toEqual(['llama3:latest']);
   });
 });
 
@@ -1666,7 +1686,7 @@ describe('modelRegistry IPC - refreshAllOnce SSRF gate (ollama-local exemption)'
     const h = createModelRegistryHandlers(deps);
     const summary = await h.refreshAllOnce();
 
-    expect(probeOllama).toHaveBeenCalledTimes(1);
+    expect(probeOllama).toHaveBeenCalledWith('http://127.0.0.1:11434/v1');
     expect(summary.succeeded).toContain('ollama-local');
     // Catalog refreshed from the live probe (not wiped to empty).
     expect(repo.getRegistryCatalog('ollama-local').map((m) => m.id)).toEqual(['llama3:latest']);

--- a/tests/unit/process/providers/modelRegistryIpc.test.ts
+++ b/tests/unit/process/providers/modelRegistryIpc.test.ts
@@ -40,6 +40,7 @@ import {
   createModelRegistryHandlers,
   CloudRegistrySource,
   resolveSpawnSecretsFromRepo,
+  _warmOllamaRuntimeModelForTests,
 } from '@process/providers/ipc/modelRegistryIpc';
 import type { ModelRegistryDeps, SpawnHandle } from '@process/providers/ipc/modelRegistryIpc';
 
@@ -54,7 +55,30 @@ describe('CloudRegistrySource - google-auth Gemini catalog (zero-models regressi
     } as never;
     const src = new CloudRegistrySource('google-gemini' as never, registry);
     const models = await src.listModels();
-    expect(models.map((m) => m.id).sort()).toEqual(['gemini-2.5-pro', 'gemini-flash-latest']);
+    expect(models.map((m) => m.id).toSorted()).toEqual(['gemini-2.5-pro', 'gemini-flash-latest']);
+  });
+});
+
+describe('Ollama runtime warm helper', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('disables streaming so the warm response can be parsed as one JSON object', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ done: true, done_reason: 'load' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(_warmOllamaRuntimeModelForTests('qwen3-coder:30b')).resolves.toEqual({ ok: true, loaded: true });
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    expect(body).toMatchObject({
+      model: 'qwen3-coder:30b',
+      keep_alive: '10m',
+      stream: false,
+    });
   });
 });
 import type { CatalogModel, ProviderId } from '@process/providers/types';

--- a/tests/unit/process/providers/modelRegistryIpc.test.ts
+++ b/tests/unit/process/providers/modelRegistryIpc.test.ts
@@ -67,7 +67,7 @@ describe('Ollama runtime warm helper', () => {
   it('disables streaming so the warm response can be parsed as one JSON object', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ done: true, done_reason: 'load' }),
+      text: async () => JSON.stringify({ done: true, done_reason: 'load' }),
     });
     vi.stubGlobal('fetch', fetchMock);
 
@@ -79,6 +79,22 @@ describe('Ollama runtime warm helper', () => {
       keep_alive: '10m',
       stream: false,
     });
+  });
+
+  it('tolerates an NDJSON warm response if Ollama or a proxy streams anyway', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        text: async () =>
+          [
+            JSON.stringify({ response: '', done: false }),
+            JSON.stringify({ response: '', done: true, done_reason: 'load' }),
+          ].join('\n'),
+      })
+    );
+
+    await expect(_warmOllamaRuntimeModelForTests('qwen3-coder:30b')).resolves.toEqual({ ok: true, loaded: true });
   });
 });
 import type { CatalogModel, ProviderId } from '@process/providers/types';

--- a/tests/unit/process/providers/modelRegistryIpc.test.ts
+++ b/tests/unit/process/providers/modelRegistryIpc.test.ts
@@ -195,6 +195,8 @@ type Fakes = {
   getRegistry: ReturnType<typeof vi.fn>;
   apiListModels: ReturnType<typeof vi.fn>;
   cliListModels: ReturnType<typeof vi.fn>;
+  getOllamaState: ReturnType<typeof vi.fn>;
+  warmOllamaModel: ReturnType<typeof vi.fn>;
 };
 
 function makeFakes(over: Partial<{ apiModels: unknown; testResult: unknown }> = {}): Fakes {
@@ -206,6 +208,8 @@ function makeFakes(over: Partial<{ apiModels: unknown; testResult: unknown }> = 
   const getRegistry = vi.fn().mockResolvedValue({});
   const apiListModels = vi.fn().mockResolvedValue(over.apiModels ?? [{ id: 'gpt-4o', providerId: 'openai' }]);
   const cliListModels = vi.fn().mockResolvedValue([{ id: 'gpt-5-codex', providerId: 'openai' }]);
+  const getOllamaState = vi.fn().mockResolvedValue({ reachable: true, models: {} });
+  const warmOllamaModel = vi.fn().mockResolvedValue({ ok: true, loaded: true });
 
   const deps: ModelRegistryDeps = {
     repo: repo as unknown as ModelRegistryDeps['repo'],
@@ -220,6 +224,10 @@ function makeFakes(over: Partial<{ apiModels: unknown; testResult: unknown }> = 
       underlyingProviderId: agentKey === 'codex' ? 'openai' : agentKey === 'claude' ? 'anthropic' : 'google-gemini',
       listModels: cliListModels,
     }),
+    ollamaRuntime: {
+      getState: getOllamaState,
+      warmModel: warmOllamaModel,
+    },
   };
 
   return {
@@ -231,6 +239,8 @@ function makeFakes(over: Partial<{ apiModels: unknown; testResult: unknown }> = 
     getRegistry,
     apiListModels,
     cliListModels,
+    getOllamaState,
+    warmOllamaModel,
   };
 }
 
@@ -251,6 +261,31 @@ describe('modelRegistry IPC - detectKeys', () => {
     const h = createModelRegistryHandlers(deps);
 
     expect(await h.detectKeys()).toEqual([]);
+  });
+});
+
+describe('modelRegistry IPC - Ollama runtime helpers', () => {
+  it('returns live Ollama runtime state from the injected runtime adapter', async () => {
+    const { deps, getOllamaState } = makeFakes();
+    getOllamaState.mockResolvedValue({
+      reachable: true,
+      models: { 'qwen3-coder:30b': { loaded: true, contextLength: 262144 } },
+    });
+    const h = createModelRegistryHandlers(deps);
+
+    await expect(h.getOllamaRuntimeState()).resolves.toEqual({
+      reachable: true,
+      models: { 'qwen3-coder:30b': { loaded: true, contextLength: 262144 } },
+    });
+  });
+
+  it('forwards warm requests to the injected Ollama runtime adapter', async () => {
+    const { deps, warmOllamaModel } = makeFakes();
+    warmOllamaModel.mockResolvedValue({ ok: true, loaded: true });
+    const h = createModelRegistryHandlers(deps);
+
+    await expect(h.warmOllamaModel({ modelId: 'qwen3-coder:30b' })).resolves.toEqual({ ok: true, loaded: true });
+    expect(warmOllamaModel).toHaveBeenCalledWith('qwen3-coder:30b');
   });
 });
 

--- a/tests/unit/process/providers/modelRegistryIpc.test.ts
+++ b/tests/unit/process/providers/modelRegistryIpc.test.ts
@@ -661,6 +661,25 @@ describe('modelRegistry IPC - refresh', () => {
     expect(result).toEqual({ ok: false });
     expect(repo.getRegistryProvider('openai')?.state).toBe('error');
   });
+
+  it('re-probes keyless ollama-local instead of replacing its catalog with an empty list', async () => {
+    const { deps, repo, apiListModels } = makeFakes();
+    repo.upsertRegistryProvider({
+      providerId: 'ollama-local',
+      connectedVia: 'auto-local',
+      state: 'connected',
+      creds: { key: '', baseUrl: 'http://127.0.0.1:11434/v1' },
+    });
+    repo.replaceRegistryCatalog('ollama-local', [catalogModel({ id: 'old-model', providerId: 'ollama-local' })]);
+    deps.probeOllama = vi.fn().mockResolvedValue({ running: true, models: ['llama3:latest', 'mistral:latest'] });
+    const h = createModelRegistryHandlers(deps);
+
+    const result = await h.refresh({ providerId: 'ollama-local' });
+
+    expect(result).toEqual({ ok: true });
+    expect(apiListModels).not.toHaveBeenCalled();
+    expect(repo.getRegistryCatalog('ollama-local').map((m) => m.id)).toEqual(['llama3:latest', 'mistral:latest']);
+  });
 });
 
 describe('modelRegistry IPC - disconnect', () => {

--- a/tests/unit/process/providers/modelRegistryIpc.test.ts
+++ b/tests/unit/process/providers/modelRegistryIpc.test.ts
@@ -96,6 +96,22 @@ describe('Ollama runtime warm helper', () => {
 
     await expect(_warmOllamaRuntimeModelForTests('qwen3-coder:30b')).resolves.toEqual({ ok: true, loaded: true });
   });
+
+  it('does not report warm success for an empty or malformed Ollama response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        text: async () => '',
+      })
+    );
+
+    await expect(_warmOllamaRuntimeModelForTests('qwen3-coder:30b')).resolves.toEqual({
+      ok: false,
+      loaded: false,
+      error: 'Ollama warm response was empty or malformed.',
+    });
+  });
 });
 import type { CatalogModel, ProviderId } from '@process/providers/types';
 import { ProviderRepository } from '@process/providers/storage/ProviderRepository';

--- a/tests/unit/renderer/wcoreModelSelection.test.ts
+++ b/tests/unit/renderer/wcoreModelSelection.test.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { IProvider } from '@/common/config/storage';
+import { registryProviderIdFor } from '@/renderer/pages/conversation/platforms/wcore/useWCoreModelSelection';
+
+describe('registryProviderIdFor', () => {
+  it('uses the provider id embedded in a bridged legacy model.config row', () => {
+    const bridged = {
+      id: 'legacy-row-uuid',
+      platform: 'openai-compatible',
+      __waylandModelRegistryBridge: 'v2:ollama-local',
+    } as Pick<IProvider, 'id' | 'platform'>;
+
+    expect(registryProviderIdFor(bridged)).toBe('ollama-local');
+  });
+
+  it('falls back to the row id when no registry bridge tag is present', () => {
+    expect(registryProviderIdFor({ id: 'openai', platform: 'openai' })).toBe('openai');
+  });
+});

--- a/tests/unit/wcore-catalogDispatch.test.ts
+++ b/tests/unit/wcore-catalogDispatch.test.ts
@@ -99,6 +99,16 @@ describe('buildSpawnConfig - catalog provider dispatch (T3.5)', () => {
     expect(hasBaseUrl(args)).toBe(true);
   });
 
+  it('injects a harmless sentinel key for keyless local openai-compatible backends', () => {
+    const model = makeNativeModel('openai-compatible', '');
+    model.baseUrl = 'http://127.0.0.1:11434/v1';
+    const { args, env } = buildSpawnConfig(model, OPTS);
+
+    expect(providerArg(args)).toBe('openai');
+    expect(env.OPENAI_API_KEY).toBe('local');
+    expect(hasBaseUrl(args)).toBe(true);
+  });
+
   it('does not leak a prior catalog scoped key when switching to a keyless native provider (RES-4 ghost key)', () => {
     // First spawn: catalog provider sets NOVITA_API_KEY.
     const first = buildSpawnConfig(makeCatalogModel('novita-ai', 'sk-x'), OPTS);


### PR DESCRIPTION
## Summary

This PR fixes the local Ollama provider path so a detected keyless local daemon can be used reliably from the desktop app.

- preserve Ollama catalogs on refresh by re-probing the local daemon instead of treating the keyless provider as empty
- allow local OpenAI-compatible backends to spawn through Wayland Core with a harmless loopback-only sentinel key
- expose Ollama runtime state in the chat model picker and warm selected models before chat starts
- refresh the chat picker after model toggles only after the legacy model mirror has been updated
- filter unsupported local vision/VLM models from Ollama and LM Studio/OpenAI-compatible local catalogs

## Why

A local Ollama daemon could appear connected in Models, but refreshing the provider could blank the model list or chat could fail because the keyless local provider was handled like a normal API-key provider. Model toggles also did not always appear in the in-chat picker immediately because the picker refresh could race ahead of the legacy mirror update.

## Validation

- bunx vitest run tests/unit/process/onboarding/autoRegisterOllama.test.ts tests/unit/process/providers/catalogAssembler.test.ts tests/unit/process/providers/modelRegistryIpc.test.ts tests/unit/wcore-catalogDispatch.test.ts
- bunx tsc --noEmit
- bun run lint && bun run typecheck
- Manual packaged macOS app validation against local Ollama

## Contributor note

I have read and agree to the contribution terms in CONTRIBUTING.md.