### PR TITLE
test(ci): de-flake the two CI-matrix tests (#292)

### DIFF
--- a/tests/unit/team-TeammateManager.test.ts
+++ b/tests/unit/team-TeammateManager.test.ts
@@ -1049,16 +1049,19 @@ describe('TeammateManager', () => {
         data: null,
       });
 
-      // Give async finalizeTurn time to run
-      await new Promise((r) => setTimeout(r, 50));
-
-      // Should have written idle notification to leader
-      expect(mbox.write).toHaveBeenCalledWith(
-        expect.objectContaining({
-          toAgentId: 'slot-lead',
-          fromAgentId: 'slot-member',
-          type: 'idle_notification',
-        })
+      // finalizeTurn writes the idle notification on a later microtask/timer, so
+      // a fixed sleep races slower (Windows) CI and intermittently sees 0 calls
+      // (#292). Poll until the write lands instead of asserting after a delay.
+      await vi.waitFor(
+        () =>
+          expect(mbox.write).toHaveBeenCalledWith(
+            expect.objectContaining({
+              toAgentId: 'slot-lead',
+              fromAgentId: 'slot-member',
+              type: 'idle_notification',
+            })
+          ),
+        { timeout: 2000 }
       );
       mgr.dispose();
     });

--- a/tests/unit/webuiStaticRoutes.test.ts
+++ b/tests/unit/webuiStaticRoutes.test.ts
@@ -43,11 +43,25 @@ describe('registerStaticRoutes', () => {
     const packagedRoot = createPackagedRendererRoot();
 
     // staticRoutes resolves the renderer build via
-    // getPlatformServices().paths.getAppPath() (not electron.app directly), so
-    // point the platform service at the packaged renderer root for this test.
-    const services = new NodePlatformServices();
-    services.paths.getAppPath = () => packagedRoot;
-    registerPlatformServices(services);
+    // getPlatformServices().paths.getAppPath() and only registers the production
+    // routes (incl. /sw.js) when <appPath>/out/renderer/index.html exists. Mock
+    // the platform module rather than registering a stubbed services singleton:
+    // the dynamically-imported staticRoutes can bind a different @/common/platform
+    // module instance than this test's static import (vitest module reset/ordering
+    // across a shard), in which case registerPlatformServices() is invisible to it
+    // and it falls back to the real on-disk out/renderer — present on a built dev
+    // box, ABSENT in an isolated CI shard, so the route set silently flips to
+    // dev-proxy mode and /sw.js disappears (the #292 shard-4/4 flake). Mocking the
+    // module pins getAppPath at our packaged root regardless of build artifacts or
+    // which instance is loaded.
+    vi.doMock('@/common/platform', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('@/common/platform')>();
+      return {
+        ...actual,
+        getPlatformServices: () =>
+          ({ paths: { getAppPath: () => packagedRoot } }) as ReturnType<typeof actual.getPlatformServices>,
+      };
+    });
 
     vi.doMock('@process/webserver/auth/middleware/TokenMiddleware', () => ({
       TokenMiddleware: {


### PR DESCRIPTION
## What

De-flake the two pre-existing unit tests that intermittently red the sharded Windows/CI matrix on unrelated PRs (this is what masked the genuine Windows bug in #290). **No behaviour changes** — both are test-harness flakes.

Closes #292.

## 1. `team-TeammateManager.test.ts` — async-timing race

`finalizeTurn > sets agent to idle after finish event with empty response` asserted `mbox.write` **synchronously** after a fixed `await setTimeout(50)`. The idle notification is written on a later microtask/timer, so under slower Windows CI the write hadn't landed yet → `Number of calls: 0`.

**Fix:** replace the fixed sleep with `vi.waitFor(…, { timeout: 2000 })` so the assertion polls until the write lands. Deterministic; no product change.

## 2. `webuiStaticRoutes.test.ts` — build-artifact / module-instance dependent

`registerStaticRoutes` only registers the production routes (incl. `/sw.js`) when `<appPath>/out/renderer/index.html` exists. The test registered a stubbed platform-services **singleton**, but the dynamically-imported `staticRoutes` can bind a *different* `@/common/platform` module instance (vitest module reset/ordering across a shard) — making `registerPlatformServices()` invisible to it. It then fell back to the **real on-disk `out/renderer`**: present on a built dev box (passes), absent in an isolated CI shard → dev-proxy mode where `/sw.js` is gone (shard 4/4 failure, all 3 OSes).

**Fix:** `vi.doMock('@/common/platform', …)` so `getAppPath()` deterministically points at the test's packaged root — independent of build artifacts and of which module instance loads.

## Verification (each file in isolation, per the dispatch — the full suite masks both)

- **#2 reproduced + fixed:** with the real `out/renderer` hidden and the singleton registration bypassed, the old test fails with `AssertionError: expected [] to include '/sw.js'`; with the mock fix it passes **with the artifact still absent**, and also with it present.
- **#1 stable** across repeated isolated runs (5×).
- Full files: `team-TeammateManager` 64/64, `webuiStaticRoutes` 1/1; both together 65/65. `tsc --noEmit` clean; `oxfmt --check` + `oxlint` clean on both files.

Branched off the current `integration/0.11.4` tip (post-#302, which touched the `/sw.js` route in this file — no conflict).