### PR TITLE
fix(projects): make setup readiness badge explicit

### DIFF
--- a/src/renderer/pages/projects/ProjectWorkspacePage.tsx
+++ b/src/renderer/pages/projects/ProjectWorkspacePage.tsx
@@ -206,13 +206,18 @@ const ProjectWorkspacePage: React.FC = () => {
             }}
           >
             <span
-              className='block w-8px h-8px rd-full'
+              className='inline-block w-8px h-8px rd-full shrink-0'
               style={{
-                background: setupReady ? 'var(--color-success-6)' : 'var(--color-primary-6)',
-                boxShadow: `0 0 0 3px ${setupReady ? 'var(--color-success-light-1)' : 'var(--color-primary-light-1)'}`,
+                display: 'inline-block',
+                width: 8,
+                height: 8,
+                minWidth: 8,
+                minHeight: 8,
+                background: setupReady ? '#22c55e' : '#f59e0b',
+                boxShadow: 'none',
               }}
             />
-            {setupReady ? t('projects.workspace.setupDone') : t('projects.workspace.setupTodo')}
+            {setupReady ? 'Ready' : t('projects.workspace.setupTodo')}
           </button>
         )}
         <Button type='text' icon={<SettingsIcon size={15} />} onClick={() => openSettings('general')}>


### PR DESCRIPTION
## Summary
- Make the project setup/readiness pill show a literal `Ready` state instead of relying on the existing setup translation key.
- Give the pill status dot explicit dimensions and colors so it remains visible in dark/light themes.

## Why
The current completed-state label can still render as `Set up`, which makes a ready project look unfinished. The dot also depends on theme variables and can appear faint or missing. This keeps the existing behavior small and focused while making the ready state unambiguous.

## Verification
- `PATH=/Volumes/4TB-SSD/Projects/wayland/node_modules/.bin:$PATH npm run lint -- src/renderer/pages/projects/ProjectWorkspacePage.tsx`
  - 0 errors
  - 1 pre-existing warning in the file about `.sort()` vs `.toSorted()`
- `git diff --check`
