### PR TITLE
fix(team): scope a Gemini teammate's model to its Gemini provider (#207)

### DIFF
--- a/src/process/team/TeamSessionService.ts
+++ b/src/process/team/TeamSessionService.ts
@@ -15,7 +15,7 @@ import type { IWorkerTaskManager } from '@process/task/IWorkerTaskManager';
 import type { IConversationService } from '@process/services/IConversationService';
 import type { AgentType } from '@process/task/agentTypes';
 import type { AgentBackend } from '@/common/types/acpTypes';
-import type { TChatConversation, TProviderWithModel } from '@/common/config/storage';
+import type { IProvider, TChatConversation, TProviderWithModel } from '@/common/config/storage';
 import { ProcessConfig } from '@process/utils/initStorage';
 import { getAssistantsDir } from '@process/utils/initStorage';
 import { EventLogger } from './EventLogger';
@@ -207,13 +207,31 @@ export class TeamSessionService {
    * default-resolved provider's (which could send an sk-flux key to an OpenAI
    * surface). Shared by the wcore and gemini pin paths.
    */
-  private async resolveOwningProviderModelById(modelId: string): Promise<TProviderWithModel | null> {
+  private async resolveOwningProviderModelById(
+    modelId: string,
+    conversationType?: string
+  ): Promise<TProviderWithModel | null> {
     const configuredProviders = await ProcessConfig.get('model.config');
     const providers = Array.isArray(configuredProviders) ? configuredProviders.filter((p) => p.enabled !== false) : [];
 
-    const owner = providers.find(
-      (p) => Array.isArray(p.model) && p.model.includes(modelId) && p.modelEnabled?.[modelId] !== false
-    );
+    const owns = (p: IProvider): boolean =>
+      Array.isArray(p.model) && p.model.includes(modelId) && p.modelEnabled?.[modelId] !== false;
+
+    // For a Gemini teammate, only a Gemini/Google provider may own the model id.
+    // Otherwise an unrelated provider that merely lists the same id (e.g.
+    // OpenRouter listing "gemma") hijacks the route and sends a Google model to
+    // the wrong endpoint, which 401s (#207). When no Gemini provider owns it,
+    // return null so the caller falls back to the default-resolved Gemini
+    // provider rather than the first foreign match.
+    if (conversationType === 'gemini') {
+      const geminiOwner = providers.find((p) => {
+        const platform = p.platform?.toLowerCase() || '';
+        return owns(p) && (platform.includes('gemini') || platform.includes('google'));
+      });
+      return geminiOwner ? ({ ...geminiOwner, useModel: modelId } as TProviderWithModel) : null;
+    }
+
+    const owner = providers.find(owns);
     if (!owner) {
       return null;
     }
@@ -463,7 +481,7 @@ export class TeamSessionService {
         // useModel-only override on the already-resolved provider when no
         // enabled provider claims it - e.g. a Google-auth Gemini model that
         // lives outside model.config.
-        const owned = await this.resolveOwningProviderModelById(agent.model);
+        const owned = await this.resolveOwningProviderModelById(agent.model, type);
         model = owned ?? { ...model, useModel: agent.model };
       }
     }

--- a/tests/unit/process/team/teamSession-resolveOwningProvider.test.ts
+++ b/tests/unit/process/team/teamSession-resolveOwningProvider.test.ts
@@ -1,0 +1,133 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Regression for #207 (gemma -> OpenRouter half): a Gemini teammate pinned to a
+// model id (e.g. "gemma") that an unrelated provider (OpenRouter) also lists was
+// routed to that foreign provider's key/baseUrl, because the owner lookup
+// returned the FIRST provider in config order that listed the id, with no
+// awareness of the teammate's backend. The fix scopes the Gemini owner search to
+// Gemini/Google-platform providers and returns null otherwise so the caller
+// falls back to the default-resolved Gemini provider.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockConfigGet } = vi.hoisted(() => ({ mockConfigGet: vi.fn() }));
+
+vi.mock('@process/utils/initStorage', () => ({
+  ProcessConfig: { get: mockConfigGet },
+  getAssistantsDir: () => '/assistants',
+}));
+
+import { TeamSessionService } from '@process/team/TeamSessionService';
+import type { ITeamRepository } from '@process/team/repository/ITeamRepository';
+import type { IConversationService } from '@process/services/IConversationService';
+import type { IProvider, TProviderWithModel } from '@/common/config/storage';
+
+function makeRepo(): ITeamRepository {
+  return {
+    create: vi.fn(),
+    findById: vi.fn(),
+    findAll: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    deleteMailboxByTeam: vi.fn(),
+    deleteTasksByTeam: vi.fn(),
+    writeMessage: vi.fn(),
+    readUnread: vi.fn(),
+    readUnreadAndMark: vi.fn(),
+    markRead: vi.fn(),
+    getMailboxHistory: vi.fn(),
+    createTask: vi.fn(),
+    findTaskById: vi.fn(),
+    updateTask: vi.fn(),
+    findTasksByTeam: vi.fn(),
+    findTasksByOwner: vi.fn(),
+    deleteTask: vi.fn(),
+    appendToBlocks: vi.fn(),
+    removeFromBlockedBy: vi.fn(),
+    appendEvent: vi.fn(),
+    listEvents: vi.fn(),
+  } as unknown as ITeamRepository;
+}
+
+function makeConversationService(): IConversationService {
+  return {
+    createConversation: vi.fn(),
+    deleteConversation: vi.fn(),
+    updateConversation: vi.fn(),
+    getConversation: vi.fn(),
+    createWithMigration: vi.fn(),
+    listAllConversations: vi.fn(),
+  } as unknown as IConversationService;
+}
+
+function makeProvider(overrides: Partial<IProvider> & { platform: string; model: string[] }): IProvider {
+  return {
+    id: overrides.platform,
+    name: overrides.platform,
+    baseUrl: '',
+    apiKey: '',
+    enabled: true,
+    ...overrides,
+  } as IProvider;
+}
+
+type OwnerProbe = {
+  resolveOwningProviderModelById: (
+    modelId: string,
+    conversationType?: string
+  ) => Promise<TProviderWithModel | null>;
+};
+
+function makeService(): OwnerProbe {
+  const svc = new TeamSessionService(
+    makeRepo(),
+    { getOrBuildTask: vi.fn(), kill: vi.fn() } as never,
+    makeConversationService()
+  );
+  return svc as unknown as OwnerProbe;
+}
+
+describe('TeamSessionService.resolveOwningProviderModelById - backend scoping (#207)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('prefers the Gemini provider over a foreign provider that also lists the id', async () => {
+    // OpenRouter is listed FIRST and also owns "gemma" - the old code returned it.
+    mockConfigGet.mockResolvedValue([
+      makeProvider({ platform: 'openrouter', model: ['gemma', 'gpt-4o'] }),
+      makeProvider({ platform: 'gemini', model: ['gemma', 'gemini-2.5-pro'] }),
+    ]);
+
+    const owned = await makeService().resolveOwningProviderModelById('gemma', 'gemini');
+
+    expect(owned?.platform).toBe('gemini');
+    expect(owned?.useModel).toBe('gemma');
+  });
+
+  it('returns null for a Gemini teammate when only a foreign provider owns the id', async () => {
+    // No Gemini provider claims "gemma" - the caller must fall back to the
+    // default-resolved Gemini provider, NOT hijack to OpenRouter.
+    mockConfigGet.mockResolvedValue([makeProvider({ platform: 'openrouter', model: ['gemma'] })]);
+
+    const owned = await makeService().resolveOwningProviderModelById('gemma', 'gemini');
+
+    expect(owned).toBeNull();
+  });
+
+  it('keeps first-match behavior for non-Gemini (wcore) teammates', async () => {
+    mockConfigGet.mockResolvedValue([
+      makeProvider({ platform: 'openrouter', model: ['deepseek-chat'] }),
+      makeProvider({ platform: 'deepseek', model: ['deepseek-chat'] }),
+    ]);
+
+    const owned = await makeService().resolveOwningProviderModelById('deepseek-chat', 'wcore');
+
+    expect(owned?.platform).toBe('openrouter');
+    expect(owned?.useModel).toBe('deepseek-chat');
+  });
+});


