### PR TITLE
test(team,task): dispose timer-driven managers in afterEach to fix unit-shard hang (#353)

### DIFF
--- a/tests/unit/WorkerTaskManager.test.ts
+++ b/tests/unit/WorkerTaskManager.test.ts
@@ -45,32 +45,43 @@ function makeConversation(id: string, type: AgentType = 'gemini') {
 
 describe('WorkerTaskManager', () => {
   let repo: IConversationRepository;
+  // Track every manager built in a test so afterEach can dispose it. Each
+  // WorkerTaskManager starts a 60s idle-check setInterval in its constructor;
+  // left un-cleared, those ref'd timers keep the vitest fork worker's event
+  // loop alive and hang the unit shard under CI load (#353).
+  const managers: WorkerTaskManager[] = [];
+  const newManager = (...args: ConstructorParameters<typeof WorkerTaskManager>): WorkerTaskManager => {
+    const mgr = new WorkerTaskManager(...args);
+    managers.push(mgr);
+    return mgr;
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
     repo = makeRepo();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     vi.useRealTimers();
+    await Promise.all(managers.splice(0).map((mgr) => mgr.clear()));
   });
 
   // --- getTask / addTask ---
 
   it('getTask returns undefined for unknown id', () => {
-    const mgr = new WorkerTaskManager(makeFactory() as any, repo);
+    const mgr = newManager(makeFactory() as any, repo);
     expect(mgr.getTask('unknown')).toBeUndefined();
   });
 
   it('addTask stores task and getTask returns it', () => {
-    const mgr = new WorkerTaskManager(makeFactory() as any, repo);
+    const mgr = newManager(makeFactory() as any, repo);
     const agent = makeAgent();
     mgr.addTask('c1', agent as any);
     expect(mgr.getTask('c1')).toBe(agent);
   });
 
   it('addTask replaces existing task with same id and kills the old one', () => {
-    const mgr = new WorkerTaskManager(makeFactory() as any, repo);
+    const mgr = newManager(makeFactory() as any, repo);
     const agent1 = makeAgent('c1', 'gemini');
     const agent2 = makeAgent('c1', 'acp');
     mgr.addTask('c1', agent1 as any);
@@ -83,7 +94,7 @@ describe('WorkerTaskManager', () => {
 
   it('kill removes task from list and calls task.kill()', () => {
     const agent = makeAgent();
-    const mgr = new WorkerTaskManager(makeFactory(agent) as any, repo);
+    const mgr = newManager(makeFactory(agent) as any, repo);
     mgr.addTask('c1', agent as any);
     mgr.kill('c1');
     expect(mgr.getTask('c1')).toBeUndefined();
@@ -99,7 +110,7 @@ describe('WorkerTaskManager', () => {
       status: 'finished',
       lastActivityAt: Date.now() - 6 * 60 * 1000,
     };
-    const mgr = new WorkerTaskManager(makeFactory(agent) as any, repo);
+    const mgr = newManager(makeFactory(agent) as any, repo);
     mgr.addTask('c1', agent as any);
 
     vi.advanceTimersByTime(1 * 60 * 1000 + 1);
@@ -111,7 +122,7 @@ describe('WorkerTaskManager', () => {
   });
 
   it('kill is a no-op for unknown id', () => {
-    const mgr = new WorkerTaskManager(makeFactory() as any, repo);
+    const mgr = newManager(makeFactory() as any, repo);
     expect(() => mgr.kill('nonexistent')).not.toThrow();
   });
 
@@ -121,7 +132,7 @@ describe('WorkerTaskManager', () => {
     vi.useFakeTimers();
     const agent1 = makeAgent('c1', 'gemini');
     const agent2 = makeAgent('c2', 'acp');
-    const mgr = new WorkerTaskManager(makeFactory() as any, repo);
+    const mgr = newManager(makeFactory() as any, repo);
     mgr.addTask('c1', agent1 as any);
     mgr.addTask('c2', agent2 as any);
     const clearPromise = mgr.clear();
@@ -135,7 +146,7 @@ describe('WorkerTaskManager', () => {
   // --- listTasks ---
 
   it('listTasks returns id and type for each task', () => {
-    const mgr = new WorkerTaskManager(makeFactory() as any, repo);
+    const mgr = newManager(makeFactory() as any, repo);
     mgr.addTask('c1', makeAgent('c1', 'gemini') as any);
     mgr.addTask('c2', makeAgent('c2', 'acp') as any);
     mgr.addTask('c3', makeAgent('c3', 'nanobot') as any);
@@ -151,7 +162,7 @@ describe('WorkerTaskManager', () => {
   it('returns cached task without hitting repo on second call', async () => {
     const agent = makeAgent();
     const factory = makeFactory(agent);
-    const mgr = new WorkerTaskManager(factory as any, repo);
+    const mgr = newManager(factory as any, repo);
     mgr.addTask('c1', agent as any);
 
     const result = await mgr.getOrBuildTask('c1');
@@ -167,7 +178,7 @@ describe('WorkerTaskManager', () => {
     const factory = makeFactory(agent);
     vi.mocked(repo.getConversation).mockReturnValue(makeConversation('c1', 'gemini') as any);
 
-    const mgr = new WorkerTaskManager(factory as any, repo);
+    const mgr = newManager(factory as any, repo);
     const result = await mgr.getOrBuildTask('c1');
 
     expect(repo.getConversation).toHaveBeenCalledWith('c1');
@@ -180,7 +191,7 @@ describe('WorkerTaskManager', () => {
     const factory = makeFactory(agent);
     vi.mocked(repo.getConversation).mockReturnValue(makeConversation('c1') as any);
 
-    const mgr = new WorkerTaskManager(factory as any, repo);
+    const mgr = newManager(factory as any, repo);
     await mgr.getOrBuildTask('c1');
     await mgr.getOrBuildTask('c1'); // second call should use cache
     expect(factory.create).toHaveBeenCalledTimes(1);
@@ -190,14 +201,14 @@ describe('WorkerTaskManager', () => {
 
   it('rejects with error when repo returns undefined', async () => {
     vi.mocked(repo.getConversation).mockReturnValue(undefined);
-    const mgr = new WorkerTaskManager(makeFactory() as any, repo);
+    const mgr = newManager(makeFactory() as any, repo);
 
     await expect(mgr.getOrBuildTask('missing')).rejects.toThrow('Conversation not found: missing');
   });
 
   it('rejects when skipCache is set and repo returns undefined', async () => {
     vi.mocked(repo.getConversation).mockReturnValue(undefined);
-    const mgr = new WorkerTaskManager(makeFactory() as any, repo);
+    const mgr = newManager(makeFactory() as any, repo);
 
     await expect(mgr.getOrBuildTask('missing', { skipCache: true })).rejects.toThrow('Conversation not found: missing');
   });
@@ -209,7 +220,7 @@ describe('WorkerTaskManager', () => {
     const factory = makeFactory(agent);
     vi.mocked(repo.getConversation).mockReturnValue(makeConversation('c1') as any);
 
-    const mgr = new WorkerTaskManager(factory as any, repo);
+    const mgr = newManager(factory as any, repo);
     mgr.addTask('c1', agent as any);
     await mgr.getOrBuildTask('c1', { skipCache: true });
 

--- a/tests/unit/formatMessageTime.test.ts
+++ b/tests/unit/formatMessageTime.test.ts
@@ -1,4 +1,24 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
+
+// Importing MessageText transitively loads `electron-log/renderer`, which opens
+// a ref'd transport handle at module-eval in the node test env (no Electron main
+// process to talk to). That handle keeps the vitest fork worker's event loop
+// alive, so the worker never exits and the unit shard hangs to the CI job
+// timeout under load (#353). The jsdom setup stubs this globally for dom tests;
+// node-env tests that import renderer modules must stub it per-file.
+vi.mock('electron-log/renderer', () => {
+  const logger = {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    verbose: vi.fn(),
+    silly: vi.fn(),
+    log: vi.fn(),
+  };
+  return { default: logger, ...logger };
+});
+
 import { formatMessageTime } from '@renderer/pages/conversation/Messages/components/MessageText';
 
 describe('formatMessageTime', () => {

--- a/tests/unit/process/team/team-changeAgentBackend.test.ts
+++ b/tests/unit/process/team/team-changeAgentBackend.test.ts
@@ -17,7 +17,7 @@
 //   - missing team / missing slot errors
 //   - newModel updates the conversation extra when supplied
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockIpcBridge = vi.hoisted(() => ({
   team: {
@@ -120,6 +120,20 @@ function makeWorkerTaskManager() {
   };
 }
 
+// Each TeamSessionService starts a 60s Watchdog sweep setInterval in its
+// constructor; left un-stopped, those ref'd timers keep the vitest fork
+// worker's event loop alive and hang the unit shard under CI load (#353).
+const services: TeamSessionService[] = [];
+function newService(...args: ConstructorParameters<typeof TeamSessionService>): TeamSessionService {
+  const svc = new TeamSessionService(...args);
+  services.push(svc);
+  return svc;
+}
+
+afterEach(async () => {
+  await Promise.all(services.splice(0).map((svc) => svc.stopAllSessions()));
+});
+
 describe('TeamSessionService.changeAgentBackend', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -127,16 +141,16 @@ describe('TeamSessionService.changeAgentBackend', () => {
 
   it('throws when the team does not exist', async () => {
     const repo = makeRepo({ findById: vi.fn().mockResolvedValue(null) });
-    const svc = new TeamSessionService(repo, makeWorkerTaskManager(), makeConversationService());
-    await expect(
-      svc.changeAgentBackend({ teamId: 'missing', slotId: 'slot-1', newBackend: 'codex' })
-    ).rejects.toThrow(/not found/i);
+    const svc = newService(repo, makeWorkerTaskManager(), makeConversationService());
+    await expect(svc.changeAgentBackend({ teamId: 'missing', slotId: 'slot-1', newBackend: 'codex' })).rejects.toThrow(
+      /not found/i
+    );
   });
 
   it('throws when the slot does not exist on the team', async () => {
     const team = makeTeam();
     const repo = makeRepo({ findById: vi.fn().mockResolvedValue(team) });
-    const svc = new TeamSessionService(repo, makeWorkerTaskManager(), makeConversationService());
+    const svc = newService(repo, makeWorkerTaskManager(), makeConversationService());
     await expect(
       svc.changeAgentBackend({ teamId: 'team-1', slotId: 'slot-ghost', newBackend: 'codex' })
     ).rejects.toThrow(/not found/i);
@@ -147,7 +161,7 @@ describe('TeamSessionService.changeAgentBackend', () => {
     const update = vi.fn().mockResolvedValue(undefined);
     const appendEvent = vi.fn().mockResolvedValue(undefined);
     const repo = makeRepo({ findById: vi.fn().mockResolvedValue(team), update, appendEvent });
-    const svc = new TeamSessionService(repo, makeWorkerTaskManager(), makeConversationService());
+    const svc = newService(repo, makeWorkerTaskManager(), makeConversationService());
 
     await svc.changeAgentBackend({ teamId: 'team-1', slotId: 'slot-1', newBackend: 'claude' });
 
@@ -169,7 +183,7 @@ describe('TeamSessionService.changeAgentBackend', () => {
       ],
     });
     const repo = makeRepo({ findById: vi.fn().mockResolvedValue(team) });
-    const svc = new TeamSessionService(repo, makeWorkerTaskManager(), makeConversationService());
+    const svc = newService(repo, makeWorkerTaskManager(), makeConversationService());
 
     await expect(
       svc.changeAgentBackend({ teamId: 'team-1', slotId: 'slot-gem', newBackend: 'claude' })
@@ -185,7 +199,7 @@ describe('TeamSessionService.changeAgentBackend', () => {
     // backend wayland-core". It must be rejected exactly like a swap to 'wcore'.
     const team = makeTeam(); // slot-1 is claude / conversationType 'acp'
     const repo = makeRepo({ findById: vi.fn().mockResolvedValue(team) });
-    const svc = new TeamSessionService(repo, makeWorkerTaskManager(), makeConversationService());
+    const svc = newService(repo, makeWorkerTaskManager(), makeConversationService());
 
     await expect(
       svc.changeAgentBackend({ teamId: 'team-1', slotId: 'slot-1', newBackend: 'wayland-core' })
@@ -194,16 +208,16 @@ describe('TeamSessionService.changeAgentBackend', () => {
 
     // Parity: the canonical id 'wcore' was already rejected; 'wayland-core' must
     // behave identically now that both resolve to the 'wcore' conversation type.
-    await expect(
-      svc.changeAgentBackend({ teamId: 'team-1', slotId: 'slot-1', newBackend: 'wcore' })
-    ).rejects.toThrow(/not supported in place/i);
+    await expect(svc.changeAgentBackend({ teamId: 'team-1', slotId: 'slot-1', newBackend: 'wcore' })).rejects.toThrow(
+      /not supported in place/i
+    );
     expect(repo.update).not.toHaveBeenCalled();
   });
 
   it('refuses to swap while a wake is in progress', async () => {
     const team = makeTeam();
     const repo = makeRepo({ findById: vi.fn().mockResolvedValue(team) });
-    const svc = new TeamSessionService(repo, makeWorkerTaskManager(), makeConversationService());
+    const svc = newService(repo, makeWorkerTaskManager(), makeConversationService());
 
     const killAgentProcess = vi.fn();
     const fakeSession = {
@@ -212,9 +226,9 @@ describe('TeamSessionService.changeAgentBackend', () => {
     };
     (svc as unknown as { sessions: Map<string, unknown> }).sessions.set('team-1', fakeSession);
 
-    await expect(
-      svc.changeAgentBackend({ teamId: 'team-1', slotId: 'slot-1', newBackend: 'codex' })
-    ).rejects.toThrow(/wake in progress/i);
+    await expect(svc.changeAgentBackend({ teamId: 'team-1', slotId: 'slot-1', newBackend: 'codex' })).rejects.toThrow(
+      /wake in progress/i
+    );
     expect(killAgentProcess).not.toHaveBeenCalled();
     expect(repo.update).not.toHaveBeenCalled();
   });
@@ -224,7 +238,7 @@ describe('TeamSessionService.changeAgentBackend', () => {
     const update = vi.fn().mockResolvedValue(undefined);
     const appendEvent = vi.fn().mockResolvedValue(undefined);
     const repo = makeRepo({ findById: vi.fn().mockResolvedValue(team), update, appendEvent });
-    const svc = new TeamSessionService(repo, makeWorkerTaskManager(), makeConversationService());
+    const svc = newService(repo, makeWorkerTaskManager(), makeConversationService());
 
     const killAgentProcess = vi.fn();
     const fakeSession = {
@@ -275,7 +289,7 @@ describe('TeamSessionService.changeAgentBackend', () => {
     const team = makeTeam();
     const repo = makeRepo({ findById: vi.fn().mockResolvedValue(team) });
     const conversationService = makeConversationService();
-    const svc = new TeamSessionService(repo, makeWorkerTaskManager(), conversationService);
+    const svc = newService(repo, makeWorkerTaskManager(), conversationService);
 
     await svc.changeAgentBackend({
       teamId: 'team-1',
@@ -285,8 +299,7 @@ describe('TeamSessionService.changeAgentBackend', () => {
     });
 
     expect(conversationService.updateConversation).toHaveBeenCalledTimes(1);
-    const [convId, payload] = (conversationService.updateConversation as ReturnType<typeof vi.fn>).mock
-      .calls[0];
+    const [convId, payload] = (conversationService.updateConversation as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(convId).toBe('conv-1');
     expect((payload as { extra?: { backend?: string; currentModelId?: string } }).extra).toMatchObject({
       backend: 'codex',
@@ -298,7 +311,7 @@ describe('TeamSessionService.changeAgentBackend', () => {
     const team = makeTeam();
     const repo = makeRepo({ findById: vi.fn().mockResolvedValue(team) });
     const conversationService = makeConversationService();
-    const svc = new TeamSessionService(repo, makeWorkerTaskManager(), conversationService);
+    const svc = newService(repo, makeWorkerTaskManager(), conversationService);
 
     await svc.changeAgentBackend({ teamId: 'team-1', slotId: 'slot-1', newBackend: 'codex' });
 

--- a/tests/unit/process/team/team-promoteToStanding.test.ts
+++ b/tests/unit/process/team/team-promoteToStanding.test.ts
@@ -13,7 +13,7 @@
 //   - getOrStartSession bumps sessionCount + sets firstActiveAt on first call,
 //     keeps firstActiveAt stable on the second call
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockIpcBridge = vi.hoisted(() => ({
   team: {
@@ -116,6 +116,20 @@ function makeWorkerTaskManager() {
   };
 }
 
+// Each TeamSessionService starts a 60s Watchdog sweep setInterval in its
+// constructor; left un-stopped, those ref'd timers keep the vitest fork
+// worker's event loop alive and hang the unit shard under CI load (#353).
+const services: TeamSessionService[] = [];
+function newService(...args: ConstructorParameters<typeof TeamSessionService>): TeamSessionService {
+  const svc = new TeamSessionService(...args);
+  services.push(svc);
+  return svc;
+}
+
+afterEach(async () => {
+  await Promise.all(services.splice(0).map((svc) => svc.stopAllSessions()));
+});
+
 describe('TeamSessionService.promoteTeamToStanding', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -123,7 +137,7 @@ describe('TeamSessionService.promoteTeamToStanding', () => {
 
   it('throws when the team does not exist', async () => {
     const repo = makeRepo({ findById: vi.fn().mockResolvedValue(null) });
-    const svc = new TeamSessionService(repo, makeWorkerTaskManager(), makeConversationService());
+    const svc = newService(repo, makeWorkerTaskManager(), makeConversationService());
     await expect(svc.promoteTeamToStanding('missing')).rejects.toThrow(/not found/i);
   });
 
@@ -132,7 +146,7 @@ describe('TeamSessionService.promoteTeamToStanding', () => {
     const update = vi.fn().mockResolvedValue(undefined);
     const appendEvent = vi.fn().mockResolvedValue(undefined);
     const repo = makeRepo({ findById: vi.fn().mockResolvedValue(team), update, appendEvent });
-    const svc = new TeamSessionService(repo, makeWorkerTaskManager(), makeConversationService());
+    const svc = newService(repo, makeWorkerTaskManager(), makeConversationService());
 
     await svc.promoteTeamToStanding('team-1');
 
@@ -161,7 +175,7 @@ describe('TeamSessionService.promoteTeamToStanding', () => {
     const update = vi.fn().mockResolvedValue(undefined);
     const appendEvent = vi.fn().mockResolvedValue(undefined);
     const repo = makeRepo({ findById: vi.fn().mockResolvedValue(team), update, appendEvent });
-    const svc = new TeamSessionService(repo, makeWorkerTaskManager(), makeConversationService());
+    const svc = newService(repo, makeWorkerTaskManager(), makeConversationService());
 
     await svc.promoteTeamToStanding('team-1');
 
@@ -178,7 +192,7 @@ describe('TeamSessionService.demoteTeamFromStanding', () => {
 
   it('throws when the team does not exist', async () => {
     const repo = makeRepo({ findById: vi.fn().mockResolvedValue(null) });
-    const svc = new TeamSessionService(repo, makeWorkerTaskManager(), makeConversationService());
+    const svc = newService(repo, makeWorkerTaskManager(), makeConversationService());
     await expect(svc.demoteTeamFromStanding('missing')).rejects.toThrow(/not found/i);
   });
 
@@ -187,7 +201,7 @@ describe('TeamSessionService.demoteTeamFromStanding', () => {
     const update = vi.fn().mockResolvedValue(undefined);
     const appendEvent = vi.fn().mockResolvedValue(undefined);
     const repo = makeRepo({ findById: vi.fn().mockResolvedValue(team), update, appendEvent });
-    const svc = new TeamSessionService(repo, makeWorkerTaskManager(), makeConversationService());
+    const svc = newService(repo, makeWorkerTaskManager(), makeConversationService());
 
     await svc.demoteTeamFromStanding('team-1');
 
@@ -214,7 +228,7 @@ describe('TeamSessionService.demoteTeamFromStanding', () => {
     const update = vi.fn().mockResolvedValue(undefined);
     const appendEvent = vi.fn().mockResolvedValue(undefined);
     const repo = makeRepo({ findById: vi.fn().mockResolvedValue(team), update, appendEvent });
-    const svc = new TeamSessionService(repo, makeWorkerTaskManager(), makeConversationService());
+    const svc = newService(repo, makeWorkerTaskManager(), makeConversationService());
 
     await svc.demoteTeamFromStanding('team-1');
 
@@ -251,7 +265,7 @@ describe('TeamSessionService.getOrStartSession - sessionCount tracking', () => {
     const team = makeTeam({ sessionCount: 0, firstActiveAt: undefined });
     const update = vi.fn().mockResolvedValue(undefined);
     const repo = makeRepo({ findById: vi.fn().mockResolvedValue(team), update });
-    const svc = new TeamSessionService(repo, makeWorkerTaskManager(), makeConversationService());
+    const svc = newService(repo, makeWorkerTaskManager(), makeConversationService());
 
     // Pre-register a session to short-circuit the heavy start path. The bump
     // logic now runs in a "no-op" path because getOrStartSession returns early.

--- a/tests/unit/process/team/team-resolveOwningProviderModelById.test.ts
+++ b/tests/unit/process/team/team-resolveOwningProviderModelById.test.ts
@@ -9,7 +9,7 @@
 // reported failure: providers[0] is the Flux entry, so the spawn sent an
 // sk-flux key to an OpenAI surface -> 401 invalid_api_key.
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockIpcBridge = vi.hoisted(() => ({
   team: {
@@ -35,12 +35,22 @@ import { TeamSessionService } from '@process/team/TeamSessionService';
 import type { ITeamRepository } from '@process/team/repository/ITeamRepository';
 import type { IConversationService } from '@process/services/IConversationService';
 
+// Each TeamSessionService starts a 60s Watchdog sweep setInterval in its
+// constructor; left un-stopped, those ref'd timers keep the vitest fork
+// worker's event loop alive and hang the unit shard under CI load (#353).
+const services: TeamSessionService[] = [];
 function makeService(): TeamSessionService {
   const repo = {} as ITeamRepository;
   const conversationService = {} as IConversationService;
   const workerTaskManager = { getOrBuildTask: vi.fn(), kill: vi.fn() };
-  return new TeamSessionService(repo, workerTaskManager as never, conversationService);
+  const svc = new TeamSessionService(repo, workerTaskManager as never, conversationService);
+  services.push(svc);
+  return svc;
 }
+
+afterEach(async () => {
+  await Promise.all(services.splice(0).map((svc) => svc.stopAllSessions()));
+});
 
 // Two enabled providers, openai FIRST (reproduces the providers[0] bug):
 // the pinned model 'claude-sonnet-4' lives on the flux provider only.
@@ -52,9 +62,7 @@ const TWO_PROVIDERS = [
 describe('TeamSessionService.resolveOwningProviderModelById (#87)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockProcessConfig.get.mockImplementation(async (key: string) =>
-      key === 'model.config' ? TWO_PROVIDERS : null
-    );
+    mockProcessConfig.get.mockImplementation(async (key: string) => (key === 'model.config' ? TWO_PROVIDERS : null));
   });
 
   it('selects the provider that OWNS the pinned model, not providers[0]', async () => {
@@ -78,7 +86,15 @@ describe('TeamSessionService.resolveOwningProviderModelById (#87)', () => {
   it('skips a provider that has the model disabled', async () => {
     mockProcessConfig.get.mockImplementation(async (key: string) =>
       key === 'model.config'
-        ? [{ id: 'flux', enabled: true, apiKey: 'sk-flux', model: ['claude-sonnet-4'], modelEnabled: { 'claude-sonnet-4': false } }]
+        ? [
+            {
+              id: 'flux',
+              enabled: true,
+              apiKey: 'sk-flux',
+              model: ['claude-sonnet-4'],
+              modelEnabled: { 'claude-sonnet-4': false },
+            },
+          ]
         : null
     );
     const svc = makeService() as unknown as {

--- a/tests/unit/process/team/team-restartAgent.test.ts
+++ b/tests/unit/process/team/team-restartAgent.test.ts
@@ -10,7 +10,7 @@
 //   - residual process is killed via session.killAgentProcess when a session
 //     is live (no-op when session is absent - repo update is the only mutation)
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockIpcBridge = vi.hoisted(() => ({
   team: {
@@ -113,6 +113,20 @@ function makeWorkerTaskManager() {
   };
 }
 
+// Each TeamSessionService starts a 60s Watchdog sweep setInterval in its
+// constructor; left un-stopped, those ref'd timers keep the vitest fork
+// worker's event loop alive and hang the unit shard under CI load (#353).
+const services: TeamSessionService[] = [];
+function newService(...args: ConstructorParameters<typeof TeamSessionService>): TeamSessionService {
+  const svc = new TeamSessionService(...args);
+  services.push(svc);
+  return svc;
+}
+
+afterEach(async () => {
+  await Promise.all(services.splice(0).map((svc) => svc.stopAllSessions()));
+});
+
 describe('TeamSessionService.restartAgent', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -120,14 +134,14 @@ describe('TeamSessionService.restartAgent', () => {
 
   it('throws when the team does not exist', async () => {
     const repo = makeRepo({ findById: vi.fn().mockResolvedValue(null) });
-    const svc = new TeamSessionService(repo, makeWorkerTaskManager(), makeConversationService());
+    const svc = newService(repo, makeWorkerTaskManager(), makeConversationService());
     await expect(svc.restartAgent('missing', 'slot-1')).rejects.toThrow(/not found/i);
   });
 
   it('throws when the slot does not exist on the team', async () => {
     const team = makeTeam();
     const repo = makeRepo({ findById: vi.fn().mockResolvedValue(team) });
-    const svc = new TeamSessionService(repo, makeWorkerTaskManager(), makeConversationService());
+    const svc = newService(repo, makeWorkerTaskManager(), makeConversationService());
     await expect(svc.restartAgent('team-1', 'slot-ghost')).rejects.toThrow(/not found/i);
   });
 
@@ -140,7 +154,7 @@ describe('TeamSessionService.restartAgent', () => {
       update,
       appendEvent,
     });
-    const svc = new TeamSessionService(repo, makeWorkerTaskManager(), makeConversationService());
+    const svc = newService(repo, makeWorkerTaskManager(), makeConversationService());
 
     await svc.restartAgent('team-1', 'slot-1');
 
@@ -171,7 +185,7 @@ describe('TeamSessionService.restartAgent', () => {
   it('refuses to restart while a wake is in flight', async () => {
     const team = makeTeam();
     const repo = makeRepo({ findById: vi.fn().mockResolvedValue(team) });
-    const svc = new TeamSessionService(repo, makeWorkerTaskManager(), makeConversationService());
+    const svc = newService(repo, makeWorkerTaskManager(), makeConversationService());
 
     // Force a live session whose wake-active check returns true
     const fakeSession = {
@@ -189,7 +203,7 @@ describe('TeamSessionService.restartAgent', () => {
   it('kills residual process via the live session before resetting status', async () => {
     const team = makeTeam();
     const repo = makeRepo({ findById: vi.fn().mockResolvedValue(team) });
-    const svc = new TeamSessionService(repo, makeWorkerTaskManager(), makeConversationService());
+    const svc = newService(repo, makeWorkerTaskManager(), makeConversationService());
 
     const killAgentProcess = vi.fn();
     const fakeSession = {

--- a/tests/unit/process/team/teamSession-isStandingFlaggedLauncher.test.ts
+++ b/tests/unit/process/team/teamSession-isStandingFlaggedLauncher.test.ts
@@ -12,7 +12,7 @@
 // assistants and matches the launcher id across bare / `builtin-` / `ext-`
 // shapes.
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/common', () => ({ ipcBridge: { team: { listChanged: { emit: vi.fn() } } } }));
 vi.mock('electron', () => ({ app: { getPath: vi.fn(() => '/tmp') } }));
@@ -79,10 +79,19 @@ function makeConversationService(): IConversationService {
 
 type StandingProbe = { isStandingFlaggedLauncher: (id: string) => Promise<boolean> };
 
+// Each TeamSessionService starts a 60s Watchdog sweep setInterval in its
+// constructor; left un-stopped, those ref'd timers keep the vitest fork
+// worker's event loop alive and hang the unit shard under CI load (#353).
+const services: TeamSessionService[] = [];
 function makeService(): StandingProbe {
   const svc = new TeamSessionService(makeRepo(), { getOrBuildTask: vi.fn(), kill: vi.fn() }, makeConversationService());
+  services.push(svc);
   return svc as unknown as StandingProbe;
 }
+
+afterEach(async () => {
+  await Promise.all(services.splice(0).map((svc) => svc.stopAllSessions()));
+});
 
 describe('TeamSessionService.isStandingFlaggedLauncher - native catalog (S1)', () => {
   beforeEach(() => {

--- a/tests/unit/process/team/teamSession-resolveOwningProvider.test.ts
+++ b/tests/unit/process/team/teamSession-resolveOwningProvider.test.ts
@@ -12,7 +12,7 @@
 // Gemini/Google-platform providers and returns null otherwise so the caller
 // falls back to the default-resolved Gemini provider.
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockConfigGet } = vi.hoisted(() => ({ mockConfigGet: vi.fn() }));
 
@@ -76,20 +76,26 @@ function makeProvider(overrides: Partial<IProvider> & { platform: string; model:
 }
 
 type OwnerProbe = {
-  resolveOwningProviderModelById: (
-    modelId: string,
-    conversationType?: string
-  ) => Promise<TProviderWithModel | null>;
+  resolveOwningProviderModelById: (modelId: string, conversationType?: string) => Promise<TProviderWithModel | null>;
 };
 
+// Each TeamSessionService starts a 60s Watchdog sweep setInterval in its
+// constructor; left un-stopped, those ref'd timers keep the vitest fork
+// worker's event loop alive and hang the unit shard under CI load (#353).
+const services: TeamSessionService[] = [];
 function makeService(): OwnerProbe {
   const svc = new TeamSessionService(
     makeRepo(),
     { getOrBuildTask: vi.fn(), kill: vi.fn() } as never,
     makeConversationService()
   );
+  services.push(svc);
   return svc as unknown as OwnerProbe;
 }
+
+afterEach(async () => {
+  await Promise.all(services.splice(0).map((svc) => svc.stopAllSessions()));
+});
 
 describe('TeamSessionService.resolveOwningProviderModelById - backend scoping (#207)', () => {
   beforeEach(() => {

--- a/tests/unit/process/teamSessionService.test.ts
+++ b/tests/unit/process/teamSessionService.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { TChatConversation } from '../../../src/common/config/storage';
 import type { IConversationService } from '../../../src/process/services/IConversationService';
 import type { ITeamRepository } from '../../../src/process/team/repository/ITeamRepository';
@@ -77,6 +77,20 @@ function makeWorkerTaskManager() {
   };
 }
 
+// Each TeamSessionService starts a 60s Watchdog sweep setInterval in its
+// constructor; left un-stopped, those ref'd timers keep the vitest fork
+// worker's event loop alive and hang the unit shard under CI load (#353).
+const services: TeamSessionService[] = [];
+function newService(...args: ConstructorParameters<typeof TeamSessionService>): TeamSessionService {
+  const svc = new TeamSessionService(...args);
+  services.push(svc);
+  return svc;
+}
+
+afterEach(async () => {
+  await Promise.all(services.splice(0).map((svc) => svc.stopAllSessions()));
+});
+
 function makeAgent(overrides: Partial<TeamAgent> = {}): TeamAgent {
   return {
     slotId: '',
@@ -102,7 +116,7 @@ describe('TeamSessionService', () => {
     const conversationService = makeConversationService({
       createConversation: vi.fn().mockResolvedValue({ id: 'conv-gemini', extra: {} }),
     });
-    const service = new TeamSessionService(repo, makeWorkerTaskManager() as any, conversationService);
+    const service = newService(repo, makeWorkerTaskManager() as any, conversationService);
 
     await service.createTeam({
       userId: 'user-1',
@@ -148,7 +162,7 @@ describe('TeamSessionService', () => {
     const conversationService = makeConversationService({
       createConversation: vi.fn().mockResolvedValue({ id: 'conv-gemini-api', extra: {} }),
     });
-    const service = new TeamSessionService(repo, makeWorkerTaskManager() as any, conversationService);
+    const service = newService(repo, makeWorkerTaskManager() as any, conversationService);
 
     await service.createTeam({
       userId: 'user-1',
@@ -206,7 +220,7 @@ describe('TeamSessionService', () => {
     const conversationService = makeConversationService({
       createConversation: vi.fn().mockResolvedValue({ id: 'conv-qwen', extra: {} }),
     });
-    const service = new TeamSessionService(repo, makeWorkerTaskManager() as any, conversationService);
+    const service = newService(repo, makeWorkerTaskManager() as any, conversationService);
 
     await service.createTeam({
       userId: 'user-1',
@@ -234,7 +248,7 @@ describe('TeamSessionService', () => {
     const conversationService = makeConversationService({
       createConversation: vi.fn().mockResolvedValue({ id: 'conv-remote', extra: {} }),
     });
-    const service = new TeamSessionService(repo, makeWorkerTaskManager() as any, conversationService);
+    const service = newService(repo, makeWorkerTaskManager() as any, conversationService);
 
     await service.createTeam({
       userId: 'user-1',
@@ -299,7 +313,7 @@ describe('TeamSessionService', () => {
     const conversationService = makeConversationService({
       createConversation: vi.fn().mockResolvedValue({ id: 'conv-preset-gemini', extra: {} }),
     });
-    const service = new TeamSessionService(repo, makeWorkerTaskManager() as any, conversationService);
+    const service = newService(repo, makeWorkerTaskManager() as any, conversationService);
 
     await service.createTeam({
       userId: 'user-1',
@@ -399,7 +413,7 @@ describe('TeamSessionService', () => {
         },
       }),
     });
-    const service = new TeamSessionService(repo, makeWorkerTaskManager() as any, conversationService);
+    const service = newService(repo, makeWorkerTaskManager() as any, conversationService);
 
     await service.addAgent('team-1', {
       conversationId: '',
@@ -459,7 +473,7 @@ describe('TeamSessionService', () => {
     const conversationService = makeConversationService({
       listAllConversations: vi.fn().mockResolvedValue([legacyConversation]),
     });
-    const service = new TeamSessionService(repo, makeWorkerTaskManager() as any, conversationService);
+    const service = newService(repo, makeWorkerTaskManager() as any, conversationService);
 
     const repairedTeam = await service.getTeam('team-legacy');
 

--- a/tests/unit/team-workspace-sync.test.ts
+++ b/tests/unit/team-workspace-sync.test.ts
@@ -154,6 +154,10 @@ function makeLeadAgent(overrides: Partial<TeamAgent> = {}): Omit<TeamAgent, 'slo
   };
 }
 
+// Each TeamSessionService starts a 60s Watchdog sweep setInterval in its
+// constructor; left un-stopped, those ref'd timers keep the vitest fork
+// worker's event loop alive and hang the unit shard under CI load (#353).
+const services: TeamSessionService[] = [];
 function makeService(
   options: {
     autoWorkspace?: string;
@@ -164,8 +168,13 @@ function makeService(
   const repo = makeRepo(options.repoOverrides ?? {});
   const workerTaskManager = makeWorkerTaskManager();
   const service = new TeamSessionService(repo, workerTaskManager, conversationService);
+  services.push(service);
   return { service, repo, conversationService, workerTaskManager };
 }
+
+afterEach(async () => {
+  await Promise.all(services.splice(0).map((svc) => svc.stopAllSessions()));
+});
 
 // ---------------------------------------------------------------------------
 // Case 1: createTeam - empty workspace back-fills from leader conversation.extra.workspace


### PR DESCRIPTION
## What

Fixes #353 — the vitest unit-test shard hangs to the CI 20-minute job timeout (open-handle leak; tests pass, the fork worker never exits).

## Root cause

`WorkerTaskManager` (60s idle-check `setInterval` in its constructor) and `TeamSessionService` (60s `Watchdog` sweep `setInterval`, started in its constructor) arm **ref'd, re-arming** timers. Nine unit test files constructed these objects without ever calling the existing teardown (`WorkerTaskManager.clear()` / `TeamSessionService.stopAllSessions()`), so each instance left a live interval pinning the worker's event loop. Under CI CPU contention a worker finishes its files with intervals still pending and never exits → the shard runs to the 20m job timeout.

Single-worker / idle-box runs do **not** reproduce it (the intervals get a chance to be torn down or the box has spare cores); it only bites under the parallel-fork contention CI runners have. That is why it presented as intermittent.

## Fix

Pure test hygiene — track every constructed manager and dispose it in `afterEach` (concurrently via `Promise.all`). **No source changes**: the manager classes already expose correct teardown. No global `forceExit` band-aid (that would mask real leaks, per the issue's acceptance).

## How it was found + verified

Built a per-file timer probe (wraps `setInterval`/`setTimeout`, flags any ref'd timer created during a file but still pending after that file's `afterAll`). On a clean 96-core box:

- Before: the probe pinpointed the leaking `setInterval` sites (`WorkerTaskManager.ts` idle-check, `Watchdog.ts` sweep via `TeamSessionService`).
- After: **zero ref'd-interval leaks** remain across all affected files.
- 69 tests across the 9 files pass; `tsc --noEmit` 0 errors; `oxlint` 0 errors and no new warnings.

`WorkerTaskManager.projectWorkspace.test.ts` already disposed its manager in `afterEach`, so it was left untouched.