### PR TITLE
ci(pr-checks): run native checks on integration/** base PRs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -42,7 +42,7 @@ on:
         default: false
   pull_request:
     types: [opened, synchronize, edited, closed, ready_for_review, reopened]
-    branches: [main, dev, 'feat/**', 'release/**']
+    branches: [main, dev, 'feat/**', 'release/**', 'integration/**']
     paths-ignore:
       - '**/*.md'
       - 'docs/**'


### PR DESCRIPTION
Adds integration/** to the pr-checks pull_request branch filter so PRs targeting the 0.11.4 cut branch get full native CI (unit + build matrix + e2e) instead of merging on labeler-only signal. One-line, workflow-config only; no run-step or untrusted-input changes.