### PR TITLE
build(wcore): bump bundled engine to v0.12.5

### DIFF
--- a/scripts/bundled-wcore-shasums.json
+++ b/scripts/bundled-wcore-shasums.json
@@ -1,5 +1,13 @@
 {
   "_comment": "Authoritative SHA-256 checksums for bundled wayland-core release archives (the downloaded .tar.gz / .zip assets), keyed by release tag then asset filename. Mirrors scripts/bundled-bun-shasums.json. Source of truth: the SHASUMS published alongside each signed FerroxLabs/wayland-core release. The downloaded archive is verified against this file BEFORE it is extracted, copied, or executed. Update this file in lockstep with DEFAULT_WCORE_VERSION in scripts/prepareWaylandCore.js and regenerate on every engine version bump.",
+  "v0.12.5": {
+    "wayland-core-v0.12.5-aarch64-apple-darwin.tar.gz": "sha256:181a553cf980906d88719ddaf32adc62c4bee0e24454c1d21c8a1a031c075e81",
+    "wayland-core-v0.12.5-x86_64-apple-darwin.tar.gz": "sha256:ce875df133d1949ad8bbfdf6d32e2d3272480b77591bd69c0b74e0f93695f8a9",
+    "wayland-core-v0.12.5-aarch64-unknown-linux-gnu.tar.gz": "sha256:5d7d80b63c3e32bed8182f3e502f1b5af8a6a58b1d4f8ed2a6dde97bfe9eda90",
+    "wayland-core-v0.12.5-x86_64-unknown-linux-gnu.tar.gz": "sha256:2516bde1f5e77ed691a26a950a2dfabb782fae5268f8299f2188ad86bf7b5257",
+    "wayland-core-v0.12.5-aarch64-pc-windows-msvc.zip": "sha256:689f32fc3f5b99b9136ed1a3e17750076fe5aeed863d65698272dee1b7b72b70",
+    "wayland-core-v0.12.5-x86_64-pc-windows-msvc.zip": "sha256:379e0adb44fd638c43e4d5f842f1573976d73d301e64e17d808ef2ea1d4a876f"
+  },
   "_ownerAction": "Fill in the canonical per-platform archive SHA-256 values from the signed wayland-core release for each tag below. Until the real values are present, release builds (CI=1 / npm_config_production / NODE_ENV=production without WCORE_ALLOW_UNVERIFIED=1) will fail closed on a missing entry. The 'PENDING-...' placeholders are intentionally invalid 64-hex strings so they can never accidentally match a real artifact.",
   "v0.12.3": {
     "wayland-core-v0.12.3-aarch64-apple-darwin.tar.gz": "sha256:9f79bd8e8c18d0517a8ef03845ffb2de9e4c5f6779cbba5a618f180e41613cf9",

--- a/scripts/prepareWaylandCore.js
+++ b/scripts/prepareWaylandCore.js
@@ -184,7 +184,7 @@ function verifyArchiveChecksum(archivePath, expectedHex, assetName, tag) {
 // FerroxLabs/wayland-core; Desktop integrates against a specific tag rather
 // than tracking `latest` so version drift can't sneak in via a release made
 // while a CI build is mid-flight. Override with WCORE_VERSION=... when bumping.
-const DEFAULT_WCORE_VERSION = 'v0.12.3';
+const DEFAULT_WCORE_VERSION = 'v0.12.5';
 
 function getVersion() {
   return (process.env.WCORE_VERSION || DEFAULT_WCORE_VERSION).trim();


### PR DESCRIPTION
Bumps the bundled wayland-core engine **v0.12.3 → v0.12.5** for the upcoming release.

Two coupled edits, applied via `scripts/stage-wcore-bump.mjs` (PR #222) — no hand-transcribed checksums:
- `DEFAULT_WCORE_VERSION` → `v0.12.5`
- six-archive SHA-256 block added to `bundled-wcore-shasums.json`, sourced from the signed release's `wayland-core-checksums.txt`.

**Verified locally:** `WCORE_REQUIRE_VERIFIED=1 WCORE_FORCE_DOWNLOAD=1 node scripts/prepareWaylandCore.js` downloaded + SHA-matched darwin-arm64 (`181a553c…`); the bundled binary reports `wayland-core 0.12.5`. CI re-downloads + verifies all six platform archives.

Merge after #222 (the helper) or standalone — the committed shasums are self-contained either way.