### PR TITLE
fix(tools): GetCandidateTools takes loaded servers, not no-arg (#344/#348)

### DIFF
--- a/src/process/services/tools/toolContract.ts
+++ b/src/process/services/tools/toolContract.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { IMcpServer } from '@/common/config/storage';
+
 /**
  * Shared contract for the MCP tool-scaling build (#344 Lane 3 + #348 Lane 2).
  * Authoritative boundary defined by the #348 ruling — both lanes import these
@@ -40,8 +42,18 @@ export const PROVIDER_TOOL_LIMITS: Record<string, number> = {
   'gpt-5': 128,
 };
 
-/** Lane 2 implements; Lane 3 consumes. Returns the candidate pool to rank + cap. */
-export type GetCandidateTools = () => CandidateTool[];
+/**
+ * Lane 2 implements; Lane 3 consumes. Builds the candidate pool from the loaded
+ * MCP servers: each ENABLED + connected server's tools, filtered by its
+ * `allowedTools` toggle (absent => all). Pure and synchronous — the caller (the
+ * session builder) loads the servers (an async source with no sync snapshot) and
+ * passes them in, so this stays trivially testable and free of I/O.
+ *
+ * Note: the #348 ruling first typed this no-arg (`() => CandidateTool[]`); that
+ * is infeasible because the server source is async, so Lane 2 + Lane 3 agreed on
+ * the `(servers)` call form — the data shapes are unchanged from the ruling.
+ */
+export type GetCandidateTools = (servers: readonly IMcpServer[]) => CandidateTool[];
 
 /**
  * Lane 3 implements. Ranks `candidates` against `context` and returns the names


### PR DESCRIPTION
Confirms Lane 2's (#351) contract-refinement question. The #348 ruling typed `GetCandidateTools = () => CandidateTool[]` (no-arg, sync), but the MCP server source is async with no sync snapshot — a no-arg sync reader is infeasible. Lane 2 implemented the pure `(servers: IMcpServer[]) => CandidateTool[]` form (the session builder holds the loaded servers at session start). This makes the shared contract type accurate. Data shapes unchanged from the ruling; only the call form differs. Tiny, types-only; tsc/oxlint/oxfmt clean. Closes the Lane 3-confirm checkbox on #348.