### PR TITLE
feat(updater): surface silent macOS install failures + break the re-offer loop (#286, non-closing)

### DIFF
--- a/src/common/update/updateTypes.ts
+++ b/src/common/update/updateTypes.ts
@@ -97,7 +97,14 @@ export type AutoUpdateStatusType =
   | 'downloading'
   | 'downloaded'
   | 'error'
+  // An update was downloaded + install attempted but never applied (silent
+  // Squirrel/ShipIt no-op), or the app can't update in place (macOS app running
+  // outside /Applications). Surfaced instead of silently re-offering (#286).
+  | 'install-failed'
   | 'cancelled';
+
+/** Why an update could not be applied, carried on an 'install-failed' status. */
+export type AutoUpdateInstallFailedReason = 'silent-noop' | 'not-in-applications';
 
 export interface AutoUpdateProgress {
   bytesPerSecond: number;
@@ -113,4 +120,6 @@ export interface AutoUpdateStatus {
   releaseNotes?: string;
   progress?: AutoUpdateProgress;
   error?: string;
+  /** Set when status === 'install-failed'. */
+  reason?: AutoUpdateInstallFailedReason;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -629,6 +629,10 @@ const createWindow = ({ showOnReady = true }: { showOnReady?: boolean } = {}): v
         const statusBroadcast = createAutoUpdateStatusBroadcast();
         autoUpdaterService.initialize(statusBroadcast);
         globalThis.__waylandUpdateChannelStatus = { available: true };
+        // Detect a silent install failure from the previous launch (downloaded +
+        // attempted but the version never advanced) before the first check, so the
+        // imminent re-offer is surfaced as a failure instead of looped silently (#286).
+        autoUpdaterService.reconcilePendingInstall();
         // Check for updates after 3 seconds delay
         setTimeout(() => {
           void autoUpdaterService.checkForUpdatesAndNotify();
@@ -1144,7 +1148,18 @@ const prefetchCleanupModules = (): Promise<CleanupModules> => {
     import('@process/bridge/fileWatchBridge'),
     import('@process/channels/tunnel'),
   ]).then(
-    ([ambient, channels, webuiBridge, webserverAdapter, officeWatch, pptPreview, database, cron, fileWatch, tunnel]) => ({
+    ([
+      ambient,
+      channels,
+      webuiBridge,
+      webserverAdapter,
+      officeWatch,
+      pptPreview,
+      database,
+      cron,
+      fileWatch,
+      tunnel,
+    ]) => ({
       ambient,
       channels,
       webuiBridge,

--- a/src/process/services/autoUpdaterService.ts
+++ b/src/process/services/autoUpdaterService.ts
@@ -9,6 +9,10 @@ import type { ProgressInfo, UpdateInfo } from 'electron-updater';
 import { app } from 'electron';
 import log from 'electron-log';
 import { EventEmitter } from 'events';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { writeFileSyncAtomic } from '@process/utils/atomicWrite';
+import type { AutoUpdateInstallFailedReason } from '@/common/update/updateTypes';
 
 /**
  * Returns the appropriate update channel name based on the current platform and architecture.
@@ -41,7 +45,15 @@ export function getUpdateChannel(): string | undefined {
 }
 
 export interface AutoUpdateStatus {
-  status: 'checking' | 'available' | 'not-available' | 'downloading' | 'downloaded' | 'error' | 'cancelled';
+  status:
+    | 'checking'
+    | 'available'
+    | 'not-available'
+    | 'downloading'
+    | 'downloaded'
+    | 'error'
+    | 'install-failed'
+    | 'cancelled';
   version?: string;
   releaseDate?: string;
   releaseNotes?: string;
@@ -52,6 +64,8 @@ export interface AutoUpdateStatus {
     total: number;
   };
   error?: string;
+  /** Set when status === 'install-failed'. */
+  reason?: AutoUpdateInstallFailedReason;
 }
 
 /** Callback type for broadcasting update status */
@@ -77,6 +91,14 @@ class AutoUpdaterService extends EventEmitter {
   private _downloadInProgress = false;
   /** Stores registered autoUpdater event handlers for cleanup and test access */
   private readonly _autoUpdaterHandlers = new Map<string, (...args: unknown[]) => void>();
+  /** Version of the most recently downloaded update (captured on 'update-downloaded'). */
+  private _lastDownloadedVersion: string | null = null;
+  /**
+   * Version whose in-place install silently failed on the previous launch
+   * (downloaded + attempted but the app version never advanced). Re-offers of
+   * this version are surfaced as install-failed instead of a plain offer (#286).
+   */
+  private _failedInstallVersion: string | null = null;
 
   constructor() {
     super();
@@ -145,6 +167,8 @@ class AutoUpdaterService extends EventEmitter {
     this._eventHandlersSetup = false;
     this._allowPrerelease = false;
     this._statusBroadcastCallback = null;
+    this._lastDownloadedVersion = null;
+    this._failedInstallVersion = null;
     // Remove listeners from this EventEmitter instance
     this.removeAllListeners();
     // Remove each registered handler from autoUpdater to prevent
@@ -207,6 +231,27 @@ class AutoUpdaterService extends EventEmitter {
 
     register('update-available', (info: UpdateInfo) => {
       log.info(`Update available: ${info.version}`);
+
+      // macOS can't apply an in-place update when the app runs outside
+      // /Applications (App Translocation / quarantined read-only path): ShipIt
+      // silently no-ops. Surface guidance instead of offering a doomed install (#286).
+      const blockReason = this.macUpdateBlockReason();
+      if (blockReason) {
+        log.warn(
+          `[autoUpdater] Update ${info.version} cannot be applied in place (${blockReason}); surfacing guidance.`
+        );
+        this.broadcastInstallFailed(blockReason, info.version);
+        return;
+      }
+
+      // A prior install of this exact version silently failed. Don't re-offer the
+      // same doomed update (the loop in #286) — surface the failure + manual path.
+      if (this._failedInstallVersion && info.version === this._failedInstallVersion) {
+        log.warn(`[autoUpdater] Suppressing re-offer of ${info.version}: prior install silently failed (#286).`);
+        this.broadcastInstallFailed('silent-noop', info.version);
+        return;
+      }
+
       this.broadcastStatus({
         status: 'available',
         version: info.version,
@@ -236,6 +281,9 @@ class AutoUpdaterService extends EventEmitter {
     register('update-downloaded', (info: UpdateInfo) => {
       log.info('Update downloaded');
       this._downloadInProgress = false;
+      // Remember which version we're about to install so quitAndInstall() can
+      // persist a pending-install marker for next-launch verification (#286).
+      this._lastDownloadedVersion = info.version;
       this.broadcastStatus({
         status: 'downloaded',
         version: info.version,
@@ -253,7 +301,10 @@ class AutoUpdaterService extends EventEmitter {
       // (it then flipped to "available"). Suppress those; only surface a real
       // download/install failure.
       if (!this._downloadInProgress) {
-        log.warn('Auto-updater check-phase error suppressed (handled via check result + manual fallback):', error.message);
+        log.warn(
+          'Auto-updater check-phase error suppressed (handled via check result + manual fallback):',
+          error.message
+        );
         return;
       }
       this._downloadInProgress = false;
@@ -331,6 +382,10 @@ class AutoUpdaterService extends EventEmitter {
 
   quitAndInstall(): void {
     log.info('Quitting and installing update...');
+    // Persist a pending-install marker BEFORE handing off to Squirrel/ShipIt, so
+    // the next launch can detect a silent apply failure (downloaded + attempted
+    // but the version never advanced) and surface it instead of looping (#286).
+    this.writePendingInstallMarker();
     // On macOS, autoUpdater.quitAndInstall() closes all windows but the
     // 'window-all-closed' handler does NOT call app.quit() (standard macOS
     // behavior + close-to-tray). This leaves the process alive and Squirrel
@@ -340,6 +395,111 @@ class AutoUpdaterService extends EventEmitter {
     setTimeout(() => {
       app.exit(0);
     }, 1000);
+  }
+
+  /**
+   * Path of the cross-launch pending-install marker under userData.
+   */
+  private pendingInstallMarkerPath(): string {
+    return path.join(app.getPath('userData'), 'pending-update.json');
+  }
+
+  /**
+   * Record the version we're about to install so the next launch can verify the
+   * apply step actually advanced the app version (#286). Best-effort: a failed
+   * write just means we lose loop-detection for this one attempt.
+   */
+  private writePendingInstallMarker(): void {
+    if (!this._lastDownloadedVersion) return;
+    try {
+      writeFileSyncAtomic(
+        this.pendingInstallMarkerPath(),
+        JSON.stringify({ version: this._lastDownloadedVersion, attemptedAt: Date.now() }),
+        { mode: 0o600 }
+      );
+    } catch (error) {
+      log.warn('[autoUpdater] Failed to write pending-update marker:', error);
+    }
+  }
+
+  /**
+   * On the next launch after an install attempt, verify the update actually
+   * applied. If the version did not advance, the post-quit Squirrel/ShipIt step
+   * silently no-op'd (#286): record the failed version (so the imminent re-offer
+   * is surfaced rather than looped), log it for diagnostics, and surface it.
+   * The marker is one-shot — always removed after reading.
+   *
+   * Call once at startup, before the first update check.
+   */
+  reconcilePendingInstall(): void {
+    const markerPath = this.pendingInstallMarkerPath();
+    let expected: string | undefined;
+    try {
+      if (!fs.existsSync(markerPath)) return;
+      const parsed = JSON.parse(fs.readFileSync(markerPath, 'utf8')) as { version?: string };
+      expected = typeof parsed.version === 'string' ? parsed.version : undefined;
+    } catch (error) {
+      log.warn('[autoUpdater] Failed to read pending-update marker:', error);
+    } finally {
+      try {
+        fs.rmSync(markerPath, { force: true });
+      } catch (error) {
+        log.warn('[autoUpdater] Failed to remove pending-update marker:', error);
+      }
+    }
+
+    if (!expected) return;
+    const current = app.getVersion();
+    if (expected === current) {
+      log.info(`[autoUpdater] Update to ${expected} applied successfully.`);
+      return;
+    }
+
+    // Downloaded + install attempted, but the version never advanced.
+    this._failedInstallVersion = expected;
+    log.error(
+      `[autoUpdater] Update to ${expected} was downloaded and install was attempted, but the app is ` +
+        `still on ${current}. The post-quit Squirrel/ShipIt apply step silently failed (#286).`
+    );
+    // Surface immediately if a renderer is already listening; the update-available
+    // interception re-surfaces it once the 3s startup check runs, as a backstop.
+    this.broadcastInstallFailed('silent-noop', expected);
+  }
+
+  /**
+   * Returns a block reason when the current process cannot apply an in-place
+   * update, else null. macOS only: App Translocation / a quarantined read-only
+   * path outside /Applications makes ShipIt silently no-op (#286).
+   */
+  private macUpdateBlockReason(): AutoUpdateInstallFailedReason | null {
+    if (process.platform !== 'darwin') return null;
+    try {
+      const inApps = (app as { isInApplicationsFolder?: () => boolean }).isInApplicationsFolder;
+      if (typeof inApps === 'function' && !inApps.call(app)) {
+        return 'not-in-applications';
+      }
+    } catch (error) {
+      log.warn('[autoUpdater] isInApplicationsFolder check failed:', error);
+    }
+    return null;
+  }
+
+  /**
+   * Broadcast an install-failed status with an actionable, human-readable
+   * message. The message is sent in the `error` field (mirroring how raw
+   * electron-updater error messages are already surfaced) so no new UI strings
+   * are required for this defensive path.
+   */
+  private broadcastInstallFailed(reason: AutoUpdateInstallFailedReason, version?: string): void {
+    const subject = version ? `Wayland ${version}` : 'The update';
+    const message =
+      reason === 'not-in-applications'
+        ? `${subject} can't be installed because Wayland is running from outside your Applications folder ` +
+          `(macOS blocks in-place updates from temporary or read-only locations). Move Wayland to ` +
+          `/Applications, reopen it, and try again.`
+        : `${subject} was downloaded but couldn't be installed automatically (the app is still running the ` +
+          `previous version). Please download and install it manually from the Releases page.`;
+    this.broadcastStatus({ status: 'install-failed', reason, version, error: message });
   }
 
   /**

--- a/src/renderer/components/settings/UpdateModal.tsx
+++ b/src/renderer/components/settings/UpdateModal.tsx
@@ -336,6 +336,15 @@ const UpdateModal: React.FC = () => {
           setStatus('error');
           setErrorMsg(evt.error || t('update.downloadFailed'));
           break;
+        case 'install-failed':
+          // A downloaded update never applied (silent Squirrel/ShipIt no-op) or
+          // the app can't update in place (macOS outside /Applications). Surface
+          // it through the error view + Releases CTA, and force the modal open so
+          // the user isn't left in a silent re-offer loop (#286).
+          setStatus('error');
+          setErrorMsg(evt.error || t('update.downloadFailed'));
+          setVisible(true);
+          break;
       }
     });
 

--- a/tests/unit/autoUpdaterServiceInstallGuard.test.ts
+++ b/tests/unit/autoUpdaterServiceInstallGuard.test.ts
@@ -1,0 +1,190 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Defensive coverage for #286: surface a silent macOS install failure
+ * (downloaded + attempted but version unchanged) and guard against offering an
+ * in-place update the app can't apply (running outside /Applications), instead
+ * of silently re-offering forever.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+let userDataDir: string;
+
+vi.mock('electron', () => ({
+  app: {
+    getVersion: vi.fn(() => '1.0.0'),
+    getPath: vi.fn(() => userDataDir),
+    isInApplicationsFolder: vi.fn(() => true),
+    isPackaged: true,
+    exit: vi.fn(),
+  },
+}));
+
+vi.mock('electron-updater', () => ({
+  autoUpdater: {
+    logger: null,
+    autoDownload: true,
+    autoInstallOnAppQuit: true,
+    allowPrerelease: false,
+    allowDowngrade: false,
+    channel: null,
+    on: vi.fn(),
+    removeListener: vi.fn(),
+    removeAllListeners: vi.fn(),
+    checkForUpdates: vi.fn(),
+    downloadUpdate: vi.fn(),
+    quitAndInstall: vi.fn(),
+    checkForUpdatesAndNotify: vi.fn(),
+  },
+}));
+
+vi.mock('electron-log', () => ({
+  default: {
+    transports: { file: { level: 'info' } },
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+import { app } from 'electron';
+import { autoUpdater } from 'electron-updater';
+
+const realPlatform = process.platform;
+function setPlatform(value: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value, configurable: true });
+}
+
+function markerPath(): string {
+  return path.join(userDataDir, 'pending-update.json');
+}
+
+async function freshService() {
+  vi.resetModules();
+  const mod = await import('@/process/services/autoUpdaterService');
+  return mod.autoUpdaterService;
+}
+
+describe('autoUpdaterService install guard (#286)', () => {
+  let service: any;
+  let broadcast: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wl-updater-'));
+    (app.getVersion as ReturnType<typeof vi.fn>).mockReturnValue('1.0.0');
+    (app.isInApplicationsFolder as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    broadcast = vi.fn();
+    service = await freshService();
+    service.initialize(broadcast);
+  });
+
+  afterEach(() => {
+    service?.resetForTest();
+    setPlatform(realPlatform);
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  });
+
+  function lastStatus() {
+    return broadcast.mock.calls.at(-1)?.[0];
+  }
+  function statuses() {
+    return broadcast.mock.calls.map((c) => c[0].status);
+  }
+
+  it('writes a pending-install marker on quitAndInstall after a download', () => {
+    service.triggerEventForTest('update-downloaded', { version: '2.0.0' });
+    service.quitAndInstall();
+
+    expect(fs.existsSync(markerPath())).toBe(true);
+    expect(JSON.parse(fs.readFileSync(markerPath(), 'utf8')).version).toBe('2.0.0');
+    expect(autoUpdater.quitAndInstall).toHaveBeenCalledWith(true, true);
+  });
+
+  it('does not write a marker if nothing was downloaded', () => {
+    service.quitAndInstall();
+    expect(fs.existsSync(markerPath())).toBe(false);
+  });
+
+  it('reconcile: version advanced → success, marker removed, no failure surfaced', () => {
+    fs.writeFileSync(markerPath(), JSON.stringify({ version: '1.0.0', attemptedAt: 1 }));
+    (app.getVersion as ReturnType<typeof vi.fn>).mockReturnValue('1.0.0');
+
+    service.reconcilePendingInstall();
+
+    expect(fs.existsSync(markerPath())).toBe(false);
+    expect(statuses()).not.toContain('install-failed');
+  });
+
+  it('reconcile: version did NOT advance → install-failed surfaced + marker removed', () => {
+    fs.writeFileSync(markerPath(), JSON.stringify({ version: '2.0.0', attemptedAt: 1 }));
+    (app.getVersion as ReturnType<typeof vi.fn>).mockReturnValue('1.0.0');
+
+    service.reconcilePendingInstall();
+
+    expect(fs.existsSync(markerPath())).toBe(false);
+    const s = lastStatus();
+    expect(s.status).toBe('install-failed');
+    expect(s.reason).toBe('silent-noop');
+    expect(s.version).toBe('2.0.0');
+    expect(s.error).toMatch(/manually/i);
+  });
+
+  it('suppresses a re-offer of the version whose install silently failed', () => {
+    fs.writeFileSync(markerPath(), JSON.stringify({ version: '2.0.0', attemptedAt: 1 }));
+    service.reconcilePendingInstall();
+    broadcast.mockClear();
+
+    service.triggerEventForTest('update-available', { version: '2.0.0' });
+
+    const s = lastStatus();
+    expect(s.status).toBe('install-failed');
+    expect(s.reason).toBe('silent-noop');
+    expect(statuses()).not.toContain('available');
+  });
+
+  it('still offers a genuinely newer version after a prior failure', () => {
+    fs.writeFileSync(markerPath(), JSON.stringify({ version: '2.0.0', attemptedAt: 1 }));
+    service.reconcilePendingInstall();
+    broadcast.mockClear();
+
+    service.triggerEventForTest('update-available', { version: '3.0.0' });
+
+    expect(lastStatus().status).toBe('available');
+  });
+
+  it('macOS outside /Applications → install-failed (not-in-applications), not an offer', () => {
+    setPlatform('darwin');
+    (app.isInApplicationsFolder as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+    service.triggerEventForTest('update-available', { version: '2.0.0' });
+
+    const s = lastStatus();
+    expect(s.status).toBe('install-failed');
+    expect(s.reason).toBe('not-in-applications');
+    expect(s.error).toMatch(/Applications/);
+    expect(statuses()).not.toContain('available');
+  });
+
+  it('macOS inside /Applications → normal offer', () => {
+    setPlatform('darwin');
+    (app.isInApplicationsFolder as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+    service.triggerEventForTest('update-available', { version: '2.0.0' });
+
+    expect(lastStatus().status).toBe('available');
+  });
+
+  it('non-macOS never runs the Applications guard', () => {
+    setPlatform('win32');
+    service.triggerEventForTest('update-available', { version: '2.0.0' });
+    expect(lastStatus().status).toBe('available');
+    expect(app.isInApplicationsFolder).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

**Defensive instrumentation for #286 — explicitly does NOT close it.** Greenlit by Sean as a loop-breaker + diagnostic-accelerator that's independent of the root cause. It does **not** touch the quit/install sequence; the apply-sequence fix waits on Sean's on-machine ShipIt diagnostic.

On macOS the post-quit Squirrel/ShipIt apply step can silently no-op (signature mismatch / app translocation / running outside `/Applications`), so the app relaunches on the old version and re-offers the same update forever with zero feedback.

## What it does (ASK #1 + ASK #2 from the issue)

- **Detect + surface silent install failure:** `quitAndInstall()` persists a pending-install marker (`version` + `attemptedAt`) via `writeFileSyncAtomic`; on next launch `reconcilePendingInstall()` (wired into the boot path in `index.ts`) compares it to `app.getVersion()`. If the version didn't advance → log it (diagnostics) and surface a new `install-failed` status. Marker is one-shot.
- **Break the loop:** suppress re-offering the exact version whose install just silently failed — surface `install-failed` with a manual-download message instead of the plain offer.
- **Translocation guard (macOS):** when `app.isInApplicationsFolder() === false` (translocation / read-only path), surface `install-failed('not-in-applications')` with move-to-`/Applications` guidance instead of offering a doomed in-place update.
- **Renderer:** maps `install-failed` onto the existing error view (message + "Open Releases" CTA) and force-opens the modal so the failure is visible.

The surfaced message rides the existing `error` field (same as raw electron-updater error messages today), so **no new i18n strings** are introduced.

## Scope / safety

Detection + surfacing only — cannot regress the happy path. It composes cleanly with integration's existing `_downloadInProgress` error-gating. **#286 stays open + `blocked`** until the diagnostic picks the root cause; this PR makes that diagnostic conclusive (the marker turns the silent no-op into a logged/surfaced event).

## Testing

- `tests/unit/autoUpdaterServiceInstallGuard.test.ts` (9): marker write on quitAndInstall, reconcile success (version advanced) vs failure (unchanged), re-offer suppression of the failed version, genuinely-newer version still offered, and the macOS `/Applications` guard (outside → install-failed, inside → offer, non-macOS → no guard).
- Existing updater suite green: **67 passed** (autoUpdaterService + updateBridge + integration).

Built on `integration/0.11.4`.