### PR TITLE
fix(onboarding): repoint the Gemini door to a Google AI Studio key

### DIFF
--- a/src/renderer/components/onboarding/ConnectDoors.tsx
+++ b/src/renderer/components/onboarding/ConnectDoors.tsx
@@ -11,7 +11,11 @@ import { ipcBridge } from '@/common';
 import type { ConnectFluxResult, DetectionResult } from '@/common/types/onboarding';
 import type { ProviderId } from '@process/providers/types';
 import { providerLabel } from './providerLabel';
+import { openExternalUrl } from '@renderer/utils/platform';
 import styles from './OnboardingFlow.module.css';
+
+/** Google AI Studio - where you mint a free Gemini API key. */
+const AI_STUDIO_KEY_URL = 'https://aistudio.google.com/apikey';
 
 /** Inline Google "G" mark - brand colors are intentional literals. */
 const GoogleMark: React.FC = () => (
@@ -69,27 +73,15 @@ const ConnectDoors: React.FC<ConnectDoorsProps> = ({ detection, onConnected, onP
     }
   }, [busy, onConnected]);
 
-  const connectGoogle = useCallback(async () => {
+  // Google retired the free OAuth Gemini path (June 2026), so a one-click
+  // "Continue with Google" can no longer mint a working free key. Send the user
+  // to Google AI Studio for a real key and advance to the paste step to enter
+  // it - the honest, working path (matches the cold-start AI Studio link).
+  const getGeminiKey = useCallback(() => {
     if (busy) return;
-    setBusy('google');
-    setErrorKey(null);
-    try {
-      const auth = await ipcBridge.googleAuth.login.invoke({});
-      if (!auth.success) {
-        setErrorKey('onboarding.doors.error.unknown');
-        return;
-      }
-      const res = await ipcBridge.modelRegistry.connect
-        .invoke({ providerId: 'google-gemini', creds: { useGoogleAuth: true } })
-        .catch(() => ({ ok: false as const, error: 'unknown' as const }));
-      if (res.ok) return onConnected();
-      setErrorKey('onboarding.doors.error.unknown');
-    } catch {
-      setErrorKey('onboarding.doors.error.unknown');
-    } finally {
-      setBusy(null);
-    }
-  }, [busy, onConnected]);
+    void openExternalUrl(AI_STUDIO_KEY_URL);
+    onPasteKey();
+  }, [busy, onPasteKey]);
 
   const connectDetected = useCallback(async () => {
     if (busy || !detectedProvider) return;
@@ -139,21 +131,22 @@ const ConnectDoors: React.FC<ConnectDoorsProps> = ({ detection, onConnected, onP
           <ArrowRight size={18} className={styles.doorArrow} />
         </button>
 
-        {/* Free door - Google → Gemini. */}
+        {/* Gemini key door - get a free key from Google AI Studio, then paste it
+            (the old one-click OAuth free-tier path was retired June 2026). */}
         <button
           type='button'
           data-testid='connect-door-google'
           className={styles.door}
-          onClick={() => void connectGoogle()}
+          onClick={() => getGeminiKey()}
           disabled={busy !== null}
         >
-          <span className={styles.doorIcon}>{busy === 'google' ? <Loader2 size={20} className='animate-spin' /> : <GoogleMark />}</span>
+          <span className={styles.doorIcon}><GoogleMark /></span>
           <span className={styles.doorMain}>
-            <span className={styles.doorTitle}>{t('onboarding.doors.google.title', { defaultValue: 'Continue with Google' })}</span>
+            <span className={styles.doorTitle}>{t('onboarding.doors.google.title', { defaultValue: 'Get a free Gemini key' })}</span>
             <span className={styles.doorBody}>
-              {t('onboarding.doors.google.body', { defaultValue: 'One click puts the Gemini models in your picker.' })}
+              {t('onboarding.doors.google.body', { defaultValue: 'Grab a free API key from Google AI Studio, then paste it in.' })}
             </span>
-            <span className={styles.doorFoot}>{t('onboarding.doors.google.foot', { defaultValue: 'Free with your Google account' })}</span>
+            <span className={styles.doorFoot}>{t('onboarding.doors.google.foot', { defaultValue: 'Free key · opens Google AI Studio' })}</span>
           </span>
           <ArrowRight size={18} className={styles.doorArrow} />
         </button>

--- a/tests/unit/renderer/components/onboarding/ConnectDoors.dom.test.tsx
+++ b/tests/unit/renderer/components/onboarding/ConnectDoors.dom.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// @vitest-environment jsdom
+
+/**
+ * Guards the onboarding "Gemini key" door. Google retired the free OAuth Gemini
+ * path (June 2026), so the door must send the user to Google AI Studio for a
+ * real key and advance to the paste step - never the old one-click OAuth.
+ */
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockOpenExternalUrl = vi.fn();
+vi.mock('@renderer/utils/platform', () => ({
+  openExternalUrl: (...args: unknown[]) => mockOpenExternalUrl(...args),
+}));
+
+const mockConnectFlux = vi.fn();
+const mockRegistryConnect = vi.fn();
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    onboarding: { connectFlux: { invoke: (...a: unknown[]) => mockConnectFlux(...a) } },
+    modelRegistry: { connect: { invoke: (...a: unknown[]) => mockRegistryConnect(...a) } },
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? _key,
+  }),
+}));
+
+// eslint-disable-next-line import/first
+import ConnectDoors from '@renderer/components/onboarding/ConnectDoors';
+// eslint-disable-next-line import/first
+import type { DetectionResult } from '@/common/types/onboarding';
+
+// envKeys empty -> the "detected key" door doesn't render; flux + Gemini doors do.
+const detection = { envKeys: [] } as unknown as DetectionResult;
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('ConnectDoors - Gemini key door', () => {
+  it('opens Google AI Studio for a key and advances to the paste step', () => {
+    const onPasteKey = vi.fn();
+    const onConnected = vi.fn();
+    render(<ConnectDoors detection={detection} onConnected={onConnected} onPasteKey={onPasteKey} />);
+
+    fireEvent.click(screen.getByTestId('connect-door-google'));
+
+    expect(mockOpenExternalUrl).toHaveBeenCalledWith('https://aistudio.google.com/apikey');
+    expect(onPasteKey).toHaveBeenCalledTimes(1);
+    // It must NOT silently "connect" a provider (the dead OAuth path did this).
+    expect(mockRegistryConnect).not.toHaveBeenCalled();
+    expect(onConnected).not.toHaveBeenCalled();
+  });
+
+  it('labels the door as a free Gemini key, not a Google sign-in', () => {
+    render(<ConnectDoors detection={detection} onConnected={vi.fn()} onPasteKey={vi.fn()} />);
+    const door = screen.getByTestId('connect-door-google');
+    expect(door.textContent).toContain('Gemini key');
+    expect(door.textContent).not.toContain('Continue with Google');
+  });
+});


