### PR TITLE
fix(mcp): route stdio oauth2-byo sign-in to install+test, not HTTP OAuth (#306)

### DIFF
--- a/src/renderer/pages/settings/McpLibrary/DetailPage.tsx
+++ b/src/renderer/pages/settings/McpLibrary/DetailPage.tsx
@@ -133,20 +133,14 @@ export function DetailPage() {
     syncMcpToAgents,
     removeMcpFromAgents,
     checkSingleServerInstallStatus,
-    setAgentInstallStatus,
+    setAgentInstallStatus
   );
   const conn = useMcpConnection(mcpServers, saveMcpServers, message);
 
   const entry = useMemo(() => library.getEntry(id), [library, id]);
-  const guide = useMemo(
-    () => (entry?.['x-wayland'].setupGuide ? library.getGuide(id) : null),
-    [library, id, entry],
-  );
+  const guide = useMemo(() => (entry?.['x-wayland'].setupGuide ? library.getGuide(id) : null), [library, id, entry]);
   const installed = mcpServers.some((s) => s.libraryEntryId === id);
-  const installedServer = useMemo(
-    () => mcpServers.find((s) => s.libraryEntryId === id),
-    [mcpServers, id],
-  );
+  const installedServer = useMemo(() => mcpServers.find((s) => s.libraryEntryId === id), [mcpServers, id]);
 
   const [tab, setTab] = useState<Tab | null>(null);
   const [env, setEnv] = useState<Record<string, string>>({});
@@ -213,21 +207,19 @@ export function DetailPage() {
         message.error(
           t('mcpLibrary.install.errorFailed', 'Install failed: {{error}}', {
             error: 'unknown',
-          }),
+          })
         );
         return null;
       }
       message.success(
         t('mcpLibrary.install.successAdded', '{{name}} added to library.', {
           name: entry.title,
-        }),
+        })
       );
       return newServer;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      message.error(
-        t('mcpLibrary.install.errorFailed', 'Install failed: {{error}}', { error: msg }),
-      );
+      message.error(t('mcpLibrary.install.errorFailed', 'Install failed: {{error}}', { error: msg }));
       return null;
     } finally {
       setInstalling(false);
@@ -288,13 +280,13 @@ export function DetailPage() {
         t('mcpLibrary.install.connected', 'Connected to {{name}} ({{count}} tools).', {
           name: entry.title,
           count: res.data?.tools?.length ?? 0,
-        }),
+        })
       );
     } catch (err) {
       message.error(
         t('mcpLibrary.install.connectFailed', 'Could not connect: {{error}}', {
           error: err instanceof Error ? err.message : String(err),
-        }),
+        })
       );
     } finally {
       setInstalling(false);
@@ -343,7 +335,7 @@ export function DetailPage() {
     message.error(
       t('mcpLibrary.install.oauthFailed', 'Authorization failed: {{error}}', {
         error: (result.success === false && result.error) || 'unknown',
-      }),
+      })
     );
   };
 
@@ -360,8 +352,8 @@ export function DetailPage() {
       message.error(
         t(
           'mcpLibrary.install.oauthTimeout',
-          'Sign-in timed out. Check the client ID/secret and redirect URI, then try again.',
-        ),
+          'Sign-in timed out. Check the client ID/secret and redirect URI, then try again.'
+        )
       );
       return true;
     }
@@ -380,7 +372,7 @@ export function DetailPage() {
       message.error(
         t('mcpLibrary.byo.saveFailed', 'Failed to save credentials: {{error}}', {
           error: saveResult.error ?? 'unknown',
-        }),
+        })
       );
       return;
     }
@@ -388,9 +380,7 @@ export function DetailPage() {
 
     // Persist via the renderer cache too so the next pageload sees byoOAuth
     // without waiting for a useMcpServers re-mount.
-    await saveMcpServers((prev) =>
-      prev.map((s) => (s.id === saveResult.server!.id ? saveResult.server! : s)),
-    );
+    await saveMcpServers((prev) => prev.map((s) => (s.id === saveResult.server!.id ? saveResult.server! : s)));
 
     const controller = new AbortController();
     oauthAbortRef.current = controller;
@@ -404,7 +394,7 @@ export function DetailPage() {
     message.error(
       t('mcpLibrary.install.oauthFailed', 'Authorization failed: {{error}}', {
         error: (retryResult.success === false && retryResult.error) || 'unknown',
-      }),
+      })
     );
   };
 
