### PR TITLE
fix(installer): resolve bun from ~/.bun/bin so headless setup + systemd work (#201)

### DIFF
--- a/installer/bin/wayland.mjs
+++ b/installer/bin/wayland.mjs
@@ -111,8 +111,33 @@ function loadEnvFile() {
 function has(cmd) {
   return spawnSync(process.platform === 'win32' ? 'where' : 'which', [cmd], { stdio: 'ignore' }).status === 0;
 }
+/** bun's canonical install dir. The bun.sh installer drops the binary here and
+ *  only edits shell rc files (.bashrc/.zshrc) - so it is NOT on the PATH of this
+ *  node process, nor of a systemd service (which starts with a minimal env). */
+function bunBinDir() {
+  return join(homedir(), '.bun', 'bin');
+}
+/** Resolve the bun executable: PATH first, then ~/.bun/bin. Relying on `which
+ *  bun` alone made `wayland setup` report "bun install failed" right after a
+ *  clean install, and the systemd service die with "bun runtime not found",
+ *  because neither context has ~/.bun/bin on PATH yet (#201). Returns the
+ *  command/path to spawn, or null when bun truly isn't installed. */
+function resolveBun() {
+  if (has('bun')) return 'bun';
+  const local = join(bunBinDir(), process.platform === 'win32' ? 'bun.exe' : 'bun');
+  return existsSync(local) ? local : null;
+}
 function hasBun() {
-  return has('bun');
+  return resolveBun() !== null;
+}
+/** Return env with ~/.bun/bin prepended to PATH, so a freshly-installed bun (and
+ *  any bun/node subprocess the server spawns) resolves without a new shell. */
+function withBunPath(env) {
+  const dir = bunBinDir();
+  if (!existsSync(dir)) return env;
+  const sep = process.platform === 'win32' ? ';' : ':';
+  const cur = env.PATH || '';
+  return cur.split(sep).includes(dir) ? env : { ...env, PATH: dir + sep + cur };
 }
 
 /** bun's installer needs unzip + curl. On a fresh Debian/Ubuntu box neither is
@@ -246,6 +271,9 @@ ExecStart=${process.execPath} ${bin} start
 Restart=always
 RestartSec=3
 Environment=DATA_DIR=${DATA_DIR}
+# systemd starts with a minimal PATH that excludes ~/.bun/bin (where the bun.sh
+# installer drops bun), so the start command would die with bun-runtime-not-found (#201).
+Environment=PATH=${bunBinDir()}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [Install]
 WantedBy=multi-user.target
@@ -269,16 +297,17 @@ function start() {
     console.log(c.r(`Server payload missing at ${SERVER}. Reinstall: npm i -g getwayland`));
     process.exit(1);
   }
-  if (!hasBun()) {
+  const bunExe = resolveBun();
+  if (!bunExe) {
     console.log(c.r('bun runtime not found. Run `wayland setup` (it installs bun) or see https://bun.sh'));
     process.exit(1);
   }
-  const env = { ...process.env, ...loadEnvFile() };
+  const env = withBunPath({ ...process.env, ...loadEnvFile() });
   env.DATA_DIR = env.DATA_DIR || DATA_DIR;
   env.PORT = env.PORT || '3000';
   env.ALLOW_REMOTE = env.ALLOW_REMOTE || 'true';
   env.NODE_ENV = env.NODE_ENV || 'production';
-  const child = spawn('bun', [SERVER], { cwd: PAYLOAD, env, stdio: 'inherit' });
+  const child = spawn(bunExe, [SERVER], { cwd: PAYLOAD, env, stdio: 'inherit' });
   child.on('exit', (code) => process.exit(code ?? 0));
   process.on('SIGINT', () => child.kill('SIGINT'));
   process.on('SIGTERM', () => child.kill('SIGTERM'));
@@ -294,15 +323,16 @@ function resetpass() {
     console.log(c.r(`Server payload missing at ${SERVER}. Reinstall: npm i -g getwayland`));
     process.exit(1);
   }
-  if (!hasBun()) {
+  const bunExe = resolveBun();
+  if (!bunExe) {
     console.log(c.r('bun runtime not found. Run `wayland setup` (it installs bun) or see https://bun.sh'));
     process.exit(1);
   }
-  const env = { ...process.env, ...loadEnvFile() };
+  const env = withBunPath({ ...process.env, ...loadEnvFile() });
   env.DATA_DIR = env.DATA_DIR || DATA_DIR;
   env.NODE_ENV = env.NODE_ENV || 'production';
   // Forward any extra args (e.g. a username) after the subcommand.
-  const child = spawn('bun', [SERVER, '--resetpass', ...process.argv.slice(3)], { cwd: PAYLOAD, env, stdio: 'inherit' });
+  const child = spawn(bunExe, [SERVER, '--resetpass', ...process.argv.slice(3)], { cwd: PAYLOAD, env, stdio: 'inherit' });
   child.on('exit', (code) => process.exit(code ?? 0));
 }
 


### PR DESCRIPTION
## Problem
Closes #201. On a headless Ubuntu box, `wayland setup` fails with **`bun install failed`** (even though bun installed fine), and the systemd service dies with **`bun runtime not found. Run wayland setup`**.

## Root cause
The bun.sh installer drops the binary at `~/.bun/bin/bun` and only edits shell rc files — so it's **not on the PATH** of the running node process, nor of a systemd service (minimal env). `hasBun()` did `which bun`, so:
- Right after a successful install, `which bun` returns nothing → setup reports the misleading `bun install failed` and aborts.
- The systemd `ExecStart` runs with a stripped PATH → `wayland start` can't find bun → `bun runtime not found`.

## Fix
- `resolveBun()` — PATH first, then `~/.bun/bin/<bun|bun.exe>`. `hasBun()` delegates to it.
- `start`/`resetpass` spawn the **resolved path** with `~/.bun/bin` prepended to the child PATH.
- The generated **systemd unit** sets `Environment=PATH` to include `~/.bun/bin` (belt-and-suspenders alongside the absolute-path resolve).

## Verified live on a fresh Ubuntu 24.04 droplet
- **Reproduced** on the published `getwayland@0.11.0`: `wayland setup` → `bun install failed` (bun was actually at `~/.bun/bin/bun` v1.3.14); `wayland start` → `bun runtime not found`.
- **After the fix**: `wayland start` boots the server via `~/.bun/bin/bun` (schema + migrations run); a systemd service installed with a **minimal PATH** (`/usr/bin:/bin`) comes up `active`, consumes real CPU running the server, and the journal has **zero** `bun runtime not found`.

No unit-test harness exists for the standalone installer CLI; verification is the live droplet repro/fix above. Ships when `getwayland` is republished.