### PR TITLE
feat(mission-control): pop out main destinations into their own window

### DIFF
--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -129,9 +129,8 @@ export const conversation = {
    * (re-reading the same content / a command failing repeatedly). Carries the
    * conversation + reason so the renderer can explain why it stopped.
    */
-  runawayHalted: buildEmitter<import('@process/services/runaway/RunawayMonitor').RunawayHalted>(
-    'conversation.runaway-halted'
-  ),
+  runawayHalted:
+    buildEmitter<import('@process/services/runaway/RunawayMonitor').RunawayHalted>('conversation.runaway-halted'),
   listChanged: buildEmitter<IConversationListChangedEvent>('conversation.list-changed'),
   getWorkspace: buildProvider<
     IDirOrFile[],

--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -232,6 +232,11 @@ export const application = {
   updateSystemInfo: buildProvider<IBridgeResponse, { cacheDir: string; workDir: string }>('system.update-info'), // Update system info
   getZoomFactor: buildProvider<number, void>('app.get-zoom-factor'),
   setZoomFactor: buildProvider<number, { factor: number }>('app.set-zoom-factor'),
+  // Pop a main destination (e.g. Mission Control) out into its own window, reusing
+  // the conversation pop-out window infrastructure. `route` is validated against an
+  // allowlist in the main process. Returns alreadyOpen:true when an existing
+  // pop-out of the same route was focused instead of a new one created (#157).
+  popoutRoute: buildProvider<{ ok: boolean; alreadyOpen: boolean }, { route: string }>('app.popout-route'),
   // CDP (Chrome DevTools Protocol) management
   getCdpStatus: buildProvider<IBridgeResponse<ICdpStatus>, void>('app.get-cdp-status'), // Get CDP status
   updateCdpConfig: buildProvider<IBridgeResponse<ICdpConfig>, Partial<ICdpConfig>>('app.update-cdp-config'), // Update CDP config

--- a/src/process/bridge/applicationBridge.ts
+++ b/src/process/bridge/applicationBridge.ts
@@ -15,6 +15,7 @@ import { ProcessConfig } from '@process/utils/initStorage';
 import { getZoomFactor, setZoomFactor } from '@process/utils/zoom';
 import { getCdpStatus, updateCdpConfig } from '@process/utils/configureChromium';
 import { initApplicationBridgeCore } from './applicationBridgeCore';
+import { openRoutePopoutWindow } from '@process/utils/popoutWindowManager';
 import type { IStartOnBootStatus } from '@/common/adapter/ipcBridge';
 
 let mainWindowRef: BrowserWindow | null = null;
@@ -214,6 +215,12 @@ export function initApplicationBridge(workerTaskManager: IWorkerTaskManager): vo
   });
 
   ipcBridge.application.getZoomFactor.provider(() => Promise.resolve(getZoomFactor()));
