### PR TITLE
fix(wcore): pass LD_LIBRARY_PATH through ENGINE_ENV_ALLOWLIST (#233)

### DIFF
--- a/src/process/agent/wcore/envBuilder.ts
+++ b/src/process/agent/wcore/envBuilder.ts
@@ -462,6 +462,11 @@ const ENGINE_ENV_ALLOWLIST: readonly string[] = [
   'TMP',
   'TEMP',
   'PWD',
+  // ── Linux dynamic linker ───────────────────────────────────────────────
+  // Shared-library search path. Required on ARM64 Ubuntu 24.04 (Noble) when
+  // the engine needs OpenSSL 1.1 from a non-system prefix. Without it the
+  // dynamic linker can't find the .so and the engine fails on startup (#233).
+  'LD_LIBRARY_PATH',
   // ── Wayland engine config (non-secret) ─────────────────────────────────
   // The user's bash-tool shell selection. Set in the environment (never by the
   // app), so a GUI-launched engine only receives it when it survives this

--- a/tests/unit/wcore-toolKeyEnv.test.ts
+++ b/tests/unit/wcore-toolKeyEnv.test.ts
@@ -133,6 +133,14 @@ describe('buildEngineSpawnEnv - SEC-1 allowlist', () => {
     expect(env.WAYLAND_BASH_SHELL).toBe('/opt/homebrew/bin/fish');
   });
 
+  it('forwards LD_LIBRARY_PATH so the engine resolves OpenSSL 1.1 on ARM64 Ubuntu 24.04 (#233)', () => {
+    process.env.LD_LIBRARY_PATH = '/opt/openssl-1.1/lib:/usr/lib/aarch64-linux-gnu';
+
+    const env = buildEngineSpawnEnv({ providerEnv: {} });
+
+    expect(env.LD_LIBRARY_PATH).toBe('/opt/openssl-1.1/lib:/usr/lib/aarch64-linux-gnu');
+  });
+
   it('always preserves the provider auth env even though it is a secret name', () => {
     const env = buildEngineSpawnEnv({ providerEnv: { ANTHROPIC_API_KEY: 'sk-ant-123' } });
     expect(env.ANTHROPIC_API_KEY).toBe('sk-ant-123');


### PR DESCRIPTION
## Problem

On ARM64 Ubuntu 24.04 (Noble) headless runs, the spawned `wayland-core` engine child process loses `LD_LIBRARY_PATH`. When the engine depends on OpenSSL 1.1 from a non-system prefix (e.g. `/opt/openssl-1.1/lib`), the dynamic linker can't find the `.so` and the engine fails to start.

Root cause: `buildEngineSpawnEnv()` filters `process.env` down to `ENGINE_ENV_ALLOWLIST`, and `LD_LIBRARY_PATH` was not in it.

## Fix

Add `LD_LIBRARY_PATH` to `ENGINE_ENV_ALLOWLIST` in `src/process/agent/wcore/envBuilder.ts`, with a comment explaining the ARM64/Noble context. Same class of fix as `WAYLAND_BASH_SHELL` (#197).

## Scope

**Desktop half only (env passthrough).** The OpenSSL 1.1 binary bundling / static-linking on Noble ARM64 is a Core-side concern that still needs handling in `wayland-core`.

## Test

Added `it('forwards LD_LIBRARY_PATH ...')` to `tests/unit/wcore-toolKeyEnv.test.ts`, mirroring the existing `WAYLAND_BASH_SHELL` test. All 8 tests in the file pass.

## Verification

- `bunx tsc --noEmit` → exit 0
- `bunx oxlint envBuilder.ts wcore-toolKeyEnv.test.ts` → 0 errors (1 pre-existing warning on an unrelated line)
- `oxfmt` → clean
- `bunx vitest run tests/unit/wcore-toolKeyEnv.test.ts` → 8 passed, 3 skipped