### PR TITLE
fix(providers): per-provider Refresh preserves the Ollama catalog (#314)

### DIFF
--- a/src/process/providers/ipc/modelRegistryIpc.ts
+++ b/src/process/providers/ipc/modelRegistryIpc.ts
@@ -787,6 +787,26 @@ export function createModelRegistryHandlers(deps: ModelRegistryDeps): ModelRegis
         }
         // `not-found` - nothing to refresh.
         if (stored.status !== 'ok') return { ok: false };
+
+        // The keyless `ollama-local` provider's catalog is the live `/api/tags`
+        // daemon listing, NOT a `buildAndPersistCatalog` assembly: assembling
+        // against an empty key builds zero models and WIPES the catalog every
+        // tick (Finding 1). `refreshAllOnce` guards this; the per-provider
+        // Refresh button must too, or each click empties the catalog (#314).
+        // Re-probe the daemon instead - an unreachable daemon leaves the
+        // existing catalog untouched (never replaced with []). The exemption is
+        // scoped to a loopback baseUrl (Finding 5) so a row whose stored host is
+        // not loopback is treated like any other custom provider and the
+        // keyless allowance can never be hijacked onto a remote host.
+        const storedBaseUrl = stored.creds.baseUrl;
+        if (
+          providerId === OLLAMA_LOCAL_ID &&
+          isLoopbackBaseUrl(typeof storedBaseUrl === 'string' ? storedBaseUrl : '')
+        ) {
+          const outcome = await refreshOllamaLocal();
+          return { ok: outcome === 'ok' };
+        }
+
         const creds = toTestCreds(stored.creds);
         const built = await buildAndPersistCatalog(providerId, creds);
         return { ok: built.ok };

--- a/tests/unit/process/providers/modelRegistryIpc.test.ts
+++ b/tests/unit/process/providers/modelRegistryIpc.test.ts
@@ -803,7 +803,10 @@ describe('modelRegistry IPC - refresh', () => {
     const result = await h.refresh({ providerId: 'xai' });
 
     expect(result).toEqual({ ok: true });
-    const ids = repo.getRegistryCatalog('xai').map((m) => m.id).toSorted();
+    const ids = repo
+      .getRegistryCatalog('xai')
+      .map((m) => m.id)
+      .toSorted();
     expect(ids).toContain('grok-4');
     expect(ids).toContain('grok-3');
   });
