### PR TITLE
test(conversation): add missing loadGlobalMemoryBlock stub to knowledge mock (#317)

### DIFF
--- a/tests/unit/ConversationServiceImpl.test.ts
+++ b/tests/unit/ConversationServiceImpl.test.ts
@@ -38,6 +38,11 @@ vi.mock('../../src/process/services/database/SqliteProjectRepository', () => ({
 }));
 vi.mock('../../src/process/services/projectKnowledge/knowledge', () => ({
   loadProjectKnowledgeBlock: vi.fn(async () => null),
+  // ConversationServiceImpl also imports loadGlobalMemoryBlock (global-memory
+  // injection, obs-rework). The mock must expose it or vitest throws "No
+  // loadGlobalMemoryBlock export is defined on the mock" when that path runs in
+  // the full sharded suite, reddening the 0.11.4 base (#317). '' = no block.
+  loadGlobalMemoryBlock: vi.fn(async () => ''),
 }));
 
 function makeRepo(overrides: Partial<IConversationRepository> = {}): IConversationRepository {


### PR DESCRIPTION
## Problem (#317 — cut-blocker)
`integration/0.11.4` unit suite is red: `ConversationServiceImpl` imports `loadGlobalMemoryBlock` (global-memory injection, obs-rework), but the `knowledge` `vi.mock` in `ConversationServiceImpl.test.ts` only stubbed `loadProjectKnowledgeBlock`. The full sharded suite throws:
```
No "loadGlobalMemoryBlock" export is defined on the "...projectKnowledge/knowledge" mock.
```
This reddens the base and masks the bug-fix train's CI (#301/#302/#303/#307/#308 all fail on the inherited base failure, not their own code).

## Fix
Add `loadGlobalMemoryBlock: vi.fn(async () => '')` to the mock so it matches the module's real exports. `''` = no global-memory block injected (the neutral default these tests assume).

## Verification & honesty note
- `ConversationServiceImpl.test.ts` stays green (26 passed) with the stub; no regression.
- I could **not** reproduce the exact error in a local single-process `bun run test` — it's CI-shard-ordering-specific (the missing export only throws when a test that exercises the global-memory path runs in a given shard). The fix is still correct: the mock now matches the source's exports, which is the root cause #317 cites.
- **Please run this through CI on the runner to confirm it greens the base.**

## Separate observation (NOT this PR)
My local full-suite run showed other failures — `ijfwArchiveService` (reads the real `~/.ijfw/memory`, populated on dev machines) and some DOM timer tests — which look like **local-env artifacts**, not base-red. Flagging for CI confirmation so the base-green assessment isn't based on my polluted local env.