### PR DESCRIPTION
## Problem
The onboarding **"Continue with Google"** door (`ConnectDoors.tsx`) did a one-click Google OAuth (`googleAuth.login` → connect `google-gemini` with `useGoogleAuth`) and advertised *"Free with your Google account."* **Google retired that free OAuth Gemini path in June 2026**, so the door now lands users on a dead path.

## Fix
Repoint the door to the working path: clicking it now opens **Google AI Studio** (`aistudio.google.com/apikey` — the same key page the cold-start link uses, see #208) and advances to the paste-a-key step, relabelled **"Get a free Gemini key."** The dead OAuth call is removed from this surface. `googleAuth` itself is untouched — the settings surfaces (GoogleButton, GeminiModalContent) still reference it; see note below.

## Test
New `ConnectDoors.dom.test.tsx` (2 tests): the door opens AI Studio + calls `onPasteKey`, never the connect path; and it's labelled as a Gemini key, not "Continue with Google". tsc 0, oxlint 0.

## Follow-up (not in scope)
The same dead OAuth-Gemini path is also used in **Settings** (`GoogleButton`, `GeminiModalContent`, `useGeminiGoogleAuthModels`). If Google killed it entirely (not just the onboarding free tier), those should get the same treatment — flagging for a product call rather than ripping out `googleAuth` app-wide here.