### PR TITLE
fix(providers): connect custom OpenAI-compatible endpoints with no /models listing (#339)

### DIFF
--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -1822,6 +1822,10 @@ export type IModelRegistryConnectResult = {
    * Non-fatal advisory on an otherwise successful connect. `'no-credit'` means
    * the key authenticated but has no usable credit yet, so the provider was
    * added connected-but-switched-off (#100); the panel surfaces a soft notice.
+   * `'no-models'` means a custom OpenAI-compatible base authenticated but exposes
+   * no model listing (e.g. Cloudflare Workers AI has no `/models`, #339), so the
+   * provider was added connected with an empty catalog - the user supplies a
+   * model id manually.
    */
   warning?: ConnectError;
 };

--- a/src/process/providers/detection/ConnectionTester.ts
+++ b/src/process/providers/detection/ConnectionTester.ts
@@ -41,6 +41,12 @@ import { ANTHROPIC_VERSION, appendQuery, authStrategyFor } from './providerAuth'
 /** Per-request fetch timeout - a slow provider must not stall a connection test. */
 const FETCH_TIMEOUT_MS = 15_000;
 
+// Placeholder model for the auth-only `/chat/completions` fallback (#339). A
+// gateway without a `/models` listing can't be probed for a real model id, so
+// we send a deliberately unknown one: the gateway authenticates the key first,
+// then rejects the model - a model-level rejection is the auth-success signal.
+const CONNECTIVITY_PROBE_MODEL = 'wayland-connectivity-probe';
+
 /** Credentials for a connection test: a single API key, or multi-field creds. */
 type TestCreds = { key: string } | { fields: Record<string, string> };
 
@@ -102,11 +108,8 @@ export class ConnectionTester {
     // Probe the custom base's `/models` endpoint for an auth-only check instead -
     // a 200 there proves the key authenticates against the host it will actually
     // use, and `ApiProviderSource` already builds the catalog from the same base.
-    if (apiKey) {
-      const customModelsEndpoint = deriveModelsEndpoint(customBaseUrl);
-      if (customModelsEndpoint) {
-        return this.probeModelsEndpoint(providerId, apiKey, customModelsEndpoint);
-      }
+    if (apiKey && customBaseUrl && deriveModelsEndpoint(customBaseUrl)) {
+      return this.probeCustomBase(providerId, apiKey, customBaseUrl);
     }
 
     const testModel = TEST_MODEL[providerId];
@@ -217,6 +220,92 @@ export class ConnectionTester {
     return { ok: true };
   }
 
+  // ─── Custom-base probe (/models happy path → /chat/completions fallback) ──────
+
+  /**
+   * Probe a user-supplied custom OpenAI-compatible base URL.
+   *
+   * Happy path is the `/models` listing - a 200 with a non-empty list proves
+   * auth AND gives `ApiProviderSource` a catalog to build from. But some
+   * OpenAI-compatible gateways (e.g. Cloudflare Workers AI) expose only
+   * `/chat/completions` + `/embeddings` and NO `/models` listing, so a 404 (or
+   * an empty list) there is NOT a dead end: fall back to an auth-only
+   * `/chat/completions` probe before declaring the connection dead (#339). A
+   * 401/403 from `/models` is a genuine auth failure and is surfaced as-is - the
+   * chat fallback must never paper over a bad key.
+   */
+  private async probeCustomBase(providerId: ProviderId, apiKey: string, customBaseUrl: string): Promise<TestResult> {
+    const modelsEndpoint = deriveModelsEndpoint(customBaseUrl) as string;
+    const auth = authStrategyFor(providerId);
+    const url = auth.kind === 'query' ? appendQuery(modelsEndpoint, auth.param, apiKey) : modelsEndpoint;
+
+    let res: Response;
+    try {
+      // No `providerId` here: the OpenAI-family false-404 retry is for transient
+      // 404s on canonical hosts. A custom gateway's 404 on `/models` is the
+      // expected "no listing" signal (#339), so retrying just adds latency before
+      // the chat fallback that is going to run anyway.
+      res = await this.fetchWithTimeout(url, { method: 'GET', headers: authHeaders(auth, apiKey) });
+    } catch {
+      return { ok: false, error: 'offline' };
+    }
+    const body = await readBody(res);
+
+    if (res.ok && !modelsBodyIsEmpty(body)) return { ok: true };
+    // A real auth rejection must NOT be rescued by the chat fallback.
+    if (res.status === 401 || res.status === 403) return { ok: false, error: 'unauthorized' };
+    // `/models` is missing (404) or returned an empty list - the gateway may
+    // simply not implement a model listing. Try the auth-only chat probe.
+    if (res.status === 404 || (res.ok && modelsBodyIsEmpty(body))) {
+      return this.probeCustomChatAuth(apiKey, customBaseUrl, auth);
+    }
+    // Any other non-2xx (billing, 5xx, …) - classify as usual.
+    return { ok: false, error: classifyStatus(res.status, body) };
+  }
+
+  /**
+   * Auth-only fallback for a custom base whose `/models` listing is absent.
+   *
+   * POSTs a minimal `/chat/completions` request with a placeholder model. This
+   * checks AUTH, not real inference: a 401/403 is a bad key; a 2xx, or a 4xx that
+   * proves the request reached the model/validation layer (model-not-found, a
+   * 400/422 bad-request), means the key authenticated against the gateway even
+   * though our placeholder model is unknown - the user supplies a real model id
+   * when adding the provider. A bare 404 with no model signal means the chat
+   * endpoint does not exist either, i.e. the base URL itself is wrong.
+   */
+  private async probeCustomChatAuth(apiKey: string, customBaseUrl: string, auth: AuthStrategy): Promise<TestResult> {
+    const chatEndpoint = deriveChatCompletionsEndpoint(customBaseUrl);
+    const url = auth.kind === 'query' ? appendQuery(chatEndpoint, auth.param, apiKey) : chatEndpoint;
+    const request = { model: CONNECTIVITY_PROBE_MODEL, messages: [{ role: 'user', content: 'hi' }], max_tokens: 1 };
+
+    let res: Response;
+    try {
+      res = await this.fetchWithTimeout(url, {
+        method: 'POST',
+        headers: authHeaders(auth, apiKey),
+        body: JSON.stringify(request),
+      });
+    } catch {
+      return { ok: false, error: 'offline' };
+    }
+    const body = await readBody(res);
+
+    if (res.status === 401 || res.status === 403) return { ok: false, error: 'unauthorized' };
+    if (mentionsBilling(body)) return { ok: false, error: 'no-credit' };
+    if (res.ok) {
+      // A 200 authenticates AND runs inference (some gateways accept any model).
+      return bodyIsError(body) ? { ok: false, error: 'unknown' } : { ok: true };
+    }
+    // Non-2xx, non-auth: a model/validation rejection proves the key got past
+    // auth into the gateway's request handling - treat as a (degraded) connect.
+    if (isModelNotFound(res.status, body) || res.status === 400 || res.status === 422) {
+      return { ok: true };
+    }
+    // Otherwise the chat endpoint is unreachable too (wrong base URL).
+    return { ok: false, error: classifyStatus(res.status, body) };
+  }
+
   // ─── fetch with timeout ─────────────────────────────────────────────────────
 
   /**
@@ -311,6 +400,17 @@ function deriveModelsEndpoint(customBaseUrl: string | undefined): string | undef
   const base = customBaseUrl.replace(/\/+$/, '');
   if (/\/v\d+$/i.test(base)) return `${base}/models`;
   return `${base}/v1/models`;
+}
+
+/**
+ * Derive a `/chat/completions` endpoint from a user-supplied custom base URL,
+ * mirroring `deriveModelsEndpoint`'s `/vN`-vs-bare handling. Used by the
+ * auth-only fallback when the gateway has no `/models` listing (#339).
+ */
+function deriveChatCompletionsEndpoint(customBaseUrl: string): string {
+  const base = customBaseUrl.replace(/\/+$/, '');
+  if (/\/v\d+$/i.test(base)) return `${base}/chat/completions`;
+  return `${base}/v1/chat/completions`;
 }
 
 /** Auth + identification headers for a request, per the provider's scheme. */

--- a/src/process/providers/ipc/modelRegistryIpc.ts
+++ b/src/process/providers/ipc/modelRegistryIpc.ts
@@ -645,9 +645,27 @@ export function createModelRegistryHandlers(deps: ModelRegistryDeps): ModelRegis
     // it honestly (the UI renders that as "Action needed - Fix"). An empty
     // catalog where at least one source errored is also a degraded connect.
     const built = await buildAndPersistCatalog(providerId, resolved);
-    if (!built.ok || (built.models === 0 && built.sourceErrors > 0)) {
+    if (!built.ok) {
       repo.updateRegistryProviderState(providerId, 'error', 'unknown');
       return { ok: false, error: 'unknown' };
+    }
+    if (built.models === 0 && built.sourceErrors > 0) {
+      // The catalog build could list nothing. For a canonical provider that is a
+      // false green (reject). But a user-supplied custom base that ALREADY passed
+      // the auth probe is a legitimately listing-less gateway - e.g. Cloudflare
+      // Workers AI authenticates but exposes /chat/completions with no /models
+      // (#339). `ConnectionTester` proved auth via the chat fallback, so hard-
+      // failing here would block a working endpoint. Land it connected with an
+      // empty catalog + a `no-models` warning so the user can add a model id,
+      // rather than rejecting. A wrong base URL never reaches here: its auth
+      // probe already failed and the connect was rejected above.
+      const isCustomBase = 'key' in resolved && typeof resolved.baseUrl === 'string' && resolved.baseUrl.length > 0;
+      if (!isCustomBase) {
+        repo.updateRegistryProviderState(providerId, 'error', 'unknown');
+        return { ok: false, error: 'unknown' };
+      }
+      repo.updateRegistryProviderConnectedVia(providerId, connectedViaLabel(creds, providerId));
+      return { ok: true, warning: 'no-models' };
     }
 
     if (noCredit) {

--- a/tests/unit/process/providers/connectionTester.test.ts
+++ b/tests/unit/process/providers/connectionTester.test.ts
@@ -281,4 +281,100 @@ describe('ConnectionTester', () => {
     expect(result.ok).toBe(false);
     expect(result.error).toBe('offline');
   });
+
+  // ─── #339: custom OpenAI-compatible base with no /models listing (Cloudflare) ──
+  // Cloudflare Workers AI exposes /chat/completions + /embeddings but NO /models,
+  // so the happy-path /models probe 404s even with a valid key. The tester must
+  // fall back to an auth-only /chat/completions probe before declaring failure.
+  const CF_BASE = 'https://api.cloudflare.com/client/v4/accounts/abc123/ai/v1';
+
+  it('connects a custom base whose /models 404s but whose /chat/completions authenticates (#339)', async () => {
+    const fetchMock = vi.fn((url: string) =>
+      Promise.resolve(
+        String(url).includes('/models')
+          ? response('no route for that URI', 404)
+          : response({ choices: [{ message: { content: 'hi' } }] }, 200)
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await tester.test('openai-compatible', { key: 'cf-token' }, CF_BASE);
+    expect(result).toEqual({ ok: true });
+
+    // /models tried first (happy path), then the /chat/completions fallback POST.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [modelsUrl] = fetchMock.mock.calls[0] as [string];
+    const [chatUrl, chatInit] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(modelsUrl).toBe(`${CF_BASE}/models`);
+    expect(chatUrl).toBe(`${CF_BASE}/chat/completions`);
+    expect(chatInit.method).toBe('POST');
+  });
+
+  it('connects when the chat fallback rejects the placeholder model (auth proven past the model layer, #339)', async () => {
+    // The gateway authenticates the key, then 404s our deliberately-unknown probe
+    // model. A model-level rejection proves auth - the connect succeeds (degraded:
+    // the user supplies a real model id when adding the provider).
+    const fetchMock = vi.fn((url: string) =>
+      Promise.resolve(
+        String(url).includes('/models')
+          ? response('not found', 404)
+          : response({ error: { message: 'model wayland-connectivity-probe not found' } }, 404)
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await tester.test('openai-compatible', { key: 'cf-token' }, CF_BASE);
+    expect(result).toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to the chat probe when /models returns an empty list (#339)', async () => {
+    const fetchMock = vi.fn((url: string) =>
+      Promise.resolve(
+        String(url).includes('/models')
+          ? response({ data: [] }, 200)
+          : response({ choices: [{ message: { content: 'hi' } }] }, 200)
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await tester.test('openai-compatible', { key: 'cf-token' }, CF_BASE);
+    expect(result).toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT run the chat fallback when /models is a real auth failure (401) (#339)', async () => {
+    // A 401 from /models is a bad key - it must surface as unauthorized, never be
+    // rescued by the chat fallback.
+    const fetchMock = vi.fn().mockResolvedValue(response({ error: 'invalid token' }, 401));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await tester.test('openai-compatible', { key: 'bad-token' }, CF_BASE);
+    expect(result).toEqual({ ok: false, error: 'unauthorized' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports unauthorized when the chat fallback itself rejects the key (#339)', async () => {
+    const fetchMock = vi.fn((url: string) =>
+      Promise.resolve(
+        String(url).includes('/models') ? response('not found', 404) : response({ error: 'invalid token' }, 401)
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await tester.test('openai-compatible', { key: 'bad-token' }, CF_BASE);
+    expect(result).toEqual({ ok: false, error: 'unauthorized' });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('still fails for a wrong base URL where neither /models nor /chat/completions exists (#339)', async () => {
+    // A bare 404 on both endpoints (no model signal) means the base URL is wrong -
+    // the fallback must NOT false-positive this into a successful connect.
+    const fetchMock = vi.fn().mockResolvedValue(response('not found', 404));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await tester.test('openai-compatible', { key: 'cf-token' }, CF_BASE);
+    expect(result.ok).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/tests/unit/process/providers/modelRegistryIpc.test.ts
+++ b/tests/unit/process/providers/modelRegistryIpc.test.ts
@@ -277,6 +277,39 @@ describe('modelRegistry IPC - connect', () => {
     expect(repo.getRegistryCatalog('openai').map((m) => m.id)).toEqual(['gpt-4o']);
   });
 
+  it('lands an auth-OK custom base with no /models listing as connected-but-empty, not error (#339)', async () => {
+    // Cloudflare Workers AI authenticates (ConnectionTester proved it via the
+    // chat fallback) but exposes no /models, so the catalog build lists nothing
+    // (the /models GET throws -> sourceErrors > 0). The connect must land the
+    // provider connected with a `no-models` warning instead of flipping it to
+    // error/rejecting - otherwise a working endpoint can never be added.
+    const { deps, repo, apiListModels } = makeFakes();
+    apiListModels.mockRejectedValue(new Error('404 no /models on this gateway'));
+    const h = createModelRegistryHandlers(deps);
+
+    const result = await h.connect({
+      providerId: 'openai-compatible',
+      creds: { key: 'cf-token', baseUrl: 'https://api.cloudflare.com/client/v4/accounts/abc/ai/v1' },
+    });
+
+    expect(result).toEqual({ ok: true, warning: 'no-models' });
+    expect(repo.getRegistryProvider('openai-compatible')?.state).toBe('connected');
+    expect(repo.getRegistryCatalog('openai-compatible')).toEqual([]);
+  });
+
+  it('still rejects a CANONICAL provider whose catalog build lists nothing (no false green)', async () => {
+    // The custom-base exemption must NOT leak to canonical providers: an openai
+    // connect whose catalog build errors to empty is still a hard failure.
+    const { deps, repo, apiListModels } = makeFakes();
+    apiListModels.mockRejectedValue(new Error('listing failed'));
+    const h = createModelRegistryHandlers(deps);
+
+    const result = await h.connect({ providerId: 'openai', creds: { key: 'sk-test' } });
+
+    expect(result).toEqual({ ok: false, error: 'unknown' });
+    expect(repo.getRegistryProvider('openai')?.state).toBe('error');
+  });
+
   it('threads the catalog baseUrl when a catalog provider has no hardcoded endpoint (#63)', async () => {
     const { deps, test } = makeFakes();
     const h = createModelRegistryHandlers(deps);


### PR DESCRIPTION
## What

Lets users connect a custom OpenAI-compatible endpoint that exposes `/chat/completions` but **no `/models` listing** — e.g. Cloudflare Workers AI (`https://api.cloudflare.com/client/v4/accounts/{id}/ai/v1`). Today the connect hard-fails with a generic error and the provider can never be added.

Closes #339.

## Root cause (two gates, both had to be opened)

1. **`ConnectionTester.test()`** probed `<base>/models` for its auth check and treated a **404 as failure** — so a gateway without a model listing 404s and the connect is rejected even with a valid key.

2. Even past that, **`connectOrRekey`** flips the provider to `error` because the catalog build can't list models: `ApiProviderSource.listModels()` throws on the `/models` 404 → `sourceErrors > 0`, tripping the `models === 0 && sourceErrors > 0` false-green guard.

## Fix

1. **Chat-completions fallback (`ConnectionTester`).** For a user-supplied custom base, a `404` / empty-list on `/models` now falls back to an **auth-only `POST /chat/completions`** probe (which CF and virtually all gateways support) before failing. Guards preserved:
   - a `401/403` on `/models` is still a real auth failure (never papered over);
   - a bare `404` on **both** endpoints (wrong base URL) still fails;
   - the custom-base `/models` GET no longer passes `providerId`, so the gateway's *expected* 404 doesn't incur the OpenAI-family false-404 retry latency before the fallback.

2. **Degraded connect (`connectOrRekey`).** An auth-proven custom base whose catalog comes back empty is now landed **connected with a `no-models` warning** (the user supplies a model id manually) instead of rejected. Canonical providers keep the strict false-green guard — the exemption is scoped to `key`+`baseUrl` providers that already passed the auth probe.

## Scope

Per the Overwatch dispatch, this is the **core connect fix**. The secondary item (surfacing the real `ConnectError` + a Cloudflare host hint in the UI) is **deferred to coordinate with #277 / PR #276** (active error-typing work) to avoid clobbering.

> Note: a `/models`-less provider lands with an **empty catalog**. The connect now succeeds (no longer hard-fails), but a manual-model-entry UX is a follow-up (it overlaps the #277/#276 renderer work).

## Tests (108 pass, tsc clean)

- **`ConnectionTester` (6):** chat fallback connects · model-not-found proves auth · empty-`/models` falls back · `401`-no-fallback · chat-`401` → unauthorized · wrong-URL still fails.
- **`connectOrRekey` (2):** custom base with no `/models` lands connected-but-empty with `no-models` warning · canonical empty-catalog still rejected.
- **Live-verified** the real `fetch` path against a local `/models`-less server: a good key connects via the chat fallback (`GET /v1/models` 404 → `POST /v1/chat/completions` 200), a bad key → `unauthorized`.

Branched off the current `integration/0.11.4` tip (ConnectionTester is also touched conceptually by #314/#328 — disjoint regions, no conflict).