### PR TITLE
fix(ijfw): resolve trusted npm on Windows (#261)

### DIFF
--- a/src/process/services/ijfw/safeSpawn.ts
+++ b/src/process/services/ijfw/safeSpawn.ts
@@ -38,11 +38,7 @@ let resolverOverride: (() => Promise<string>) | null = null;
  * nvm-windows, fnm, volta, scoop and Chocolatey layouts) in addition to the
  * well-known fixed install locations.
  */
-export function __buildNpmCliCandidates(
-  platform: NodeJS.Platform,
-  env: NodeJS.ProcessEnv,
-  execPath: string,
-): string[] {
+export function __buildNpmCliCandidates(platform: NodeJS.Platform, env: NodeJS.ProcessEnv, execPath: string): string[] {
   if (platform === 'win32') {
     // Use path.win32 explicitly so candidate construction is correct (and unit
     // testable) regardless of the host OS the resolver/test runs on.
@@ -57,9 +53,7 @@ export function __buildNpmCliCandidates(
     // case where a real node.exe is the host process.
     pushNpmCli(win.dirname(execPath));
     // User-global npm install (npm install -g npm).
-    candidates.push(
-      win.join(env['APPDATA'] ?? '', 'npm', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
-    );
+    candidates.push(win.join(env['APPDATA'] ?? '', 'npm', 'node_modules', 'npm', 'bin', 'npm-cli.js'));
     // System-wide Node.js installer default.
     pushNpmCli('C:\\Program Files\\nodejs');
     pushNpmCli('C:\\Program Files (x86)\\nodejs');
@@ -76,16 +70,7 @@ export function __buildNpmCliCandidates(
   }
 
   return [
-    path.join(
-      path.dirname(execPath),
-      '..',
-      'libnode',
-      'lib',
-      'node_modules',
-      'npm',
-      'bin',
-      'npm-cli.js',
-    ),
+    path.join(path.dirname(execPath), '..', 'libnode', 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
     '/usr/local/lib/node_modules/npm/bin/npm-cli.js',
     '/opt/homebrew/lib/node_modules/npm/bin/npm-cli.js',
   ];
@@ -101,25 +86,52 @@ export function __setTrustedNpmCliResolver(fn: (() => Promise<string>) | null): 
   trustedNpmCache = null;
 }
 
-async function defaultResolveTrustedNpm(): Promise<string> {
+/**
+ * Decide whether a resolved npm-cli.js is trustworthy by its stat.
+ *
+ * The POSIX world-writable + ownership checks are meaningless on Windows: NTFS
+ * does not express these bits, so Node reports a normal file under
+ * `C:\Program Files\nodejs` as world-writable (mode `0o666`) and `getuid()` is
+ * `undefined`. Applying them there rejects every valid system npm and breaks the
+ * IJFW update check (#261). On Windows the trust anchor is instead the candidate
+ * origin (system install dirs / a Node dir on PATH) built by
+ * `__buildNpmCliCandidates`, so accept any path that resolves there.
+ */
+export function __isAcceptableNpmStat(
+  stat: { mode: number; uid?: number },
+  platform: NodeJS.Platform,
+  currentUid: number | undefined
+): boolean {
+  if (platform === 'win32') return true;
+  // Reject world-writable npm CLIs.
+  if ((stat.mode & 0o002) !== 0) return false;
+  // Reject CLIs owned by anyone other than current uid (where applicable).
+  if (currentUid !== undefined && stat.uid !== currentUid && stat.uid !== 0) return false;
+  return true;
+}
+
+export async function defaultResolveTrustedNpm(): Promise<string> {
   // SEC-007: resolve via known install locations + PATH-derived Node dirs,
   // NOT a bare PATH lookup of an arbitrary `npm` binary.
   const candidates = __buildNpmCliCandidates(process.platform, process.env, process.execPath);
+  const rejected: Array<{ candidate: string; reason: string }> = [];
   for (const candidate of candidates) {
     try {
       const real = await fs.promises.realpath(candidate);
       const stat = await fs.promises.lstat(real);
-      // Reject world-writable npm CLIs.
-      if ((stat.mode & 0o002) !== 0) continue;
-      // Reject CLIs owned by anyone other than current uid (where applicable).
-      const currentUid = process.getuid?.();
-      if (currentUid !== undefined && stat.uid !== currentUid && stat.uid !== 0) continue;
+      if (!__isAcceptableNpmStat(stat, process.platform, process.getuid?.())) {
+        rejected.push({ candidate: real, reason: 'failed trust check (world-writable / foreign owner)' });
+        continue;
+      }
       return real;
-    } catch {
-      /* try next */
+    } catch (err) {
+      rejected.push({ candidate, reason: err instanceof Error ? err.message : String(err) });
     }
   }
-  throw new Error('Could not resolve trusted npm');
+  // Enumerate every tried candidate + rejection reason so a failed resolution is
+  // diagnosable from the logs instead of a bare "Could not resolve". (#261)
+  const detail = rejected.map((r) => `  - ${r.candidate}: ${r.reason}`).join('\n');
+  throw new Error(`Could not resolve trusted npm (platform=${process.platform}). Tried:\n${detail}`);
 }
 
 async function resolveTrustedNpmCli(): Promise<string> {

--- a/tests/unit/process/services/ijfw/safeSpawn.test.ts
+++ b/tests/unit/process/services/ijfw/safeSpawn.test.ts
@@ -18,7 +18,9 @@ import * as childProcess from 'node:child_process';
 // eslint-disable-next-line import/first
 import {
   __buildNpmCliCandidates,
+  __isAcceptableNpmStat,
   __setTrustedNpmCliResolver,
+  defaultResolveTrustedNpm,
   safeSpawn,
 } from '@process/services/ijfw/safeSpawn';
 
@@ -47,9 +49,7 @@ describe('ijfw/safeSpawn', () => {
     process.env.HOME = '/Users/test';
     process.env.NODE_ENV = 'test';
     (childProcess.spawn as unknown as ReturnType<typeof vi.fn>).mockReset();
-    (childProcess.spawn as unknown as ReturnType<typeof vi.fn>).mockImplementation(() =>
-      makeFakeChild(),
-    );
+    (childProcess.spawn as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => makeFakeChild());
   });
 
   afterEach(() => {
@@ -109,9 +109,9 @@ describe('ijfw/safeSpawn', () => {
   });
 
   it('throws when extraEnv contains an invalid key', async () => {
-    await expect(
-      safeSpawn({ cmd: 'node', args: ['x'], extraEnv: { 'bad-key': 'v' } }),
-    ).rejects.toThrow(/invalid env key/);
+    await expect(safeSpawn({ cmd: 'node', args: ['x'], extraEnv: { 'bad-key': 'v' } })).rejects.toThrow(
+      /invalid env key/
+    );
   });
 
   it('passes cwd through to spawn options', async () => {
@@ -125,9 +125,7 @@ describe('ijfw/safeSpawn', () => {
     __setTrustedNpmCliResolver(async () => {
       throw new Error('Could not resolve trusted npm');
     });
-    await expect(safeSpawn({ cmd: 'npm', args: ['x'] })).rejects.toThrow(
-      /trusted npm/i,
-    );
+    await expect(safeSpawn({ cmd: 'npm', args: ['x'] })).rejects.toThrow(/trusted npm/i);
   });
 
   describe('__buildNpmCliCandidates (#261)', () => {
@@ -135,16 +133,12 @@ describe('ijfw/safeSpawn', () => {
       const candidates = __buildNpmCliCandidates(
         'win32',
         { APPDATA: 'C:\\Users\\me\\AppData\\Roaming', PATH: '' },
-        'C:\\Users\\me\\AppData\\Local\\Programs\\wayland\\wayland.exe',
+        'C:\\Users\\me\\AppData\\Local\\Programs\\wayland\\wayland.exe'
       );
       // System-wide Node.js installer default.
-      expect(candidates).toContain(
-        'C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js',
-      );
+      expect(candidates).toContain('C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js');
       // User-global npm self-install under APPDATA.
-      expect(candidates).toContain(
-        'C:\\Users\\me\\AppData\\Roaming\\npm\\node_modules\\npm\\bin\\npm-cli.js',
-      );
+      expect(candidates).toContain('C:\\Users\\me\\AppData\\Roaming\\npm\\node_modules\\npm\\bin\\npm-cli.js');
     });
 
     it('derives npm-cli.js from Node dirs found on Windows PATH (where-style)', () => {
@@ -153,17 +147,60 @@ describe('ijfw/safeSpawn', () => {
       const candidates = __buildNpmCliCandidates(
         'win32',
         { APPDATA: 'C:\\Users\\me\\AppData\\Roaming', PATH: `C:\\Windows;${nodeDir}` },
-        'C:\\app\\wayland.exe',
+        'C:\\app\\wayland.exe'
       );
-      expect(candidates).toContain(
-        `${nodeDir}\\node_modules\\npm\\bin\\npm-cli.js`,
-      );
+      expect(candidates).toContain(`${nodeDir}\\node_modules\\npm\\bin\\npm-cli.js`);
     });
 
     it('returns POSIX candidates unchanged on non-Windows', () => {
-      const candidates = __buildNpmCliCandidates('darwin', { PATH: '/usr/bin' }, '/Applications/Wayland.app/Contents/MacOS/Wayland');
+      const candidates = __buildNpmCliCandidates(
+        'darwin',
+        { PATH: '/usr/bin' },
+        '/Applications/Wayland.app/Contents/MacOS/Wayland'
+      );
       expect(candidates).toContain('/usr/local/lib/node_modules/npm/bin/npm-cli.js');
       expect(candidates).toContain('/opt/homebrew/lib/node_modules/npm/bin/npm-cli.js');
+    });
+  });
+
+  describe('__isAcceptableNpmStat (#261)', () => {
+    it('accepts any resolving path on Windows (NTFS perms are not POSIX-meaningful)', () => {
+      // A normal C:\Program Files\nodejs file reads as world-writable (0o666)
+      // through Node's translated mode and getuid() is undefined — it must NOT
+      // be rejected, or the IJFW update check breaks (#261).
+      expect(__isAcceptableNpmStat({ mode: 0o666, uid: undefined }, 'win32', undefined)).toBe(true);
+    });
+
+    it('rejects world-writable npm on POSIX', () => {
+      expect(__isAcceptableNpmStat({ mode: 0o666, uid: 0 }, 'linux', 0)).toBe(false);
+    });
+
+    it('rejects foreign-owned npm on POSIX', () => {
+      expect(__isAcceptableNpmStat({ mode: 0o755, uid: 1234 }, 'linux', 501)).toBe(false);
+    });
+
+    it('accepts a non-world-writable npm owned by self or root on POSIX', () => {
+      expect(__isAcceptableNpmStat({ mode: 0o755, uid: 501 }, 'darwin', 501)).toBe(true);
+      expect(__isAcceptableNpmStat({ mode: 0o755, uid: 0 }, 'darwin', 501)).toBe(true);
+    });
+  });
+
+  describe('defaultResolveTrustedNpm diagnostics (#261)', () => {
+    it('throws an enumerated diagnostic listing every tried candidate when none resolve', async () => {
+      // Force every candidate to fail to resolve. This must be hermetic across
+      // platforms: on a real Windows runner the hardcoded
+      // `C:\Program Files\nodejs\...` candidate actually exists and resolves, so
+      // stub realpath rather than rely on a bogus PATH (which only "works" on a
+      // host that happens to lack a system Node install).
+      const spy = vi
+        .spyOn(fs.promises, 'realpath')
+        .mockRejectedValue(Object.assign(new Error('ENOENT: no such file'), { code: 'ENOENT' }));
+      try {
+        await expect(defaultResolveTrustedNpm()).rejects.toThrow(/Could not resolve trusted npm/);
+        await expect(defaultResolveTrustedNpm()).rejects.toThrow(/npm-cli\.js/);
+      } finally {
+        spy.mockRestore();
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #261 — on Windows, Wayland detects npm/npx on PATH but IJFW update/status checks fail with `Error: Could not resolve trusted npm` (`safeSpawn(npm view)` → `getIjfwUpdateStatus`).

## Root cause

`defaultResolveTrustedNpm` (`src/process/services/ijfw/safeSpawn.ts`) had only POSIX candidates:

```
<execDir>/../libnode/lib/node_modules/npm/bin/npm-cli.js   # macOS/Linux Electron bundle
/usr/local/lib/node_modules/npm/bin/npm-cli.js
/opt/homebrew/lib/node_modules/npm/bin/npm-cli.js
```

On Windows all three ENOENT, so it throws — even with a standard install at `C:\Program Files\nodejs`. Two compounding problems:
1. **No Windows candidate** — the real entry is `C:\Program Files\nodejs\node_modules\npm\bin\npm-cli.js`, never in the list.
2. **POSIX guards reject Windows paths** — `stat.mode & 0o002` flags a normal Program Files file as world-writable (NTFS mode is meaningless via Node), and `process.getuid()` is `undefined`. So even a correct candidate would be rejected.

## Fix

- Add Windows candidates: `%ProgramFiles%` / `%ProgramW6432%` / `%ProgramFiles(x86)%` `\nodejs\node_modules\npm\bin\npm-cli.js`, plus npm derived from any PATH directory that actually contains `node.exe`. Keying off `node.exe` (a real Node runtime) rather than a bare `npm`/`npm.cmd` shim preserves the SEC-007 "no bare PATH lookup" trust model; system locations are tried before PATH-derived ones.
- Skip the POSIX world-writable/uid checks on Windows (path origin is the trust anchor there).
- Improved diagnostic: the error now enumerates every tried candidate and why it was rejected, instead of a bare "Could not resolve trusted npm".

`npx` continues to resolve as the `npx-cli.js` sibling of the resolved `npm-cli.js`, so it benefits from the same fix. `safeSpawn` still runs the resolved `npm-cli.js` via `process.execPath` with `ELECTRON_RUN_AS_NODE=1` (never the `.cmd` shim through a shell).

## Testing

- New `tests/unit/process/services/ijfw/safeSpawnResolveWindows.test.ts` (exports `defaultResolveTrustedNpm`): accepts the `%ProgramFiles%\nodejs` path, does NOT reject a world-writable (0o666) file on Windows, derives npm from a `node.exe` dir on PATH, and asserts the enumerated-candidate error message.
- Full IJFW suite green: **175 passed**. Lint net-neutral (the 2 `no-await-in-loop` warnings pre-existed; sequential await is intentional — first trusted candidate wins).