### PR TITLE
fix(build): raise V8 heap ceiling for electron-vite bundling so dist builds don't OOM (#260)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,7 @@ See the `testing` skill (`.claude/skills/testing/SKILL.md`) for complete workflo
 ```bash
 bun run lint:fix       # auto-fix lint issues in .ts / .tsx (oxlint)
 bun run format         # auto-format .ts / .tsx / .css / .json / .md (oxfmt)
-bunx tsc --noEmit      # verify no type errors
+bun run typecheck      # verify no type errors (raises the heap; raw `tsc --noEmit` OOMs on large checkouts)
 ```
 
 **Before every PR** - run the full CI check locally to catch everything CI catches (end-of-file, trailing whitespace, all file types):

--- a/scripts/build-with-builder.js
+++ b/scripts/build-with-builder.js
@@ -17,6 +17,16 @@ const crypto = require('crypto');
 const prepareBundledBun = require('./prepareBundledBun');
 const prepareWaylandCore = require('./prepareWaylandCore');
 
+// Raise the V8 old-space ceiling for the bundling step. electron-vite transforms
+// ~13k modules in a single process; on machines with the default ~2 GB heap the
+// renderer build OOMs partway through ("Ineffective mark-compacts near heap
+// limit - JavaScript heap out of memory", #260). 8192 MB matches the `typecheck`
+// script. Setting it on process.env propagates to every execSync child below
+// (they all spread process.env). An explicit caller --max-old-space-size wins.
+if (!/--max[-_]old[-_]space[-_]size/.test(process.env.NODE_OPTIONS || '')) {
+  process.env.NODE_OPTIONS = `${process.env.NODE_OPTIONS || ''} --max-old-space-size=8192`.trim();
+}
+
 // DMG retry logic for macOS: detects DMG creation failures by checking artifacts
 // (.app exists but .dmg missing) and retries only the DMG step using
 // electron-builder --prepackaged with the .app path (not the parent directory).


### PR DESCRIPTION
## Problem (#260)
`bun run build` / `bun run dist:linux` / `dist:win` OOM during the renderer bundle on machines with the default ~2 GB V8 old-space limit:
```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```
electron-vite transforms ~13k modules in a single process; that peak exceeds 2 GB. The reporter crashed at ~module 13043.

## Fix
Set `NODE_OPTIONS=--max-old-space-size=8192` once at the top of `scripts/build-with-builder.js` — every `dist:*`/`build*` script routes through it, so one change covers all platforms. It propagates to the `bunx electron-vite build` child via the existing `execSync` env spread. An explicit caller `--max-old-space-size` still wins. 8192 matches the existing `typecheck` script.

Also repoints AGENTS.md's typecheck command at `bun run typecheck` (heap-raised) instead of raw `bunx tsc --noEmit`, which OOMs the same way (the reporter's first failing command).

## Live verification
- **Reproduced** on the real build: `NODE_OPTIONS=--max-old-space-size=320 bunx electron-vite build` → exact #260 OOM (node/V8 frames). Proves the build runs under node and honors the flag.
- **Fixed**: full build via `build-with-builder.js` (which now sets the flag) → **13322 modules transformed, built in 2m49s, 0 OOM**, `out/renderer/index.html` + `out/main/index.js` produced.

## Scope
Build tooling only — no runtime/app code. No shipped-binary behavior change.