### PR TITLE
fix(onboarding): make the 'get a free Gemini key' link open the browser (#202)

### DIFF
--- a/src/renderer/components/onboarding/OnboardingFlow.tsx
+++ b/src/renderer/components/onboarding/OnboardingFlow.tsx
@@ -731,7 +731,19 @@ const OnboardingFlow: React.FC<OnboardingFlowProps> = ({ detection, onFinish }) 
                 {keyStatus()}
                 <p className={styles.keyhint}>
                   {t('onboarding.flow.outcome.geminiKeyHint')}{' '}
-                  <a href='https://aistudio.google.com/apikey' target='_blank' rel='noreferrer'>
+                  <a
+                    href='https://aistudio.google.com/apikey'
+                    rel='noreferrer'
+                    onClick={(e) => {
+                      // In the Electron renderer a bare target=_blank anchor opens
+                      // nothing (no system browser, no new window), so the link was
+                      // dead on desktop (#202). Route through openExternalUrl, which
+                      // uses shell.openExternal on desktop and window.open in the
+                      // WebUI. href stays for right-click-copy / accessibility.
+                      e.preventDefault();
+                      void openExternalUrl('https://aistudio.google.com/apikey');
+                    }}
+                  >
                     {t('onboarding.flow.outcome.geminiKeyLink')}
                   </a>
                 </p>


### PR DESCRIPTION
## Problem
Closes #202. In the first-run wizard, the **"get a free Gemini key"** link does nothing on desktop — no browser opens, no copyable link.

## Root cause
`OnboardingFlow.tsx:734` rendered a bare `<a href="https://aistudio.google.com/apikey" target="_blank">`. In the Electron renderer that opens nothing (no system browser, and new windows are blocked), so the link was dead. Notably the **sibling Flux get-key button** in the same file (line ~505) already does it correctly via `openExternalUrl` — this one link was the lone hold-out.

## Fix
Intercept the click and route it through `openExternalUrl` (already imported in this file), which uses `shell.openExternal` on desktop and `window.open` in the WebUI, with scheme allowlisting. `href` is kept so right-click-copy / accessibility still work.

## Verification
- `bunx tsc --noEmit` → clean
- `bunx oxlint` → no new warnings (2 pre-existing in this file, untouched)
- No new i18n (reuses `geminiKeyHint` / `geminiKeyLink`)
- Mirrors the already-shipped `openExternalUrl(FLUX_KEY_URL)` pattern in the same component. No unit test added — this large onboarding component has no test harness, and the change is a 1-line behavioral fix matching an existing working sibling; happy to live-verify in a fresh-wizard run if preferred.