@@ -499,7 +489,7 @@ export function DetailPage() {
       title: t('mcpLibrary.detail.removeTitle', 'Remove {{name}}?', { name: entry.title }),
       content: t(
         'mcpLibrary.detail.removeBody',
-        'This deletes the connector and its sign-in. You can reinstall it any time.',
+        'This deletes the connector and its sign-in. You can reinstall it any time.'
       ),
       okText: t('mcpLibrary.detail.removeConfirm', 'Remove'),
       cancelText: t('mcpLibrary.detail.cancel', 'Cancel'),
@@ -520,8 +510,7 @@ export function DetailPage() {
   const maintainerLabel =
     w.maintainerType === 'official' ? 'Official' : w.maintainerType === 'wayland' ? 'Wayland' : 'Community';
   const primaryCategory = w.categories?.[0] ? titleCase(w.categories[0]) : undefined;
-  const transportType =
-    entry.packages[0]?.transport.type ?? entry.remotes?.[0]?.type ?? 'hosted';
+  const transportType = entry.packages[0]?.transport.type ?? entry.remotes?.[0]?.type ?? 'hosted';
 
   const toolCount = installedServer?.tools?.length ?? 0;
   const syncedAt = formatRelativeTime(installedServer?.lastConnected);
@@ -554,25 +543,18 @@ export function DetailPage() {
           <div className={styles.statusMeta}>
             {w.auth.method === 'none'
               ? t('mcpLibrary.detail.notInstalledKeyless', 'No account needed. Install and it works.')
-              : t(
-                  'mcpLibrary.detail.notInstalledAuth',
-                  'Install, then sign in or add a token to connect.',
-                )}
+              : t('mcpLibrary.detail.notInstalledAuth', 'Install, then sign in or add a token to connect.')}
           </div>
           <button
-            type="button"
+            type='button'
             className={styles.btnPrimary}
             onClick={() =>
-              w.auth.method === 'none'
-                ? void install()
-                : void onPrimary(isApiKey ? 'api-key-save' : 'oauth-flow')
+              w.auth.method === 'none' ? void install() : void onPrimary(isApiKey ? 'api-key-save' : 'oauth-flow')
             }
             disabled={installing || oauthInFlight}
           >
             <Plus size={16} />
-            {installing
-              ? t('mcpLibrary.install.installing', 'Installing…')
-              : t('mcpLibrary.install.button', 'Install')}
+            {installing ? t('mcpLibrary.install.installing', 'Installing…') : t('mcpLibrary.install.button', 'Install')}
           </button>
           {w.auth.method !== 'none' && (
             <div className={styles.note}>
@@ -596,27 +578,21 @@ export function DetailPage() {
             {t('mcpLibrary.detail.needsSignInMeta', 'Installed, but not connected yet.')}
           </div>
           <button
-            type="button"
+            type='button'
             className={`${styles.btnPrimary} ${styles.btnWarn}`}
             onClick={() => void onPrimary('oauth-flow')}
             disabled={oauthInFlight}
           >
             <LogIn size={16} />
-            {oauthInFlight
-              ? t('mcpLibrary.detail.signingIn', 'Signing in…')
-              : t('mcpLibrary.detail.signIn', 'Sign in')}
+            {oauthInFlight ? t('mcpLibrary.detail.signingIn', 'Signing in…') : t('mcpLibrary.detail.signIn', 'Sign in')}
           </button>
           {oauthInFlight && installedServer && (
-            <button
-              type="button"
-              className={styles.btn2}
-              onClick={() => cancelOAuth(installedServer)}
-            >
+            <button type='button' className={styles.btn2} onClick={() => cancelOAuth(installedServer)}>
               {t('mcpLibrary.detail.cancelSignIn', 'Cancel sign-in')}
             </button>
           )}
           <div className={styles.lifecycle}>
-            <button type="button" className={`${styles.btn2} ${styles.btn2Danger}`} onClick={confirmRemove}>
+            <button type='button' className={`${styles.btn2} ${styles.btn2Danger}`} onClick={confirmRemove}>
               <Trash2 size={14} />
               {t('mcpLibrary.detail.remove', 'Remove connector')}
             </button>
@@ -634,17 +610,16 @@ export function DetailPage() {
             {t('mcpLibrary.detail.needsAttention', 'Needs attention')}
           </div>
           <div className={styles.statusMeta}>
-            {installedServer.lastError ??
-              t('mcpLibrary.detail.errorMeta', 'The last connection attempt failed.')}
+            {installedServer.lastError ?? t('mcpLibrary.detail.errorMeta', 'The last connection attempt failed.')}
           </div>
-          <button type="button" className={styles.btnPrimary} onClick={reconnect} disabled={reconnecting}>
+          <button type='button' className={styles.btnPrimary} onClick={reconnect} disabled={reconnecting}>
             <RefreshCw size={16} />
             {reconnecting
               ? t('mcpLibrary.detail.reconnecting', 'Reconnecting…')
               : t('mcpLibrary.detail.reconnect', 'Reconnect')}
           </button>
           <div className={styles.lifecycle}>
-            <button type="button" className={`${styles.btn2} ${styles.btn2Danger}`} onClick={confirmRemove}>
+            <button type='button' className={`${styles.btn2} ${styles.btn2Danger}`} onClick={confirmRemove}>
               <Trash2 size={14} />
               {t('mcpLibrary.detail.remove', 'Remove connector')}
             </button>
@@ -670,7 +645,7 @@ export function DetailPage() {
               : t('mcpLibrary.detail.notConnectedKey', 'Installed. Add your token to connect it.')}
           </div>
           <button
-            type="button"
+            type='button'
             className={`${styles.btnPrimary} ${styles.btnWarn}`}
             onClick={() => (isOauth ? void onPrimary('oauth-flow') : setTab('setup-guide'))}
             disabled={oauthInFlight}
@@ -683,16 +658,12 @@ export function DetailPage() {
               : t('mcpLibrary.detail.addToken', 'Add token')}
           </button>
           {isOauth && oauthInFlight && installedServer && (
-            <button
-              type="button"
-              className={styles.btn2}
-              onClick={() => cancelOAuth(installedServer)}
-            >
+            <button type='button' className={styles.btn2} onClick={() => cancelOAuth(installedServer)}>
               {t('mcpLibrary.detail.cancelSignIn', 'Cancel sign-in')}
             </button>
           )}
           <div className={styles.lifecycle}>
-            <button type="button" className={`${styles.btn2} ${styles.btn2Danger}`} onClick={confirmRemove}>
+            <button type='button' className={`${styles.btn2} ${styles.btn2Danger}`} onClick={confirmRemove}>
               <Trash2 size={14} />
               {t('mcpLibrary.detail.remove', 'Remove connector')}
             </button>
@@ -710,7 +681,7 @@ export function DetailPage() {
             {t('mcpLibrary.detail.off', 'Off')}
           </div>
         ) : (
-          <StatusChip status="running" />
+          <StatusChip status='running' />
         )}
         <div className={styles.statusMeta} style={{ marginTop: 8 }}>
           {t('mcpLibrary.detail.connectedMeta', '{{count}} tools', { count: toolCount })}
@@ -724,7 +695,7 @@ export function DetailPage() {
           />
         </div>
         <div className={styles.lifecycle}>
-          <button type="button" className={styles.btn2} onClick={reconnect} disabled={reconnecting}>
+          <button type='button' className={styles.btn2} onClick={reconnect} disabled={reconnecting}>
             <RefreshCw size={14} />
             {reconnecting
               ? t('mcpLibrary.detail.reconnecting', 'Reconnecting…')
@@ -732,7 +703,7 @@ export function DetailPage() {
           </button>
         </div>
         <div className={styles.lifecycle}>
-          <button type="button" className={`${styles.btn2} ${styles.btn2Danger}`} onClick={confirmRemove}>
+          <button type='button' className={`${styles.btn2} ${styles.btn2Danger}`} onClick={confirmRemove}>
             <Trash2 size={14} />
             {t('mcpLibrary.detail.remove', 'Remove connector')}
           </button>
@@ -782,7 +753,7 @@ export function DetailPage() {
   return (
     <div className={styles.page}>
       {contextHolder}
-      <button type="button" className={styles.back} onClick={() => navigate('/settings/mcp-library/browse')}>
+      <button type='button' className={styles.back} onClick={() => navigate('/settings/mcp-library/browse')}>
         <ArrowLeft size={15} /> {t('mcpLibrary.detail.back', 'MCP Library')}
       </button>
 
@@ -792,7 +763,7 @@ export function DetailPage() {
           {safeUrl(w.iconUrl) ? (
             <img
               src={safeUrl(w.iconUrl)}
-              alt=""
+              alt=''
               onError={(e) => {
                 (e.currentTarget as HTMLImageElement).style.display = 'none';
                 const parent = e.currentTarget.parentElement;
@@ -829,7 +800,7 @@ export function DetailPage() {
         {tabs.map((tb) => (
           <button
             key={tb.key}
-            type="button"
+            type='button'
             className={`${styles.tab} ${activeTab === tb.key ? styles.tabActive : ''}`}
             onClick={() => setTab(tb.key)}
           >
@@ -890,14 +861,12 @@ export function DetailPage() {
             <>
               <h2 className={styles.hSec}>{t('mcpLibrary.detail.setupHeading', 'Setup guide')}</h2>
               {isReady && (
-                <div className={styles.setupSuccess} role="status">
+                <div className={styles.setupSuccess} role='status'>
                   <Check size={16} />
                   <span>
-                    {t(
-                      'mcpLibrary.install.setupComplete',
-                      '{{name}} is connected and ready. Ask any chat to use it.',
-                      { name: entry.title },
-                    )}
+                    {t('mcpLibrary.install.setupComplete', '{{name}} is connected and ready. Ask any chat to use it.', {
+                      name: entry.title,
+                    })}
                   </span>
                 </div>
               )}
@@ -918,7 +887,7 @@ export function DetailPage() {
               {showFallbackConnect && (
                 <div className={styles.connectBar}>
                   <button
-                    type="button"
+                    type='button'
                     className={styles.btnPrimary}
                     onClick={() => void onPrimary(isApiKey ? 'api-key-save' : 'oauth-flow')}
                     disabled={installing || oauthInFlight}
@@ -935,11 +904,7 @@ export function DetailPage() {
                           })}
                   </button>
                   {!isApiKey && oauthInFlight && installedServer && (
-                    <button
-                      type="button"
-                      className={styles.btn2}
-                      onClick={() => void cancelOAuth(installedServer)}
-                    >
+                    <button type='button' className={styles.btn2} onClick={() => void cancelOAuth(installedServer)}>
                       {t('mcpLibrary.detail.cancelSignIn', 'Cancel')}
                     </button>
                   )}
@@ -1011,10 +976,7 @@ export function DetailPage() {
                 </p>
               )}
               <p className={styles.availableNote}>
-                {t(
-                  'mcpLibrary.detail.availableNote',
-                  'Connectors are available to all your agents while enabled.',
-                )}
+                {t('mcpLibrary.detail.availableNote', 'Connectors are available to all your agents while enabled.')}
               </p>
             </div>
           )}
@@ -1023,19 +985,19 @@ export function DetailPage() {
             <div className={styles.panel}>
               <h3>{t('mcpLibrary.detail.links', 'Links')}</h3>
               {safeUrl(entry.websiteUrl) && (
-                <button type="button" className={styles.link} onClick={() => openUrl(entry.websiteUrl)}>
+                <button type='button' className={styles.link} onClick={() => openUrl(entry.websiteUrl)}>
                   <ExternalLink size={14} />
                   {t('mcpLibrary.detail.linkWebsite', 'Website')}
                 </button>
               )}
               {safeUrl(entry.repository?.url) && (
-                <button type="button" className={styles.link} onClick={() => openUrl(entry.repository?.url)}>
+                <button type='button' className={styles.link} onClick={() => openUrl(entry.repository?.url)}>
                   <ExternalLink size={14} />
                   {t('mcpLibrary.detail.linkSource', 'Source repository')}
                 </button>
               )}
               {safeUrl(w.auth.providerSignupUrl) && (
-                <button type="button" className={styles.link} onClick={() => openUrl(w.auth.providerSignupUrl)}>
+                <button type='button' className={styles.link} onClick={() => openUrl(w.auth.providerSignupUrl)}>
                   <Shield size={14} />
                   {t('mcpLibrary.detail.linkSignup', 'Create an account')}
                 </button>

--- a/src/renderer/pages/settings/McpLibrary/DetailPage.tsx
+++ b/src/renderer/pages/settings/McpLibrary/DetailPage.tsx
@@ -244,13 +244,21 @@ export function DetailPage() {
   };
 
   /**
-   * api-key save+connect: persist the installed server with the user's token
-   * (now embedded as a Bearer header by entryToServerData), run a REAL
-   * connection test that reaches the server and lists tools, and only enable
-   * the server when that test passes. This replaces the prior decorative token
-   * field whose value went nowhere and the false-positive "connected" banner.
+   * Save + connect a credential-bearing server: persist the installed server
+   * with the user's env-supplied credentials, run a REAL connection test that
+   * reaches the server and lists tools, and only enable the server when that
+   * test passes. Replaces the prior decorative token field whose value went
+   * nowhere and the false-positive "connected" banner.
+   *
+   * Shared by two auth models that connect identically — by starting the server
+   * with credentials already on it, NOT via the HTTP loopback OAuth path:
+   *  - api-key connectors (token embedded as a Bearer header by entryToServerData)
+   *  - stdio oauth2-byo connectors (#306): they carry their OAuth client creds on
+   *    transport.env (e.g. GOOGLE_OAUTH_CLIENT_ID/SECRET) and run their OWN OAuth
+   *    inside the spawned subprocess, so login() (which rejects non-HTTP
+   *    transports) must never be called for them.
    */
-  const saveAndConnectApiKey = async () => {
+  const saveAndConnect = async () => {
     const hasToken = Object.values(env).some((v) => typeof v === 'string' && v.trim().length > 0);
     // Some api-key connectors take an OPTIONAL key (Context7's free tier works
     // without one) - their guide has no token input. Only block on a missing
@@ -296,12 +304,24 @@ export function DetailPage() {
   const onPrimary = async (action: string) => {
     // api-key hosted MCP: persist token + test + enable on success.
     if (action === 'api-key-save') {
-      await saveAndConnectApiKey();
+      await saveAndConnect();
       return;
     }
     // Install first (or reuse the existing server if already installed), then
     // trigger OAuth for entries whose setup guide emits an 'oauth-flow' action.
     if (action !== 'oauth-flow') return;
+
+    // #306: An oauth2-byo connector on a STDIO transport (Google Workspace,
+    // gcloud, Teams, MS365, Xero) does its OWN OAuth inside the spawned
+    // subprocess using env credentials — it is NOT HTTP-family, so the desktop
+    // loopback OAuth path (login()) hard-rejects it ("OAuth requires an
+    // HTTP-family transport, got 'stdio'"). Route it to the env-install path:
+    // persist the creds and start + test the server so it self-authenticates.
+    const transport = installedServer?.transport.type ?? entry.packages[0]?.transport.type ?? entry.remotes?.[0]?.type;
+    if (transport === 'stdio') {
+      await saveAndConnect();
+      return;
+    }
 
     let server: IMcpServer | null = installedServer ?? null;
     if (!server) {

--- a/src/renderer/pages/settings/McpLibrary/entryToServerData.ts
+++ b/src/renderer/pages/settings/McpLibrary/entryToServerData.ts
@@ -29,7 +29,7 @@ function appendQueryParam(url: string, name: string, value: string): string {
  */
 export function entryToServerData(
   entry: CatalogEntry,
-  envValues: Record<string, string>,
+  envValues: Record<string, string>
 ): Omit<IMcpServer, 'id' | 'createdAt' | 'updatedAt'> {
   const pkg = entry.packages.length > 0 ? entry.packages[0] : undefined;
   const remote = entry.remotes && entry.remotes.length > 0 ? entry.remotes[0] : undefined;
@@ -37,6 +37,16 @@ export function entryToServerData(
   if (!pkg && !remote) {
     throw new Error(`Catalog entry ${entry.name} has no installable target.`);
   }
+
+  // Trim user-entered credential values. A stray space/newline picked up when
+  // pasting (e.g. a Google OAuth client secret) would otherwise be persisted
+  // verbatim onto transport.env and silently break the subprocess's own auth
+  // with `invalid_client` - the visible characters look correct, so it's a
+  // brutal one to diagnose. Empty values are preserved so an unset optional var
+  // still round-trips.
+  const cleanEnv: Record<string, string> = Object.fromEntries(
+    Object.entries(envValues).map(([k, v]) => [k, typeof v === 'string' ? v.trim() : v])
+  );
 
   // Prefer remote (hosted MCP) if both are present - no local spawn required.
   // For an api-key hosted server the user's token is sent as a Bearer
@@ -70,7 +80,7 @@ export function entryToServerData(
   // with `{{VAR}}` substituted from the user's setup-guide inputs. Empty args
   // (an unfilled optional `{{VAR}}`) are dropped so we never pass a bare flag value.
   const runtimeArgs = (pkg?.runtimeArguments ?? [])
-    .map((a) => a.replace(/\{\{(\w+)\}\}/g, (_m, k) => envValues[k] ?? ''))
+    .map((a) => a.replace(/\{\{(\w+)\}\}/g, (_m, k) => cleanEnv[k] ?? ''))
     .filter((a) => a.length > 0);
   const transport: IMcpServerTransport = remote
     ? {
@@ -87,13 +97,13 @@ export function entryToServerData(
           type: 'stdio',
           command: 'node',
           args: [pkg!.identifier, ...runtimeArgs],
-          env: envValues,
+          env: cleanEnv,
         }
       : {
           type: 'stdio',
           command: pkg!.runtimeHint,
           args: [...(pkg!.identifier ? [pkg!.identifier] : []), ...runtimeArgs],
-          env: envValues,
+          env: cleanEnv,
         };
 
   // The catalog id is reverse-DNS with a slash (com.vendor/name), but an MCP

--- a/tests/unit/renderer/mcp-library/DetailPage.stdioOauth.dom.test.tsx
+++ b/tests/unit/renderer/mcp-library/DetailPage.stdioOauth.dom.test.tsx
@@ -1,0 +1,262 @@
+// @vitest-environment jsdom
+
+/**
+ * #306 - DetailPage transport-aware "Sign in" routing for oauth2-byo connectors.
+ *
+ * An oauth2-byo connector splits by transport:
+ *   - STDIO (Google Workspace, gcloud, Teams, MS365, Xero): the spawned
+ *     subprocess runs its OWN OAuth using env credentials. The desktop loopback
+ *     OAuth path (login()) hard-rejects non-HTTP transports
+ *     ("OAuth requires an HTTP-family transport, got 'stdio'"), so clicking
+ *     "Sign in" must install + connection-test the server, NOT call login().
+ *   - HTTP-family (Atlassian, GitHub, ...): real loopback OAuth via login().
+ *
+ * These tests pin both halves of that discriminator so the #306 fix can't
+ * regress into the old "got 'stdio'" failure, and so the fix doesn't break the
+ * HTTP OAuth path that #283/#242 depend on.
+ */
+
+import React from 'react';
+import { test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import type { IMcpServer } from '@/common/config/storage';
+
+const { handleAddMcpServer, handleToggleMcpServer, login, messageSuccess, messageError, testMcpConnection } =
+  vi.hoisted(() => ({
+    handleAddMcpServer:
+      vi.fn<(data: Omit<IMcpServer, 'id' | 'createdAt' | 'updatedAt'>) => Promise<IMcpServer | null>>(),
+    handleToggleMcpServer: vi.fn<(id: string, enabled: boolean) => Promise<void>>(),
+    login: vi.fn<(server: IMcpServer) => Promise<{ success: boolean; error?: string; code?: string }>>(),
+    messageSuccess: vi.fn<(msg: string) => void>(),
+    messageError: vi.fn<(msg: string) => void>(),
+    testMcpConnection: vi.fn().mockResolvedValue({ success: true, data: { success: true, tools: [] } }),
+  }));
+
+vi.mock('@/common/adapter/ipcBridge', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/common/adapter/ipcBridge')>();
+  return {
+    ...actual,
+    mcpService: {
+      ...actual.mcpService,
+      testMcpConnection: { invoke: testMcpConnection },
+    },
+  };
+});
+
+const hookState: { mcpServers: IMcpServer[] } = { mcpServers: [] };
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, defaultValue?: string | object, interp?: Record<string, string>) => {
+      const tpl = typeof defaultValue === 'string' ? defaultValue : _key;
+      if (!interp) return tpl;
+      return tpl.replace(/\{\{(\w+)\}\}/g, (_m, k) => interp[k] ?? '');
+    },
+  }),
+}));
+
+vi.mock('@renderer/hooks/mcp', () => ({
+  useMcpServers: () => ({
+    mcpServers: hookState.mcpServers,
+    allMcpServers: hookState.mcpServers,
+    extensionMcpServers: [],
+    setMcpServers: vi.fn(),
+    saveMcpServers: vi.fn().mockResolvedValue(undefined),
+  }),
+  useMcpAgentStatus: () => ({
+    agentInstallStatus: {},
+    setAgentInstallStatus: vi.fn(),
+    loadingServers: new Set(),
+    isServerLoading: () => false,
+    checkAgentInstallStatus: vi.fn().mockResolvedValue(undefined),
+    debouncedCheckAgentInstallStatus: vi.fn(),
+    checkSingleServerInstallStatus: vi.fn().mockResolvedValue(undefined),
+  }),
+  useMcpOperations: () => ({
+    syncMcpToAgents: vi.fn().mockResolvedValue(undefined),
+    removeMcpFromAgents: vi.fn().mockResolvedValue(undefined),
+    handleMcpOperationResult: vi.fn(),
+  }),
+  useMcpOAuth: () => ({
+    oauthStatus: {},
+    loggingIn: {},
+    checkOAuthStatus: vi.fn().mockResolvedValue(undefined),
+    checkMultipleServers: vi.fn().mockResolvedValue(undefined),
+    login,
+    setByoCredentials: vi.fn().mockResolvedValue({ success: true, server: null }),
+    cancelMcpOAuth: vi.fn(),
+    logout: vi.fn().mockResolvedValue({ success: true }),
+  }),
+  useMcpServerCRUD: () => ({
+    handleAddMcpServer,
+    handleBatchImportMcpServers: vi.fn().mockResolvedValue([]),
+    handleEditMcpServer: vi.fn().mockResolvedValue(undefined),
+    handleDeleteMcpServer: vi.fn().mockResolvedValue(undefined),
+    handleToggleMcpServer,
+  }),
+  useMcpConnection: () => ({
+    testingServers: {},
+    handleTestMcpConnection: vi.fn(),
+    refreshServerStatuses: vi.fn(),
+  }),
+}));
+
+vi.mock('@arco-design/web-react', async () => {
+  const actual = await vi.importActual<typeof import('@arco-design/web-react')>('@arco-design/web-react');
+  return {
+    ...actual,
+    Message: {
+      ...actual.Message,
+      success: messageSuccess,
+      error: messageError,
+      useMessage: () => [
+        { success: messageSuccess, error: messageError },
+        React.createElement('div', { 'data-testid': 'arco-context-holder' }),
+      ],
+    },
+  };
+});
+
+import { DetailPage } from '@renderer/pages/settings/McpLibrary/DetailPage';
+
+const GOOGLE_WORKSPACE_ID = 'io.github.taylorwilsdon/google-workspace-mcp';
+const ATLASSIAN_ID = 'com.atlassian/atlassian-mcp';
+
+function renderDetail(entryId: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/settings/mcp-library/${encodeURIComponent(entryId)}`]}>
+      <Routes>
+        <Route path='/settings/mcp-library/:entryId' element={<DetailPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  hookState.mcpServers = [];
+  handleAddMcpServer.mockReset();
+  handleToggleMcpServer.mockReset().mockResolvedValue(undefined);
+  login.mockReset().mockResolvedValue({ success: true });
+  messageSuccess.mockReset();
+  messageError.mockReset();
+  testMcpConnection.mockReset().mockResolvedValue({ success: true, data: { success: true, tools: [] } });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+test('stdio oauth2-byo: "Sign in" installs + connection-tests and NEVER calls login()', async () => {
+  const fakeServer: IMcpServer = {
+    id: 'mcp_gws',
+    name: GOOGLE_WORKSPACE_ID.replace(/[^A-Za-z0-9_.-]/g, '-'),
+    enabled: false,
+    transport: {
+      type: 'stdio',
+      command: 'uvx',
+      args: ['workspace-mcp'],
+      env: { GOOGLE_OAUTH_CLIENT_ID: 'cid.apps.googleusercontent.com', GOOGLE_OAUTH_CLIENT_SECRET: 'secret' },
+    },
+    originalJson: '{}',
+    createdAt: 1,
+    updatedAt: 1,
+    source: 'library',
+    libraryEntryId: GOOGLE_WORKSPACE_ID,
+  };
+  handleAddMcpServer.mockResolvedValue(fakeServer);
+
+  renderDetail(GOOGLE_WORKSPACE_ID);
+  await screen.findByText('Google Workspace');
+
+  // The setup guide (with the OAuth client-id/secret inputs and the
+  // "Sign in with Google" action) is the default tab when not yet connected.
+  fireEvent.click(screen.getByRole('button', { name: /^Setup$/i }));
+
+  fireEvent.change(await screen.findByLabelText(/Client ID/i), {
+    target: { value: 'cid.apps.googleusercontent.com' },
+  });
+  fireEvent.change(await screen.findByLabelText(/Client Secret/i), { target: { value: 'secret' } });
+
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /Sign in with Google/i }));
+  });
+
+  // Core #306 guarantee: a stdio transport must NEVER reach the HTTP loopback
+  // OAuth path (which rejects it).
+  await waitFor(() => expect(handleAddMcpServer).toHaveBeenCalledTimes(1));
+  expect(login).not.toHaveBeenCalled();
+
+  // It must self-authenticate via the env-install path: persist creds, then run
+  // a real connection test (the subprocess runs its own OAuth on start).
+  expect(handleAddMcpServer).toHaveBeenCalledWith(
+    expect.objectContaining({
+      transport: expect.objectContaining({
+        type: 'stdio',
+        env: expect.objectContaining({ GOOGLE_OAUTH_CLIENT_ID: 'cid.apps.googleusercontent.com' }),
+      }),
+    })
+  );
+  expect(testMcpConnection).toHaveBeenCalledTimes(1);
+  expect(handleToggleMcpServer).toHaveBeenCalledWith('mcp_gws', true);
+  expect(messageSuccess).toHaveBeenCalled();
+});
+
+test('stdio oauth2-byo: a failed connection test does NOT enable the server and surfaces the error', async () => {
+  const fakeServer: IMcpServer = {
+    id: 'mcp_gws',
+    name: GOOGLE_WORKSPACE_ID.replace(/[^A-Za-z0-9_.-]/g, '-'),
+    enabled: false,
+    transport: { type: 'stdio', command: 'uvx', args: ['workspace-mcp'], env: {} },
+    originalJson: '{}',
+    createdAt: 1,
+    updatedAt: 1,
+    source: 'library',
+    libraryEntryId: GOOGLE_WORKSPACE_ID,
+  };
+  handleAddMcpServer.mockResolvedValue(fakeServer);
+  testMcpConnection.mockResolvedValue({ success: true, data: { success: false, error: 'auth declined' } });
+
+  renderDetail(GOOGLE_WORKSPACE_ID);
+  await screen.findByText('Google Workspace');
+  fireEvent.click(screen.getByRole('button', { name: /^Setup$/i }));
+  fireEvent.change(await screen.findByLabelText(/Client ID/i), { target: { value: 'cid' } });
+  fireEvent.change(await screen.findByLabelText(/Client Secret/i), { target: { value: 'secret' } });
+
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /Sign in with Google/i }));
+  });
+
+  await waitFor(() => expect(testMcpConnection).toHaveBeenCalledTimes(1));
+  expect(login).not.toHaveBeenCalled();
+  // Failed probe must not flip the server on.
+  expect(handleToggleMcpServer).not.toHaveBeenCalledWith('mcp_gws', true);
+  expect(messageError).toHaveBeenCalled();
+});
+
+test('HTTP-family oauth2-byo: "Sign in" still runs the loopback OAuth via login()', async () => {
+  const fakeServer: IMcpServer = {
+    id: 'mcp_atl',
+    name: ATLASSIAN_ID.replace(/[^A-Za-z0-9_.-]/g, '-'),
+    enabled: false,
+    transport: { type: 'streamable_http', url: 'https://mcp.atlassian.com/v1/sse' },
+    originalJson: '{}',
+    createdAt: 1,
+    updatedAt: 1,
+    source: 'library',
+    libraryEntryId: ATLASSIAN_ID,
+  };
+  handleAddMcpServer.mockResolvedValue(fakeServer);
+
+  renderDetail(ATLASSIAN_ID);
+
+  // Not-installed oauth2-byo header CTA dispatches onPrimary('oauth-flow').
+  await act(async () => {
+    fireEvent.click(await screen.findByRole('button', { name: /^Install$/ }));
+  });
+
+  // HTTP-family transport must take the real loopback OAuth path - the #306
+  // guard only diverts stdio.
+  await waitFor(() => expect(login).toHaveBeenCalledTimes(1));
+  expect(testMcpConnection).not.toHaveBeenCalled();
+});

--- a/tests/unit/renderer/mcp-library/entryToServerData.test.ts
+++ b/tests/unit/renderer/mcp-library/entryToServerData.test.ts
@@ -78,3 +78,50 @@ describe('entryToServerData query-param api-key auth (#130)', () => {
     expect(data.transport.url).toBe('https://mcp.exa.ai/mcp?exaApiKey=live-key');
   });
 });
+
+describe('entryToServerData stdio credential trimming (#306)', () => {
+  const stdioEntry = baseEntry({
+    packages: [{ runtimeHint: 'uvx', identifier: 'workspace-mcp', runtimeArguments: [] }],
+    'x-wayland': {
+      tier: 'builder',
+      categories: ['productivity'],
+      maintainerType: 'community',
+      iconUrl: 'icons/test.svg',
+      auth: { method: 'oauth2-byo' },
+    },
+  } as unknown as Partial<CatalogEntry>);
+
+  it('strips stray whitespace off pasted env credentials before persisting (invalid_client guard)', () => {
+    const data = entryToServerData(stdioEntry, {
+      GOOGLE_OAUTH_CLIENT_ID: '  1012723604691-abc.apps.googleusercontent.com\n',
+      GOOGLE_OAUTH_CLIENT_SECRET: 'GOCSPX-realsecret \t',
+    });
+
+    expect(data.transport.type).toBe('stdio');
+    expect(data.transport.env).toEqual({
+      GOOGLE_OAUTH_CLIENT_ID: '1012723604691-abc.apps.googleusercontent.com',
+      GOOGLE_OAUTH_CLIENT_SECRET: 'GOCSPX-realsecret',
+    });
+  });
+
+  it('substitutes the trimmed value into a {{VAR}} runtime arg', () => {
+    const entry = baseEntry({
+      packages: [{ runtimeHint: 'npx', identifier: 'svc', runtimeArguments: ['--token', '{{TOKEN}}'] }],
+      'x-wayland': {
+        tier: 'builder',
+        categories: ['developer'],
+        maintainerType: 'community',
+        iconUrl: 'icons/test.svg',
+        auth: { method: 'oauth2-byo' },
+      },
+    } as unknown as Partial<CatalogEntry>);
+
+    const data = entryToServerData(entry, { TOKEN: '  abc123  ' });
+    expect(data.transport.args).toEqual(['svc', '--token', 'abc123']);
+  });
+
+  it('keeps an empty optional env var (preserved as empty, not dropped) after trimming', () => {
+    const data = entryToServerData(stdioEntry, { GOOGLE_OAUTH_CLIENT_ID: 'cid', OPTIONAL: '   ' });
+    expect(data.transport.env).toEqual({ GOOGLE_OAUTH_CLIENT_ID: 'cid', OPTIONAL: '' });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #306. Google Workspace (and gcloud / Teams / MS365 / Xero) are **stdio** MCP servers declared `oauth2-byo`. Their setup-guide "Sign in" button emits `action: "oauth-flow"`, which `DetailPage.onPrimary()` routed unconditionally to the desktop loopback OAuth path (`login()`). That path hard-rejects non-HTTP transports, so the click failed with:

> Authorization failed: OAuth requires an HTTP-family transport (http / sse / streamable_http), got 'stdio'

These servers run their **own** OAuth inside the spawned subprocess using env credentials already on `transport.env` (e.g. `GOOGLE_OAUTH_CLIENT_ID`/`SECRET`). They must connect like a keyed stdio install — not via `login()`.

- `onPrimary()`: when `action === 'oauth-flow'` and the resolved transport is **stdio**, route to the env-install path (persist creds → `testMcpConnection` → enable on success) instead of `login()`.
- HTTP-family `oauth2-byo` connectors (GitHub/Atlassian/…) are unchanged — still use the loopback OAuth flow.
- Shared helper renamed `saveAndConnectApiKey` → `saveAndConnect` (both auth models use it). No new i18n keys.
- First commit is a formatting-only oxfmt 0.41 normalization of `DetailPage.tsx` (pre-existing debt) so the fix diff stays reviewable.

## Verification (live, clean dev launch)

Confirmed end-to-end with a real Google Cloud OAuth client on `Wayland-Dev-2`:
- The `stdio` error is gone; the server installs, enumerates **122 tools**, and connects (`Transport: stdio`, `ListToolsRequest` OK).
- On first tool call, the subprocess runs the real Google OAuth and **opens the browser** (`redirect_uri=http://localhost:8000/oauth2callback`), loading the env client creds our fix persisted.

## Test plan

- [x] `DetailPage.stdioOauth.dom.test.tsx` — stdio never calls `login()` (installs + tests instead); failed probe does not enable; HTTP-family `oauth2-byo` still calls `login()`
- [x] Full `mcp-library` suite (18) green; `tsc` clean; oxlint clean; oxfmt clean; i18n passes
- [x] Live: Google Workspace connects + triggers real OAuth browser on first tool use