### PR TITLE
feat(tools): shared toolContract for MCP tool-scaling (#344 Lane 3 / #348 Lane 2)

### DIFF
--- a/src/process/services/tools/toolContract.ts
+++ b/src/process/services/tools/toolContract.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Shared contract for the MCP tool-scaling build (#344 Lane 3 + #348 Lane 2).
+ * Authoritative boundary defined by the #348 ruling — both lanes import these
+ * exact shapes; keep them in lockstep with that ruling.
+ *
+ * Lane 2 (#348) builds the candidate pool: every ENABLED + connected MCP
+ * server's tools, filtered by the per-server `IMcpServer.allowedTools` toggle
+ * (absent => all). It IMPLEMENTS `GetCandidateTools` and never writes
+ * `configBridge.allow_list`.
+ *
+ * Lane 3 (#344, this lane) ranks those candidates against the conversation
+ * context (BM25) and caps them to the active provider's tool-array limit, then
+ * writes the selection to `configBridge.allow_list`. It IMPLEMENTS
+ * `SelectToolsForSession` and OWNS the allow_list writer.
+ */
+
+/** A single MCP tool offered as a candidate for per-session selection. */
+export type CandidateTool = {
+  /** Owning MCP server id. */
+  serverId: string;
+  /** Tool name exactly as the engine/provider sees it. */
+  name: string;
+  /** Human description — used for BM25 ranking and the management UI. */
+  description: string;
+};
+
+/**
+ * Per-provider hard cap on the tool array a single request may carry (OpenAI's
+ * limit is 128). The selector leaves headroom under this for built-in/engine
+ * tools rather than filling it to the brim.
+ */
+export const PROVIDER_TOOL_LIMITS: Record<string, number> = {
+  openai: 128,
+  'gpt-5': 128,
+};
+
+/** Lane 2 implements; Lane 3 consumes. Returns the candidate pool to rank + cap. */
+export type GetCandidateTools = () => CandidateTool[];
+
+/**
+ * Lane 3 implements. Ranks `candidates` against `context` and returns the names
+ * of the tools to keep for the session, capped to `providerId`'s limit.
+ */
+export type SelectToolsForSession = (candidates: CandidateTool[], providerId: string, context: string) => string[];


### PR DESCRIPTION
## What

Lands `src/process/services/tools/toolContract.ts` — the authoritative boundary both lanes of the MCP tool-scaling build import, per the **#348 Overwatch ruling**. Critical path: **Lane 2 (#348) is contract-blocked**, so this ships first (tiny, types-only) before the ToolSelector body.

Part of #344.

## Contract (verbatim from the #348 ruling)

- `CandidateTool { serverId, name, description }` — a candidate MCP tool (description feeds BM25 + UI).
- `PROVIDER_TOOL_LIMITS` — per-provider hard tool-array cap (`openai`/`gpt-5` = 128); the selector leaves headroom under it for built-ins.
- `GetCandidateTools` — **Lane 2 implements, Lane 3 consumes** (the candidate pool).
- `SelectToolsForSession` — **Lane 3 implements** (ranks + caps; owns the `configBridge.allow_list` writer).

`CandidateTool` is a `type` (not `interface`) per the repo convention — identical shape/import surface, lint-clean.

## Lane boundaries (from the ruling)

- Lane 2 (#348) owns `IMcpServer.allowedTools` (absent ⇒ all) + `getCandidateTools` + listTools exposure + DetailPage toggles. **Never writes `allow_list`.**
- Lane 3 (#344, this lane) owns selection/cap + the `allow_list` writer + session-time injection.

Types-only, no behaviour. `tsc` / `oxlint` / `oxfmt` clean.