### PR TITLE
fix(providers): route MiniMax through the native engine provider (#135)

### DIFF
--- a/src/process/agent/wcore/envBuilder.ts
+++ b/src/process/agent/wcore/envBuilder.ts
@@ -122,6 +122,10 @@ const NATIVE_ENGINE_PROVIDER_IDS = [
   'fireworks',
   'cerebras',
   'nvidia',
+  // minimax is an Anthropic-wire native provider in the bundled engine (0.12.5):
+  // `--provider minimax` -> api.minimax.io/anthropic with MINIMAX_API_KEY. Without
+  // this it falls through to `--provider openai` and breaks (#135).
+  'minimax',
 ] as const;
 const NATIVE_ENGINE_PROVIDER_SET: ReadonlySet<string> = new Set(NATIVE_ENGINE_PROVIDER_IDS);
 

--- a/src/process/providers/detection/KeyDiscovery.ts
+++ b/src/process/providers/detection/KeyDiscovery.ts
@@ -63,6 +63,7 @@ export const PROVIDER_ENV_VARS: Partial<Record<ProviderId, readonly string[]>> =
   cerebras: ['CEREBRAS_API_KEY'],
   moonshot: ['MOONSHOT_API_KEY'],
   nvidia: ['NVIDIA_API_KEY'],
+  minimax: ['MINIMAX_API_KEY'],
 };
 
 /**
@@ -86,6 +87,7 @@ const ENV_SCAN_ORDER: readonly ProviderId[] = [
   'cerebras',
   'moonshot',
   'nvidia',
+  'minimax',
 ];
 
 /**

--- a/tests/unit/process/providers/keyDiscovery.test.ts
+++ b/tests/unit/process/providers/keyDiscovery.test.ts
@@ -323,4 +323,8 @@ describe('KeyDiscovery - PROVIDER_ENV_VARS map', () => {
     expect(PROVIDER_ENV_VARS.moonshot).toEqual(['MOONSHOT_API_KEY']);
     expect(PROVIDER_ENV_VARS.nvidia).toEqual(['NVIDIA_API_KEY']);
   });
+
+  it('covers minimax with its canonical env var (issue #135)', () => {
+    expect(PROVIDER_ENV_VARS.minimax).toEqual(['MINIMAX_API_KEY']);
+  });
 });

--- a/tests/unit/wcore-catalogDispatch.test.ts
+++ b/tests/unit/wcore-catalogDispatch.test.ts
@@ -197,29 +197,33 @@ describe('buildSpawnConfig - engine-native provider routing (#177)', () => {
     ['fireworks', 'FIREWORKS_API_KEY'],
     ['cerebras', 'CEREBRAS_API_KEY'],
     ['nvidia', 'NVIDIA_API_KEY'],
+    ['minimax', 'MINIMAX_API_KEY'],
   ];
 
-  it.each(NATIVE)('routes %s via the v2 bridge tag as --provider %s with the scoped key, NO --base-url', (id, envVar) => {
-    // Persisted exactly as the legacy bridge stores it: platform collapses to
-    // 'openai-compatible', a non-empty (but wrong-for-engine) base URL is
-    // present, and the only identity carrier is the `v2:<id>` tag.
-    const model: TProviderWithModel = {
-      id: 'native-uuid',
-      platform: 'openai-compatible',
-      name: id,
-      baseUrl: 'https://example.invalid/v1',
-      apiKey: `${id}-secret`,
-      useModel: 'some-model',
-      __waylandModelRegistryBridge: `v2:${id}`,
-    } as TProviderWithModel;
-    const { args, env } = buildSpawnConfig(model, OPTS);
+  it.each(NATIVE)(
+    'routes %s via the v2 bridge tag as --provider %s with the scoped key, NO --base-url',
+    (id, envVar) => {
+      // Persisted exactly as the legacy bridge stores it: platform collapses to
+      // 'openai-compatible', a non-empty (but wrong-for-engine) base URL is
+      // present, and the only identity carrier is the `v2:<id>` tag.
+      const model: TProviderWithModel = {
+        id: 'native-uuid',
+        platform: 'openai-compatible',
+        name: id,
+        baseUrl: 'https://example.invalid/v1',
+        apiKey: `${id}-secret`,
+        useModel: 'some-model',
+        __waylandModelRegistryBridge: `v2:${id}`,
+      } as TProviderWithModel;
+      const { args, env } = buildSpawnConfig(model, OPTS);
 
-    expect(providerArg(args)).toBe(id);
-    expect(hasBaseUrl(args)).toBe(false);
-    expect(env[envVar]).toBe(`${id}-secret`);
-    // Must NOT leak to the shared OpenAI key (the #177 root cause).
-    expect(env.OPENAI_API_KEY).toBeUndefined();
-  });
+      expect(providerArg(args)).toBe(id);
+      expect(hasBaseUrl(args)).toBe(false);
+      expect(env[envVar]).toBe(`${id}-secret`);
+      // Must NOT leak to the shared OpenAI key (the #177 root cause).
+      expect(env.OPENAI_API_KEY).toBeUndefined();
+    }
+  );
 
   it.each(NATIVE)('routes %s stored directly as the platform (forward-compat) as --provider %s', (id, envVar) => {
     const { args, env } = buildSpawnConfig(makeNativeModel(id, `${id}-key`), OPTS);


### PR DESCRIPTION
## What

Fixes #135 (MiniMax integration broken). MiniMax was recognized by the catalog but never dispatched through its native engine provider — it fell through to `--provider openai`, the exact #177 failure class. This routes it correctly.

## Changes
- `envBuilder.ts`: add `minimax` to `NATIVE_ENGINE_PROVIDER_IDS` → spawns as `--provider minimax` (no `--base-url`; the engine owns it).
- `KeyDiscovery.ts`: add `minimax: ['MINIMAX_API_KEY']` to `PROVIDER_ENV_VARS` + `ENV_SCAN_ORDER` (the #177 anti-divergence contract requires every native id to have a canonical key env var).
- Tests: minimax added to the native-routing `it.each` table (`wcore-catalogDispatch.test.ts`) and a discovery assertion (`keyDiscovery.test.ts`).

## Engine verification
Verified against the **bundled wayland-core 0.12.5 binary** (not a checkout): it lists `minimax` in its `--provider` enum, maps it to `https://api.minimax.io/anthropic` (Anthropic wire), reads `MINIMAX_API_KEY`, and an internal comment confirms *"Anthropic-wire providers (minimax*…): not OpenAI-compat."* So routing via `--provider minimax` is structurally correct.

## Open items
- **Needs live verification** with a real MiniMax API key — CI can't exercise the live provider.
- Layer-3 `CHAT_START_PLATFORM` for minimax is left as `'openai-compatible'`, matching the working deepseek/groq precedent (the `--provider` flag is the identity carrier). If the engine team confirms minimax needs an explicit `anthropic`/`minimax` platform string, that's a one-line follow-up.

## Verification
- 55/55 routing + discovery tests pass · `tsc` 0 · `oxlint` 0 errors · `oxfmt` clean