### PR TITLE
test(onboarding): fix Windows-only codexAuthFile path assertion

### DIFF
--- a/tests/unit/process/codexAuthFile.test.ts
+++ b/tests/unit/process/codexAuthFile.test.ts
@@ -33,7 +33,7 @@ describe('codexAuthPath', () => {
   });
 
   it('honors $CODEX_HOME', () => {
-    expect(codexAuthPath({ CODEX_HOME: '/tmp/custom-codex' })).toBe('/tmp/custom-codex/auth.json');
+    expect(codexAuthPath({ CODEX_HOME: '/tmp/custom-codex' })).toBe(path.join('/tmp/custom-codex', 'auth.json'));
   });
 
   it('ignores a blank $CODEX_HOME', () => {
@@ -83,7 +83,9 @@ describe('parseCodexAuthDoc', () => {
 
   it('prefers an explicit account_id over the id_token claim', () => {
     const idToken = makeIdToken({ 'https://api.openai.com/auth': { chatgpt_account_id: 'acct-jwt' } });
-    const bundle = parseCodexAuthDoc({ tokens: { access_token: 'acc', id_token: idToken, account_id: 'acct-explicit' } });
+    const bundle = parseCodexAuthDoc({
+      tokens: { access_token: 'acc', id_token: idToken, account_id: 'acct-explicit' },
+    });
     expect(bundle?.accountId).toBe('acct-explicit');
   });
 
@@ -112,7 +114,9 @@ describe('writeCodexAuthFile / readCodexAuthFile round-trip', () => {
     const tokens: ChatGptTokens = {
       accessToken: 'acc',
       refreshToken: 'ref',
-      idToken: makeIdToken({ 'https://api.openai.com/auth': { chatgpt_account_id: 'acct-1', chatgpt_plan_type: 'plus' } }),
+      idToken: makeIdToken({
+        'https://api.openai.com/auth': { chatgpt_account_id: 'acct-1', chatgpt_plan_type: 'plus' },
+      }),
       accountId: 'acct-1',
     };
 


### PR DESCRIPTION
Fixes #290

## Summary

`tests/unit/process/codexAuthFile.test.ts` fails on Windows CI (`Unit Tests Shard (windows-2022 2/4)`). The `codexAuthPath > honors $CODEX_HOME` case asserted a hardcoded POSIX path:

```ts
expect(codexAuthPath({ CODEX_HOME: '/tmp/custom-codex' })).toBe('/tmp/custom-codex/auth.json');
```

`codexAuthPath` builds the path with `path.join`, which is platform-native, so on Windows it returns `\tmp\custom-codex\auth.json` and the assertion fails:

```
AssertionError: expected '\tmp\custom-codex\auth.json' to be '/tmp/custom-codex/auth.json'
```

The fix makes the expectation platform-aware, matching the sibling cases in the same file (`defaults to ~/.codex/auth.json` and `ignores a blank $CODEX_HOME` already use `path.join`):

```ts
expect(codexAuthPath({ CODEX_HOME: '/tmp/custom-codex' })).toBe(path.join('/tmp/custom-codex', 'auth.json'));
```

**Test-only.** Production code (`codexAuthPath`) is unchanged and already correct — returning native separators is the intended behaviour.

## Note

Touching this file caused `oxfmt` to also normalize two pre-existing long lines in `parseCodexAuthDoc` / `writeCodexAuthFile` (the formatter runs on the whole changed file, so the format gate requires it). Those are whitespace-only.

## Test plan

- [x] `bun run test tests/unit/process/codexAuthFile.test.ts`: 11/11 passing
- [x] `oxfmt --check`: clean
- [x] `oxlint`: 0 warnings / 0 errors
- [x] Logic verified cross-platform: `path.win32.join('/tmp/custom-codex', 'auth.json')` → `\tmp\custom-codex\auth.json` (matches the Windows CI `Received`); `path.posix.join(...)` → `/tmp/custom-codex/auth.json`

Spotted while triaging CI on #276 (an unrelated STT change).