### PR DESCRIPTION
## Problem (#207, symptom 2)
A Team **gemini** member pinned to a model id like `gemma` was routed to **OpenRouter** (or any provider that also lists that id) instead of Google, so inference 401s/fails.

Root cause: `TeamSessionService.resolveOwningProviderModelById(modelId)` returned the **first** enabled provider in config order whose `model[]` includes the id, with no awareness of the teammate's backend. When OpenRouter is connected and lists `gemma`, it wins the lookup and its key/baseUrl hydrate the spawn.

## Fix
Thread the teammate's resolved conversation `type` into `resolveOwningProviderModelById`. For a `gemini` teammate, scope the owner search to **Gemini/Google-platform** providers; return `null` when none own it so the caller falls back to the **default-resolved Gemini provider** (the correct Google route) rather than the first foreign match. Non-gemini (wcore) resolution is unchanged.

## Tests
`tests/unit/process/team/teamSession-resolveOwningProvider.test.ts`:
- Gemini teammate prefers the Gemini provider over an OpenRouter provider listed first (fails on old code)
- returns null when only a foreign provider owns the id (caller falls back to Google)
- preserves first-match behavior for non-gemini (wcore) teammates

tsc clean, no new lint warnings on changed lines, 341 team+import tests pass.

## Not in this PR — #207 symptom 1 (Flux-Fast revert)
The other half (a **claude** teammate's native model pick reverting to Flux Fast after the 1.5s poll) is **not** fixed here. It lives in the **shared** `AcpModelSelector`/`acpModelPin` picker used by normal conversations too. Static analysis shows the likely cause is a respawn-on-native-pick remounting the selector (new `conversationId` key) and re-initializing `selectedFluxModelRef` from the Flux `initialModelId`. A naive guard (`&& !userChangedModel` on the Flux pin) would regress *deliberate* Flux selection in conversations, so a safe fix needs a live runtime trace. Keeping #207 open for that half.