### PR TITLE
fix(providers): add GitHub Models recognition, drop dead key prefixes

### DIFF
--- a/src/process/providers/detection/providerKeyPatterns.ts
+++ b/src/process/providers/detection/providerKeyPatterns.ts
@@ -106,23 +106,20 @@ export const PROVIDER_KEY_PATTERNS: PatternRule[] = [
     priority: 100,
   },
   {
-    provider: 'deepgram',
-    test: (k) => k.startsWith('dg_'),
+    // GitHub Models inference gateway authenticates with a GitHub PAT - classic
+    // `ghp_` or fine-grained `github_pat_`. A PAT pasted into the model-key field
+    // signals model intent, so route it to the connectable github-models catalog
+    // provider (#224 audit).
+    provider: 'github-models',
+    test: (k) => k.startsWith('ghp_') || k.startsWith('github_pat_'),
     match: 'unique',
     priority: 100,
   },
-  {
-    provider: 'assemblyai',
-    test: (k) => k.startsWith('aai_'),
-    match: 'unique',
-    priority: 100,
-  },
-  {
-    provider: 'elevenlabs',
-    test: (k) => k.startsWith('xi-api-'),
-    match: 'unique',
-    priority: 100,
-  },
+  // NOTE: deepgram (`dg_`), assemblyai (`aai_`), and elevenlabs (`xi-api-`) prefix
+  // rules were removed - those were never real key prefixes (Deepgram/AssemblyAI
+  // keys are prefix-less; `xi-api-key` is ElevenLabs' HEADER name, not the key),
+  // so the rules could never match a real key. Those providers stay connectable
+  // via Browse (#224 audit).
 
   // --- Structural sk- variants (priority 95) ---
   // These are bare-sk shapes with enough structural signal to resolve to a

