### PR TITLE
fix(models): let a remote WebUI add a local OpenAI-compatible endpoint (#71)

### DIFF
--- a/src/renderer/pages/settings/ModelsSettings/BrowseModal.tsx
+++ b/src/renderer/pages/settings/ModelsSettings/BrowseModal.tsx
@@ -276,13 +276,7 @@ const BrowseModal: React.FC<Props> = ({ visible, onClose, initialProvider, conne
         onClick={() => handlePick(provider)}
         aria-label={t('settings.modelsPage.browse.connectAria', { provider: provider.displayName })}
       >
-        <ProviderLogo
-          id={provider.id}
-          mono={provider.mono}
-          bg={provider.bg}
-          darkText={provider.darkText}
-          size={28}
-        />
+        <ProviderLogo id={provider.id} mono={provider.mono} bg={provider.bg} darkText={provider.darkText} size={28} />
         <span className={styles.tileText}>
           <span className={styles.tileName}>{provider.displayName}</span>
           {cloud && <span className={styles.tileSub}>{t('settings.modelsPage.browse.cloudTag')}</span>}

--- a/src/renderer/pages/settings/ModelsSettings/BrowseModal.tsx
+++ b/src/renderer/pages/settings/ModelsSettings/BrowseModal.tsx
@@ -33,6 +33,14 @@ type Props = {
    * the grid (spec §4.3).
    */
   initialProvider?: ProviderId;
+  /**
+   * Connect a single-key provider, threading an optional `baseUrl`. Supplied by
+   * the parent so the connect routes through its headless-aware path: on desktop
+   * the `modelRegistry.connect` IPC, in a remote/WebUI session the write-only
+   * `/api/providers/connect` HTTP route (the IPC is remote-denied). This is what
+   * lets a remote WebUI add a local OpenAI-compatible endpoint host-side (#71).
+   */
+  connectKey: (providerId: ProviderId, key: string, baseUrl?: string) => Promise<IModelRegistryConnectResult>;
 };
 
 /** Map a `ConnectError` code to its inline-error i18n key suffix. */
@@ -72,7 +80,7 @@ type CatalogState =
  * A successful connect closes the modal; `useModelRegistry.connect` reloads the
  * connected list on its own.
  */
-const BrowseModal: React.FC<Props> = ({ visible, onClose, initialProvider }) => {
+const BrowseModal: React.FC<Props> = ({ visible, onClose, initialProvider, connectKey }) => {
   const { t } = useTranslation();
   const { providers, connect, getProviderCatalog } = useModelRegistry();
 
@@ -210,8 +218,10 @@ const BrowseModal: React.FC<Props> = ({ visible, onClose, initialProvider }) => 
     setConnecting(true);
     setErrorKey(null);
     try {
-      const creds = baseUrl ? { key, baseUrl } : { key };
-      const res = await connect(view.provider.id, creds);
+      // Route through the parent's headless-aware connect so a remote/WebUI
+      // session adds the endpoint host-side over the write-only HTTP route
+      // instead of the remote-denied `modelRegistry.connect` IPC (#71).
+      const res = await connectKey(view.provider.id, key, baseUrl || undefined);
       if (res.ok) {
         onClose();
       } else {
@@ -222,7 +232,7 @@ const BrowseModal: React.FC<Props> = ({ visible, onClose, initialProvider }) => 
     } finally {
       setConnecting(false);
     }
-  }, [view, keyValue, baseUrlValue, connect, onClose]);
+  }, [view, keyValue, baseUrlValue, connectKey, onClose]);
 
   // ---- Cloud connect (passed to CloudCredentialForm) ---------------------
   const handleCloudConnect = useCallback(

--- a/src/renderer/pages/settings/ModelsSettings/index.tsx
+++ b/src/renderer/pages/settings/ModelsSettings/index.tsx
@@ -269,13 +269,16 @@ const ModelsSettingsInner: React.FC = () => {
   // (remote-secure-config W1.A). It returns status only; on success we reload
   // the read-only registry list (which IS remote-allowed) so the new row shows.
   const connectKey = useCallback(
-    async (providerId: ProviderId, key: string) => {
+    async (providerId: ProviderId, key: string, baseUrl?: string) => {
       if (headless) {
-        const res = await connectProviderHttp(providerId, key);
+        // The write-only HTTP route accepts an optional baseUrl (it forwards it
+        // to the same host-side connect the desktop IPC uses), so a remote WebUI
+        // can add a local OpenAI-compatible endpoint host-side (#71).
+        const res = await connectProviderHttp(providerId, key, baseUrl);
         if (res.ok) await reload();
         return res;
       }
-      return connect(providerId, { key });
+      return connect(providerId, baseUrl ? { key, baseUrl } : { key });
     },
     [headless, connect, reload]
   );
@@ -473,7 +476,12 @@ const ModelsSettingsInner: React.FC = () => {
         />
       </div>
 
-      <BrowseModal visible={browseOpen} onClose={handleBrowseClose} initialProvider={browseInitialProvider} />
+      <BrowseModal
+        visible={browseOpen}
+        onClose={handleBrowseClose}
+        initialProvider={browseInitialProvider}
+        connectKey={connectKey}
+      />
     </SettingsPageShell>
   );
 };

--- a/tests/unit/renderer/browseModal.dom.test.tsx
+++ b/tests/unit/renderer/browseModal.dom.test.tsx
@@ -57,6 +57,12 @@ vi.mock('react-i18next', () => ({
 // modelRegistry IPC surface (consumed by useModelRegistry + BrowseModal).
 const mockList = vi.fn();
 const mockConnect = vi.fn();
+// The single-key connect now routes through the parent's headless-aware
+// `connectKey(providerId, key, baseUrl?)` prop (#71); the cloud form still calls
+// the `connect` IPC directly. BrowseModal's contract is to invoke `connectKey`,
+// so the single-key tests assert against this mock; the parent owns the
+// desktop-vs-WebUI routing and is covered separately.
+const mockConnectKey = vi.fn();
 
 vi.mock('../../../src/common/adapter/ipcBridge', () => ({
   modelRegistry: {
@@ -99,13 +105,15 @@ const connectedProvider: IModelRegistryProviderView = {
 beforeEach(() => {
   mockList.mockReset().mockResolvedValue([]);
   mockConnect.mockReset().mockResolvedValue({ ok: true });
+  mockConnectKey.mockReset().mockResolvedValue({ ok: true });
 });
 
 afterEach(() => {
   vi.clearAllMocks();
 });
 
-const renderModal = (onClose: () => void = vi.fn()) => render(<BrowseModal visible onClose={onClose} />);
+const renderModal = (onClose: () => void = vi.fn()) =>
+  render(<BrowseModal visible onClose={onClose} connectKey={mockConnectKey} />);
 
 /** All provider-tile elements in DOM order. */
 const tiles = () => Array.from(document.querySelectorAll('[data-provider]'));
@@ -202,18 +210,15 @@ describe('BrowseModal', () => {
     fireEvent.change(keyInput, { target: { value: 'sk-test-key' } });
     fireEvent.click(screen.getByText('settings.modelsPage.browse.connect'));
 
-    await waitFor(() =>
-      expect(mockConnect).toHaveBeenCalledWith({
-        providerId: 'openai',
-        creds: { key: 'sk-test-key' },
-      })
-    );
+    // The single-key flow routes through the parent's `connectKey` prop (no
+    // baseUrl for a plain single-key provider).
+    await waitFor(() => expect(mockConnectKey).toHaveBeenCalledWith('openai', 'sk-test-key', undefined));
     // A successful connect closes the modal.
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 
   it('shows the inline error when a single-key connect fails', async () => {
-    mockConnect.mockResolvedValue({ ok: false, error: 'unauthorized' });
+    mockConnectKey.mockResolvedValue({ ok: false, error: 'unauthorized' });
     renderModal();
     await screen.findByText('settings.modelsPage.browse.group.frontier');
 
@@ -223,7 +228,7 @@ describe('BrowseModal', () => {
     fireEvent.change(keyInput, { target: { value: 'sk-bad-key' } });
     fireEvent.click(screen.getByText('settings.modelsPage.browse.connect'));
 
-    await waitFor(() => expect(mockConnect).toHaveBeenCalled());
+    await waitFor(() => expect(mockConnectKey).toHaveBeenCalled());
     const alert = await screen.findByRole('alert');
     expect(alert.textContent).toMatch(/browse\.errorUnauthorized/);
   });
@@ -368,11 +373,9 @@ describe('BrowseModal', () => {
     fireEvent.change(baseUrlInput, { target: { value: 'https://my-endpoint.example/v1' } });
     fireEvent.click(screen.getByText('settings.modelsPage.browse.connect'));
 
+    // openai-compatible threads the baseUrl through `connectKey`.
     await waitFor(() =>
-      expect(mockConnect).toHaveBeenCalledWith({
-        providerId: 'openai-compatible',
-        creds: { key: 'sk-anything', baseUrl: 'https://my-endpoint.example/v1' },
-      })
+      expect(mockConnectKey).toHaveBeenCalledWith('openai-compatible', 'sk-anything', 'https://my-endpoint.example/v1')
     );
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
@@ -387,12 +390,8 @@ describe('BrowseModal', () => {
     fireEvent.change(keyInput, { target: { value: 'sk-anything' } });
     fireEvent.click(screen.getByText('settings.modelsPage.browse.connect'));
 
-    await waitFor(() =>
-      expect(mockConnect).toHaveBeenCalledWith({
-        providerId: 'openai-compatible',
-        creds: { key: 'sk-anything' },
-      })
-    );
+    // A blank baseUrl is dropped to `undefined` before reaching `connectKey`.
+    await waitFor(() => expect(mockConnectKey).toHaveBeenCalledWith('openai-compatible', 'sk-anything', undefined));
   });
 
   it('does NOT render the Base URL input for non-openai-compatible single-key providers', async () => {

--- a/tests/unit/renderer/browseModalCatalog.dom.test.tsx
+++ b/tests/unit/renderer/browseModalCatalog.dom.test.tsx
@@ -60,6 +60,10 @@ vi.mock('react-i18next', () => ({
 const mockList = vi.fn();
 const mockConnect = vi.fn();
 const mockGetProviderCatalog = vi.fn();
+// The single-key connect (catalog + openai-compatible) now routes through the
+// parent's headless-aware `connectKey(providerId, key, baseUrl?)` prop (#71);
+// BrowseModal's contract is to invoke it, so these tests assert against it.
+const mockConnectKey = vi.fn();
 
 vi.mock('../../../src/common/adapter/ipcBridge', () => ({
   modelRegistry: {
@@ -105,6 +109,7 @@ const CATALOG_ENTRY = 'settings.modelsPage.browse.catalog.entry';
 beforeEach(() => {
   mockList.mockReset().mockResolvedValue([]);
   mockConnect.mockReset().mockResolvedValue({ ok: true });
+  mockConnectKey.mockReset().mockResolvedValue({ ok: true });
   mockGetProviderCatalog.mockReset().mockResolvedValue(catalogEntries);
 });
 
@@ -112,7 +117,8 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-const renderModal = (onClose: () => void = vi.fn()) => render(<BrowseModal visible onClose={onClose} />);
+const renderModal = (onClose: () => void = vi.fn()) =>
+  render(<BrowseModal visible onClose={onClose} connectKey={mockConnectKey} />);
 
 /** Open the catalog view from the grid. */
 const openCatalog = async () => {
@@ -202,12 +208,8 @@ describe('BrowseModal — named-provider catalog', () => {
     fireEvent.change(keyInput, { target: { value: 'sk-novita-key' } });
     fireEvent.click(screen.getByText('settings.modelsPage.browse.connect'));
 
-    await waitFor(() =>
-      expect(mockConnect).toHaveBeenCalledWith({
-        providerId: 'novita',
-        creds: { key: 'sk-novita-key' },
-      })
-    );
+    // Routes through `connectKey` with no baseUrl (the engine resolves it).
+    await waitFor(() => expect(mockConnectKey).toHaveBeenCalledWith('novita', 'sk-novita-key', undefined));
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 
@@ -246,11 +248,9 @@ describe('BrowseModal — named-provider catalog', () => {
     fireEvent.change(baseUrlInput, { target: { value: 'https://my-endpoint.example/v1' } });
     fireEvent.click(screen.getByText('settings.modelsPage.browse.connect'));
 
+    // The manual baseUrl is threaded through `connectKey` as its third arg.
     await waitFor(() =>
-      expect(mockConnect).toHaveBeenCalledWith({
-        providerId: 'openai-compatible',
-        creds: { key: 'sk-custom', baseUrl: 'https://my-endpoint.example/v1' },
-      })
+      expect(mockConnectKey).toHaveBeenCalledWith('openai-compatible', 'sk-custom', 'https://my-endpoint.example/v1')
     );
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });

--- a/tests/unit/renderer/modelsSettings.dom.test.tsx
+++ b/tests/unit/renderer/modelsSettings.dom.test.tsx
@@ -54,6 +54,8 @@ const mockDetectKeys = vi.fn();
 const mockConnect = vi.fn();
 const mockDisconnect = vi.fn();
 const mockGoogleLogin = vi.fn();
+// Headless write-only HTTP connect route (remote WebUI path).
+const mockConnectProviderHttp = vi.fn();
 
 vi.mock('../../../src/common/adapter/ipcBridge', () => ({
   modelRegistry: {
@@ -77,6 +79,11 @@ vi.mock('../../../src/common/adapter/ipcBridge', () => ({
     setAutoRefresh: { invoke: vi.fn().mockResolvedValue({ ok: true }) },
     listChanged: { on: vi.fn(() => vi.fn()) },
   },
+}));
+
+// Write-only provider-key HTTP client (the headless/remote WebUI connect path).
+vi.mock('../../../src/renderer/services/ProviderKeyService', () => ({
+  connectProviderHttp: (...a: unknown[]) => mockConnectProviderHttp(...a),
 }));
 
 // `@/common` barrel - GoogleButton imports `ipcBridge` from here.
@@ -139,6 +146,7 @@ beforeEach(() => {
   mockConnect.mockReset().mockResolvedValue({ ok: true });
   mockDisconnect.mockReset().mockResolvedValue({ ok: true });
   mockGoogleLogin.mockReset().mockResolvedValue({ success: true, data: { account: '' } });
+  mockConnectProviderHttp.mockReset().mockResolvedValue({ ok: true });
   // Default: no pending deep-link. Tests opt in by overriding per case.
   mockConsumePendingDeepLink.mockReset().mockReturnValue(null);
 });
@@ -318,6 +326,52 @@ describe('ModelsSettings page', () => {
     // The page should not announce a detected OpenAI key alongside the
     // connected row - exactly one detected-row should be present.
     expect(screen.queryByText(/detected\.found:provider=OpenAI/)).not.toBeInTheDocument();
+  });
+
+  it('routes a headless OpenAI-compatible add through the host-side HTTP route with baseUrl (#71)', async () => {
+    // Remote/WebUI session: no electronAPI, so isElectronDesktop() is false and
+    // the page is headless. Adding a local OpenAI-compatible endpoint from Browse
+    // must go through the write-only /api/providers/connect route (host-side),
+    // carrying the baseUrl, NOT the remote-denied modelRegistry.connect IPC.
+    mockList.mockResolvedValue([]);
+    mockDetectKeys.mockResolvedValue([]);
+    mockConnectProviderHttp.mockResolvedValue({ ok: true });
+
+    const savedElectronAPI = (window as unknown as { electronAPI?: unknown }).electronAPI;
+    delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+    try {
+      renderPage();
+
+      // Open Browse, pick the OpenAI-compatible BYO tile. Arco's Modal renders
+      // in a portal on document.body, so query the document, not the container.
+      fireEvent.click(await screen.findByText('settings.modelsPage.connect.browse'));
+      const tile = await waitFor(() => {
+        const el = document.querySelector('[data-provider="openai-compatible"]');
+        if (!el) throw new Error('openai-compatible tile not found');
+        return el as HTMLElement;
+      });
+      fireEvent.click(tile);
+
+      // Fill the api key + the custom endpoint base URL.
+      const keyInput = await screen.findByPlaceholderText('settings.modelsPage.browse.keyPlaceholder');
+      fireEvent.change(keyInput, { target: { value: 'sk-local-test' } });
+      const baseUrlInput = screen.getByPlaceholderText('settings.modelsPage.browse.baseUrlPlaceholder');
+      fireEvent.change(baseUrlInput, { target: { value: 'http://127.0.0.1:8003/v1' } });
+
+      fireEvent.click(screen.getByText('settings.modelsPage.browse.connect'));
+
+      await waitFor(() =>
+        expect(mockConnectProviderHttp).toHaveBeenCalledWith(
+          'openai-compatible',
+          'sk-local-test',
+          'http://127.0.0.1:8003/v1'
+        )
+      );
+      // The remote-denied IPC is never used in headless mode.
+      expect(mockConnect).not.toHaveBeenCalled();
+    } finally {
+      (window as unknown as { electronAPI?: unknown }).electronAPI = savedElectronAPI;
+    }
   });
 
   it('shares one providers snapshot across the page and the Browse modal (shared registry state)', async () => {


### PR DESCRIPTION
Fixes #71.

## Root cause (not what the original report assumed)
The connection-test is **not** the blocker — `mode.fetchModelList` is a host-side `buildProvider` and isn't remote-denied, so it already runs on the host over the WS. The wall is the **persist/connect** step: BrowseModal's single-key connect called `modelRegistry.connect` directly, which is in `REMOTE_DENIED_KEYS` (a paired WebUI must never reach the credential-write IPC). So adding *any* provider — including a local OpenAI-compatible endpoint — from a remote WebUI dead-ended.

## Fix — reuse the existing host-side write seam
There's already a write-only HTTP route for exactly this — `/api/providers/connect` (`providerKeyRoutes.ts`, W1.A): it accepts `{ providerId, key, baseUrl? }`, runs the **same** `connectModelRegistryProvider` path the desktop IPC uses (test + encrypt-to-keychain + catalog), and returns **status only**, never a key. `ModelsSettings` already routed `ConnectPanel` through it via the headless-aware `connectKey` helper — but `BrowseModal` (the only screen with a base-URL field) wasn't wired through it.

- `index.tsx`: thread an optional `baseUrl` through `connectKey` (desktop → IPC `connect`; headless → `connectProviderHttp`, which already forwards `baseUrl`). Pass `connectKey` into `BrowseModal`.
- `BrowseModal.tsx`: single-key connect now calls the parent's `connectKey` instead of `useModelRegistry().connect`, threading the `openai-compatible` `baseUrl`.

The local endpoint is now added **host-side** (so `127.0.0.1` resolves on the host, not the client). Desktop stays on the IPC path; the bridge allowlist and the `modelRegistry.connect` remote-deny are **untouched** — no new credential surface, no SSRF widening (the host-side connect runs the same safe-base-URL guard as desktop).

## Scope
Single-key / OpenAI-compatible only. Cloud multi-field providers (AWS Bedrock etc.) keep their existing IPC path — the HTTP route is `key`+`baseUrl` only, so remote multi-field add is a separate, larger change. Keyless-local also untouched (desktop's own form requires a key today; relaxing it is a consistent-both-sides enhancement, not this bug).

## Tests
`modelsSettings.dom.test.tsx`: new headless case asserts an `openai-compatible` add routes through `connectProviderHttp` **with the baseUrl** and **never** the remote-denied `modelRegistry.connect` IPC. Regression-verified: **fails on the pre-fix source**, passes on the fix. Full file 40/40; `providerKeyRoutes` 9/9; `tsc` clean; `oxlint` clean (no new warnings); i18n gate clean (no new keys).

## Remaining E2E (optional)
A droplet run (a `/v1/models` reachable only from the host, added via a remote WebUI from another machine) would confirm host-side execution end-to-end. The fix reuses the already-proven W1.A host-side route, and the unit test pins the routing, so this is gold-plating rather than a gate.