### PR TITLE
fix(memory): Obsidian import opens a folder picker; import buttons show results (#133)

### DIFF
--- a/src/renderer/pages/memory/components/EmptyStateHero.tsx
+++ b/src/renderer/pages/memory/components/EmptyStateHero.tsx
@@ -13,8 +13,8 @@
  */
 
 import React, { useCallback, useEffect, useState } from 'react';
-import { Input } from '@arco-design/web-react';
-import { memory as memoryBridge } from '@/common/adapter/ipcBridge';
+import { Input, Message } from '@arco-design/web-react';
+import { dialog, memory as memoryBridge } from '@/common/adapter/ipcBridge';
 import { useTranslation } from 'react-i18next';
 import styles from './EmptyStateHero.module.css';
 
@@ -48,7 +48,7 @@ const CARDS: CardDef[] = [
     icon: '📓',
     titleKey: 'archive.import.obsidian',
     titleFallback: 'Import Obsidian vault',
-    defaultSubline: 'Click to detect vaults',
+    defaultSubline: 'Click to choose your vault folder',
   },
   {
     key: 'drop',
@@ -92,30 +92,67 @@ const EmptyStateHero: React.FC<EmptyStateHeroProps> = ({ onImportComplete, onSea
 
   const handleCardClick = useCallback(
     async (key: CardDef['key']): Promise<void> => {
+      // Obsidian imports from a user-chosen vault. The old code hardcoded
+      // `~/Documents`, so on any machine without a vault there (common on
+      // Windows) the import found nothing, fired onImportComplete, and the
+      // still-empty archive flashed "No matches" - reading as a dead button
+      // (#133). Open a native folder picker so the user points at their actual
+      // vault; a cancel aborts cleanly without the empty-state flash.
+      let vaultPath: string | undefined;
+      if (key === 'obsidian') {
+        try {
+          const picked = await dialog.showOpen.invoke({ properties: ['openDirectory'] });
+          if (!picked || picked.length === 0) return; // cancelled - no-op
+          vaultPath = picked[0];
+        } catch {
+          return;
+        }
+      }
+
       setLoading((prev) => ({ ...prev, [key]: true }));
       try {
         switch (key) {
-          case 'claude-mem':
-            await memoryBridge.import.claudeMem.invoke();
+          case 'claude-mem': {
+            const r = await memoryBridge.import.claudeMem.invoke();
+            Message.success(
+              t('archive.import.claudeMem.success', `Imported ${r.count} entries · ${r.errors.length} errors`),
+            );
+            if (r.count > 0) onImportComplete?.();
             break;
-          case 'obsidian':
-            await memoryBridge.import.obsidianVault.invoke({ vaultPath: '~/Documents' });
+          }
+          case 'obsidian': {
+            const r = await memoryBridge.import.obsidianVault.invoke({ vaultPath: vaultPath as string });
+            Message.success(
+              t('archive.import.obsidian.success', `Imported ${r.count} entries · ${r.errors.length} errors`),
+            );
+            if (r.count > 0) onImportComplete?.();
             break;
-          case 'drop':
-            await memoryBridge.import.processDropFolder.invoke();
+          }
+          case 'drop': {
+            const r = await memoryBridge.import.processDropFolder.invoke();
+            Message.success(
+              t('archive.import.dropFolder.success', `Imported ${r.count} entries · ${r.errors.length} errors`),
+            );
+            if (r.count > 0) onImportComplete?.();
             break;
-          case 'dev-scan':
-            await memoryBridge.import.scanDevDir.invoke();
+          }
+          case 'dev-scan': {
+            const r = await memoryBridge.import.scanDevDir.invoke();
+            Message.success(
+              t('archive.import.devScan.success', `Imported ${r.count} entries from ${r.projectsFound ?? 0} projects`),
+            );
+            if (r.count > 0) onImportComplete?.();
             break;
+          }
         }
-        onImportComplete?.();
       } catch {
-        // Non-fatal - user sees no entries, they can try again
+        // Surface the failure instead of silently flashing the empty archive.
+        Message.error(t('archive.import.failed', 'Import failed. Please try again.'));
       } finally {
         setLoading((prev) => ({ ...prev, [key]: false }));
       }
     },
-    [onImportComplete],
+    [onImportComplete, t],
   );
 
   return (

--- a/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/src/renderer/services/i18n/i18n-keys.d.ts
@@ -1157,6 +1157,7 @@ export type I18nKey =
   | 'memory.archive.import.dropFolder.processBtn'
   | 'memory.archive.import.dropFolder.success'
   | 'memory.archive.import.dropFolder.title'
+  | 'memory.archive.import.failed'
   | 'memory.archive.import.importing'
   | 'memory.archive.import.obsidian.btn'
   | 'memory.archive.import.obsidian.count'

--- a/src/renderer/services/i18n/locales/en-US/memory.json
+++ b/src/renderer/services/i18n/locales/en-US/memory.json
@@ -399,6 +399,7 @@
       "title": "Import memories",
       "close": "Close import drawer",
       "importing": "Importing…",
+      "failed": "Import failed. Please try again.",
       "status": {
         "ready": "ready",
         "checking": "checking",

--- a/tests/unit/renderer/pages/memory/EmptyStateHero.dom.test.tsx
+++ b/tests/unit/renderer/pages/memory/EmptyStateHero.dom.test.tsx
@@ -20,12 +20,15 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
-const { mockMemoryImport } = vi.hoisted(() => ({
+const { mockMemoryImport, mockDialog } = vi.hoisted(() => ({
   mockMemoryImport: {
     claudeMem: { invoke: vi.fn() },
     obsidianVault: { invoke: vi.fn() },
     scanDevDir: { invoke: vi.fn() },
     processDropFolder: { invoke: vi.fn() },
+  },
+  mockDialog: {
+    showOpen: { invoke: vi.fn() },
   },
 }));
 
@@ -33,12 +36,14 @@ vi.mock('@/common/adapter/ipcBridge', () => ({
   memory: {
     import: mockMemoryImport,
   },
+  dialog: mockDialog,
 }));
 
 vi.mock('@arco-design/web-react', async () => {
   const actual = await vi.importActual<Record<string, unknown>>('@arco-design/web-react');
   return {
     ...actual,
+    Message: { success: vi.fn(), error: vi.fn() },
     Input: ({ placeholder, onChange, 'data-testid': testId }: {
       placeholder?: string;
       onChange?: (val: string) => void;
@@ -65,6 +70,7 @@ beforeEach(() => {
   mockMemoryImport.claudeMem.invoke.mockResolvedValue({ count: 100, errors: [] });
   mockMemoryImport.obsidianVault.invoke.mockResolvedValue({ count: 30, errors: [] });
   mockMemoryImport.processDropFolder.invoke.mockResolvedValue({ count: 5, errors: [] });
+  mockDialog.showOpen.invoke.mockResolvedValue(['/Users/me/MyVault']);
 });
 
 describe('EmptyStateHero', () => {
@@ -121,5 +127,52 @@ describe('EmptyStateHero', () => {
     });
     expect(mockMemoryImport.claudeMem.invoke).toHaveBeenCalled();
     expect(onImportComplete).toHaveBeenCalled();
+  });
+
+  // #133: the Obsidian card used to import a hardcoded `~/Documents`, so on a
+  // machine without a vault there it silently found nothing and the empty
+  // archive flashed "No matches". It must open a folder picker and import the
+  // chosen vault instead.
+  it('opens a folder picker for Obsidian and imports the picked vault (#133)', async () => {
+    mockDialog.showOpen.invoke.mockResolvedValueOnce(['/Users/me/MyVault']);
+    const onImportComplete = vi.fn();
+    await act(async () => {
+      render(<EmptyStateHero onImportComplete={onImportComplete} />);
+    });
+    await act(async () => {
+      screen.getByTestId('empty-import-card-obsidian').click();
+      await new Promise((r) => setTimeout(r, 10));
+    });
+    expect(mockDialog.showOpen.invoke).toHaveBeenCalledWith({ properties: ['openDirectory'] });
+    expect(mockMemoryImport.obsidianVault.invoke).toHaveBeenCalledWith({ vaultPath: '/Users/me/MyVault' });
+    expect(onImportComplete).toHaveBeenCalled();
+  });
+
+  it('does not import (or flash a refresh) when the Obsidian picker is cancelled (#133)', async () => {
+    mockDialog.showOpen.invoke.mockResolvedValueOnce(undefined); // user cancelled the dialog
+    const onImportComplete = vi.fn();
+    await act(async () => {
+      render(<EmptyStateHero onImportComplete={onImportComplete} />);
+    });
+    await act(async () => {
+      screen.getByTestId('empty-import-card-obsidian').click();
+      await new Promise((r) => setTimeout(r, 10));
+    });
+    expect(mockMemoryImport.obsidianVault.invoke).not.toHaveBeenCalled();
+    expect(onImportComplete).not.toHaveBeenCalled();
+  });
+
+  it('does not refresh when an import yields zero entries (no empty-state flash) (#133)', async () => {
+    mockMemoryImport.processDropFolder.invoke.mockResolvedValueOnce({ count: 0, errors: [] });
+    const onImportComplete = vi.fn();
+    await act(async () => {
+      render(<EmptyStateHero onImportComplete={onImportComplete} />);
+    });
+    await act(async () => {
+      screen.getByTestId('empty-import-card-drop').click();
+      await new Promise((r) => setTimeout(r, 10));
+    });
+    expect(mockMemoryImport.processDropFolder.invoke).toHaveBeenCalled();
+    expect(onImportComplete).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Problem
Closes #133. In Memory → Archive, clicking **Import Obsidian / Import claude-mem / Watch drop folder / Scan ~/dev** just flickers and flashes `No matches` for a moment — the buttons read as dead, and there's no way to point at your actual Obsidian vault.

## Root cause
`EmptyStateHero` never opened a folder picker. Each card ran an import against a **hardcoded path** — Obsidian against `~/Documents`, dev-scan against `~/dev`, claude-mem against `~/.claude-mem`. On a machine without data at those paths (common on Windows), the import returned 0 entries, `onImportComplete` fired anyway, and the still-empty archive re-rendered its `No matches` empty state — the "flicker".

## Fix
- **Obsidian** now opens a native folder picker (`dialog.showOpen` with `openDirectory` — the same helper used across the app) and imports the chosen vault. The Obsidian importer already treats the passed path as the vault root, so a picked absolute path just works. Cancelling the dialog is a clean no-op (no flash).
- **All four cards** now surface a result toast (entries imported, or a failure) instead of silently flashing the empty archive, and only refresh the list when something was actually imported. Reuses the existing per-source `success`/`error` i18n keys (ImportDrawer's pattern); adds one generic `archive.import.failed`.
- Updated the Obsidian card subline to "Click to choose your vault folder".

## Verification
- `bunx tsc --noEmit` → 0; `bunx oxlint` → 0; `node scripts/check-i18n.js` → pass; `bun run i18n:types` regenerated.
- `vitest` EmptyStateHero suite 9/9 — incl. 3 new #133 guards (picker opens + picked vault imported; cancel → no import; zero-result → no refresh) that all fail on the old code.

Note: native folder dialogs aren't drivable via our CDP harness, so this is verified by the unit contract rather than a live screenshot.