--- a/src/renderer/pages/settings/ModelsSettings/providerCatalog.ts
+++ b/src/renderer/pages/settings/ModelsSettings/providerCatalog.ts
@@ -346,9 +346,13 @@ export function recognizeKey(raw: string): KeyRecognition {
   if (key.startsWith('csk-')) return { kind: 'recognized', provider: 'cerebras' };
   if (key.startsWith('nvapi-')) return { kind: 'recognized', provider: 'nvidia' };
   if (key.startsWith('esecret_')) return { kind: 'recognized', provider: 'anyscale' };
-  if (key.startsWith('dg_')) return { kind: 'recognized', provider: 'deepgram' };
-  if (key.startsWith('aai_')) return { kind: 'recognized', provider: 'assemblyai' };
-  if (key.startsWith('xi-api-')) return { kind: 'recognized', provider: 'elevenlabs' };
+  // GitHub Models inference uses a GitHub PAT (classic `ghp_` / fine-grained
+  // `github_pat_`); route to the connectable github-models catalog provider (#224 audit).
+  if (key.startsWith('ghp_') || key.startsWith('github_pat_')) {
+    return { kind: 'recognized', provider: 'github-models' };
+  }
+  // Removed dead `dg_` (deepgram), `aai_` (assemblyai), `xi-api-` (elevenlabs)
+  // rules - never real key prefixes; those providers connect via Browse (#224 audit).
 
   // Multi-field cloud provider (priority 90) - needs the credential form, not a
   // bare key.

--- a/tests/unit/providers-ProviderDetector.test.ts
+++ b/tests/unit/providers-ProviderDetector.test.ts
@@ -97,22 +97,21 @@ describe('ProviderDetector.detect - unique prefix matches', () => {
     if (r.kind === 'unique') expect(r.provider).toBe('anyscale');
   });
 
-  it('detects deepgram from dg_ prefix', () => {
-    const r = detector.detect('dg_abcdef1234567890');
-    expect(r.kind).toBe('unique');
-    if (r.kind === 'unique') expect(r.provider).toBe('deepgram');
+  it('detects github-models from a GitHub PAT (ghp_ / github_pat_)', () => {
+    const classic = detector.detect('ghp_abcdef1234567890');
+    expect(classic.kind).toBe('unique');
+    if (classic.kind === 'unique') expect(classic.provider).toBe('github-models');
+    const fine = detector.detect('github_pat_11ABCDEF0_abcdef');
+    expect(fine.kind).toBe('unique');
+    if (fine.kind === 'unique') expect(fine.provider).toBe('github-models');
   });
 
-  it('detects assemblyai from aai_ prefix', () => {
-    const r = detector.detect('aai_abcdef1234567890');
-    expect(r.kind).toBe('unique');
-    if (r.kind === 'unique') expect(r.provider).toBe('assemblyai');
-  });
-
-  it('detects elevenlabs from xi-api- prefix', () => {
-    const r = detector.detect('xi-api-abcdef1234567890');
-    expect(r.kind).toBe('unique');
-    if (r.kind === 'unique') expect(r.provider).toBe('elevenlabs');
+  it('does NOT prefix-detect deepgram/assemblyai/elevenlabs (those keys are prefix-less; rules removed)', () => {
+    // `dg_`, `aai_`, and `xi-api-` were never real key prefixes; they no longer
+    // false-match. These providers stay connectable via Browse (#224 audit).
+    expect(detector.detect('dg_abcdef1234567890').kind).toBe('unknown');
+    expect(detector.detect('aai_abcdef1234567890').kind).toBe('unknown');
+    expect(detector.detect('xi-api-abcdef1234567890').kind).toBe('unknown');
   });
 });
 

--- a/tests/unit/renderer/modelsSettings.dom.test.tsx
+++ b/tests/unit/renderer/modelsSettings.dom.test.tsx
@@ -431,9 +431,8 @@ describe('recognizeKey', () => {
     ['cerebras', 'csk-abcdef'],
     ['nvidia', 'nvapi-abcdef'],
     ['anyscale', 'esecret_abcdef'],
-    ['deepgram', 'dg_abcdef'],
-    ['assemblyai', 'aai_abcdef'],
-    ['elevenlabs', 'xi-api-abcdef'],
+    ['github-models', 'ghp_abcdef1234567890'],
+    ['github-models', 'github_pat_11ABCDEF0_abcdef'],
     // Structural sk- variants - these resolve uniquely despite the bare-sk
     // prefix because their internal shape is distinctive (32-hex for DeepSeek;
     // 48-mixed-alnum minus OpenAI's `T3BlbkFJ` signature for Moonshot).


### PR DESCRIPTION
## What

Follow-up to the #224 key-format audit, after verifying each candidate against the actual provider catalog (not just the prefix).

**Added** — **GitHub Models** (`ghp_` / `github_pat_` → `github-models`). It's a real, connectable catalog provider (`models.github.ai/inference`, openai-compatible, `GITHUB_TOKEN`), so a GitHub PAT pasted into the model-key field now auto-recognizes.

**Removed** — three prefix rules that **could never match a real key**:
- elevenlabs `xi-api-` — `xi-api-key` is the HTTP *header name*, not the key (real keys are `sk_`, which collides with Novita, so no prefix replacement)
- deepgram `dg_` — Deepgram keys are prefix-less
- assemblyai `aai_` — AssemblyAI keys are prefix-less

Those three providers stay connectable via Browse. Renderer recognizer + main-process `PROVIDER_KEY_PATTERNS` updated in lockstep (parity test); detector + recognizer test cases updated.

## Deliberately NOT included (held with evidence)

These were on the original "add these" list, but on verification they aren't shippable as recognition:

- **Voyage `pa-` / Jina `jina_`** — embeddings-only providers with **no Wayland provider entry** (they appear only as embedding-model *name* patterns; you can't chat with them). Recognizing their keys would be a dead-end false positive (recognized → connect → fails, nothing to use). They'd need a real provider integration first.
- **DeepSeek regex widening** — the current narrow `sk-[a-f0-9]{32}` already degrades gracefully to the bare-`sk-` ambiguous bucket (DeepSeek is a candidate there; connect confirms it), so a too-narrow rule isn't a hard failure. Widening to alphanumeric/longer risks mis-catching 48-char Moonshot/OpenAI keys. Needs a real DeepSeek key to confirm the actual format before touching.

## Tests

`tsc` clean; `oxlint` 0 warnings; recognizer parity test + ProviderDetector suite green (67 tests), incl. new GitHub-PAT detection and explicit "no longer false-matches dg_/aai_/xi-api-" assertions.

Refs #224
