### PR TITLE
fix(projects): surface the real cause when a New-Project draft fails

### DIFF
--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -129,9 +129,8 @@ export const conversation = {
    * (re-reading the same content / a command failing repeatedly). Carries the
    * conversation + reason so the renderer can explain why it stopped.
    */
-  runawayHalted: buildEmitter<import('@process/services/runaway/RunawayMonitor').RunawayHalted>(
-    'conversation.runaway-halted'
-  ),
+  runawayHalted:
+    buildEmitter<import('@process/services/runaway/RunawayMonitor').RunawayHalted>('conversation.runaway-halted'),
   listChanged: buildEmitter<IConversationListChangedEvent>('conversation.list-changed'),
   getWorkspace: buildProvider<
     IDirOrFile[],

--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -2699,7 +2699,7 @@ export const project = {
    * takes name/description directly rather than a project id. Never rejects.
    */
   generateKnowledgeDraft: buildProvider<
-    { draft: string; error?: 'no-model' | 'failed' },
+    { draft: string; error?: 'no-model' | 'failed'; detail?: string },
     {
       name?: string;
       description?: string;

--- a/src/process/bridge/projectBridge.ts
+++ b/src/process/bridge/projectBridge.ts
@@ -265,7 +265,10 @@ export function initProjectBridge(): void {
       } catch (err) {
         console.error('[projectBridge] generateKnowledgeDraft failed:', err);
         const msg = err instanceof Error ? err.message : '';
-        return { draft: '', error: msg === 'no-usable-model' ? 'no-model' : 'failed' };
+        if (msg === 'no-usable-model') return { draft: '', error: 'no-model' };
+        // Surface the real cause (provider status + message, or an abort/timeout)
+        // so the wizard can tell the user WHY instead of a dead-end 'failed' (#221).
+        return { draft: '', error: 'failed', detail: msg || undefined };
       }
     }
   );

--- a/src/renderer/pages/projects/components/KnowledgeWizard.tsx
+++ b/src/renderer/pages/projects/components/KnowledgeWizard.tsx
@@ -49,6 +49,9 @@ const KnowledgeWizard: React.FC<{
   const [draft, setDraft] = useState('');
   const [generating, setGenerating] = useState(false);
   const [genError, setGenError] = useState<'no-model' | 'failed' | null>(null);
+  // Underlying provider cause for a 'failed' draft (e.g. '401: invalid key'), so
+  // the user sees WHY instead of a dead-end message (#221).
+  const [genDetail, setGenDetail] = useState<string | null>(null);
 
   const AUDIENCE_CHIPS = useMemo(
     () => [
@@ -104,9 +107,10 @@ const KnowledgeWizard: React.FC<{
   const generate = useCallback(async () => {
     setGenerating(true);
     setGenError(null);
+    setGenDetail(null);
     try {
       const constraintText = [...constraints, extra.trim()].filter(Boolean).join('; ');
-      const { draft: out, error } = await ipcBridge.project.generateKnowledgeDraft.invoke({
+      const { draft: out, error, detail } = await ipcBridge.project.generateKnowledgeDraft.invoke({
         name: projectName,
         description: projectDescription,
         kind,
@@ -116,8 +120,10 @@ const KnowledgeWizard: React.FC<{
         audience: audience.length > 0 ? audience.join(', ') : undefined,
         constraints: constraintText || undefined,
       });
-      if (error) setGenError(error);
-      else if (out) setDraft(out);
+      if (error) {
+        setGenError(error);
+        setGenDetail(detail ?? null);
+      } else if (out) setDraft(out);
       else setGenError('failed');
     } catch {
       setGenError('failed');
@@ -286,6 +292,11 @@ const KnowledgeWizard: React.FC<{
                         ? t('projects.wizard.draft.noModel')
                         : t('projects.wizard.draft.failed')}
                     </span>
+                    {genError === 'failed' && genDetail && (
+                      <span className='max-w-340px text-11px text-t-tertiary'>
+                        {t('projects.wizard.draft.failedReason', { detail: genDetail })}
+                      </span>
+                    )}
                     {genError === 'failed' && (
                       <Button size='small' icon={<RefreshCw size={13} />} onClick={() => void generate()}>
                         {t('projects.wizard.draft.retry')}

--- a/src/renderer/pages/projects/components/KnowledgeWizard.tsx
+++ b/src/renderer/pages/projects/components/KnowledgeWizard.tsx
@@ -110,7 +110,11 @@ const KnowledgeWizard: React.FC<{
     setGenDetail(null);
     try {
       const constraintText = [...constraints, extra.trim()].filter(Boolean).join('; ');
-      const { draft: out, error, detail } = await ipcBridge.project.generateKnowledgeDraft.invoke({
+      const {
+        draft: out,
+        error,
+        detail,
+      } = await ipcBridge.project.generateKnowledgeDraft.invoke({
         name: projectName,
         description: projectDescription,
         kind,
@@ -142,8 +146,7 @@ const KnowledgeWizard: React.FC<{
     t('projects.wizard.step.questions'),
     t('projects.wizard.step.draft'),
   ];
-  const heading =
-    kind === 'rules' ? t('projects.wizard.titleRules') : t('projects.wizard.titleInstructions');
+  const heading = kind === 'rules' ? t('projects.wizard.titleRules') : t('projects.wizard.titleInstructions');
 
   const next = () => setStep((s) => Math.min(2, s + 1));
   const back = () => setStep((s) => Math.max(0, s - 1));
@@ -288,9 +291,7 @@ const KnowledgeWizard: React.FC<{
                 ) : genError ? (
                   <div className='flex flex-col items-center justify-center gap-8px py-36px text-center'>
                     <span className='text-13px text-t-secondary'>
-                      {genError === 'no-model'
-                        ? t('projects.wizard.draft.noModel')
-                        : t('projects.wizard.draft.failed')}
+                      {genError === 'no-model' ? t('projects.wizard.draft.noModel') : t('projects.wizard.draft.failed')}
                     </span>
                     {genError === 'failed' && genDetail && (
                       <span className='max-w-340px text-11px text-t-tertiary'>

--- a/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/src/renderer/services/i18n/i18n-keys.d.ts
@@ -2028,6 +2028,7 @@ export type I18nKey =
   | 'projects.wizard.constraints.q'
   | 'projects.wizard.continue'
   | 'projects.wizard.draft.failed'
+  | 'projects.wizard.draft.failedReason'
   | 'projects.wizard.draft.generating'
   | 'projects.wizard.draft.modelNote'
   | 'projects.wizard.draft.noModel'

--- a/src/renderer/services/i18n/locales/en-US/projects.json
+++ b/src/renderer/services/i18n/locales/en-US/projects.json
@@ -205,6 +205,7 @@
       "generating": "Drafting…",
       "noModel": "Connect a model with an API key to draft with AI.",
       "failed": "Could not generate a draft.",
+      "failedReason": "Reason: {{detail}}",
       "retry": "Try again"
     },
     "back": "Back",

--- a/tests/unit/bridge/projectBridge.generateDraft.test.ts
+++ b/tests/unit/bridge/projectBridge.generateDraft.test.ts
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Regression for #221: generateKnowledgeDraft must surface the underlying
+ * provider failure to the renderer as `detail`, not collapse every error into a
+ * bare `failed`. The New-Project instructions wizard showed "Could not generate
+ * a draft." with no cause, making real failures (bad key, 404 model, rate limit,
+ * request timeout) undiagnosable from the UI. Draft generation goes through the
+ * direct-HTTP `oneShotComplete` path, NOT the wayland-core engine, so the engine
+ * fix in 0.12.5 (#200) does not address this.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Capture each provider handler as initProjectBridge() registers it, so we can
+// invoke the real generateKnowledgeDraft closure in isolation.
+const handlers: Record<string, (arg: unknown) => unknown> = {};
+const makeChannel = (key: string) => ({
+  provider: (fn: (arg: unknown) => unknown) => {
+    handlers[key] = fn;
+  },
+});
+
+vi.mock('@/common', () => ({
+  ipcBridge: { project: new Proxy({}, { get: (_t, prop: string) => makeChannel(prop) }) },
+}));
+vi.mock('@process/services/projectServiceSingleton', () => ({ projectServiceSingleton: {} }));
+vi.mock('@process/services/projectKnowledge/knowledge', () => ({
+  readProjectKnowledge: vi.fn(),
+  writeProjectKnowledge: vi.fn(),
+  listProjectReference: vi.fn(),
+  addProjectReference: vi.fn(),
+  removeProjectReference: vi.fn(),
+  readProjectSummaries: vi.fn(),
+  writeProjectSummary: vi.fn(),
+  appendProjectDecision: vi.fn(),
+  readProjectIjfwMemory: vi.fn(),
+}));
+vi.mock('@process/services/completion/oneShot', () => ({
+  hasUsableModel: vi.fn(),
+  oneShotComplete: vi.fn(),
+  pickBestModel: vi.fn(),
+}));
+
+import { initProjectBridge } from '../../../src/process/bridge/projectBridge';
+import { oneShotComplete, pickBestModel } from '@process/services/completion/oneShot';
+
+const mockPick = vi.mocked(pickBestModel);
+const mockComplete = vi.mocked(oneShotComplete);
+
+// A truthy model so the handler proceeds to oneShotComplete (shape is irrelevant:
+// oneShotComplete is mocked, so the real provider fields are never read).
+const A_MODEL = { provider: { apiKey: 'k' }, modelId: 'gpt-5' } as unknown as Awaited<
+  ReturnType<typeof pickBestModel>
+>;
+const draftArgs = { kind: 'context' as const, description: 'a thing' };
+
+type DraftResult = { draft: string; error?: 'no-model' | 'failed'; detail?: string };
+const runDraft = () => handlers['generateKnowledgeDraft'](draftArgs) as Promise<DraftResult>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const k of Object.keys(handlers)) delete handlers[k];
+  initProjectBridge();
+});
+
+describe('generateKnowledgeDraft error surfacing (#221)', () => {
+  it('returns the underlying provider error as `detail` when generation fails', async () => {
+    mockPick.mockResolvedValue(A_MODEL);
+    mockComplete.mockRejectedValue(new Error('401: invalid x-api-key'));
+
+    const res = await runDraft();
+
+    expect(res.error).toBe('failed');
+    expect(res.detail).toBe('401: invalid x-api-key');
+    expect(res.draft).toBe('');
+  });
+
+  it('maps a missing usable model to `no-model` with no leaked detail', async () => {
+    mockPick.mockResolvedValue(null);
+
+    const res = await runDraft();
+
+    expect(res.error).toBe('no-model');
+    expect(res.detail).toBeUndefined();
+  });
+
+  it('returns the trimmed draft and no error on success', async () => {
+    mockPick.mockResolvedValue(A_MODEL);
+    mockComplete.mockResolvedValue('# Draft\nHello');
+
+    const res = await runDraft();
+
+    expect(res.error).toBeUndefined();
+    expect(res.draft).toContain('Hello');
+  });
+});

--- a/tests/unit/bridge/projectBridge.generateDraft.test.ts
+++ b/tests/unit/bridge/projectBridge.generateDraft.test.ts
@@ -54,9 +54,7 @@ const mockComplete = vi.mocked(oneShotComplete);
 
 // A truthy model so the handler proceeds to oneShotComplete (shape is irrelevant:
 // oneShotComplete is mocked, so the real provider fields are never read).
-const A_MODEL = { provider: { apiKey: 'k' }, modelId: 'gpt-5' } as unknown as Awaited<
-  ReturnType<typeof pickBestModel>
->;
+const A_MODEL = { provider: { apiKey: 'k' }, modelId: 'gpt-5' } as unknown as Awaited<ReturnType<typeof pickBestModel>>;
 const draftArgs = { kind: 'context' as const, description: 'a thing' };
 
 type DraftResult = { draft: string; error?: 'no-model' | 'failed'; detail?: string };


### PR DESCRIPTION
## What

Fixes **#221** — the New-Project instructions wizard ("Project › New") failing with a dead-end **"Could not generate a draft."**

## Root cause (corrects the original triage)

This is **not** the #200 engine bug. Draft generation does not touch wayland-core — it runs through the direct-HTTP `oneShotComplete` path (`src/process/services/completion/oneShot.ts`), calling the provider's `/v1/messages` · `:generateContent` · `/chat/completions` endpoints directly. So bundling engine 0.12.5 (0.11.1) does **not** fix it.

The handler caught every failure and collapsed it to a bare `'failed'`:

```ts
return { draft: '', error: msg === 'no-usable-model' ? 'no-model' : 'failed' };
```

The real cause (bad/expired key → 401, wrong model id → 404, rate limit → 429, or the 90s request timeout/abort) was `console.error`'d in the main process but **never surfaced** — the wizard only ever showed the generic message, so the failure was undiagnosable from the UI.

## Change

- `generateKnowledgeDraft` now returns the underlying error as `detail` for the `failed` case (the distinct `no-model` case is unchanged, and never leaks a `detail`).
- `ipcBridge` contract gains `detail?: string`.
- The wizard renders it beneath the generic message: **"Reason: `<provider message>`"** (`projects.wizard.draft.failedReason`, en-US; other locales fall back).
- The surfaced text is provider status + message or an abort — it never contains the API key.

## Tests / checks

- New regression `tests/unit/bridge/projectBridge.generateDraft.test.ts` (3 cases: provider error → `detail` surfaced; missing model → `no-model`, no detail; success → draft). Fails on the old code (no `detail`).
- `tsc --noEmit` clean; `oxlint` adds zero new warnings; `check-i18n` passes; existing bridge/knowledge suites (78 tests) green.

Refs #221
