### PR TITLE
fix(acp): repair OpenCode agent — session/set_mode + session/set_model (#298)

### DIFF
--- a/src/common/types/agentModes.ts
+++ b/src/common/types/agentModes.ts
@@ -50,6 +50,36 @@ export function mapModeForAcpBridge(mode: string): string {
 }
 
 /**
+ * Resolve the effective `session/set_mode` modeId to send to an ACP agent,
+ * validated against the modes the agent actually advertised (in session/new or
+ * initialize).
+ *
+ * The requested mode is first translated to the bridge vocabulary via
+ * `mapModeForAcpBridge` (e.g. 'autoGuarded' -> 'default'). The result is then
+ * checked against the agent's advertised modes: some backends do not expose a
+ * 'default' agent - opencode's primary mode is 'build' - so sending an
+ * unadvertised modeId makes the agent reject the request ("Agent not found:
+ * default") and the session never becomes usable (issue #298). When the agent
+ * advertised modes and the mapped id is not among them, fall back to the agent's
+ * advertised current/primary mode (or the first advertised mode).
+ *
+ * When the agent advertised no modes (e.g. the Claude bridge, which honors
+ * 'default'/'acceptEdits' without listing them in a top-level `modes` object),
+ * the mapped id is trusted as-is so existing backends are unaffected.
+ */
+export function resolveAcpSessionModeId(
+  mode: string,
+  availableModes: ReadonlyArray<{ id: string }> | undefined,
+  currentModeId: string | null | undefined
+): string {
+  const bridgeModeId = mapModeForAcpBridge(mode);
+  if (!availableModes || availableModes.length === 0) return bridgeModeId;
+  if (availableModes.some((m) => m.id === bridgeModeId)) return bridgeModeId;
+  if (currentModeId && availableModes.some((m) => m.id === currentModeId)) return currentModeId;
+  return availableModes[0].id;
+}
+
+/**
  * Get the full-auto mode value for a given backend.
  * Falls back to 'yolo' for unknown backends.
  */

--- a/src/process/acp/infra/ProcessAcpClient.ts
+++ b/src/process/acp/infra/ProcessAcpClient.ts
@@ -27,6 +27,7 @@ import type {
 } from '@agentclientprotocol/sdk';
 import { ClientSideConnection, PROTOCOL_VERSION } from '@agentclientprotocol/sdk';
 import { AgentDisconnectedError, AgentSpawnError, AgentStartupError } from '@process/acp/errors/AcpError';
+import { normalizeError } from '@process/acp/errors/errorNormalize';
 import { mapModeForAcpBridge } from '@/common/types/agentModes';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -70,6 +71,10 @@ export class ProcessAcpClient implements AcpClient {
   private _lastExit: AgentExitInfo | null = null;
   private disconnectHandler: ((info: DisconnectInfo) => void) | null = null;
   private hasActivePrompt = false;
+
+  // Learned capability: set to true once the agent rejects session/set_model
+  // with -32601 (Method not found), so we stop re-sending it (#298).
+  private setModelUnsupported = false;
 
   // Pending request tracking
   private readonly pendingRequests = new Set<PendingRequest>();
@@ -222,7 +227,24 @@ export class ProcessAcpClient implements AcpClient {
   }
 
   async setModel(sessionId: string, modelId: string): Promise<void> {
-    await this.runConnectionRequest(() => this.conn.unstable_setSessionModel({ sessionId, modelId }));
+    // Feature-detect session/set_model. Some agents (e.g. opencode v1.17.9) do
+    // not implement it and reject with JSON-RPC -32601 "Method not found". Once
+    // learned, skip the call instead of repeating it on every prompt re-assert -
+    // which otherwise floods the logs and never selects a model (#298).
+    if (this.setModelUnsupported) return;
+    try {
+      await this.runConnectionRequest(() => this.conn.unstable_setSessionModel({ sessionId, modelId }));
+    } catch (err) {
+      if (normalizeError(err).code === 'ACP_METHOD_NOT_FOUND') {
+        this.setModelUnsupported = true;
+        console.warn(
+          `[ProcessAcpClient] ${this.options.backend}: session/set_model not supported by this agent; ` +
+            'skipping model selection (the agent manages its own model).'
+        );
+        return;
+      }
+      throw err;
+    }
   }
 
   async setMode(sessionId: string, modeId: string): Promise<void> {

--- a/src/process/acp/session/AcpSession.ts
+++ b/src/process/acp/session/AcpSession.ts
@@ -5,6 +5,7 @@ import type {
   UsageUpdate,
 } from '@agentclientprotocol/sdk';
 import * as path from 'node:path';
+import { resolveAcpSessionModeId } from '@/common/types/agentModes';
 import { AcpError } from '@process/acp/errors/AcpError';
 import { buildAcpSetupGuidance } from '@process/acp/errors/setupFailure';
 import type { ClientFactory, DisconnectInfo } from '@process/acp/infra/IAcpClient';
@@ -253,9 +254,14 @@ export class AcpSession {
     if (this._status === 'idle' || this._status === 'error') return;
     const { client, sessionId } = this.lifecycle;
     if (this._status === 'active' && client && sessionId) {
+      // Validate against the agent's advertised modes: backends like opencode
+      // have no `default` agent (their primary is `build`), so an unadvertised
+      // modeId is rejected with "Agent not found" and breaks the session (#298).
+      const { availableModes, currentModeId } = this.configTracker.modeSnapshot();
+      const resolved = resolveAcpSessionModeId(modeId, availableModes, currentModeId);
       client
-        .setMode(sessionId, modeId)
-        .then(() => this.configTracker.setCurrentMode(modeId))
+        .setMode(sessionId, resolved)
+        .then(() => this.configTracker.setCurrentMode(resolved))
         .then(() => this.callbacks.onModeUpdate(this.configTracker.modeSnapshot()))
         .catch((err) => console.warn('[AcpSession] setMode failed:', err));
     }

--- a/src/process/acp/session/SessionLifecycle.ts
+++ b/src/process/acp/session/SessionLifecycle.ts
@@ -1,4 +1,4 @@
-import { getFullAutoMode } from '@/common/types/agentModes';
+import { getFullAutoMode, resolveAcpSessionModeId } from '@/common/types/agentModes';
 import { isFluxModelId } from '@/common/config/flux';
 import { parseInitializeResult } from '@/common/types/acpTypes';
 import type { AuthMethod, LoadSessionResponse, McpServer, NewSessionResponse } from '@agentclientprotocol/sdk';
@@ -327,9 +327,16 @@ export class SessionLifecycle {
       }
     }
     if (pending.mode) {
+      // Validate the desired mode against the agent's advertised modes before
+      // re-asserting it. Wayland seeds the desired mode from the generic
+      // `default`, but backends like opencode have no `default` agent (their
+      // primary is `build`) and reject it with "Agent not found", breaking the
+      // session at startup/reconnect (#298).
+      const { availableModes, currentModeId } = this.host.configTracker.modeSnapshot();
+      const mode = resolveAcpSessionModeId(pending.mode, availableModes, currentModeId);
       try {
-        await this._client.setMode(this._sessionId, pending.mode);
-        this.host.configTracker.setCurrentMode(pending.mode);
+        await this._client.setMode(this._sessionId, mode);
+        this.host.configTracker.setCurrentMode(mode);
       } catch {
         /* best effort */
       }

--- a/tests/integration/process/acp/session/AcpSession.modeResolution.test.ts
+++ b/tests/integration/process/acp/session/AcpSession.modeResolution.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AcpSession } from '@process/acp/session/AcpSession';
+import type { AcpClient, ClientFactory } from '@process/acp/infra/IAcpClient';
+import type { AgentConfig, SessionCallbacks } from '@process/acp/types';
+
+function createMockCallbacks(): SessionCallbacks {
+  return {
+    onMessage: vi.fn(),
+    onSessionId: vi.fn(),
+    onStatusChange: vi.fn(),
+    onConfigUpdate: vi.fn(),
+    onModelUpdate: vi.fn(),
+    onModeUpdate: vi.fn(),
+    onContextUsage: vi.fn(),
+    onPermissionRequest: vi.fn(),
+    onSignal: vi.fn(),
+  };
+}
+
+// opencode-style agent: advertises build/plan modes (no `default` agent).
+function createOpencodeClient(): AcpClient {
+  return {
+    start: vi.fn().mockResolvedValue({ protocolVersion: '0.1', capabilities: {} }),
+    createSession: vi.fn().mockResolvedValue({
+      sessionId: 'sess-oc',
+      modes: {
+        currentModeId: 'build',
+        availableModes: [
+          { id: 'build', name: 'Build' },
+          { id: 'plan', name: 'Plan' },
+        ],
+      },
+      models: { currentModelId: undefined, availableModels: [] },
+      configOptions: [],
+    }),
+    loadSession: vi.fn().mockResolvedValue({ sessionId: 'sess-oc' }),
+    prompt: vi.fn().mockResolvedValue({ stopReason: 'end_turn' }),
+    cancel: vi.fn().mockResolvedValue(undefined),
+    setModel: vi.fn().mockResolvedValue(undefined),
+    setMode: vi.fn().mockResolvedValue(undefined),
+    setConfigOption: vi.fn().mockResolvedValue(undefined),
+    closeSession: vi.fn().mockResolvedValue(undefined),
+    extMethod: vi.fn().mockResolvedValue({}),
+    authenticate: vi.fn().mockResolvedValue({}),
+    lifecycleSnapshot: { pid: null, running: false, lastExit: null },
+    onDisconnect: vi.fn(),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+const opencodeConfig: AgentConfig = {
+  agentBackend: 'opencode',
+  agentSource: 'extension',
+  agentId: 'extension:opencode',
+  cwd: '/tmp',
+  command: '/usr/bin/opencode',
+  args: ['acp'],
+};
+
+describe('AcpSession mode resolution for opencode (#298)', () => {
+  let callbacks: SessionCallbacks;
+  let client: AcpClient;
+  let clientFactory: ClientFactory;
+
+  beforeEach(() => {
+    callbacks = createMockCallbacks();
+    client = createOpencodeClient();
+    clientFactory = { create: vi.fn(() => client) };
+  });
+
+  it('re-asserts the agent primary mode (build), never the generic "default"', async () => {
+    // Wayland seeds the desired mode from its generic default ("default"),
+    // exactly as AcpAgentManager does (sessionMode = currentMode = 'default').
+    const session = new AcpSession(opencodeConfig, clientFactory, callbacks, {
+      initialDesired: { mode: 'default' },
+    });
+
+    session.start();
+    await vi.waitFor(() => expect(session.status).toBe('active'));
+
+    const setModeCalls = (client.setMode as ReturnType<typeof vi.fn>).mock.calls;
+    // The agent must never receive "default" — opencode rejects it as
+    // "Agent not found: default".
+    for (const [, modeId] of setModeCalls) {
+      expect(modeId).not.toBe('default');
+    }
+    // It should have re-asserted using the advertised primary mode.
+    expect(setModeCalls.some(([, modeId]) => modeId === 'build')).toBe(true);
+  });
+
+  it('user mode switch validates against advertised modes', async () => {
+    const session = new AcpSession(opencodeConfig, clientFactory, callbacks);
+    session.start();
+    await vi.waitFor(() => expect(session.status).toBe('active'));
+
+    (client.setMode as ReturnType<typeof vi.fn>).mockClear();
+
+    // A stale/unsupported mode id resolves to the advertised primary mode.
+    session.setMode('default');
+    await vi.waitFor(() => expect((client.setMode as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0));
+    const [, modeId] = (client.setMode as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(modeId).toBe('build');
+
+    // A real advertised mode passes through unchanged.
+    (client.setMode as ReturnType<typeof vi.fn>).mockClear();
+    session.setMode('plan');
+    await vi.waitFor(() => expect((client.setMode as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0));
+    expect((client.setMode as ReturnType<typeof vi.fn>).mock.calls[0][1]).toBe('plan');
+  });
+});

--- a/tests/unit/process/acp/infra/ProcessAcpClientSetModel.test.ts
+++ b/tests/unit/process/acp/infra/ProcessAcpClientSetModel.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { RequestError } from '@agentclientprotocol/sdk';
+import { ProcessAcpClient } from '@process/acp/infra/ProcessAcpClient';
+import type { ProtocolHandlers } from '@process/acp/types';
+
+function makeClient(connOverrides: Record<string, unknown>) {
+  const handlers = {} as ProtocolHandlers;
+  const client = new ProcessAcpClient(() => Promise.reject(new Error('no spawn in unit test')), {
+    backend: 'opencode',
+    handlers,
+  });
+  // Inject a fake SDK connection so the `conn` getter resolves it (bypasses spawn).
+  (client as unknown as { connection: unknown }).connection = {
+    unstable_setSessionModel: vi.fn(),
+    ...connOverrides,
+  };
+  return client;
+}
+
+describe('ProcessAcpClient.setModel feature-detection (#298)', () => {
+  it('stops calling session/set_model after a -32601 "Method not found" rejection', async () => {
+    const setSessionModel = vi.fn().mockRejectedValue(new RequestError(-32601, 'Method not found'));
+    const client = makeClient({ unstable_setSessionModel: setSessionModel });
+
+    // First call learns the method is unsupported and swallows the error.
+    await expect(client.setModel('sess-1', 'gpt-5')).resolves.toBeUndefined();
+    expect(setSessionModel).toHaveBeenCalledTimes(1);
+
+    // Subsequent calls are skipped entirely - no repeated RPC, no log flood.
+    await expect(client.setModel('sess-1', 'gpt-5')).resolves.toBeUndefined();
+    await expect(client.setModel('sess-1', 'claude')).resolves.toBeUndefined();
+    expect(setSessionModel).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-throws non-method-not-found errors (does not mark unsupported)', async () => {
+    const setSessionModel = vi
+      .fn()
+      .mockRejectedValueOnce(new RequestError(-32603, 'Internal error'))
+      .mockResolvedValue(undefined);
+    const client = makeClient({ unstable_setSessionModel: setSessionModel });
+
+    await expect(client.setModel('sess-1', 'gpt-5')).rejects.toBeInstanceOf(RequestError);
+    // Not marked unsupported - a later call still goes through.
+    await expect(client.setModel('sess-1', 'gpt-5')).resolves.toBeUndefined();
+    expect(setSessionModel).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps sending session/set_model on the happy path', async () => {
+    const setSessionModel = vi.fn().mockResolvedValue(undefined);
+    const client = makeClient({ unstable_setSessionModel: setSessionModel });
+
+    await client.setModel('sess-1', 'gpt-5');
+    await client.setModel('sess-1', 'claude');
+    expect(setSessionModel).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/resolveAcpSessionModeId.test.ts
+++ b/tests/unit/resolveAcpSessionModeId.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { resolveAcpSessionModeId } from '@/common/types/agentModes';
+
+describe('resolveAcpSessionModeId', () => {
+  it('maps Wayland-internal autoGuarded → bridge default when no modes are advertised', () => {
+    // Claude bridge advertises no top-level modes; the mapped id passes through.
+    expect(resolveAcpSessionModeId('autoGuarded', undefined, null)).toBe('default');
+    expect(resolveAcpSessionModeId('default', [], null)).toBe('default');
+    expect(resolveAcpSessionModeId('acceptEdits', [], 'default')).toBe('acceptEdits');
+  });
+
+  it('keeps the requested mode when it is one of the advertised modes', () => {
+    const modes = [{ id: 'build' }, { id: 'plan' }];
+    expect(resolveAcpSessionModeId('plan', modes, 'build')).toBe('plan');
+    expect(resolveAcpSessionModeId('build', modes, 'build')).toBe('build');
+  });
+
+  it('falls back to the advertised current/primary mode for opencode (#298)', () => {
+    // opencode advertises build/plan and has no `default` agent. Both the literal
+    // `default` and the mapped `autoGuarded → default` must resolve to `build`.
+    const modes = [{ id: 'build' }, { id: 'plan' }];
+    expect(resolveAcpSessionModeId('default', modes, 'build')).toBe('build');
+    expect(resolveAcpSessionModeId('autoGuarded', modes, 'build')).toBe('build');
+  });
+
+  it('falls back to the first advertised mode when currentModeId is missing or invalid', () => {
+    const modes = [{ id: 'build' }, { id: 'plan' }];
+    expect(resolveAcpSessionModeId('default', modes, null)).toBe('build');
+    expect(resolveAcpSessionModeId('default', modes, undefined)).toBe('build');
+    expect(resolveAcpSessionModeId('default', modes, 'nonexistent')).toBe('build');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #298 — the bundled OpenCode (ACP) agent could never reach a usable session.

Two ACP requests from Wayland were rejected by `opencode`:

1. **`session/set_mode { modeId: "default" }` → "Agent not found: default".** OpenCode has no `default` agent; its primary mode is `build`. Wayland seeds the desired session mode from the generic `default` (`AcpAgentManager.currentMode`), so at session start / reconnect `SessionLifecycle.reassertConfig` sent `default` and OpenCode rejected it.
2. **`session/set_model` → `-32601 "Method not found"`.** OpenCode v1.17.9 doesn't implement it, and Wayland re-asserted it on every prompt (30+ log occurrences).

## Changes

- **`resolveAcpSessionModeId(mode, availableModes, currentModeId)`** (`src/common/types/agentModes.ts`): validates the requested mode against the modes the agent advertised in `session/new`/`initialize`. If the mode isn't advertised, falls back to the agent's advertised current/primary mode (e.g. `build`). Backends that advertise **no** top-level modes (the Claude bridge) are unaffected — the mode passes through unchanged.
- Apply it in **`AcpSession.setMode`** (user mode switch) and **`SessionLifecycle.reassertConfig`** (startup/reconnect re-assert).
- **`ProcessAcpClient.setModel`**: feature-detect `session/set_model`. On a `-32601` rejection, mark it unsupported and skip subsequent calls — no log flood, graceful no-op (the agent manages its own model).

## Scope / safety

Only the OpenCode ACP path changes behavior. Claude/Qwen/Cursor advertise modes differently (or not at all) and pass through unchanged — verified by the existing 219 ACP tests.

## Testing

- `tests/unit/resolveAcpSessionModeId.test.ts` — resolver logic.
- `tests/integration/process/acp/session/AcpSession.modeResolution.test.ts` — drives the **real** `AcpSession` + `SessionLifecycle` + `ConfigTracker` with an opencode-shaped agent; asserts `set_mode` never receives `default` and re-asserts `build`.
- `tests/unit/process/acp/infra/ProcessAcpClientSetModel.test.ts` — `-32601` learned-skip, non-`-32601` re-throw, happy path.
- Full ACP suite green: **219 passed**.