### PR TITLE
feat(server): add TRUST_PROXY env var for Express trust proxy setting

### DIFF
--- a/src/process/webserver/index.ts
+++ b/src/process/webserver/index.ts
@@ -255,6 +255,20 @@ export async function startWebServerWithInstance(port: number, allowRemote = fal
 
   // Create Express app and server
   const app = express();
+
+  // Trust proxy — required when running behind a reverse proxy (Traefik,
+  // nginx, etc.) so that rate limiters and `req.secure` correctly read
+  // X-Forwarded-For and X-Forwarded-Proto headers set by the proxy.
+  //   TRUST_PROXY=1   → trust the first hop (single proxy, most common)
+  //   TRUST_PROXY=N   → trust N hops
+  //   TRUST_PROXY     → trust all (equivalent to true)
+  //   unset           → trust none (Express default)
+  const trustProxy = process.env.TRUST_PROXY;
+  if (trustProxy !== undefined) {
+    const parsed = parseInt(trustProxy, 10);
+    app.set('trust proxy', isNaN(parsed) ? true : parsed);
+  }
+
   const server = createServer(app);
   // Use noServer mode so we can route WebSocket upgrades manually.
   // This lets us forward Vite HMR upgrades to the Vite dev server during


### PR DESCRIPTION
## Problem

Running Wayland behind a reverse proxy (Traefik, nginx, Caddy, etc.) triggers an error from `express-rate-limit`:

```
ValidationError: The 'X-Forwarded-For' header is set but the Express 'trust proxy' setting is false (default). This could indicate a misconfiguration which would prevent express-rate-limit from accurately determining the client IP.
```

The proxy correctly sets the `X-Forwarded-For` header, but Express ignores it because `trust proxy` defaults to `false`. This means:

- **Rate limiters** operate on the proxy's IP, not the real client IP (all traffic appears to come from one IP)
- **`req.secure` / `req.protocol`** cannot detect HTTPS behind the proxy
- **Warning logs** are emitted on every proxied request

## Solution

Introduce a `TRUST_PROXY` environment variable that configures Express's built-in `trust proxy` setting:

| `TRUST_PROXY` | Express setting | Use case |
|---|---|---|
| unset | `false` (default) | No proxy — existing behaviour unchanged |
| `1` | `1` (first hop) | Single reverse proxy (e.g., Traefik, nginx) |
| `N` | `N` hops | Multiple proxy hops |
| any non-numeric value | `true` (trust all) | Complex proxy chains |

## Usage

```bash
# Single reverse proxy (most common — Traefik, nginx, Caddy)
docker run -e TRUST_PROXY=1 -e ALLOW_REMOTE=true seppaleinen/wayland

# When deployed behind multiple proxy hops (e.g., CDN → nginx → app)
docker run -e TRUST_PROXY=2 -e ALLOW_REMOTE=true seppaleinen/wayland
```

## Testing

- [x] `TRUST_PROXY=1` with Traefik → rate limiter correctly reads `X-Forwarded-For` IP, no errors
- [x] `TRUST_PROXY` unset → Express default behaviour, zero regression
- [x] Validated against Express docs: https://expressjs.com/en/guide/behind-proxies.html

## Implementation

Two lines of runtime logic plus a doc comment — minimal footprint, maximum compatibility:

```ts
const trustProxy = process.env.TRUST_PROXY;
if (trustProxy !== undefined) {
  const parsed = parseInt(trustProxy, 10);
  app.set('trust proxy', isNaN(parsed) ? true : parsed);
}
```