### PR TITLE
fix(workflows): bind WCore workflow launch to the real provider (#198)

### DIFF
--- a/src/renderer/pages/workflows/WorkflowDetailModal.tsx
+++ b/src/renderer/pages/workflows/WorkflowDetailModal.tsx
@@ -31,6 +31,7 @@ import type { WorkflowSession } from '@/common/types/workflowTypes';
 import { WorkflowResumePrompt } from '@renderer/pages/guid/components/workflow/WorkflowResumePrompt';
 import { toDisplayName } from '@renderer/pages/settings/SkillsSettings/displayName';
 import { getAgentKey } from '@renderer/pages/guid/hooks/agentSelectionUtils';
+import { resolveSelectedProvider } from '@renderer/components/model/modelSelector/resolveSelectedProvider';
 import { fetchDetectedAgents } from '@renderer/utils/model/agentTypes';
 import type { AvailableAgent } from '@renderer/utils/model/agentTypes';
 import type { AcpBackendAll } from '@/common/types/acpTypes';
@@ -80,7 +81,7 @@ const WorkflowDetailModal: React.FC<WorkflowDetailModalProps> = ({ entry, onClos
   // Picker state - loaded on modal open from ConfigStorage + fetchDetectedAgents
   const [availableAgents, setAvailableAgents] = useState<AvailableAgent[] | null>(null);
   const [selectedAgentKey, setSelectedAgentKey] = useState<string>('claude');
-  const [modelOptions, setModelOptions] = useState<Array<{ id: string; label: string }>>([]);
+  const [modelOptions, setModelOptions] = useState<Array<{ id: string; label: string; providerId?: string }>>([]);
   const [selectedModelId, setSelectedModelId] = useState<string>('');
 
   const depends = useMemo(() => parseDepends(entry?.metadata?.depends), [entry]);
@@ -103,7 +104,7 @@ const WorkflowDetailModal: React.FC<WorkflowDetailModalProps> = ({ entry, onClos
       ]);
 
       const modelInfo = cachedModels?.[backend];
-      let models = modelInfo?.availableModels ?? [];
+      let models: Array<{ id: string; label: string; providerId?: string }> = modelInfo?.availableModels ?? [];
 
       // The ACP cache only fills as a side-effect of running that backend in a
       // chat, so a backend the user hasn't opened yet (commonly Wayland Core or
@@ -113,7 +114,10 @@ const WorkflowDetailModal: React.FC<WorkflowDetailModalProps> = ({ entry, onClos
       if (models.length === 0) {
         try {
           const curated = await ipcBridge.modelRegistry.curatedForAgent.invoke({ agentKey: backend });
-          models = curated.map((m) => ({ id: m.id, label: m.displayName }));
+          // Keep providerId so buildLaunchTarget can resolve the real connected
+          // provider (e.g. 'openai', 'perplexity') instead of a synthetic
+          // backend-keyed row that useWCoreModelSelection later clears (#198).
+          models = curated.map((m) => ({ id: m.id, label: m.displayName, providerId: m.providerId }));
         } catch {
           // Registry unavailable - leave empty; the picker shows the connect hint.
         }
@@ -249,7 +253,20 @@ const WorkflowDetailModal: React.FC<WorkflowDetailModalProps> = ({ entry, onClos
     try {
       const providers = await ConfigStorage.get('model.config');
       const providerList = Array.isArray(providers) ? providers : [];
-      const match = providerList.find((p) => p.platform === backend || p.id === backend);
+      // Resolve the REAL provider that owns the selected model. The picker
+      // carries the registry providerId (e.g. 'openai', 'perplexity'); match on
+      // that first - via the same resolver the WCore model selector uses - so a
+      // Wayland Core model binds to its actual connected provider. Matching only
+      // on `platform === backend` failed for wcore (backend 'wcore' never equals
+      // a provider platform like 'openai'), so the launcher built a synthetic
+      // 'wcore-fallback' row that useWCoreModelSelection then cleared as stale,
+      // leaving the send box stuck on "No model selected" (#198). The legacy
+      // backend match stays as the fallback for options with no providerId (an
+      // ACP-cache model for a backend the user already opened).
+      const selectedProviderId = modelOptions.find((m) => m.id === selectedModelId)?.providerId ?? '';
+      const match =
+        resolveSelectedProvider(providerList, (p) => p.model ?? [], resolvedModelId, selectedProviderId) ??
+        providerList.find((p) => p.platform === backend || p.id === backend);
       if (match) {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { model: _modelArr, ...rest } = match;

--- a/tests/unit/renderer/pages/workflows/WorkflowDetailModal.dom.test.tsx
+++ b/tests/unit/renderer/pages/workflows/WorkflowDetailModal.dom.test.tsx
@@ -24,6 +24,7 @@ const mockUpdateSessionState = vi.fn();
 const mockGetReport = vi.fn();
 const mockGetBody = vi.fn();
 const mockFindActive = vi.fn();
+const mockCuratedForAgent = vi.fn();
 
 vi.mock('@/common', () => ({
   ipcBridge: {
@@ -37,6 +38,9 @@ vi.mock('@/common', () => ({
     skills: {
       getReport: { invoke: (...args: unknown[]) => mockGetReport(...args) },
       getBody: { invoke: (...args: unknown[]) => mockGetBody(...args) },
+    },
+    modelRegistry: {
+      curatedForAgent: { invoke: (...args: unknown[]) => mockCuratedForAgent(...args) },
     },
   },
 }));
@@ -129,6 +133,8 @@ describe('WorkflowDetailModal - launch wiring (v0.6.1 picker)', () => {
     mockFetchDetectedAgents.mockReset();
     mockConfigStorageGet.mockReset();
     mockConfigStorageSet.mockReset();
+    mockCuratedForAgent.mockReset();
+    mockCuratedForAgent.mockResolvedValue([]);
 
     mockGetReport.mockResolvedValue({});
     // Default: no SKILL.md body -> modal shows the generic fallback copy.
@@ -327,6 +333,62 @@ describe('WorkflowDetailModal - launch wiring (v0.6.1 picker)', () => {
     expect(callArg).toHaveProperty('model');
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(mockNavigate).toHaveBeenCalledWith('/conversation/conv_new', expect.any(Object));
+  });
+
+  // --- #198: WCore model carries provider identity into launch ------------
+
+  it('resolves the real provider for a WCore model instead of a synthetic fallback (#198)', async () => {
+    // Repro: Wayland Core picker is empty in the ACP cache (user hasn't opened
+    // a WCore chat), so the model list comes from the curated registry, which
+    // carries a registry providerId ('openai') - NOT the backend key ('wcore').
+    // The bug: buildLaunchTarget matched providers by `platform === backend`,
+    // which never matched for wcore, so it built a synthetic 'wcore-fallback'
+    // provider that the send box later rejected as "No model selected".
+    mockFetchDetectedAgents.mockResolvedValue([WCORE_AGENT]);
+    mockCuratedForAgent.mockResolvedValue([{ id: 'gpt-5.5', displayName: 'GPT-5.5', providerId: 'openai' }]);
+    mockConfigStorageGet.mockImplementation((key: string) => {
+      if (key === 'guid.lastSelectedAgent') return Promise.resolve(null);
+      // No wcore entry -> picker falls back to the curated registry list.
+      if (key === 'acp.cachedModels') return Promise.resolve({});
+      if (key === 'acp.config') return Promise.resolve({});
+      if (key === 'model.config') {
+        // The real connected provider: opaque legacy id, platform 'openai',
+        // and the model in its catalog. Its id is NOT 'openai' and its platform
+        // is NOT 'wcore', so only providerId/membership resolution finds it.
+        return Promise.resolve([
+          {
+            id: 'openai-7f3a',
+            platform: 'openai',
+            name: 'OpenAI',
+            baseUrl: 'https://api.openai.com',
+            apiKey: 'sk-real',
+            model: ['gpt-5.5'],
+          },
+        ]);
+      }
+      return Promise.resolve(null);
+    });
+
+    const newSession = makeSession({ id: 'sess_new', conversation_id: 'conv_new' });
+    mockStart.mockResolvedValue({ sessionId: 'sess_new', session: newSession });
+
+    render(<WorkflowDetailModal entry={makeEntry()} onClose={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByTestId('workflow-model-select')).toBeTruthy());
+
+    clickLaunch();
+
+    await waitFor(() => expect(mockStart).toHaveBeenCalledTimes(1));
+
+    const callArg = mockStart.mock.calls[0][0] as { model: Record<string, unknown> };
+    // The launch target must carry the REAL provider, not a synthetic fallback.
+    expect(callArg.model.id).toBe('openai-7f3a');
+    expect(callArg.model.platform).toBe('openai');
+    expect(callArg.model.apiKey).toBe('sk-real');
+    expect(callArg.model.useModel).toBe('gpt-5.5');
+    // Guard against the regression specifically.
+    expect(callArg.model.id).not.toBe('wcore-fallback');
+    expect(callArg.model.platform).not.toBe('wcore');
   });
 
   // --- Resume probe tests (Audit B HIGH-2) --------------------------------


### PR DESCRIPTION
## Problem
Closes #198. Launching a Wayland Workflow on **Wayland Core** opens the conversation but the send box reports `No model selected` and blocks every prompt, with no in-workflow model selector to recover.

## Root cause
`WorkflowDetailModal` built its picker options as `{ id, label }`, dropping the model registry `providerId`. `buildLaunchTarget()` could then only match a provider by `platform === backend`. For Wayland Core that never matches (`backend === 'wcore'` vs a real provider platform like `openai`/`perplexity`/`deepseek`), so it built a **synthetic `wcore-fallback` provider**. `useWCoreModelSelection` subsequently clears that selection as stale (it belongs to no connected provider), and `WCoreSendBox` blocks sending because `currentModel?.useModel` is gone.

## Fix
- Carry `providerId` through the picker options (from the curated registry list).
- In `buildLaunchTarget()`, resolve the owning provider with **`resolveSelectedProvider`** — the same resolver the in-chat WCore model selector uses, so this inherits the bridge-tag/membership resolution that fixed #124/#167/#168. The legacy `platform === backend` match remains only as a fallback for ACP-cache options that carry no `providerId`.

## Test
Added a regression test (`WorkflowDetailModal.dom.test.tsx`): a WCore launch where the picker model comes from the curated registry (providerId `openai`) and the connected provider has an opaque legacy id + platform `openai`. Asserts the launch target binds to the **real** provider (id/platform/apiKey/useModel) and never to `wcore-fallback`/platform `wcore`. Fails on the old code.

## Verification
- `bunx tsc --noEmit` → 0
- `bunx oxlint` on both files → 0 warnings
- `vitest` modal suite 12/12, `resolveSelectedProvider` suite 13/13
- No new i18n strings (reuses existing `picker.noModel`).