### PR TITLE
fix(team): stop Wayland Core team members failing with "No CLI path" (#204)

### DIFF
--- a/src/process/team/TeamSessionService.ts
+++ b/src/process/team/TeamSessionService.ts
@@ -908,13 +908,19 @@ export class TeamSessionService {
   }
 
   private resolveConversationType(agentType: string): AgentType {
-    if (agentType === 'gemini') return 'gemini';
-    if (agentType === 'wcore') return 'wcore';
-    if (agentType === 'codex') return 'acp';
-    if (agentType === 'openclaw-gateway') return 'openclaw-gateway';
-    if (agentType === 'nanobot') return 'nanobot';
-    if (agentType === 'remote') return 'remote';
-    return 'acp';
+    // Delegate to the canonical backend→type map so this can never drift from
+    // it again. A divergent copy here is exactly what broke Teams for Wayland
+    // Core (#204): the `wayland-core`/`agent-profile` aliases - both the WCore
+    // engine, not an ACP CLI - fell through to 'acp', so an in-place backend
+    // swap to "wayland-core" passed the same-type guard, kept its 'acp'
+    // conversation, and then died on spawn with `No CLI path for backend
+    // "wayland-core"`. With the alias mapped to 'wcore', that swap is now
+    // correctly rejected as a cross-type change (remove + re-add instead).
+    const type = getConversationTypeForBackend(agentType);
+    // getConversationTypeForBackend's return type includes 'codex' (a
+    // create-params type) but it never returns it - codex maps to 'acp'. Narrow
+    // back to the team layer's AgentType.
+    return type === 'codex' ? 'acp' : type;
   }
 
   async renameAgent(teamId: string, slotId: string, newName: string): Promise<void> {

--- a/tests/unit/process/team/team-changeAgentBackend.test.ts
+++ b/tests/unit/process/team/team-changeAgentBackend.test.ts
@@ -177,6 +177,29 @@ describe('TeamSessionService.changeAgentBackend', () => {
     expect(repo.update).not.toHaveBeenCalled();
   });
 
+  it('refuses an in-place swap to "wayland-core" (the WCore engine alias) instead of corrupting an acp conversation (#204)', async () => {
+    // The picker offers "wayland-core" as the WCore engine id. Before the fix,
+    // resolveConversationType('wayland-core') wrongly returned 'acp' (missing
+    // alias), so this swap passed the same-type guard, kept the member's 'acp'
+    // conversation, and then spawned via the ACP connector -> "No CLI path for
+    // backend wayland-core". It must be rejected exactly like a swap to 'wcore'.
+    const team = makeTeam(); // slot-1 is claude / conversationType 'acp'
+    const repo = makeRepo({ findById: vi.fn().mockResolvedValue(team) });
+    const svc = new TeamSessionService(repo, makeWorkerTaskManager(), makeConversationService());
+
+    await expect(
+      svc.changeAgentBackend({ teamId: 'team-1', slotId: 'slot-1', newBackend: 'wayland-core' })
+    ).rejects.toThrow(/not supported in place/i);
+    expect(repo.update).not.toHaveBeenCalled();
+
+    // Parity: the canonical id 'wcore' was already rejected; 'wayland-core' must
+    // behave identically now that both resolve to the 'wcore' conversation type.
+    await expect(
+      svc.changeAgentBackend({ teamId: 'team-1', slotId: 'slot-1', newBackend: 'wcore' })
+    ).rejects.toThrow(/not supported in place/i);
+    expect(repo.update).not.toHaveBeenCalled();
+  });
+
   it('refuses to swap while a wake is in progress', async () => {
     const team = makeTeam();
     const repo = makeRepo({ findById: vi.fn().mockResolvedValue(team) });


### PR DESCRIPTION
## Problem
Refs #204. Running a Team on **Wayland Core** fails with `Session failed to start` / `Failed to spawn agent "wayland-core": No CLI path for backend "wayland-core"`, and changing a member's backend throws `Cannot swap … "acp" → "wcore" … is not supported in place`.

## Root cause
`TeamSessionService.resolveConversationType` was a **divergent duplicate** of the canonical `getConversationTypeForBackend`, and it omitted the `wayland-core` and `agent-profile` aliases (both are the WCore engine, not an ACP CLI). They fell through to `'acp'`. So when a user changed an `acp` member's backend to `wayland-core` (the id the backend picker offers for WCore), `changeAgentBackend`'s same-conversation-type guard compared `'acp' === 'acp'` and **allowed the in-place swap** — keeping the member's `acp` conversation. On the next turn that `acp` conversation was spawned through the ACP connector (`LegacyConnectorFactory`), which has no CLI path for `wayland-core` → the error. Picking the other id `wcore` resolved to `'wcore'` and was (correctly) rejected, so the user was stuck both ways.

## Fix
Make `resolveConversationType` delegate to `getConversationTypeForBackend` so the two can never drift again (this divergence is exactly what caused the bug). The `wayland-core`/`agent-profile` aliases now resolve to `'wcore'`, so the in-place swap to `wayland-core` is **correctly rejected** as a cross-type change (remove + re-add), identical to `wcore` — instead of silently corrupting the conversation into the `No CLI path` failure. Fresh WCore team members (created with the wcore type from the start) were already fine.

## Test
Extended `team-changeAgentBackend.test.ts`: an `acp` member swapped to `wayland-core` must be rejected with "not supported in place" and must not persist, with a parity assertion against `wcore`. Fails on the old code (the swap was silently allowed).

## Verification
- `bunx tsc --noEmit` → 0
- `bunx oxlint` → no new warnings (12 pre-existing in this file, untouched)
- `vitest` team suites: changeAgentBackend 9/9, plus teamSessionService / TeamSession / buildAgentConversationParams / team-renderer / agentSelectUtils 68/68

## Not in scope (separate follow-up)
This report also bundles a **Teams model-picker revert** (a `claude` member shows/reverts to "Flux Fast"; picking Sonnet reverts after ~1.5s) and a **gemma→OpenRouter routing** issue. Those live in the shared ACP model picker / team model resolution, are a different root cause, and touch the main conversation surface — I'm filing them separately rather than bundling a riskier shared-picker change here.