+
+  // Pop a main destination (e.g. Mission Control) out into its own window (#157).
+  // The route is validated against an allowlist inside openRoutePopoutWindow.
+  ipcBridge.application.popoutRoute.provider(async ({ route }) => {
+    return openRoutePopoutWindow(route);
+  });
 
   ipcBridge.application.setZoomFactor.provider(async ({ factor }) => {
     const updatedFactor = setZoomFactor(factor);

--- a/src/process/bridge/applicationBridge.ts
+++ b/src/process/bridge/applicationBridge.ts
@@ -20,19 +20,14 @@ import type { IStartOnBootStatus } from '@/common/adapter/ipcBridge';
 
 let mainWindowRef: BrowserWindow | null = null;
 
-const START_ON_BOOT_UNSUPPORTED_MESSAGE =
-  'Start on boot requires a packaged macOS, Windows, or Linux app.';
+const START_ON_BOOT_UNSUPPORTED_MESSAGE = 'Start on boot requires a packaged macOS, Windows, or Linux app.';
 export const START_ON_BOOT_WINDOWS_ARG = '--start-on-boot';
 const START_ON_BOOT_LINUX_ARG = '--start-on-boot';
 const LINUX_DESKTOP_FILE_NAME = 'wayland.desktop';
 
 const isStartOnBootSupported = (): boolean => {
   if (!app.isPackaged) return false;
-  return (
-    process.platform === 'darwin' ||
-    process.platform === 'win32' ||
-    process.platform === 'linux'
-  );
+  return process.platform === 'darwin' || process.platform === 'win32' || process.platform === 'linux';
 };
 
 const getStartOnBootWindowsArgs = (): string[] => [START_ON_BOOT_WINDOWS_ARG];

--- a/src/process/utils/popoutRoutes.ts
+++ b/src/process/utils/popoutRoutes.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Pure helpers for popping a main destination (not a conversation) out into its
+ * own window (#157). Kept free of Electron/IPC imports so the route allowlist
+ * and deep-link construction are unit-testable in plain node; the Electron
+ * window manager (`popoutWindowManager.ts`) composes these.
+ *
+ * Security: `route` arrives from the renderer, so it is validated against a
+ * fixed allowlist before it ever reaches `loadURL`/`loadFile`. Only known
+ * top-level destinations may be popped out; anything else is rejected.
+ */
+
+/** Top-level routes that may be popped out into their own window. */
+export const POPOUT_ALLOWED_ROUTES = ['mission-control'] as const;
+
+export type PopoutRoute = (typeof POPOUT_ALLOWED_ROUTES)[number];
+
+/** True when `route` is an allowlisted pop-out destination. */
+export function isAllowedPopoutRoute(route: string): route is PopoutRoute {
+  return (POPOUT_ALLOWED_ROUTES as readonly string[]).includes(route);
+}
+
+/**
+ * Registry key for a route pop-out. Namespaced with a `route:` prefix so it can
+ * never collide with a conversation id in the shared pop-out window registry.
+ */
+export function routePopoutKey(route: PopoutRoute): string {
+  return `route:${route}`;
+}
+
+/**
+ * Hash deep-link for a route pop-out, e.g. `#/mission-control?mode=popout`. The
+ * `mode=popout` flag drives the renderer's chrome-less shell (same flag the
+ * conversation pop-out uses), so a popped-out route renders without the sider.
+ */
+export function routePopoutHash(route: PopoutRoute): string {
+  return `#/${route}?mode=popout`;
+}
+
+/** The bare hash (no leading `#`) for Electron's `loadFile({ hash })` form. */
+export function routePopoutLoadFileHash(route: PopoutRoute): string {
+  return `/${route}?mode=popout`;
+}

--- a/src/process/utils/popoutWindowManager.ts
+++ b/src/process/utils/popoutWindowManager.ts
@@ -5,12 +5,14 @@
  */
 
 /**
- * Pop-out chat window manager (#27 phase 2).
+ * Pop-out window manager (#27 phase 2; #157 route pop-outs).
  *
- * Opens a single conversation in its own OS BrowserWindow for multi-monitor
- * work. The window loads the SAME renderer entry as the main window, deep-linked
- * to `#/conversation/<id>?mode=popout` so the renderer hides the sider / tab bar
- * and runs as a focused standalone surface.
+ * Opens a single conversation - or an allowlisted top-level route such as
+ * Mission Control - in its own OS BrowserWindow for multi-monitor work. The
+ * window loads the SAME renderer entry as the main window, deep-linked with
+ * `?mode=popout` (e.g. `#/conversation/<id>?mode=popout` or
+ * `#/mission-control?mode=popout`) so the renderer hides the sider / tab bar and
+ * runs as a focused standalone surface.
  *
  * Live agent streams need NO new plumbing: each pop-out registers via
  * `initMainAdapterWithWindow`, and `common/adapter/main.ts` already broadcasts
@@ -38,6 +40,12 @@ import { ipcBridge } from '@/common';
 import { ProcessConfig } from '@process/utils/initStorage';
 import { initMainAdapterWithWindow } from '@/common/adapter/main';
 import { resolvePopoutAction, resolvePopoutBounds, type PopoutBounds } from '@process/utils/popoutBounds';
+import {
+  isAllowedPopoutRoute,
+  routePopoutHash,
+  routePopoutKey,
+  routePopoutLoadFileHash,
+} from '@process/utils/popoutRoutes';
 
 /**
  * Registry of live pop-out windows keyed by conversation id. Window instances
@@ -103,8 +111,54 @@ function schedulePersistBounds(win: BrowserWindow): void {
  * when an existing window was focused instead of a new one created.
  */
 export async function openPopoutWindow(conversationId: string): Promise<{ ok: boolean; alreadyOpen: boolean }> {
-  if (resolvePopoutAction(popouts, conversationId) === 'focus') {
-    const existing = popouts.get(conversationId)!;
+  return openPopout({
+    key: conversationId,
+    deepLink: `#/conversation/${encodeURIComponent(conversationId)}?mode=popout`,
+    loadFileHash: `/conversation/${encodeURIComponent(conversationId)}?mode=popout`,
+    // Conversation pop-outs notify all windows on close so the main-window tab
+    // un-dims its placeholder. Route pop-outs have no such placeholder.
+    onClosed: () => {
+      try {
+        ipcBridge.conversation.popoutClosed.emit({ conversation_id: conversationId });
+      } catch (err) {
+        console.warn('[Popout] Failed to emit popoutClosed:', err);
+      }
+    },
+  });
+}
+
+/**
+ * Open (or focus) a pop-out window for an allowlisted top-level route (e.g.
+ * Mission Control), reusing the conversation pop-out window infrastructure
+ * (#157). Rejects any route not on the allowlist - `route` is renderer-supplied.
+ */
+export async function openRoutePopoutWindow(route: string): Promise<{ ok: boolean; alreadyOpen: boolean }> {
+  if (!isAllowedPopoutRoute(route)) {
+    console.warn('[Popout] Rejected non-allowlisted route pop-out:', route);
+    return { ok: false, alreadyOpen: false };
+  }
+  return openPopout({
+    key: routePopoutKey(route),
+    deepLink: routePopoutHash(route),
+    loadFileHash: routePopoutLoadFileHash(route),
+  });
+}
+
+/**
+ * Shared pop-out window creation, keyed by an arbitrary registry key. Dedupes
+ * (focuses an existing live window), creates a chrome-less BrowserWindow loading
+ * `deepLink`, registers it for live bridge streams, and persists shared geometry.
+ * `onClosed` runs after the window closes (in addition to registry cleanup).
+ */
+async function openPopout(opts: {
+  key: string;
+  deepLink: string;
+  loadFileHash: string;
+  onClosed?: () => void;
+}): Promise<{ ok: boolean; alreadyOpen: boolean }> {
+  const { key, deepLink, loadFileHash, onClosed } = opts;
+  if (resolvePopoutAction(popouts, key) === 'focus') {
+    const existing = popouts.get(key)!;
     if (existing.isMinimized()) existing.restore();
     existing.show();
     existing.focus();
@@ -184,7 +238,7 @@ export async function openPopoutWindow(conversationId: string): Promise<{ ok: bo
   // Register with the bridge so live streams reach this window.
   initMainAdapterWithWindow(win);
 
-  popouts.set(conversationId, win);
+  popouts.set(key, win);
 
   win.once('ready-to-show', () => {
     if (!win.isDestroyed()) {
@@ -204,23 +258,17 @@ export async function openPopoutWindow(conversationId: string): Promise<{ ok: bo
   win.on('move', () => schedulePersistBounds(win));
 
   win.on('closed', () => {
-    popouts.delete(conversationId);
-    // Notify ALL windows so the main window un-dims its placeholder tab. Closing
-    // by any path (dock-back, OS close, app quit) funnels through here.
-    try {
-      ipcBridge.conversation.popoutClosed.emit({ conversation_id: conversationId });
-    } catch (err) {
-      console.warn('[Popout] Failed to emit popoutClosed:', err);
-    }
+    popouts.delete(key);
+    // Closing by any path (dock-back, OS close, app quit) funnels through here.
+    if (onClosed) onClosed();
   });
 
-  loadPopoutContent(win, conversationId);
+  loadPopoutContent(win, deepLink, loadFileHash);
 
   return { ok: true, alreadyOpen: false };
 }
 
-function loadPopoutContent(win: BrowserWindow, conversationId: string): void {
-  const deepLink = `#/conversation/${encodeURIComponent(conversationId)}?mode=popout`;
+function loadPopoutContent(win: BrowserWindow, deepLink: string, loadFileHash: string): void {
   const rendererUrl = process.env['ELECTRON_RENDERER_URL'];
   if (!app.isPackaged && rendererUrl) {
     win.loadURL(`${rendererUrl}/${deepLink}`).catch((error) => {
@@ -228,11 +276,9 @@ function loadPopoutContent(win: BrowserWindow, conversationId: string): void {
     });
   } else {
     const fallbackFile = path.join(__dirname, '../renderer/index.html');
-    win
-      .loadFile(fallbackFile, { hash: `/conversation/${encodeURIComponent(conversationId)}?mode=popout` })
-      .catch((error) => {
-        console.error('[Popout] loadFile failed:', error);
-      });
+    win.loadFile(fallbackFile, { hash: loadFileHash }).catch((error) => {
+      console.error('[Popout] loadFile failed:', error);
+    });
   }
 }
 

--- a/src/renderer/pages/mission-control/index.tsx
+++ b/src/renderer/pages/mission-control/index.tsx
@@ -171,8 +171,17 @@ const OperationsView: React.FC = () => {
   const { t } = useTranslation();
   const { snapshot, loading, refresh } = useMissionControl();
   const entries = snapshot?.entries ?? [];
-  const counts: LedgerCounts =
-    snapshot?.counts ?? { running: 0, verifying: 0, pending: 0, blocked: 0, failed: 0, zombie: 0, done: 0, idle: 0, total: 0 };
+  const counts: LedgerCounts = snapshot?.counts ?? {
+    running: 0,
+    verifying: 0,
+    pending: 0,
+    blocked: 0,
+    failed: 0,
+    zombie: 0,
+    done: 0,
+    idle: 0,
+    total: 0,
+  };
 
   return (
     <>

--- a/src/renderer/pages/mission-control/index.tsx
+++ b/src/renderer/pages/mission-control/index.tsx
@@ -7,7 +7,9 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Tabs } from '@arco-design/web-react';
-import { Clock, Gauge, RefreshCw, Users } from 'lucide-react';
+import { Clock, Gauge, PictureInPicture2, RefreshCw, Users } from 'lucide-react';
+import { ipcBridge } from '@/common';
+import { useIsPopoutMode } from '@/renderer/hooks/system/useIsPopoutMode';
 import { useMissionControl } from './useMissionControl';
 import { CostTab } from './cost/CostTab';
 import PageShell from '@/renderer/components/layout/PageShell';
@@ -212,6 +214,22 @@ const OperationsView: React.FC = () => {
 
 const MissionControlPage: React.FC = () => {
   const { t } = useTranslation();
+  const isPopout = useIsPopoutMode();
+
+  // Hide the pop-out trigger when this page is itself rendered inside a pop-out
+  // window - there is nothing to pop out into from there (#157).
+  const actions = isPopout ? undefined : (
+    <Button
+      type='text'
+      size='small'
+      icon={<PictureInPicture2 size={16} />}
+      aria-label={t('missionControl.popout')}
+      title={t('missionControl.popout')}
+      onClick={() => {
+        void ipcBridge.application.popoutRoute.invoke({ route: 'mission-control' });
+      }}
+    />
+  );
 
   return (
     <PageShell
@@ -219,6 +237,7 @@ const MissionControlPage: React.FC = () => {
       icon={<Gauge size={20} />}
       subtitle={t('missionControl.description')}
       width='full'
+      actions={actions}
     >
       <Tabs defaultActiveTab='operations' className={styles.tabs}>
         <Tabs.TabPane key='operations' title={t('missionControl.tabs.operations')}>

--- a/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/src/renderer/services/i18n/i18n-keys.d.ts
@@ -1602,6 +1602,7 @@ export type I18nKey =
   | 'missionControl.meta.verdictFail'
   | 'missionControl.meta.verdictPass'
   | 'missionControl.pageTitle'
+  | 'missionControl.popout'
   | 'missionControl.refresh'
   | 'missionControl.section.active'
   | 'missionControl.section.attention'

--- a/src/renderer/services/i18n/locales/en-US/missionControl.json
+++ b/src/renderer/services/i18n/locales/en-US/missionControl.json
@@ -3,6 +3,7 @@
   "pageTitle": "Mission Control",
   "description": "Every task and scheduled job across your teams, live in one place.",
   "refresh": "Refresh",
+  "popout": "Open in new window",
   "live": "Live",
   "empty": "All quiet",
   "emptyHint": "Team tasks and scheduled jobs appear here the moment they start.",

--- a/tests/unit/applicationBridge.test.ts
+++ b/tests/unit/applicationBridge.test.ts
@@ -45,6 +45,7 @@ describe('applicationBridge CDP functionality', () => {
         relaunch: vi.fn(),
         exit: vi.fn(),
       },
+      ipcMain: { handle: vi.fn(), on: vi.fn(), removeHandler: vi.fn() },
     }));
 
     // Mock fs
@@ -133,6 +134,7 @@ function mockElectronApp(extra?: Record<string, any>) {
       commandLine: { appendSwitch: vi.fn() },
       ...extra,
     },
+    ipcMain: { handle: vi.fn(), on: vi.fn(), removeHandler: vi.fn() },
   };
 }
 
@@ -239,6 +241,7 @@ describe('CDP configuration functions', () => {
           openDevTools: { provider: vi.fn(), emit: vi.fn(), invoke: vi.fn() },
           getZoomFactor: { provider: vi.fn(), emit: vi.fn(), invoke: vi.fn() },
           setZoomFactor: { provider: vi.fn(), emit: vi.fn(), invoke: vi.fn() },
+          popoutRoute: { provider: vi.fn(), emit: vi.fn(), invoke: vi.fn() },
           getCdpStatus: { provider: vi.fn(), emit: vi.fn(), invoke: vi.fn() },
           updateCdpConfig: { provider: vi.fn(), emit: vi.fn(), invoke: vi.fn() },
           getStartOnBootStatus: { provider: vi.fn(), emit: vi.fn(), invoke: vi.fn() },

--- a/tests/unit/bridge/applicationBridge.startOnBoot.test.ts
+++ b/tests/unit/bridge/applicationBridge.startOnBoot.test.ts
@@ -33,6 +33,7 @@ describe('applicationBridge start-on-boot helpers', () => {
       ipcBridge: {
         application: {
           restart: { provider: vi.fn() },
+          popoutRoute: { provider: vi.fn() },
           isDevToolsOpened: { provider: vi.fn() },
           openDevTools: { provider: vi.fn() },
           getZoomFactor: { provider: vi.fn() },
@@ -71,6 +72,13 @@ describe('applicationBridge start-on-boot helpers', () => {
 
     vi.doMock('@process/bridge/applicationBridgeCore', () => ({
       initApplicationBridgeCore: vi.fn(),
+    }));
+
+    // applicationBridge now imports the popout manager, which loads the main IPC
+    // adapter at module scope (ipcMain.handle). These start-on-boot tests don't
+    // exercise popout, so stub the module to keep the import side-effect-free.
+    vi.doMock('@process/utils/popoutWindowManager', () => ({
+      openRoutePopoutWindow: vi.fn(),
     }));
   };
 
@@ -195,6 +203,7 @@ describe('applicationBridge start-on-boot helpers', () => {
         getLoginItemSettings: vi.fn(),
         setLoginItemSettings: vi.fn(),
       },
+      ipcMain: { handle: vi.fn(), on: vi.fn(), removeHandler: vi.fn() },
     }));
 
     const { getStartOnBootStatus } = await import('@process/bridge/applicationBridge');
@@ -233,6 +242,7 @@ describe('applicationBridge start-on-boot helpers', () => {
       ipcBridge: {
         application: {
           restart: { provider: vi.fn() },
+          popoutRoute: { provider: vi.fn() },
           isDevToolsOpened: { provider: vi.fn() },
           openDevTools: { provider: vi.fn() },
           getZoomFactor: { provider: vi.fn() },
@@ -287,6 +297,7 @@ describe('applicationBridge start-on-boot helpers', () => {
         getLoginItemSettings: vi.fn(() => ({ openAtLogin: true, wasOpenedAtLogin: true })),
         setLoginItemSettings: vi.fn(),
       },
+      ipcMain: { handle: vi.fn(), on: vi.fn(), removeHandler: vi.fn() },
     }));
 
     const { initApplicationBridge } = await import('@process/bridge/applicationBridge');
@@ -319,6 +330,7 @@ describe('applicationBridge start-on-boot helpers', () => {
       ipcBridge: {
         application: {
           restart: { provider: vi.fn() },
+          popoutRoute: { provider: vi.fn() },
           isDevToolsOpened: { provider: vi.fn() },
           openDevTools: { provider: vi.fn() },
           getZoomFactor: { provider: vi.fn() },
@@ -369,6 +381,7 @@ describe('applicationBridge start-on-boot helpers', () => {
         getLoginItemSettings: vi.fn(),
         setLoginItemSettings: vi.fn(),
       },
+      ipcMain: { handle: vi.fn(), on: vi.fn(), removeHandler: vi.fn() },
     }));
 
     const { initApplicationBridge } = await import('@process/bridge/applicationBridge');

--- a/tests/unit/popoutRoutes.test.ts
+++ b/tests/unit/popoutRoutes.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isAllowedPopoutRoute,
+  POPOUT_ALLOWED_ROUTES,
+  routePopoutHash,
+  routePopoutKey,
+  routePopoutLoadFileHash,
+} from '../../src/process/utils/popoutRoutes';
+
+describe('popout route helpers (#157)', () => {
+  it('allows mission-control', () => {
+    expect(isAllowedPopoutRoute('mission-control')).toBe(true);
+  });
+
+  it('rejects routes not on the allowlist (renderer-supplied input)', () => {
+    expect(isAllowedPopoutRoute('settings')).toBe(false);
+    expect(isAllowedPopoutRoute('../etc/passwd')).toBe(false);
+    expect(isAllowedPopoutRoute('conversation/abc')).toBe(false);
+    expect(isAllowedPopoutRoute('')).toBe(false);
+    expect(isAllowedPopoutRoute('mission-control?mode=evil')).toBe(false);
+  });
+
+  it('namespaces the registry key so it cannot collide with a conversation id', () => {
+    expect(routePopoutKey('mission-control')).toBe('route:mission-control');
+  });
+
+  it('builds the chrome-less hash deep link', () => {
+    expect(routePopoutHash('mission-control')).toBe('#/mission-control?mode=popout');
+  });
+
+  it('builds the loadFile hash without a leading #', () => {
+    expect(routePopoutLoadFileHash('mission-control')).toBe('/mission-control?mode=popout');
+  });
+
+  it('keeps every allowlisted route consistent across the three builders', () => {
+    for (const route of POPOUT_ALLOWED_ROUTES) {
+      expect(routePopoutKey(route)).toBe(`route:${route}`);
+      expect(routePopoutHash(route)).toBe(`#/${route}?mode=popout`);
+      expect(routePopoutLoadFileHash(route)).toBe(`/${route}?mode=popout`);
+    }
+  });
+});


### PR DESCRIPTION
## What

Implements **#157** — pop **Mission Control** out into its own window so you can watch live activity on a second monitor while you work in a chat.

## How

Generalizes the existing conversation pop-out window infrastructure rather than adding a parallel one:

- The window-creation core (`openPopout`) is now keyed by an **arbitrary registry key** + deep link. The conversation path (`openPopoutWindow`) is behaviorally **unchanged** — same `#/conversation/<id>?mode=popout` deep link, same `popoutClosed` emit (passed in as an `onClosed` callback).
- New `openRoutePopoutWindow(route)` opens an allowlisted top-level route via the same chrome-less `?mode=popout` shell (which already renders sider-less via `Layout`'s popout branch + the route-agnostic `useIsPopoutMode`).
- New bridge `ipcBridge.application.popoutRoute({ route })`.
- Mission Control's `PageShell` header gains a pop-out button, **hidden when the page is itself in a pop-out** (`useIsPopoutMode`).

## Security

`route` is renderer-supplied, so it is validated against a fixed allowlist (`POPOUT_ALLOWED_ROUTES`, currently just `mission-control`) **before** it ever reaches `loadURL`/`loadFile`. The registry key is namespaced `route:<route>` so it can never collide with a conversation id. Window `webPreferences`, `setWindowOpenHandler(deny)`, and the `will-navigate` origin guard are inherited unchanged from the existing manager.

## Verification

- New pure-helper unit tests `tests/unit/popoutRoutes.test.ts` (6 cases: allowlist accept/reject incl. traversal + query-injection attempts, key namespacing, deep-link builders).
- `tsc --noEmit` clean; `oxlint` 0 warnings on touched files; `check-i18n` passes; existing popout suites green (`popoutBounds` + `isPopoutMode`, 16 tests).
- **Live window smoke test on macOS** (dev app, driven over CDP): clicking the button opens a real `#/mission-control?mode=popout` window (1→2 targets); a second click **dedupes** (focuses, stays at 1 pop-out); the pop-out window is chrome-less (`.app-shell--popout`, no `.layout-sider`), hides its own pop-out button, and renders Mission Control. ✅

Refs #157
