### PR TITLE
fix(wcore): pass WAYLAND_BASH_SHELL to the GUI-spawned engine (#197 sub#2)

### DIFF
--- a/src/process/agent/wcore/envBuilder.ts
+++ b/src/process/agent/wcore/envBuilder.ts
@@ -462,6 +462,13 @@ const ENGINE_ENV_ALLOWLIST: readonly string[] = [
   'TMP',
   'TEMP',
   'PWD',
+  // ── Wayland engine config (non-secret) ─────────────────────────────────
+  // The user's bash-tool shell selection. Set in the environment (never by the
+  // app), so a GUI-launched engine only receives it when it survives this
+  // filter; CLI/headless already inherit the full env. Without it the engine
+  // falls back to its default shell (#197). Reaches `full` via process.env or
+  // the login-shell capture (see SHELL_INHERITED_ENV_VARS in shellEnv.ts).
+  'WAYLAND_BASH_SHELL',
   // ── Windows system (load-bearing for spawning + DLL resolution) ─────────
   'SYSTEMROOT',
   'SYSTEMDRIVE',

--- a/src/process/utils/shellEnv.ts
+++ b/src/process/utils/shellEnv.ts
@@ -172,6 +172,7 @@ const SHELL_INHERITED_ENV_VARS = [
   'ANTHROPIC_AUTH_TOKEN', // Claude authentication (#776)
   'ANTHROPIC_API_KEY',
   'ANTHROPIC_BASE_URL',
+  'WAYLAND_BASH_SHELL', // User's bash-tool shell selection for the engine (#197)
 ] as const;
 
 /** Cache for shell environment (loaded once per session) */

--- a/tests/unit/wcore-toolKeyEnv.test.ts
+++ b/tests/unit/wcore-toolKeyEnv.test.ts
@@ -125,6 +125,14 @@ describe('buildEngineSpawnEnv - SEC-1 allowlist', () => {
     expect(env.HOME).toBe(process.env.HOME);
   });
 
+  it('forwards WAYLAND_BASH_SHELL so the GUI-spawned engine inherits the shell selection (#197)', () => {
+    process.env.WAYLAND_BASH_SHELL = '/opt/homebrew/bin/fish';
+
+    const env = buildEngineSpawnEnv({ providerEnv: {} });
+
+    expect(env.WAYLAND_BASH_SHELL).toBe('/opt/homebrew/bin/fish');
+  });
+
   it('always preserves the provider auth env even though it is a secret name', () => {
     const env = buildEngineSpawnEnv({ providerEnv: { ANTHROPIC_API_KEY: 'sk-ant-123' } });
     expect(env.ANTHROPIC_API_KEY).toBe('sk-ant-123');


### PR DESCRIPTION
Addresses **sub-issue #2** of #197 (the app half).

## Problem
A desktop-launched engine ignored the user's bash-tool shell selection and fell back to its default shell. CLI/headless runs were fine — they inherit the full environment.

Root cause is the SEC-1 engine-spawn allowlist: `buildEngineSpawnEnv()` filters the spawn env through `ENGINE_ENV_ALLOWLIST` (`envBuilder.ts`), which **omitted `WAYLAND_BASH_SHELL`**, so it was stripped before reaching the engine.

## Fix
Two one-line additions so the var is delivered on every launch mode, via the same inheritance path Wayland already uses for `ANTHROPIC_API_KEY` and the TLS/cert vars:
- **`ENGINE_ENV_ALLOWLIST`** (`envBuilder.ts`) — add `WAYLAND_BASH_SHELL` so it survives the spawn filter. Fixes launches where the var is already in `process.env` (terminal / `launchctl setenv`).
- **`SHELL_INHERITED_ENV_VARS`** (`shellEnv.ts`) — add it so `loadShellEnvironment()` captures it from the login shell on Finder/launchd launches, where `process.env` wouldn't otherwise carry it.

It's a non-secret, Wayland-namespaced config var, so no sandbox secret marker is needed.

**Residual limitation (same as every other inherited var today):** the login-shell probe is `<shell> -l -c env` (login, non-interactive), so a var exported only in an interactive rc (`.zshrc`/`.bashrc`) isn't captured — only login-profile exports (`.zprofile`/`.zshenv`) and `process.env` are. This matches how `PATH`/certs/provider-keys already behave.

## Tests
- `wcore-toolKeyEnv.test.ts`: new test asserts `buildEngineSpawnEnv` forwards `WAYLAND_BASH_SHELL`. Regression-verified — it **fails on the old allowlist**, passes on the fix. Full file 37 passed / 3 native-sqlite-skipped.
- `tsc --noEmit` clean; `oxlint` clean (no new warnings).

## Scope
App half only. Engine-side selector fix = wayland-core #62; sub-issues #3 (system32 resolution) and #4 (PowerShell-under-AppContainer DLL load) are engine-sandbox, not app-side. Does not touch the engine.