### PR TITLE
fix(skills): wayland_search_skills returns metadata, not all bodies (#199)

### DIFF
--- a/src/process/resources/builtinMcp/constants.ts
+++ b/src/process/resources/builtinMcp/constants.ts
@@ -13,6 +13,9 @@ export const BUILTIN_IMAGE_GEN_LEGACY_NAMES = ['Wayland Image Generation', BUILT
 export const BUILTIN_SEARCH_SKILLS_ID = 'builtin-search-skills';
 export const BUILTIN_SEARCH_SKILLS_NAME = 'wayland-search-skills';
 export const BUILTIN_SEARCH_SKILLS_TOOL_NAME = 'wayland_search_skills';
+// Second tool on the same stdio server: paginated body reader, so search can
+// return lightweight metadata and bodies are fetched on demand (issue #199).
+export const BUILTIN_READ_SKILL_TOOL_NAME = 'wayland_read_skill';
 
 // Bundled @wayland MCP servers shipped with the installer (no npm publish).
 // Each catalog entry's transport stores the bare filename as args[0]; the

--- a/src/process/resources/builtinMcp/searchSkillsServer.ts
+++ b/src/process/resources/builtinMcp/searchSkillsServer.ts
@@ -5,11 +5,18 @@
  */
 
 /**
- * Built-in MCP server factory for wayland_search_skills.
- * Returns an object with a single tool `call` method - not a stdio server.
- * Intended to be wired into the builtin MCP catalog by the caller.
+ * Built-in MCP server factory for the skill-discovery tools.
+ * Returns an object with two tool methods (`call` for search, `readSkill` for
+ * paginated body reads) - not a stdio server. Wired into the builtin MCP
+ * catalog by the caller.
  *
- * The BM25 index is built once per server instance on the first call and
+ * Two-step retrieval (issue #199): `call` returns lightweight metadata by
+ * default (name, description, score, excerpt, body size) so a 25-hit search no
+ * longer serialises ~40k tokens of inline bodies and blow Claude Code's 25k
+ * Read cap on the persisted tool result. Full bodies are fetched on demand,
+ * either inline-but-capped via `includeBody`, or page-by-page via `readSkill`.
+ *
+ * The BM25 index is built once per server instance on the first `call` and
  * cached thereafter.
  */
 
@@ -18,11 +25,63 @@ import { SkillLibrary } from '@process/services/skills/SkillLibrary';
 import { SkillRetriever } from '@process/services/skills/SkillRetriever';
 
 // ---------------------------------------------------------------------------
+// Tuning constants (kept local - this factory is bundled into the standalone
+// stdio subprocess and must avoid dragging in config/storage side effects).
+// These are also the robustness boundary: the zod schema in the entrypoint
+// constrains inputs, but every size knob is re-clamped here so a malformed or
+// adversarial call can never reproduce the oversized-output bug.
+// ---------------------------------------------------------------------------
+
+const DEFAULT_LIMIT = 5;
+const MAX_LIMIT = 50;
+/** When bodies are inlined, return at most this many hits regardless of limit. */
+const INCLUDE_BODY_LIMIT_CAP = 8;
+const DEFAULT_MAX_BODY_CHARS = 2000;
+const MAX_INLINE_BODY_CHARS = 4000;
+const EXCERPT_CHARS = 240;
+/** Rough chars-per-token heuristic for body-size estimates. */
+const CHARS_PER_TOKEN = 4;
+const DEFAULT_READ_CHARS = 8000;
+const MAX_READ_CHARS = 20000;
+
+// ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
 
+export type SearchSkillHit = {
+  name: string;
+  description: string;
+  score: number;
+  /** First slice of the body (frontmatter stripped, whitespace collapsed). */
+  excerpt: string;
+  /** Total body length in characters - lets the caller plan pagination. */
+  bodyChars: number;
+  /** Approximate token cost of the FULL body (bodyChars / 4, rounded up). */
+  bodyTokenEstimate: number;
+  /** Present only when `includeBody` is true; capped at `maxBodyChars`. */
+  body?: string;
+  /** True when an inlined `body` was truncated to `maxBodyChars`. */
+  bodyTruncated?: boolean;
+};
+
 export type SearchSkillsResult = {
-  results: Array<{ name: string; description: string; score: number; body: string }>;
+  results: SearchSkillHit[];
+  message?: string;
+};
+
+export type ReadSkillResult = {
+  name: string;
+  found: boolean;
+  /** The slice [offset, offset + maxChars); absent when `found` is false. */
+  body?: string;
+  /** Start index of the returned slice within the full body. */
+  offset: number;
+  /** Total body length in characters. */
+  totalChars: number;
+  /** Offset to pass for the next page, or null when the body is exhausted. */
+  nextOffset: number | null;
+  /** Approximate token cost of the FULL body. */
+  bodyTokenEstimate: number;
   message?: string;
 };
 
@@ -34,6 +93,23 @@ export type SearchSkillsDeps = {
   retriever?: {
     retrieve(query: string, limit: number): Array<{ name: string; description: string; score: number }>;
   };
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(Math.max(Math.trunc(value), min), max);
+
+const estimateTokens = (chars: number): number => Math.ceil(chars / CHARS_PER_TOKEN);
+
+/** A short, readable preview: strip a leading YAML frontmatter block, collapse
+ * whitespace, and cap at EXCERPT_CHARS so the search payload stays tiny. */
+const makeExcerpt = (body: string): string => {
+  const withoutFrontmatter = body.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, '');
+  const collapsed = withoutFrontmatter.replace(/\s+/g, ' ').trim();
+  return collapsed.length > EXCERPT_CHARS ? `${collapsed.slice(0, EXCERPT_CHARS)}…` : collapsed;
 };
 
 // ---------------------------------------------------------------------------
@@ -58,10 +134,27 @@ export const createSearchSkillsServer = (deps: SearchSkillsDeps = {}) => {
   return {
     name: 'wayland_search_skills',
 
-    async call({ query, limit = 25 }: { query: string; limit?: number }): Promise<SearchSkillsResult> {
+    async call({
+      query,
+      limit = DEFAULT_LIMIT,
+      includeBody = false,
+      maxBodyChars = DEFAULT_MAX_BODY_CHARS,
+    }: {
+      query: string;
+      limit?: number;
+      includeBody?: boolean;
+      maxBodyChars?: number;
+    }): Promise<SearchSkillsResult> {
       await ensureIndex();
 
-      const hits = retrieverInstance!.retrieve(query, limit);
+      // Re-clamp every size knob here so oversized output is impossible no
+      // matter what the caller sends. Inlining bodies tightens the cap further.
+      const effectiveLimit = includeBody
+        ? clamp(limit, 1, INCLUDE_BODY_LIMIT_CAP)
+        : clamp(limit, 1, MAX_LIMIT);
+      const bodyCap = clamp(maxBodyChars, 1, MAX_INLINE_BODY_CHARS);
+
+      const hits = retrieverInstance!.retrieve(query, effectiveLimit);
 
       if (hits.length === 0) {
         return {
@@ -70,12 +163,27 @@ export const createSearchSkillsServer = (deps: SearchSkillsDeps = {}) => {
         };
       }
 
-      const results: SearchSkillsResult['results'] = [];
+      const results: SearchSkillHit[] = [];
       for (const hit of hits) {
+        // Blocked/quarantined skills load as null and are NEVER surfaced.
         const body = await library.loadBody(hit.name);
-        if (body !== null) {
-          results.push({ ...hit, body });
+        if (body === null) continue;
+
+        const bodyChars = body.length;
+        const entry: SearchSkillHit = {
+          name: hit.name,
+          description: hit.description,
+          score: hit.score,
+          excerpt: makeExcerpt(body),
+          bodyChars,
+          bodyTokenEstimate: estimateTokens(bodyChars),
+        };
+        if (includeBody) {
+          const truncated = bodyChars > bodyCap;
+          entry.body = truncated ? body.slice(0, bodyCap) : body;
+          entry.bodyTruncated = truncated;
         }
+        results.push(entry);
       }
 
       if (results.length === 0) {
@@ -86,6 +194,47 @@ export const createSearchSkillsServer = (deps: SearchSkillsDeps = {}) => {
       }
 
       return { results };
+    },
+
+    /** Read one named skill body, paginated. Use after `call` to pull the full
+     * instructions for a chosen skill without the whole result set. */
+    async readSkill({
+      name,
+      offset = 0,
+      maxChars = DEFAULT_READ_CHARS,
+    }: {
+      name: string;
+      offset?: number;
+      maxChars?: number;
+    }): Promise<ReadSkillResult> {
+      const body = await library.loadBody(name);
+      if (body === null) {
+        return {
+          name,
+          found: false,
+          offset: 0,
+          totalChars: 0,
+          nextOffset: null,
+          bodyTokenEstimate: 0,
+          message: `Skill '${name}' was not found or is unavailable (unknown or blocked).`,
+        };
+      }
+
+      const totalChars = body.length;
+      const start = clamp(offset, 0, totalChars);
+      const pageChars = clamp(maxChars, 1, MAX_READ_CHARS);
+      const slice = body.slice(start, start + pageChars);
+      const end = start + slice.length;
+
+      return {
+        name,
+        found: true,
+        body: slice,
+        offset: start,
+        totalChars,
+        nextOffset: end < totalChars ? end : null,
+        bodyTokenEstimate: estimateTokens(totalChars),
+      };
     },
   };
 };

--- a/src/process/resources/builtinMcp/searchSkillsServerEntry.ts
+++ b/src/process/resources/builtinMcp/searchSkillsServerEntry.ts
@@ -22,25 +22,42 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
-import { BUILTIN_SEARCH_SKILLS_NAME, BUILTIN_SEARCH_SKILLS_TOOL_NAME } from './constants';
+import {
+  BUILTIN_READ_SKILL_TOOL_NAME,
+  BUILTIN_SEARCH_SKILLS_NAME,
+  BUILTIN_SEARCH_SKILLS_TOOL_NAME,
+} from './constants';
 import { createSearchSkillsServer } from './searchSkillsServer';
 
-const TOOL_DESCRIPTION = `Search the full Wayland skill library (~2,000+ entries) by natural-language query and return the matching skill bodies inline.
+const SEARCH_TOOL_DESCRIPTION = `Search the full Wayland skill library (~2,000+ entries) by natural-language query. Returns lightweight metadata by default so you can pick the right skill before pulling its full instructions.
 
 When to use:
 - The user's task hints at a domain not covered by the small set of skills already loaded in your context (those advertised in the system prompt).
 - You need a specific recipe (e.g., "stripe webhook signing", "diff two PDFs", "git rebase recovery") that is not currently visible.
 
-How it works:
+How it works (two steps):
+1. Search returns up to \`limit\` ranked results (default 5). Each has \`name\`, \`description\`, \`score\`, a short \`excerpt\`, and \`bodyChars\`/\`bodyTokenEstimate\` so you know how big the full skill is.
+2. To read a skill, either set \`includeBody: true\` here (bodies are inlined but capped at \`maxBodyChars\`, default 2000) for a quick peek, or call \`${BUILTIN_READ_SKILL_TOOL_NAME}\` to read the full body page-by-page.
 - Lexical BM25 retrieval over titles + descriptions + tags + metadata.
-- Returns up to \`limit\` ranked results (default 25). Each result has \`name\`, \`description\`, \`score\`, and the full skill \`body\` (markdown).
 - Blocked or quarantined skills are NEVER returned.
-
-After retrieval, treat the returned \`body\` as additional context: read it, follow its guidance, and cite the skill by \`name\` if relevant.
 
 Input:
 - \`query\`: natural-language description of what you are trying to do. Be specific.
-- \`limit\`: optional; max number of results to return (default 25).`;
+- \`limit\`: optional; max results to return (default 5, max 50).
+- \`includeBody\`: optional; when true, inline each body capped at \`maxBodyChars\` (limited to a few results to keep output small).
+- \`maxBodyChars\`: optional; per-body character cap when \`includeBody\` is true (default 2000).`;
+
+const READ_TOOL_DESCRIPTION = `Read the full markdown body of one Wayland skill by exact \`name\` (use \`${BUILTIN_SEARCH_SKILLS_TOOL_NAME}\` first to find the name). Paginated so large skills don't exceed your context limits.
+
+How it works:
+- Returns the slice starting at \`offset\` for up to \`maxChars\` characters (default 8000), plus \`totalChars\` and \`nextOffset\`.
+- If \`nextOffset\` is non-null, call again with that value to read the next page; null means you've reached the end.
+- Blocked, quarantined, or unknown skills return \`found: false\`.
+
+Input:
+- \`name\`: exact skill name from a prior search result.
+- \`offset\`: optional; character index to start at (default 0; pass the previous \`nextOffset\`).
+- \`maxChars\`: optional; max characters to return this page (default 8000, max 20000).`;
 
 async function main(): Promise<void> {
   const server = new McpServer({
@@ -52,20 +69,31 @@ async function main(): Promise<void> {
 
   server.tool(
     BUILTIN_SEARCH_SKILLS_TOOL_NAME,
-    TOOL_DESCRIPTION,
+    SEARCH_TOOL_DESCRIPTION,
     {
       query: z.string().describe('Natural-language description of the task or topic to find skills for.'),
       limit: z
         .number()
         .int()
         .positive()
-        .max(100)
+        .max(50)
         .optional()
-        .describe('Optional. Maximum number of skills to return (default 25, max 100).'),
+        .describe('Optional. Maximum number of skills to return (default 5, max 50).'),
+      includeBody: z
+        .boolean()
+        .optional()
+        .describe('Optional. When true, inline each skill body capped at maxBodyChars (default false).'),
+      maxBodyChars: z
+        .number()
+        .int()
+        .positive()
+        .max(4000)
+        .optional()
+        .describe('Optional. Per-body character cap when includeBody is true (default 2000, max 4000).'),
     },
-    async ({ query, limit }) => {
+    async ({ query, limit, includeBody, maxBodyChars }) => {
       try {
-        const result = await handler.call({ query, limit: limit ?? 25 });
+        const result = await handler.call({ query, limit, includeBody, maxBodyChars });
         return {
           content: [
             {
@@ -81,6 +109,51 @@ async function main(): Promise<void> {
             {
               type: 'text' as const,
               text: `wayland_search_skills error: ${message}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.tool(
+    BUILTIN_READ_SKILL_TOOL_NAME,
+    READ_TOOL_DESCRIPTION,
+    {
+      name: z.string().describe('Exact skill name from a prior wayland_search_skills result.'),
+      offset: z
+        .number()
+        .int()
+        .nonnegative()
+        .optional()
+        .describe('Optional. Character index to start reading from (default 0; pass the previous nextOffset).'),
+      maxChars: z
+        .number()
+        .int()
+        .positive()
+        .max(20000)
+        .optional()
+        .describe('Optional. Maximum characters to return this page (default 8000, max 20000).'),
+    },
+    async ({ name, offset, maxChars }) => {
+      try {
+        const result = await handler.readSkill({ name, offset, maxChars });
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `wayland_read_skill error: ${message}`,
             },
           ],
           isError: true,

--- a/tests/unit/process/resources/builtinMcp/searchSkillsServer.test.ts
+++ b/tests/unit/process/resources/builtinMcp/searchSkillsServer.test.ts
@@ -44,8 +44,8 @@ function makeRetriever(
 // ---------------------------------------------------------------------------
 
 describe('createSearchSkillsServer', () => {
-  describe('call - happy path', () => {
-    it('returns ranked results with body content', async () => {
+  describe('call - happy path (metadata-only default)', () => {
+    it('returns ranked metadata WITHOUT inline bodies by default (issue #199)', async () => {
       const library = makeLibrary(
         [makeEntry('alpha'), makeEntry('beta')],
         { alpha: '# Alpha skill body', beta: '# Beta skill body' }
@@ -60,38 +60,95 @@ describe('createSearchSkillsServer', () => {
 
       expect(result.message).toBeUndefined();
       expect(result.results).toHaveLength(2);
-      expect(result.results[0]).toEqual({
+      // No full body inline - the bug was returning every body at once.
+      expect(result.results[0].body).toBeUndefined();
+      expect(result.results[0]).toMatchObject({
         name: 'alpha',
         description: 'Description for alpha',
         score: 2.5,
-        body: '# Alpha skill body',
+        excerpt: '# Alpha skill body',
+        bodyChars: '# Alpha skill body'.length,
+        bodyTokenEstimate: Math.ceil('# Alpha skill body'.length / 4),
       });
-      expect(result.results[1]).toEqual({
-        name: 'beta',
-        description: 'Description for beta',
-        score: 1.2,
-        body: '# Beta skill body',
-      });
+      expect(result.results[1].name).toBe('beta');
+      expect(result.results[1].body).toBeUndefined();
     });
 
-    it('passes limit to retriever', async () => {
+    it('strips leading YAML frontmatter from the excerpt', async () => {
+      const body = '---\nname: x\ndescription: y\n---\nReal content starts here.';
+      const library = makeLibrary([makeEntry('x')], { x: body });
+      const retriever = makeRetriever([{ name: 'x', description: 'Description for x', score: 1 }]);
+
+      const server = createSearchSkillsServer({ library, retriever });
+      const result = await server.call({ query: 'x' });
+
+      expect(result.results[0].excerpt).toBe('Real content starts here.');
+    });
+
+    it('passes limit through to the retriever', async () => {
       const library = makeLibrary([makeEntry('foo')], { foo: 'body' });
       const retriever = makeRetriever([{ name: 'foo', description: 'Description for foo', score: 1 }]);
 
       const server = createSearchSkillsServer({ library, retriever });
-      await server.call({ query: 'foo', limit: 5 });
+      await server.call({ query: 'foo', limit: 10 });
 
-      expect(retriever.retrieve).toHaveBeenCalledWith('foo', 5);
+      expect(retriever.retrieve).toHaveBeenCalledWith('foo', 10);
     });
 
-    it('defaults limit to 25 when not specified', async () => {
+    it('defaults limit to 5 when not specified', async () => {
       const library = makeLibrary([makeEntry('foo')], { foo: 'body' });
       const retriever = makeRetriever([{ name: 'foo', description: 'Description for foo', score: 1 }]);
 
       const server = createSearchSkillsServer({ library, retriever });
       await server.call({ query: 'foo' });
 
-      expect(retriever.retrieve).toHaveBeenCalledWith('foo', 25);
+      expect(retriever.retrieve).toHaveBeenCalledWith('foo', 5);
+    });
+
+    it('clamps an oversized limit to the metadata max (50)', async () => {
+      const library = makeLibrary([makeEntry('foo')], { foo: 'body' });
+      const retriever = makeRetriever([{ name: 'foo', description: 'Description for foo', score: 1 }]);
+
+      const server = createSearchSkillsServer({ library, retriever });
+      await server.call({ query: 'foo', limit: 999 });
+
+      expect(retriever.retrieve).toHaveBeenCalledWith('foo', 50);
+    });
+  });
+
+  describe('call - includeBody mode', () => {
+    it('inlines bodies capped at maxBodyChars and flags truncation', async () => {
+      const longBody = 'x'.repeat(5000);
+      const library = makeLibrary([makeEntry('big')], { big: longBody });
+      const retriever = makeRetriever([{ name: 'big', description: 'Description for big', score: 1 }]);
+
+      const server = createSearchSkillsServer({ library, retriever });
+      const result = await server.call({ query: 'big', includeBody: true, maxBodyChars: 100 });
+
+      expect(result.results[0].body).toHaveLength(100);
+      expect(result.results[0].bodyTruncated).toBe(true);
+      expect(result.results[0].bodyChars).toBe(5000);
+    });
+
+    it('returns the full body when shorter than the cap', async () => {
+      const library = makeLibrary([makeEntry('small')], { small: '# Short' });
+      const retriever = makeRetriever([{ name: 'small', description: 'Description for small', score: 1 }]);
+
+      const server = createSearchSkillsServer({ library, retriever });
+      const result = await server.call({ query: 'small', includeBody: true });
+
+      expect(result.results[0].body).toBe('# Short');
+      expect(result.results[0].bodyTruncated).toBe(false);
+    });
+
+    it('caps the result count tighter when bodies are inlined (limit cap 8)', async () => {
+      const library = makeLibrary([makeEntry('foo')], { foo: 'body' });
+      const retriever = makeRetriever([{ name: 'foo', description: 'Description for foo', score: 1 }]);
+
+      const server = createSearchSkillsServer({ library, retriever });
+      await server.call({ query: 'foo', limit: 50, includeBody: true });
+
+      expect(retriever.retrieve).toHaveBeenCalledWith('foo', 8);
     });
   });
 
@@ -178,6 +235,58 @@ describe('createSearchSkillsServer', () => {
       await server.call({ query: 'real' });
 
       expect(library.list).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('readSkill - paginated body reader (issue #199)', () => {
+    it('returns the first page with totalChars and a nextOffset', async () => {
+      const body = 'a'.repeat(10000);
+      const library = makeLibrary([makeEntry('doc')], { doc: body });
+
+      const server = createSearchSkillsServer({ library });
+      const result = await server.readSkill({ name: 'doc', maxChars: 4000 });
+
+      expect(result.found).toBe(true);
+      expect(result.body).toHaveLength(4000);
+      expect(result.offset).toBe(0);
+      expect(result.totalChars).toBe(10000);
+      expect(result.nextOffset).toBe(4000);
+      expect(result.bodyTokenEstimate).toBe(2500);
+    });
+
+    it('reads the next page from nextOffset and reports the end with null', async () => {
+      const body = 'a'.repeat(6000);
+      const library = makeLibrary([makeEntry('doc')], { doc: body });
+
+      const server = createSearchSkillsServer({ library });
+      const page2 = await server.readSkill({ name: 'doc', offset: 4000, maxChars: 4000 });
+
+      expect(page2.body).toHaveLength(2000);
+      expect(page2.offset).toBe(4000);
+      expect(page2.nextOffset).toBeNull();
+    });
+
+    it('returns found:false for an unknown or blocked skill', async () => {
+      const library = makeLibrary([], { gone: null });
+
+      const server = createSearchSkillsServer({ library });
+      const result = await server.readSkill({ name: 'gone' });
+
+      expect(result.found).toBe(false);
+      expect(result.body).toBeUndefined();
+      expect(result.message).toContain('gone');
+    });
+
+    it('clamps an out-of-range offset to the body length', async () => {
+      const library = makeLibrary([makeEntry('doc')], { doc: 'short' });
+
+      const server = createSearchSkillsServer({ library });
+      const result = await server.readSkill({ name: 'doc', offset: 9999 });
+
+      expect(result.found).toBe(true);
+      expect(result.offset).toBe(5);
+      expect(result.body).toBe('');
+      expect(result.nextOffset).toBeNull();
     });
   });
 });


### PR DESCRIPTION
Fixes #199.

## Problem
`wayland_search_skills` returned the full markdown **body of every hit inline**, with a default `limit` of 25. A single search could serialise ~40k tokens, exceeding Claude Code's 25k-token cap when it persists the tool result — the agent then **cannot read its own search output** and the turn fails (reporter: `43361 tokens exceeds maximum 25000`).

This is app-side: the tool lives in the bundled MCP server (`searchSkillsServer.ts`), which has no equivalent in the engine. (Issue was labelled `area:core`; the engine maintainer confirmed the fix belongs here.)

## Fix — two-step retrieval
**Search** (`wayland_search_skills`) now returns lightweight metadata by default:
`{ name, description, score, excerpt, bodyChars, bodyTokenEstimate }`, with a smaller default `limit` of 5 (max 50). The `excerpt` strips leading YAML frontmatter and is capped, so the payload stays small.

**Bodies are fetched on demand**, two ways:
- `includeBody: true` inlines each body capped at `maxBodyChars` (default 2000), and the hit count is capped tighter (≤8) when bodies are inlined.
- New **`wayland_read_skill`** tool reads one skill's full body **page-by-page** (`offset` + `maxChars`, returns `totalChars` + `nextOffset`).

Every size knob is **re-clamped in the factory** (the robustness boundary), so oversized output is impossible regardless of caller input. Blocked/quarantined skills are still never surfaced.

## Tests
- `searchSkillsServer.test.ts`: 17/17. New coverage for metadata-only default (no inline body), frontmatter-stripped excerpt, `limit` defaults/clamps, `includeBody` truncation + tighter limit cap, and `readSkill` pagination / not-found / offset-clamp.
- Regression-verified: **11/17 fail against the pre-change source**, all 17 pass on the fix.
- `tsc --noEmit` clean; `oxlint` clean (no new warnings). Process-only change (no renderer/i18n surface).

No catalog/spawn wiring change: the second tool registers on the same stdio server; nothing allowlists the tool name (all references are advertising prose).