### PR TITLE
feat(tools): ToolSelector BM25 selection + per-provider cap (#344 Lane 3)

### DIFF
--- a/src/process/services/tools/ToolSelector.ts
+++ b/src/process/services/tools/ToolSelector.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Lane 3 (#344) tool selector. Ranks the candidate MCP tools (built by Lane 2's
+ * `getCandidateTools`) against the conversation context with BM25 and caps the
+ * result to the active provider's tool-array limit, so an OpenAI/gpt-5 request
+ * can never exceed 128 tools (the 400 "tools array too long" error, #344).
+ *
+ * Reuses the proven BM25 core (`@process/utils/bm25`) shared with `SkillRetriever`
+ * rather than copying the formula. Owns the selection; the `configBridge.allow_list`
+ * writer + session-time injection live alongside (separate from Lane 2).
+ */
+
+import { buildBm25Index, rankBm25 } from '../../utils/bm25';
+import { PROVIDER_TOOL_LIMITS } from './toolContract';
+import type { CandidateTool, SelectToolsForSession } from './toolContract';
+
+/**
+ * Fallback tool-array cap for any provider NOT in `PROVIDER_TOOL_LIMITS`. Set to
+ * the strictest known limit (OpenAI = 128) so a capped provider we haven't mapped
+ * yet can never overflow into the 400 error (#344). A provider that could accept
+ * more still gets up to this many of the MOST RELEVANT tools — ample for a turn.
+ */
+export const DEFAULT_PROVIDER_TOOL_LIMIT = 128;
+
+/**
+ * Slots held back under the provider cap for engine/provider BUILT-IN tools
+ * (web search, etc.) that get appended outside this MCP selection — so selected
+ * MCP tools + built-ins together stay under the hard limit.
+ */
+export const BUILTIN_TOOL_HEADROOM = 8;
+
+/**
+ * Effective MCP-tool budget for a provider: its hard cap minus built-in headroom,
+ * floored at 1. Never indexes `PROVIDER_TOOL_LIMITS` unguarded — unknown
+ * providers fall back to `DEFAULT_PROVIDER_TOOL_LIMIT`.
+ */
+export function resolveToolBudget(providerId: string): number {
+  const limit = PROVIDER_TOOL_LIMITS[providerId] ?? DEFAULT_PROVIDER_TOOL_LIMIT;
+  return Math.max(1, limit - BUILTIN_TOOL_HEADROOM);
+}
+
+/**
+ * Select the MCP tools to expose for a session: BM25-rank `candidates` against
+ * `context`, then return the (deduplicated) tool NAMES to keep, capped to the
+ * provider's budget. Under budget => all candidates kept (relevance-ordered);
+ * over budget => truncated to the top-N by score (context matches first, then
+ * remaining tools in stable input order so the budget is used).
+ */
+export const selectToolsForSession: SelectToolsForSession = (
+  candidates: CandidateTool[],
+  providerId: string,
+  context: string
+): string[] => {
+  const budget = resolveToolBudget(providerId);
+
+  // Rank by "name description" vs the conversation context. rankBm25 returns only
+  // docs that matched >=1 query term, most-relevant first.
+  const index = buildBm25Index(candidates, (t) => `${t.name} ${t.description}`);
+  const ranked = rankBm25(index, context, candidates.length).map((h) => h.ref);
+
+  // Append candidates that matched nothing in stable input order, so an
+  // under-budget set keeps everything and an over-budget set still fills the
+  // budget with the next-best tools after the context matches.
+  const matched = new Set(ranked);
+  const ordered = [...ranked, ...candidates.filter((c) => !matched.has(c))];
+
+  // The provider sees tool NAMES; dedupe by name so the allow_list never repeats
+  // one (two servers can expose the same name). Take up to `budget` names.
+  const names: string[] = [];
+  const seen = new Set<string>();
+  for (const tool of ordered) {
+    if (seen.has(tool.name)) continue;
+    seen.add(tool.name);
+    names.push(tool.name);
+    if (names.length >= budget) break;
+  }
+  return names;
+};

--- a/src/process/utils/bm25.ts
+++ b/src/process/utils/bm25.ts
@@ -1,0 +1,124 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Pure-TS BM25 retrieval core — the scoring math + tokenizer extracted verbatim
+ * from `SkillRetriever` so a second consumer (the MCP ToolSelector, #344) can
+ * reuse the SAME proven ranking instead of copying it (which would silently
+ * drift the moment anyone tuned the params).
+ *
+ * Type-agnostic: an index is built over arbitrary items via a text extractor and
+ * each hit carries the original `ref`, so callers map results back to their own
+ * domain types. NO domain coupling lives here — filters (e.g. blocked skills) and
+ * field mapping stay in the caller's adapter.
+ *
+ * BM25 parameters: k1 = 1.5, b = 0.75. IDF uses +0.5 Robertson/Lucene smoothing.
+ * Tokenization: lowercase word-boundary split, no stemming.
+ */
+
+export const BM25_K1 = 1.5;
+export const BM25_B = 0.75;
+
+/** Lowercase word-boundary tokenizer (no stemming, no stopword filtering). */
+export function tokenize(text: string): string[] {
+  return text.toLowerCase().match(/\b[a-z0-9_-]+\b/g) ?? [];
+}
+
+type Bm25Doc<T> = {
+  ref: T;
+  termFreqs: Map<string, number>;
+  length: number;
+};
+
+/** An immutable BM25 index over items of type `T`. Build once, rank many. */
+export type Bm25Index<T> = {
+  docs: Bm25Doc<T>[];
+  df: Map<string, number>;
+  avgdl: number;
+};
+
+/** A scored match: the original item plus its score and distinct-term count. */
+export type Bm25Hit<T> = {
+  ref: T;
+  score: number;
+  /** How many DISTINCT query terms this doc contains — a corpus-size-independent
+   * relevance signal (a spurious match shares one query word, a genuine match
+   * shares several). */
+  matchedTerms: number;
+};
+
+/** Build a BM25 index from `items`, deriving each doc's text via `toText`. */
+export function buildBm25Index<T>(items: readonly T[], toText: (item: T) => string): Bm25Index<T> {
+  const docs: Bm25Doc<T>[] = [];
+  const df = new Map<string, number>();
+  let totalLength = 0;
+
+  for (const item of items) {
+    const tokens = tokenize(toText(item));
+    const termFreqs = new Map<string, number>();
+    for (const t of tokens) {
+      termFreqs.set(t, (termFreqs.get(t) ?? 0) + 1);
+    }
+
+    docs.push({ ref: item, termFreqs, length: tokens.length });
+    totalLength += tokens.length;
+
+    // DF counts (one per unique term per doc).
+    for (const term of termFreqs.keys()) {
+      df.set(term, (df.get(term) ?? 0) + 1);
+    }
+  }
+
+  const avgdl = items.length > 0 ? totalLength / items.length : 1;
+  return { docs, df, avgdl };
+}
+
+/**
+ * Score `index` against `query` and return the top `limit` hits, sorted by
+ * descending BM25 score. The math is identical to `SkillRetriever.retrieve`.
+ */
+export function rankBm25<T>(index: Bm25Index<T>, query: string, limit: number): Bm25Hit<T>[] {
+  const { docs, df, avgdl } = index;
+  const N = docs.length;
+  if (N === 0) return [];
+
+  // Distinct query terms — a repeated query word must not be scored or counted
+  // twice (keeps `matchedTerms` a clean distinct-term count).
+  const queryTerms = [...new Set(tokenize(query))];
+  if (queryTerms.length === 0) return [];
+
+  const scores = new Float64Array(N);
+  const matched = new Uint16Array(N);
+
+  for (const term of queryTerms) {
+    const termDf = df.get(term) ?? 0;
+    if (termDf === 0) continue;
+
+    // IDF with +0.5 smoothing (Robertson / Lucene-style).
+    const idf = Math.log((N - termDf + 0.5) / (termDf + 0.5) + 1);
+
+    for (let i = 0; i < N; i++) {
+      const doc = docs[i];
+      const tf = doc.termFreqs.get(term) ?? 0;
+      if (tf === 0) continue;
+
+      const norm = 1 - BM25_B + BM25_B * (doc.length / avgdl);
+      const tfSat = (tf * (BM25_K1 + 1)) / (tf + BM25_K1 * norm);
+      scores[i] += idf * tfSat;
+      matched[i] += 1;
+    }
+  }
+
+  const hits: Bm25Hit<T>[] = [];
+  for (let i = 0; i < N; i++) {
+    if (scores[i] > 0) {
+      hits.push({ ref: docs[i].ref, score: scores[i], matchedTerms: matched[i] });
+    }
+  }
+
+  hits.sort((a, b) => b.score - a.score);
+  return hits.slice(0, limit);
+}

--- a/tests/unit/process/services/tools/ToolSelector.test.ts
+++ b/tests/unit/process/services/tools/ToolSelector.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  selectToolsForSession,
+  resolveToolBudget,
+  DEFAULT_PROVIDER_TOOL_LIMIT,
+  BUILTIN_TOOL_HEADROOM,
+} from '@process/services/tools/ToolSelector';
+import type { CandidateTool } from '@process/services/tools/toolContract';
+
+const tool = (name: string, description = ''): CandidateTool => ({ serverId: 'srv', name, description });
+
+describe('resolveToolBudget', () => {
+  it('caps known providers to their limit minus built-in headroom', () => {
+    expect(resolveToolBudget('openai')).toBe(128 - BUILTIN_TOOL_HEADROOM);
+    expect(resolveToolBudget('gpt-5')).toBe(128 - BUILTIN_TOOL_HEADROOM);
+  });
+
+  it('falls back to a safe default for unknown providers (never overflows)', () => {
+    expect(resolveToolBudget('some-future-provider')).toBe(DEFAULT_PROVIDER_TOOL_LIMIT - BUILTIN_TOOL_HEADROOM);
+    expect(resolveToolBudget('')).toBe(DEFAULT_PROVIDER_TOOL_LIMIT - BUILTIN_TOOL_HEADROOM);
+  });
+});
+
+describe('selectToolsForSession', () => {
+  it('keeps every tool (relevance-ordered) when under budget', () => {
+    const candidates = [
+      tool('calendar_list', 'list google calendar events'),
+      tool('gmail_send', 'send an email message'),
+      tool('drive_search', 'search google drive files'),
+    ];
+    const result = selectToolsForSession(candidates, 'openai', "what's on my calendar today");
+    expect(result).toHaveLength(3);
+    expect(result[0]).toBe('calendar_list'); // context match ranks first
+    expect(new Set(result)).toEqual(new Set(['calendar_list', 'gmail_send', 'drive_search']));
+  });
+
+  it('caps an over-budget set to the provider budget (the #344 222 > 128 regression)', () => {
+    // 222 candidates, OpenAI -> must come back within the cap, never the full 222.
+    const candidates = Array.from({ length: 222 }, (_, i) => tool(`tool_${i}`, `description for tool number ${i}`));
+    const result = selectToolsForSession(candidates, 'gpt-5', 'anything');
+    expect(result.length).toBe(resolveToolBudget('gpt-5'));
+    expect(result.length).toBeLessThanOrEqual(128);
+  });
+
+  it('puts the context-relevant tools first when over budget', () => {
+    const budget = resolveToolBudget('openai');
+    const candidates = [
+      ...Array.from({ length: budget + 50 }, (_, i) => tool(`filler_${i}`, `unrelated filler ${i}`)),
+      tool('kubernetes_deploy', 'deploy an application to a kubernetes cluster'),
+    ];
+    const result = selectToolsForSession(candidates, 'openai', 'deploy to kubernetes cluster');
+    expect(result[0]).toBe('kubernetes_deploy');
+    expect(result.length).toBe(budget);
+  });
+
+  it('deduplicates by tool name (two servers exposing the same name)', () => {
+    const candidates: CandidateTool[] = [
+      { serverId: 'a', name: 'search', description: 'search server A' },
+      { serverId: 'b', name: 'search', description: 'search server B' },
+      tool('unique', 'a unique tool'),
+    ];
+    const result = selectToolsForSession(candidates, 'openai', 'search');
+    expect(result.filter((n) => n === 'search')).toHaveLength(1);
+    expect(result).toContain('unique');
+  });
+
+  it('returns [] for no candidates', () => {
+    expect(selectToolsForSession([], 'openai', 'anything')).toEqual([]);
+  });
+});

--- a/tests/unit/process/utils/bm25.test.ts
+++ b/tests/unit/process/utils/bm25.test.ts
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { tokenize, buildBm25Index, rankBm25 } from '@process/utils/bm25';
+import { SkillRetriever } from '@process/services/skills/SkillRetriever';
+import type { SkillIndexEntry } from '@/common/types/skillTypes';
+
+const entry = (o: Partial<SkillIndexEntry> = {}): SkillIndexEntry => ({
+  name: o.name ?? 'sample-skill',
+  description: o.description ?? 'A sample skill',
+  type: 'skill',
+  source: 'wayland-library',
+  metadata: { tags: o.metadata?.tags ?? [], category: o.metadata?.category ?? '' },
+  path: `bodies/${o.name ?? 'sample-skill'}.md`,
+  security: o.security,
+});
+
+// The exact text SkillRetriever concatenates internally (name + description + tags + category).
+const toText = (e: SkillIndexEntry) =>
+  [e.name, e.description, ...(e.metadata.tags ?? []), e.metadata.category ?? ''].join(' ');
+
+describe('bm25 tokenize', () => {
+  it('lowercases and splits on word boundaries, keeping - and _', () => {
+    expect(tokenize('Hello World')).toEqual(['hello', 'world']);
+    expect(tokenize('git-workflow snake_case')).toEqual(['git-workflow', 'snake_case']);
+    expect(tokenize('  Punctuation! Marks?  ')).toEqual(['punctuation', 'marks']);
+  });
+
+  it('returns [] for empty or symbol-only text', () => {
+    expect(tokenize('')).toEqual([]);
+    expect(tokenize('!!! ??? ...')).toEqual([]);
+  });
+});
+
+describe('bm25 rank', () => {
+  type Doc = { id: string; text: string };
+  const docs: Doc[] = [
+    { id: 'py', text: 'python project setup virtualenv pip' },
+    { id: 'react', text: 'react component hooks frontend' },
+    { id: 'sql', text: 'optimized sql queries relational databases postgres' },
+    { id: 'git', text: 'git branching merge workflows version control' },
+  ];
+  const index = buildBm25Index(docs, (d) => d.text);
+
+  it('ranks the most relevant doc first', () => {
+    expect(rankBm25(index, 'sql database query', 10)[0].ref.id).toBe('sql');
+  });
+
+  it('returns only docs that matched >=1 query term, with a distinct matchedTerms count', () => {
+    const hits = rankBm25(index, 'python pip', 10);
+    expect(hits.map((h) => h.ref.id)).toEqual(['py']);
+    expect(hits[0].matchedTerms).toBe(2);
+  });
+
+  it('counts a repeated query term once (distinct terms)', () => {
+    const once = rankBm25(index, 'python', 10)[0];
+    const thrice = rankBm25(index, 'python python python', 10)[0];
+    expect(thrice.score).toBeCloseTo(once.score, 10);
+    expect(thrice.matchedTerms).toBe(1);
+  });
+
+  it('respects the limit', () => {
+    expect(rankBm25(index, 'project component sql git', 2)).toHaveLength(2);
+  });
+
+  it('returns [] for an empty index, empty query, or no-match query', () => {
+    expect(
+      rankBm25(
+        buildBm25Index([] as Doc[], (d) => d.text),
+        'x',
+        5
+      )
+    ).toEqual([]);
+    expect(rankBm25(index, '', 5)).toEqual([]);
+    expect(rankBm25(index, 'nonexistentterm', 5)).toEqual([]);
+  });
+});
+
+describe('bm25 parity with SkillRetriever (proves the extraction is verbatim)', () => {
+  const entries = [
+    entry({
+      name: 'python-project-setup',
+      description: 'Set up a new Python project',
+      metadata: { tags: ['python', 'pip'], category: 'software-engineering' },
+    }),
+    entry({
+      name: 'react-component',
+      description: 'Generate a React component with hooks',
+      metadata: { tags: ['react', 'hooks'], category: 'frontend' },
+    }),
+    entry({
+      name: 'sql-query',
+      description: 'Write optimized SQL queries',
+      metadata: { tags: ['sql', 'postgres'], category: 'database' },
+    }),
+  ];
+
+  it('produces identical scores, order, and matchedTerms for the same docs', () => {
+    const query = 'python sql project';
+    const skillHits = new SkillRetriever({ entries }).retrieve(query, 10);
+    const bmHits = rankBm25(buildBm25Index(entries, toText), query, 10);
+
+    expect(bmHits.map((h) => h.ref.name)).toEqual(skillHits.map((s) => s.name));
+    expect(bmHits).toHaveLength(skillHits.length);
+    for (let i = 0; i < bmHits.length; i++) {
+      expect(bmHits[i].score).toBeCloseTo(skillHits[i].score, 12);
+      expect(bmHits[i].matchedTerms).toBe(skillHits[i].matchedTerms);
+    }
+  });
+});


### PR DESCRIPTION
## What

Lane 3 selection core for #344: BM25-rank candidate MCP tools against the conversation context and cap to the provider's tool-array limit, so an OpenAI/gpt-5 request can never exceed 128 tools (the live 400 — 222 > 128).

**Stacks on #350** (the contract) — until #350 merges, the diff also shows the `toolContract.ts` commit; review the second commit (`feat(tools): ToolSelector …`) for this PR. Part of #344.

## Decision: extract a shared BM25 core (cross-audited)

A 5-agent research + adversarial audit chose **extract** over a focused copy or an adapter: ToolSelector is a genuine second consumer of the BM25 scoring math, so copying it would silently drift the moment anyone tuned the params, and the adapter would couple Lane 3 to the `SkillIndexEntry` type the contract excludes.

- **`src/process/utils/bm25.ts`** — pure, type-agnostic BM25 (`tokenize` + scoring) **lifted verbatim** from `SkillRetriever` (k1=1.5/b=0.75, Robertson IDF, tf-saturation). A **parity test asserts identical scores/order vs SkillRetriever**. Placed in `utils` (pure-algorithm home, beside `backoff.ts`) — `skills/` is already at the 10-child limit.
- **SkillRetriever → delegate to `bm25.ts`** is a **deferred, behavior-neutral follow-up** — skills hot path untouched during the 0.11.4 cut.

## ToolSelector

`selectToolsForSession(candidates, providerId, context)` → ranks `name + description` vs context, dedupes by tool name, caps to `resolveToolBudget` = `PROVIDER_TOOL_LIMITS[provider]` (or a **safe default for unknown providers**) minus `BUILTIN_TOOL_HEADROOM`. Under budget keeps all (relevance-ordered); over budget keeps the top-N (context matches first). Selection only — never writes `allow_list` (Lane 3 writer lands next).

## Tests (15, all green)

9 bm25 (incl. **SkillRetriever parity**) + 6 ToolSelector (budget incl. unknown-provider default, **222 > 128 cap regression**, relevance-first, name dedupe). `tsc`/`oxlint`/`oxfmt` clean; skills suite unaffected.

## Next (separate PR)

`getCandidateTools()` wiring (Lane 2, via DI) → `configBridge.allow_list` writer → inject only needed stdio servers at `WCoreManager` session start → over-cap pre-flight notice.