### PR TITLE
test(webui): green /sw.js static-route test on integration branch (#299)

### DIFF
--- a/tests/unit/webuiStaticRoutes.test.ts
+++ b/tests/unit/webuiStaticRoutes.test.ts
@@ -3,6 +3,8 @@ import os from 'os';
 import path from 'path';
 import express from 'express';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { registerPlatformServices } from '@/common/platform';
+import { NodePlatformServices } from '@/common/platform/NodePlatformServices';
 
 const tempDirs: string[] = [];
 
@@ -27,6 +29,9 @@ function getRegisteredGetRoutePaths(app: express.Express): Array<string | RegExp
 afterEach(() => {
   vi.resetModules();
   vi.restoreAllMocks();
+  // Restore the default node platform services registered by vitest.setup.ts so
+  // the per-test stub below does not leak into other tests in this file.
+  registerPlatformServices(new NodePlatformServices());
 
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
@@ -37,12 +42,13 @@ describe('registerStaticRoutes', () => {
   it('does not register a dedicated /favicon.ico route in production static mode', async () => {
     const packagedRoot = createPackagedRendererRoot();
 
-    vi.doMock('electron', () => ({
-      app: {
-        setName: vi.fn(),
-        getAppPath: () => packagedRoot,
-      },
-    }));
+    // staticRoutes resolves the renderer build via
+    // getPlatformServices().paths.getAppPath() (not electron.app directly), so
+    // point the platform service at the packaged renderer root for this test.
+    const services = new NodePlatformServices();
+    services.paths.getAppPath = () => packagedRoot;
+    registerPlatformServices(services);
+
     vi.doMock('@process/webserver/auth/middleware/TokenMiddleware', () => ({
       TokenMiddleware: {
         extractToken: () => null,


### PR DESCRIPTION
## Summary

Fixes #299 — greens `tests/unit/webuiStaticRoutes.test.ts` on `feat/workflows-collaborative-surface` (failing on all shards), unblocking #291→#290 and #276→#277.

## Root cause (test fixture, not production)

`staticRoutes.resolveRendererPath()` resolves the renderer build via `getPlatformServices().paths.getAppPath()` (migrated in `18cf85c1a`). The test still mocked `electron.app.getAppPath` directly. In the vitest **node** environment, `getPlatformServices()` is `NodePlatformServices`, whose `getAppPath()` returns `process.cwd()` — so the test's mocked packaged root was never consulted:

- `resolveRendererPath()` → `process.cwd()` has no `out/renderer/index.html` → returns `null`
- `registerStaticRoutes` takes the **Vite dev-proxy** branch and registers **no** routes
- `expect(getRegisteredGetRoutePaths(app)).toContain('/sw.js')` fails on an empty `[]`

The `/sw.js` registration in `staticRoutes.ts` (lines 155-159) is already correct — in real Electron, `ElectronPlatformServices` returns the packaged app path and the production static routes (including `/sw.js`) register fine. **This was a test-only red.**

## Fix

Register a platform-services stub pointing at the packaged renderer root (the real resolution path) instead of mocking `electron`; restore the default `NodePlatformServices` in `afterEach` so the stub can't leak into sibling tests.

## Testing

- Target test passes and now genuinely exercises the production static path (the "No renderer build found" dev-proxy log is gone).
- Neighboring webui/webserver + platform-services tests green (99 passed) — no fixture leakage from the `afterEach` change.