### PR TITLE
fix(providers): recognize Google AQ. and OpenAI service-account/admin API keys

### DIFF
--- a/src/process/providers/detection/providerKeyPatterns.ts
+++ b/src/process/providers/detection/providerKeyPatterns.ts
@@ -35,13 +35,19 @@ export const PROVIDER_KEY_PATTERNS: PatternRule[] = [
   },
   {
     provider: 'openai',
-    test: (k) => k.startsWith('sk-proj-'),
+    // Project keys (`sk-proj-`), plus service-account (`sk-svcacct-`) and Admin
+    // API (`sk-admin-`) keys - all OpenAI-issued, all distinct from the bare
+    // legacy `sk-` shape handled structurally below (#224 audit).
+    test: (k) => k.startsWith('sk-proj-') || k.startsWith('sk-svcacct-') || k.startsWith('sk-admin-'),
     match: 'unique',
     priority: 100,
   },
   {
     provider: 'google-gemini',
-    test: (k) => k.startsWith('AIza'),
+    // Google AI Studio issues two key formats: the classic `AIza` "traffic"
+    // keys and the newer `AQ.` "authentication" keys that some accounts now get
+    // exclusively. Both are valid Generative Language API keys (#224).
+    test: (k) => k.startsWith('AIza') || k.startsWith('AQ.'),
     match: 'unique',
     priority: 100,
   },

--- a/src/renderer/pages/settings/ModelsSettings/providerCatalog.ts
+++ b/src/renderer/pages/settings/ModelsSettings/providerCatalog.ts
@@ -334,8 +334,15 @@ export function recognizeKey(raw: string): KeyRecognition {
   if (key.startsWith('sk-ant-')) return { kind: 'recognized', provider: 'anthropic' };
   if (key.startsWith('sk-flux-')) return { kind: 'recognized', provider: 'flux-router' };
   if (key.startsWith('sk-or-')) return { kind: 'recognized', provider: 'openrouter' };
-  if (key.startsWith('sk-proj-')) return { kind: 'recognized', provider: 'openai' };
-  if (key.startsWith('AIza')) return { kind: 'recognized', provider: 'google-gemini' };
+  // OpenAI project (`sk-proj-`), service-account (`sk-svcacct-`), and Admin API
+  // (`sk-admin-`) keys - all distinct from the bare legacy `sk-` shape (#224 audit).
+  if (key.startsWith('sk-proj-') || key.startsWith('sk-svcacct-') || key.startsWith('sk-admin-')) {
+    return { kind: 'recognized', provider: 'openai' };
+  }
+  // Google AI Studio issues classic `AIza` "traffic" keys and newer `AQ.`
+  // "authentication" keys (some accounts now get the latter exclusively); both
+  // are valid Generative Language API keys (#224).
+  if (key.startsWith('AIza') || key.startsWith('AQ.')) return { kind: 'recognized', provider: 'google-gemini' };
   if (key.startsWith('gsk_')) return { kind: 'recognized', provider: 'groq' };
   if (key.startsWith('xai-')) return { kind: 'recognized', provider: 'xai' };
   if (key.startsWith('hf_')) return { kind: 'recognized', provider: 'huggingface' };

--- a/tests/unit/renderer/modelsSettings.dom.test.tsx
+++ b/tests/unit/renderer/modelsSettings.dom.test.tsx
@@ -420,7 +420,12 @@ describe('recognizeKey', () => {
     ['flux-router', 'sk-flux-abcdef'],
     ['openrouter', 'sk-or-v1-abcdef'],
     ['openai', 'sk-proj-abcdef'],
+    ['openai', 'sk-svcacct-abcdef'],
+    ['openai', 'sk-admin-abcdef'],
     ['google-gemini', 'AIzaSyAbcdef'],
+    // Google's newer `AQ.` "authentication" key format - some accounts now get
+    // it exclusively, and it must auto-recognize just like the classic AIza (#224).
+    ['google-gemini', 'AQ.Ab8cDefGhiJklMnoPqr'],
     ['groq', 'gsk_abcdef'],
     ['xai', 'xai-abcdef'],
     ['huggingface', 'hf_abcdef'],


### PR DESCRIPTION
## What

Fixes **#224** — pasting a Google API key into "Paste an API key" failed with **"That key was not recognized. Open Browse and pick your provider."**

## Root cause

Google AI Studio has rolled out a **new key format**: keys now start with **`AQ.`** ("authentication" keys) instead of the classic **`AIza`** ("traffic" keys), and some accounts now receive `AQ.` keys exclusively. Our paste recognizer (`recognizeKey` + its main-process parity source `PROVIDER_KEY_PATTERNS`) only knew `AIza`, so an `AQ.` key fell through to `unknown` and the connect was **never attempted** — hence the "not recognized" error. **Browse worked** because the Browse flow lets the user pick the provider explicitly, bypassing prefix recognition (which also proves the connect/validation path already accepts `AQ.` keys — recognition was the only blocker).

Confirmed via Google's developer forum + AI Studio docs (the `AQ.` / `AIza` split is documented and widely reported).

> Note for triage: this is **not** the same cluster as #225 (Flux `sk-flux-`). `sk-flux-` *is* recognized at the v0.11.1 tag, so #225 is a separate bug — commented on the board.

## Change

- Teach both the renderer recognizer and the main-process `PROVIDER_KEY_PATTERNS` the `AQ.` Google prefix (kept in lockstep — there's a CI parity test).
- **Audit win** (the issue prompted a sweep of the whole prefix table): also broaden **OpenAI** to its **service-account (`sk-svcacct-`)** and **Admin API (`sk-admin-`)** key prefixes, which previously fell through to the ambiguous bare-`sk-` bucket.

## Tests / checks

- Extended the `recognizeKey` parity table with `AQ.`, `sk-svcacct-`, `sk-admin-` cases; `modelsSettings.dom.test.tsx` green (43) incl. the renderer↔main-process parity test; provider detector suite green.
- `tsc --noEmit` clean; `oxlint` 0 warnings on touched files.

A broader provider-key-format audit (other providers with changed/missing prefixes) was run and is summarized for follow-up; this PR ships only the high-confidence, additive recognitions.

Refs #224