@@ -1751,6 +1754,90 @@ describe('modelRegistry IPC - refreshAllOnce SSRF gate (ollama-local exemption)'
     expect(probeOllama).not.toHaveBeenCalled();
     expect(summary.failed).toContain('ollama-local');
     expect(summary.succeeded).not.toContain('ollama-local');
+  });
+});
+
+describe('modelRegistry IPC - per-provider refresh (ollama-local guard, #314)', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it('re-probes the daemon instead of wiping the catalog when Refresh is clicked for loopback ollama-local (#314)', async () => {
+    // The per-provider Refresh button used buildAndPersistCatalog for every
+    // provider; for keyless ollama-local that assembles zero models and empties
+    // the catalog (Finding 1) - the daemon is up but the picker drops to 0. The
+    // guard must route a loopback ollama-local row to a live daemon re-probe
+    // instead, the same exemption refreshAllOnce already has.
+    process.env.NODE_ENV = 'production';
+
+    const { deps, repo } = makeFakes();
+    const probeOllama = vi.fn().mockResolvedValue({ running: true, models: ['llama3.2:3b'] });
+    deps.probeOllama = probeOllama;
+
+    repo.upsertRegistryProvider({
+      providerId: 'ollama-local',
+      connectedVia: 'auto-local',
+      state: 'connected',
+      creds: { key: '', baseUrl: 'http://127.0.0.1:11434/v1' },
+    });
+    // A previously-populated catalog that the buggy path would wipe to [].
+    repo.replaceRegistryCatalog('ollama-local', [catalogModel({ id: 'llama3.2:3b', providerId: 'ollama-local' })]);
+
+    const h = createModelRegistryHandlers(deps);
+    const result = await h.refresh({ providerId: 'ollama-local' });
+
+    expect(result).toEqual({ ok: true });
+    // Routed to the live re-probe, NOT buildAndPersistCatalog.
+    expect(probeOllama).toHaveBeenCalledTimes(1);
+    // Catalog refreshed from the daemon listing - never emptied.
+    expect(repo.getRegistryCatalog('ollama-local').map((m) => m.id)).toEqual(['llama3.2:3b']);
+  });
+
+  it('leaves the existing catalog untouched when the daemon is unreachable (never wipes to [])', async () => {
+    process.env.NODE_ENV = 'production';
+    const { deps, repo } = makeFakes();
+    const probeOllama = vi.fn().mockResolvedValue({ running: false, models: [] });
+    deps.probeOllama = probeOllama;
+
+    repo.upsertRegistryProvider({
+      providerId: 'ollama-local',
+      connectedVia: 'auto-local',
+      state: 'connected',
+      creds: { key: '', baseUrl: 'http://127.0.0.1:11434/v1' },
+    });
+    repo.replaceRegistryCatalog('ollama-local', [catalogModel({ id: 'llama3.2:3b', providerId: 'ollama-local' })]);
+
+    const h = createModelRegistryHandlers(deps);
+    const result = await h.refresh({ providerId: 'ollama-local' });
+
+    // A transient daemon-down reports not-ok but must keep the last-known models
+    // - the picker survives an Ollama restart instead of blanking.
+    expect(result).toEqual({ ok: false });
+    expect(repo.getRegistryCatalog('ollama-local').map((m) => m.id)).toEqual(['llama3.2:3b']);
+    expect(probeOllama).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT take the keyless re-probe path for a non-loopback ollama-local row (Finding 5)', async () => {
+    process.env.NODE_ENV = 'production';
+    const { deps, repo } = makeFakes();
+    const probeOllama = vi.fn().mockResolvedValue({ running: true, models: ['x'] });
+    deps.probeOllama = probeOllama;
+
+    // A row claiming to be ollama-local but pointing off-loopback (link-local
+    // cloud-metadata) must NOT get the keyless re-probe exemption.
+    repo.upsertRegistryProvider({
+      providerId: 'ollama-local',
+      connectedVia: 'auto-local',
+      state: 'connected',
+      creds: { key: '', baseUrl: 'http://169.254.169.254/v1' },
+    });
+
+    const h = createModelRegistryHandlers(deps);
+    await h.refresh({ providerId: 'ollama-local' });
+
+    // Off-loopback is treated like any other provider - no keyless exemption.
+    expect(probeOllama).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## What

Mirror the `refreshAllOnce` keyless-Ollama guard into the single-provider `refresh` handler so **Settings → Models → Ollama (Local) → Manage → Refresh** no longer empties the catalog.

Closes #314.

## Root cause

`h.refresh()` called `buildAndPersistCatalog(providerId, creds)` for **every** provider. For keyless `ollama-local` that assembles zero models from the generic OpenAI-compatible source (empty key) and replaces the catalog with `[]` — so the per-provider Refresh button drops the picker to 0 even while the daemon is up and serving models. The global **Refresh models** path (`refreshAllOnce`) already guards this (`providerId === OLLAMA_LOCAL_ID && isLoopbackBaseUrl(...) → refreshOllamaLocal()`, the "Finding 1" comment); `h.refresh` lacked the guard, so the two refresh surfaces diverged.

## Fix

Add the same guard at the top of `h.refresh`: a **loopback** `ollama-local` row is refreshed via a live `/api/tags` daemon re-probe (`refreshOllamaLocal`), not a catalog assembly. An unreachable daemon leaves the existing catalog untouched (never wiped to `[]`). The exemption stays scoped to a loopback baseUrl (Finding 5) so it can't be hijacked onto a remote host.

Distinct from #294 (catalog present but hidden via `enabled:false`) — here the catalog is *emptied*, so there is nothing for the curator to re-enable.

## Tests

3 unit cases on the per-provider path:
- loopback `ollama-local` re-probes and **preserves** the catalog (not wiped),
- daemon-unreachable keeps the last-known models (`{ ok: false }`, catalog intact),
- non-loopback `ollama-local` row gets **no** keyless exemption (Finding 5).

`bun run test` (modelRegistryIpc): 80 passed / 6 skipped. `tsc --noEmit`: clean.

## Live verification

Drove the real `h.refresh → refreshOllamaLocal → autoRegisterOllamaInRepo` chain against a running local Ollama daemon (isolated in-memory repo, no shared-config mutation):

```
[LIVECHECK] result= {"ok":true} catalog= ["qwen2.5:0.5b","smollm2:135m"]
```

— matches the daemon's actual `/api/tags` listing exactly; a seeded stale placeholder was replaced, never wiped to `[]`. (Live check is throwaway — the daemon isn't present on CI; the 3 committed unit tests cover the contract.)

## Scope note

`modelRegistryIpc.ts` has pre-existing `oxfmt@0.41.0` drift on a few lines unrelated to this change; left untouched to keep the diff to the functional fix only.