### PR TITLE
fix(model): hold a native Claude pick against the agent's reported model (#207)

### DIFF
--- a/src/renderer/components/agent/AcpModelSelector.tsx
+++ b/src/renderer/components/agent/AcpModelSelector.tsx
@@ -128,11 +128,12 @@ const AcpModelSelector: React.FC<{
           showFlux,
           userChangedModel: hasUserChangedModel.current,
           selectedModelId: selectedModelRef.current,
+          backend,
         });
         return isSameModelInfo(prev, next) ? prev : next;
       });
     },
-    [showFlux]
+    [showFlux, backend]
   );
 
   const loadCachedModelInfo = useCallback(

--- a/src/renderer/components/agent/acpModelPin.ts
+++ b/src/renderer/components/agent/acpModelPin.ts
@@ -20,15 +20,32 @@ import type { AcpModelInfo } from '@/common/types/acpTypes';
  */
 export function resolvePinnedModelInfo(
   next: AcpModelInfo,
-  pins: { fluxModelId: FluxModelId | null; showFlux: boolean; userChangedModel: boolean; selectedModelId: string | null }
+  pins: {
+    fluxModelId: FluxModelId | null;
+    showFlux: boolean;
+    userChangedModel: boolean;
+    selectedModelId: string | null;
+    backend?: string;
+  }
 ): AcpModelInfo {
   if (pins.fluxModelId && pins.showFlux) {
     return { ...next, currentModelId: pins.fluxModelId, currentModelLabel: FLUX_MODEL_DISPLAY[pins.fluxModelId] };
   }
   const sel = pins.selectedModelId;
-  if (pins.userChangedModel && sel && next.currentModelId !== sel && next.availableModels.some((m) => m.id === sel)) {
-    const label = next.availableModels.find((m) => m.id === sel)?.label || sel;
-    return { ...next, currentModelId: sel, currentModelLabel: label };
+  if (pins.userChangedModel && sel) {
+    // The Claude picker emits registry ids ("claude-opus-4-8") while the agent
+    // advertises slot ids ("opus"/"sonnet"/"haiku"). An exact-only match leaves
+    // the native pin dead for Claude, so the display falls through to the agent's
+    // reported model on every 1.5s poll - Flux for a flux-routed teammate, i.e.
+    // the pick visibly reverts to Flux Fast (#207). Match the pick to an
+    // available slot (Claude only, to avoid false matches on other ACP backends)
+    // and pin THAT slot's id + friendly label so the selection holds.
+    const match = next.availableModels.find(
+      (m) => m.id === sel || (pins.backend === 'claude' && sel.toLowerCase().includes(m.id.toLowerCase()))
+    );
+    if (match && next.currentModelId !== match.id) {
+      return { ...next, currentModelId: match.id, currentModelLabel: match.label || match.id };
+    }
   }
   return next;
 }

--- a/tests/unit/acpModelPin.test.ts
+++ b/tests/unit/acpModelPin.test.ts
@@ -68,4 +68,44 @@ describe('resolvePinnedModelInfo', () => {
     });
     expect(out.currentModelId).toBe('opus');
   });
+
+  // #207: the Claude flyout emits registry ids ("claude-opus-4-8") while the
+  // agent advertises slot ids ("opus"). An exact-only match left the native pin
+  // dead, so a flux-routed Claude teammate's native pick fell through to the
+  // agent's reported Flux model on every poll (reverted to Flux Fast).
+  it('holds a native Claude pick when the flyout id is a registry id and the agent reports Flux (#207)', () => {
+    const out = resolvePinnedModelInfo(info('flux-fast', ['sonnet', 'opus', 'haiku']), {
+      fluxModelId: null, // selectedFluxModelRef is cleared once a native model is picked
+      showFlux: true,
+      userChangedModel: true,
+      selectedModelId: 'claude-opus-4-8',
+      backend: 'claude',
+    });
+    expect(out.currentModelId).toBe('opus');
+    expect(out.currentModelLabel).toBe('OPUS'); // friendly slot label, not the raw registry id
+  });
+
+  it('maps the Claude registry id to the matching slot (sonnet, not opus) (#207)', () => {
+    const out = resolvePinnedModelInfo(info('flux-fast', ['sonnet', 'opus', 'haiku']), {
+      fluxModelId: null,
+      showFlux: true,
+      userChangedModel: true,
+      selectedModelId: 'claude-sonnet-4-6',
+      backend: 'claude',
+    });
+    expect(out.currentModelId).toBe('sonnet');
+  });
+
+  it('does NOT substring-match for non-Claude backends (no false slot match)', () => {
+    // For codex, "gpt-5-codex" must NOT be coerced onto the available "gpt-5".
+    const next = info('o3', ['gpt-5', 'o3']);
+    const out = resolvePinnedModelInfo(next, {
+      ...NO_PINS,
+      userChangedModel: true,
+      selectedModelId: 'gpt-5-codex',
+      backend: 'codex',
+    });
+    expect(out).toBe(next);
+    expect(out.currentModelId).toBe('o3');
+  });
 });


### PR DESCRIPTION
## Problem (#207, symptom 1)
A Team member with backend **claude** shows **Flux Fast**; picking a native slot (e.g. *Claude Sonnet 4.6*) holds for ~1.5s then reverts to Flux Fast.

## Root cause (confirmed live via CDP)
The curated Claude picker emits **registry ids** (`claude-opus-4-8`), but the Claude agent advertises **slot ids** (`opus`/`sonnet`/`haiku`). `resolvePinnedModelInfo`'s native pin used an exact match — `availableModels.some(m => m.id === sel)` — which is **never true for Claude**. So the user's pick was dropped on every 1.5s poll and the pill fell through to whatever the agent reported. For a flux-routed teammate the agent's report is the Flux model → the pick visibly reverts to **Flux Fast**.

Live trace (instrumented build, then removed): with the agent reporting `sonnet` and the user picking `claude-opus-4-8`, the old logic produced `out: sonnet`; the fix produces `out: opus` and the pill holds **Opus**.

Two earlier hypotheses were **refuted** during the live session:
- *Remount* — `respawnForRoutingChange` reuses the same `conversation_id`, so the selector does not remount.
- *A `!userChangedModel` guard on the Flux pin* — that would break **deliberate** Flux selection in normal conversations.

## Fix
In `resolvePinnedModelInfo`, match the picked id to an available slot using a Claude-gated substring match (the 3 Claude slots are unambiguous), and pin **that slot's id + friendly label**. Non-Claude ACP backends keep exact-match only (no false matches — covered by a test). The Flux pin path is unchanged.

## Tests
`tests/unit/acpModelPin.test.ts` (+3, fails on old code):
- holds a native Claude pick when the flyout id is a registry id and the agent reports Flux
- maps the registry id to the correct slot (sonnet, not opus)
- does NOT substring-match for non-Claude backends (codex `gpt-5-codex` ≠ `gpt-5`)

17/17 pin+selector tests pass, tsc clean, oxlint 0/0. Closes the symptom-1 half of #207 (symptom 2 shipped in #217).