### PR TITLE
fix(doctor): real MCP-timeout fix + skip disabled providers (#273 #271)

### DIFF
--- a/src/process/doctor/checks/mcpChecks.ts
+++ b/src/process/doctor/checks/mcpChecks.ts
@@ -84,11 +84,20 @@ export async function checkMcpServers(deps: McpCheckDeps): Promise<DoctorCheckOu
   const needAuth: string[] = [];
   let okCount = 0;
 
-  // Probe sequentially: connection tests can spawn CLIs / open sockets, and a
-  // burst of parallel spawns is a worse failure mode than a slightly slower run.
-  // Each probe is individually bounded so one hung server cannot starve the rest.
-  for (const server of enabled) {
-    const result = await probeWithTimeout(deps.testConnection, server, perServerTimeoutMs);
+  // Probe every server CONCURRENTLY, each under its own timeout. A sequential
+  // run sums the per-server budgets: with the dozen-plus servers this check
+  // exists to diagnose (#273), several hung probes at `perServerTimeoutMs` each
+  // would blow past the runner's 30s whole-check budget and collapse right back
+  // into the opaque "timed out after 30s" with no per-server detail. Bounding the
+  // total to ~one per-server timeout regardless of count is the only way to keep
+  // the partial diagnostics the user actually needs. Result order matches
+  // `enabled` so the report is stable.
+  const results = await Promise.all(
+    enabled.map((server) => probeWithTimeout(deps.testConnection, server, perServerTimeoutMs))
+  );
+  for (let i = 0; i < enabled.length; i += 1) {
+    const server = enabled[i];
+    const result = results[i];
     if (result === TIMED_OUT) {
       timedOut.push(server.name);
     } else if (result.success) {

--- a/src/process/doctor/checks/providerChecks.ts
+++ b/src/process/doctor/checks/providerChecks.ts
@@ -26,6 +26,21 @@ export type ProviderRegistryReader = {
   listRegistryProviders: () => RegistryProvider[];
   getRegistryProviderCreds: (providerId: ProviderId) => RegistryCredsResult;
   countRegistryCatalog: (providerId: ProviderId) => number;
+  /**
+   * How many of a provider's catalog models are effectively ENABLED (curated
+   * defaults with the user's per-model overrides applied) — the same notion the
+   * Models page provider on/off toggle uses.
+   */
+  countEnabledModels?: (providerId: ProviderId) => number;
+  /**
+   * Whether the user has written ANY explicit per-model enable/disable override
+   * for the provider. This is what distinguishes a deliberate "switch the
+   * provider OFF" (the toggle writes `false` overrides for every model) from a
+   * provider that simply has zero models enabled BY DEFAULT (the curator marks
+   * non-flagship / legacy / out-of-recency models disabled, and a fresh connect
+   * writes no overrides at all). Only the former is "user-disabled" (issue #271).
+   */
+  hasModelOverrides?: (providerId: ProviderId) => boolean;
 };
 
 /** The connect-probe surface — `ConnectionTester.test` (narrowed for tests). */
@@ -83,6 +98,29 @@ function baseUrlFromCreds(creds: Record<string, unknown>): string | undefined {
 }
 
 /**
+ * True when the user has intentionally switched a provider OFF, so connectivity
+ * must skip it entirely — not probe, warn, or report (Overwatch ruling on issue
+ * #271). "User-disabled" requires ALL of:
+ *  - a non-empty catalog (an EMPTY catalog is the "no models" state the
+ *    model-registry check owns, not a disable — still probe it);
+ *  - zero effectively-enabled models; AND
+ *  - at least one explicit per-model override.
+ *
+ * The override requirement is the crucial guard: the curator marks many models
+ * disabled BY DEFAULT (non-flagship / legacy / out-of-recency), and a fresh
+ * connect writes no overrides — so "zero enabled" ALONE does not imply user
+ * intent. Without it, a genuinely-connected provider whose models all default
+ * off would be silently skipped, hiding a real auth/credit failure. Only a
+ * deliberate toggle-OFF (which writes `false` overrides) counts. Requires both
+ * `countEnabledModels` and `hasModelOverrides`; absent either, nothing is
+ * treated as disabled (probe it — never silence a real failure).
+ */
+function isUserDisabled(reader: ProviderRegistryReader, id: ProviderId): boolean {
+  if (!reader.countEnabledModels || !reader.hasModelOverrides) return false;
+  return reader.countRegistryCatalog(id) > 0 && reader.hasModelOverrides(id) && reader.countEnabledModels(id) === 0;
+}
+
+/**
  * Provider connectivity — for every connected provider, run the real probe and
  * classify the worst outcome. FAIL on auth/credit/undecryptable errors; WARN on
  * a provider that cannot be probed (no key, offline host) so it is surfaced
@@ -92,12 +130,24 @@ export async function checkProviderConnectivity(
   reader: ProviderRegistryReader,
   probe: ConnectProbe
 ): Promise<DoctorCheckOutcome> {
-  const providers = reader.listRegistryProviders();
-  if (providers.length === 0) {
+  const allProviders = reader.listRegistryProviders();
+  if (allProviders.length === 0) {
     return {
       status: 'warn',
       detail: 'No providers are connected.',
       remediation: 'Connect at least one provider in Settings → Models so the app can run inference.',
+    };
+  }
+
+  // A provider the user intentionally switched OFF is not routable and not a
+  // fault — skip it entirely (no probe, no warn, no report) per the #271 ruling.
+  const providers = allProviders.filter((p) => !isUserDisabled(reader, p.providerId));
+  const disabledCount = allProviders.length - providers.length;
+  if (providers.length === 0) {
+    return {
+      status: 'warn',
+      detail: `No enabled providers to check (${disabledCount} disabled provider(s) skipped).`,
+      remediation: 'Enable a provider in Settings → Models, or connect a new one, so the app can run inference.',
     };
   }
 
@@ -127,9 +177,7 @@ export async function checkProviderConnectivity(
     }
 
     const key = keyFromCreds(credsResult.creds);
-    const creds = key
-      ? { key }
-      : { fields: credsResult.creds as Record<string, string> };
+    const creds = key ? { key } : { fields: credsResult.creds as Record<string, string> };
     const result = await probe.test(provider.providerId, creds, baseUrlFromCreds(credsResult.creds));
 
     if (result.ok) {
@@ -165,7 +213,11 @@ export async function checkProviderConnectivity(
       remediation: 'Check the provider host is reachable and the credentials are present in Settings → Models.',
     };
   }
-  return { status: 'pass', detail: `${okCount} of ${providers.length} connected provider(s) passed the live probe.` };
+  const disabledSuffix = disabledCount > 0 ? ` (${disabledCount} disabled provider(s) skipped)` : '';
+  return {
+    status: 'pass',
+    detail: `${okCount} of ${providers.length} enabled provider(s) passed the live probe${disabledSuffix}.`,
+  };
 }
 
 /**

--- a/src/process/doctor/registry.ts
+++ b/src/process/doctor/registry.ts
@@ -22,6 +22,8 @@ import { agentRegistry } from '@process/agent/AgentRegistry';
 import { getDatabase } from '@process/services/database';
 import { ProviderRepository } from '@process/providers/storage/ProviderRepository';
 import { ConnectionTester } from '@process/providers/detection/ConnectionTester';
+import { Curator } from '@process/providers/catalog/Curator';
+import type { ProviderId } from '@process/providers/types';
 import { detectWCore } from '@process/agent/wcore/binaryResolver';
 import { readConfig, resolveUserConfigPath } from '@process/agent/wcore/configBridge';
 import { isEncryptionAvailable } from '@process/secrets/safeStorage';
@@ -43,6 +45,24 @@ import { checkSecretStorage, checkEngineConfigIntegrity } from './checks/configC
 async function providerRepo(): Promise<ProviderRepository> {
   const db = await getDatabase();
   return new ProviderRepository(db.getDriver());
+}
+
+/**
+ * Effectively-enabled model count for a provider — the curated catalog with the
+ * user's per-model overrides applied, mirroring the Models page provider on/off
+ * toggle (a provider reads "off" when this is `0`). Drives the Doctor's
+ * skip-disabled rule (#271); the connectivity check treats a provider with a
+ * non-empty catalog but `0` enabled models as user-switched-off.
+ */
+function countEnabledModels(repo: ProviderRepository, curator: Curator, providerId: ProviderId): number {
+  const curated = curator.curate(repo.getRegistryCatalog(providerId));
+  const overrides = new Map(repo.listRegistryOverrides(providerId).map((o) => [o.modelId, o.enabled]));
+  let enabled = 0;
+  for (const model of curated) {
+    const override = overrides.get(model.id);
+    if (override === undefined ? model.enabled : override) enabled += 1;
+  }
+  return enabled;
 }
 
 /** True when `path` exists on disk (an `fs.access` probe). */
@@ -119,11 +139,14 @@ export function buildDoctorChecks(): DoctorCheck[] {
       category: 'providers',
       run: async () => {
         const repo = await providerRepo();
+        const curator = new Curator();
         return checkProviderConnectivity(
           {
             listRegistryProviders: () => repo.listRegistryProviders(),
             getRegistryProviderCreds: (id) => repo.getRegistryProviderCreds(id),
             countRegistryCatalog: (id) => repo.countRegistryCatalog(id),
+            countEnabledModels: (id) => countEnabledModels(repo, curator, id),
+            hasModelOverrides: (id) => repo.listRegistryOverrides(id).length > 0,
           },
           connectionTester
         );

--- a/src/process/doctor/registry.ts
+++ b/src/process/doctor/registry.ts
@@ -26,7 +26,7 @@ import { detectWCore } from '@process/agent/wcore/binaryResolver';
 import { readConfig, resolveUserConfigPath } from '@process/agent/wcore/configBridge';
 import { isEncryptionAvailable } from '@process/secrets/safeStorage';
 import { mcpService } from '@process/services/mcpServices/McpService';
-import { ConfigStorage } from '@/common/config/storage';
+import { ProcessConfig } from '@process/utils/initStorage';
 import type { IMcpServer, TChatConversation } from '@/common/config/storage';
 import type { IProject } from '@/common/types/project';
 import { projectServiceSingleton } from '@process/services/projectServiceSingleton';
@@ -55,9 +55,20 @@ async function pathExists(path: string): Promise<boolean> {
   }
 }
 
-/** The persisted MCP server list (the `mcp.config` key the MCP Library writes). */
+/**
+ * The persisted MCP server list (the `mcp.config` key the MCP Library writes).
+ *
+ * Read through `ProcessConfig` (the main-process, file-backed config) rather
+ * than `ConfigStorage`. `ConfigStorage.get` is a renderer↔main bridge round-trip;
+ * because this check runs INSIDE the `doctor.runDoctor` bridge invocation, a
+ * nested bridge call never resolves (reentrancy) and the whole MCP check hangs
+ * until the runner's 30s timeout — collapsing into the opaque "Check timed out
+ * after 30s" with no per-server detail (issue #273). `ProcessConfig` reads the
+ * same backing file directly in-process, so it resolves immediately and the
+ * per-server probes below can actually run.
+ */
 async function listMcpServers(): Promise<IMcpServer[]> {
-  return (await ConfigStorage.get('mcp.config').catch(() => [] as IMcpServer[])) ?? [];
+  return (await ProcessConfig.get('mcp.config').catch(() => [] as IMcpServer[])) ?? [];
 }
 
 /**
@@ -81,9 +92,7 @@ async function listConfiguredWorkspaces(): Promise<WorkspaceEntry[]> {
     add(`Project "${project.name}"`, project.workspace);
   }
 
-  const conversations = await conversationServiceSingleton
-    .listAllConversations()
-    .catch((): TChatConversation[] => []);
+  const conversations = await conversationServiceSingleton.listAllConversations().catch((): TChatConversation[] => []);
   for (const conversation of conversations) {
     // `extra.workspace` exists on gemini/acp conversations; read defensively
     // since the union is wide and some kinds carry no workspace.

--- a/tests/unit/process/doctor/mcpChecksConcurrency.test.ts
+++ b/tests/unit/process/doctor/mcpChecksConcurrency.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { checkMcpServers } from '@process/doctor/checks/mcpChecks';
+import type { IMcpServer } from '@/common/config/storage';
+
+const mcpServer = (over: Partial<IMcpServer>): IMcpServer =>
+  ({
+    id: over.id ?? 'id',
+    name: over.name ?? 'srv',
+    enabled: over.enabled ?? true,
+    transport: { type: 'stdio', command: 'x', args: [] } as IMcpServer['transport'],
+    createdAt: 0,
+    updatedAt: 0,
+    originalJson: '{}',
+    ...over,
+  }) as IMcpServer;
+
+describe('checkMcpServers concurrency (#273)', () => {
+  it('probes servers concurrently so many hung servers do not sum their timeouts', async () => {
+    const servers = Array.from({ length: 6 }, (_, i) => mcpServer({ name: `srv${i}`, id: `srv${i}` }));
+    const perServerTimeoutMs = 50;
+    const started = Date.now();
+    const result = await checkMcpServers({
+      listServers: async () => servers,
+      // Every server hangs forever — only the per-server timeout resolves them.
+      testConnection: async () => new Promise<never>(() => {}),
+      perServerTimeoutMs,
+    });
+    const elapsed = Date.now() - started;
+    expect(result.status).toBe('fail');
+    expect(result.detail).toContain('6 of 6');
+    // Concurrent: total ≈ one per-server timeout. A sequential run would be
+    // ~6×50ms=300ms; staying well under that proves the probes overlap, which is
+    // what keeps the whole check under the runner's 30s budget for the
+    // dozen-plus-server case this fix targets.
+    expect(elapsed).toBeLessThan(perServerTimeoutMs * 3);
+  });
+});

--- a/tests/unit/process/doctor/providerChecksDisabled.test.ts
+++ b/tests/unit/process/doctor/providerChecksDisabled.test.ts
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { checkProviderConnectivity } from '@process/doctor/checks/providerChecks';
+import type { ProviderRegistryReader, ConnectProbe } from '@process/doctor/checks/providerChecks';
+import type { RegistryProvider, RegistryCredsResult } from '@process/providers/storage/ProviderRepository';
+import type { ProviderId } from '@process/providers/types';
+
+const provider = (id: ProviderId): RegistryProvider => ({
+  providerId: id,
+  connectedVia: 'api-key',
+  state: 'connected',
+  credsEncrypted: 'enc',
+});
+
+/**
+ * Reader with per-provider catalog count, effectively-enabled count, and whether
+ * the user wrote any explicit override (the deliberate-disable signal).
+ */
+const makeReader = (
+  providers: RegistryProvider[],
+  catalog: Record<string, number>,
+  enabled: Record<string, number>,
+  overridden: Record<string, boolean> = {}
+): ProviderRegistryReader => ({
+  listRegistryProviders: () => providers,
+  getRegistryProviderCreds: (): RegistryCredsResult => ({ status: 'ok', creds: { key: 'sk-test' } }),
+  countRegistryCatalog: (id) => catalog[id] ?? 0,
+  countEnabledModels: (id) => enabled[id] ?? 0,
+  hasModelOverrides: (id) => overridden[id] ?? false,
+});
+
+describe('checkProviderConnectivity — skip user-disabled providers (#271)', () => {
+  it('does not probe, warn, or report a user-disabled provider', async () => {
+    let probedDisabled = false;
+    const reader = makeReader(
+      [provider('openai'), provider('deepseek')],
+      { openai: 10, deepseek: 8 }, // both have catalogs
+      { openai: 5, deepseek: 0 }, // deepseek has 0 enabled
+      { deepseek: true } // ...because the user explicitly toggled it OFF (overrides written)
+    );
+    const probe: ConnectProbe = {
+      test: async (id) => {
+        if (id === 'deepseek') probedDisabled = true;
+        return id === 'deepseek' ? { ok: false, error: 'no-credit' } : { ok: true };
+      },
+    };
+    const result = await checkProviderConnectivity(reader, probe);
+    expect(probedDisabled).toBe(false); // never probed
+    expect(result.status).toBe('pass'); // disabled provider does not fail/warn
+    expect(result.detail).not.toContain('deepseek'); // not reported
+    expect(result.detail).toContain('skipped'); // surfaced as skipped
+  });
+
+  it('still reports an ENABLED-but-misconfigured provider (not treated as disabled)', async () => {
+    const reader = makeReader([provider('openai')], { openai: 8 }, { openai: 3 });
+    const probe: ConnectProbe = { test: async () => ({ ok: false, error: 'unauthorized' }) };
+    const result = await checkProviderConnectivity(reader, probe);
+    expect(result.status).toBe('fail');
+    expect(result.detail).toContain('openai');
+  });
+
+  // Regression: a provider with 0 enabled models BY DEFAULT (no user override —
+  // the curator just didn't flag any model on) must NOT be mistaken for
+  // user-disabled. It must still be probed, so a real auth/credit break on it
+  // surfaces instead of being silently skipped (the failure this check exists to
+  // catch). 0-enabled WITHOUT an explicit override ≠ user intent.
+  it('PROBES a provider with 0 enabled-by-default models and no override, and reports its failure', async () => {
+    let probed = false;
+    const reader = makeReader(
+      [provider('openai')],
+      { openai: 12 }, // has a catalog
+      { openai: 0 }, // but nothing enabled by default (curator flagged none)
+      { openai: false } // and the user wrote NO override → not a deliberate disable
+    );
+    const probe: ConnectProbe = {
+      test: async () => {
+        probed = true;
+        return { ok: false, error: 'unauthorized' };
+      },
+    };
+    const result = await checkProviderConnectivity(reader, probe);
+    expect(probed).toBe(true); // must be probed, not skipped
+    expect(result.status).toBe('fail'); // the real failure is surfaced
+    expect(result.detail).toContain('openai');
+  });
+
+  it('does NOT treat an empty-catalog provider as disabled (still probes it)', async () => {
+    let probed = false;
+    const reader = makeReader([provider('mistral')], { mistral: 0 }, { mistral: 0 });
+    const probe: ConnectProbe = {
+      test: async () => {
+        probed = true;
+        return { ok: true };
+      },
+    };
+    const result = await checkProviderConnectivity(reader, probe);
+    expect(probed).toBe(true); // empty catalog ≠ user-disabled
+    expect(result.status).toBe('pass');
+  });
+
+  it('warns when every provider is user-disabled', async () => {
+    const reader = makeReader([provider('openai')], { openai: 5 }, { openai: 0 }, { openai: true });
+    const probe: ConnectProbe = { test: async () => ({ ok: true }) };
+    const result = await checkProviderConnectivity(reader, probe);
+    expect(result.status).toBe('warn');
+    expect(result.detail).toContain('disabled');
+  });
+});


### PR DESCRIPTION
Doctor cluster, rebased onto `integration/0.11.4` and re-validated against it. 0.11.4 already fixed #269/#270/#272; this PR adds only the deltas it was missing.

> **#288 (timer) was removed from this PR.** Live testing showed the user-visible task timer on 0.11.4 is `OrbitThinking` (the #252 observability rework), not `ThoughtDisplay` — and the idle-timer symptom no longer reproduces. It overlaps the UI/UX instance's work and is handed to Overwatch to route. This PR is doctor-only.

## #273 — MCP check times out at 30s with no per-server detail
The real bug: `doctor/registry.ts` read `mcp.config` via `ConfigStorage.get`, a renderer↔main bridge round-trip. Because the MCP check runs *inside* the `doctor.runDoctor` bridge call, that nested call deadlocks — `listServers()` never resolves and the runner kills the check at 30s (0.11.4's per-server timeout never even runs).
- Read via `ProcessConfig` (in-process, file-backed) — no bridge.
- Probe servers **concurrently** so many servers can't sum per-server timeouts past 30s.
- **Live-verified:** MCP check resolves in ~7s with per-server detail instead of the 30s hang.

## #271 — Doctor fails user-disabled providers (Overwatch ruling)
Skip user-disabled providers in connectivity **entirely** (no probe/warn/report), on top of 0.11.4's `no-credit→warn`. "Disabled" = non-empty catalog, zero effectively-enabled models, **and an explicit override present** (a cross-audit caught that 0-enabled alone would false-skip a connected provider whose models are all curator-default-off; the override requirement is the fix). Enabled-but-misconfigured still reports; empty-catalog is not disabled.
- **Live-verified:** toggled a real provider OFF → Doctor reports it skipped (not failed), connectivity drops to "5 of 5 enabled, 1 disabled skipped"; toggled back ON → returns to 6 of 6.

## Validation
- `tsc` 0 errors, oxlint/oxfmt clean (1 pre-existing `no-await-in-loop` warning), i18n passed.
- New regression tests for MCP concurrency and disabled-provider skipping (incl. the off-by-default false-skip case), in separate files to avoid touching the existing suite.
- 3-way adversarial cross-audit run; the one real bug it found (#271 false-skip) is fixed.