### PR TITLE
fix(installer): reap orphaned processes in the Windows uninstaller (#139)

### DIFF
--- a/resources/windows-installer-arm64.nsh
+++ b/resources/windows-installer-arm64.nsh
@@ -17,3 +17,21 @@ Function .onVerifyInstDir
     Quit
   ${EndIf}
 FunctionEnd
+
+; #139: closing or uninstalling Wayland could leave orphaned processes behind -
+; the app plus the bun/node helpers it spawned - which kept holding files in the
+; install dir, so the uninstall left files that couldn't be deleted. electron-
+; builder's own un.checkAppRunning only handles the main Wayland.exe, not the
+; helper processes that outlived it.
+;
+; customUnInit runs in un.onInit, before the uninstaller removes any files. Kill
+; the app's whole process tree, then sweep any process still running from the
+; install dir (matched by executable PATH, so unrelated node.exe processes are
+; never touched). The uninstaller's own process is excluded by PID so the sweep
+; cannot terminate itself mid-uninstall. (Keep in sync with windows-installer-x64.nsh.)
+!macro customUnInit
+  System::Call 'kernel32::GetCurrentProcessId() i .r9'
+  nsExec::Exec 'taskkill /F /T /IM "${APP_EXECUTABLE_FILENAME}"'
+  nsExec::Exec `powershell -NoProfile -ExecutionPolicy Bypass -Command "$$d = '$INSTDIR'; $$self = $9; Get-Process -ErrorAction SilentlyContinue | Where-Object { $$_.Id -ne $$self -and $$_.Path -and $$_.Path.ToLower().StartsWith($$d.ToLower()) } | Stop-Process -Force -ErrorAction SilentlyContinue"`
+  Sleep 1500
+!macroend

--- a/resources/windows-installer-x64.nsh
+++ b/resources/windows-installer-x64.nsh
@@ -27,3 +27,21 @@ Function .onVerifyInstDir
     Quit
   ${EndIf}
 FunctionEnd
+
+; #139: closing or uninstalling Wayland could leave orphaned processes behind -
+; the app plus the bun/node helpers it spawned - which kept holding files in the
+; install dir, so the uninstall left files that couldn't be deleted. electron-
+; builder's own un.checkAppRunning only handles the main Wayland.exe, not the
+; helper processes that outlived it.
+;
+; customUnInit runs in un.onInit, before the uninstaller removes any files. Kill
+; the app's whole process tree, then sweep any process still running from the
+; install dir (matched by executable PATH, so unrelated node.exe processes are
+; never touched). The uninstaller's own process is excluded by PID so the sweep
+; cannot terminate itself mid-uninstall. (Keep in sync with windows-installer-arm64.nsh.)
+!macro customUnInit
+  System::Call 'kernel32::GetCurrentProcessId() i .r9'
+  nsExec::Exec 'taskkill /F /T /IM "${APP_EXECUTABLE_FILENAME}"'
+  nsExec::Exec `powershell -NoProfile -ExecutionPolicy Bypass -Command "$$d = '$INSTDIR'; $$self = $9; Get-Process -ErrorAction SilentlyContinue | Where-Object { $$_.Id -ne $$self -and $$_.Path -and $$_.Path.ToLower().StartsWith($$d.ToLower()) } | Stop-Process -Force -ErrorAction SilentlyContinue"`
+  Sleep 1500
+!macroend


### PR DESCRIPTION
## Problem
Refs #139. Closing or uninstalling Wayland on Windows leaves **orphaned node processes** that hold files in the install dir, so the uninstall leaves files behind (and they accumulate across open/close cycles).

## Context
The app-side close cleanup (process tree-kill for WCore/OpenClaw/tunnel/MCP/Nanobot) already shipped in 0.10.2+. This PR is the **uninstaller** half: electron-builder's own `un.checkAppRunning` only watches the main `Wayland.exe`, not the bun/node helpers it spawned that outlived it.

## Fix
Add a `customUnInit` macro (runs in `un.onInit`, **before** any file removal) to both arch NSIS includes (`resources/windows-installer-{x64,arm64}.nsh` — the files `scripts/build-with-builder.js` passes via `--config.nsis.include`):
1. `taskkill /F /T /IM Wayland.exe` — the app + its live child tree.
2. A PowerShell sweep of any process **still running from `$INSTDIR`** — matched by executable path, so unrelated `node.exe` processes are never touched, and **excluding the uninstaller's own PID** so it can't terminate itself mid-uninstall.

## Verification (on a real Windows box)
- **Kill mechanism** (dummy process tree, no impact to any real install): an in-dir process is killed; a process matching the excluded "self" PID survives; an out-of-dir `node.exe` survives. ✅
- **NSIS compiles**: both arch `.nsh` (arch-check function + `!include x64.nsh` + the new macro) compile cleanly with electron-builder's exact makensis (NSIS 3.0.4.1); the macro lands in the uninstaller. ✅
- **Hook timing**: confirmed from electron-builder's `uninstaller.nsh` template — `customUnInit` runs in `un.onInit`, before `RMDir /r $INSTDIR`. ✅

The full packaged install→close→uninstall e2e isn't run here because it would destroy the live install on the test box; it exercises naturally on the next Windows build.