### PR TITLE
fix(models): render curated catalog in AcpModelSelector before first connection (#345)

### DIFF
--- a/src/renderer/components/agent/AcpModelSelector.tsx
+++ b/src/renderer/components/agent/AcpModelSelector.tsx
@@ -566,10 +566,28 @@ const AcpModelSelector: React.FC<{
     );
   }
 
-  // State 1b: Cache lookup finished and there are genuinely no cached/live
-  // models for this backend (never connected) - show the first-connection
-  // guidance so the user knows a message will surface the catalog.
+  // State 1b: Cache lookup finished and the agent has not produced live/cached
+  // model info yet. When this backend maps to a connected provider whose curated
+  // catalog is non-empty (claude->anthropic, codex->openai), surface that catalog
+  // as a selectable dropdown instead of dead-ending on the "first connection"
+  // tooltip - the curated registry is authoritative even before the agent reports
+  // its own models, so the picker should never be stuck closed here (#345; mirrors
+  // GuidModelSelector's cold-start picker, which renders off `curatedForAgent`).
+  // Selecting a row routes through `handleSelectModel` -> `setModel`, whose IPC
+  // result lands the real `modelInfo`. Fall back to the guidance tooltip only when
+  // there are genuinely no curated models (vendor CLIs, or no provider connected).
   if (!modelInfo) {
+    if (hasCuratedModels) {
+      return (
+        <Dropdown trigger='click' droplist={flyoutDroplist}>
+          <Button className='sendbox-model-btn header-model-btn agent-mode-compact-pill' shape='round' size='small'>
+            <span className='flex items-center gap-6px min-w-0 leading-none'>
+              <MarqueePillLabel>{defaultModelLabel}</MarqueePillLabel>
+            </span>
+          </Button>
+        </Dropdown>
+      );
+    }
     return (
       <Tooltip content={t('conversation.welcome.modelSwitchNotSupported')} position='top'>
         <Button

--- a/tests/unit/AcpModelSelector.dom.test.tsx
+++ b/tests/unit/AcpModelSelector.dom.test.tsx
@@ -325,6 +325,46 @@ describe('AcpModelSelector', () => {
     });
   });
 
+  it('renders the curated provider catalog as a selectable dropdown when the agent has not reported models yet (#345)', async () => {
+    // No live model info and no cached catalog, but the backend maps to a
+    // connected provider whose curated catalog is non-empty (codex->openai).
+    // State 1b must surface that catalog as a selectable dropdown instead of
+    // dead-ending on the first-connection tooltip.
+    ipcMock.getModelInfo.mockResolvedValue({
+      success: true,
+      data: { modelInfo: null },
+    });
+    configGetMock.mockResolvedValue(null);
+    ipcMock.curatedForAgent.mockResolvedValue([
+      {
+        id: 'gpt-5.5-codex',
+        providerId: 'openai',
+        displayName: 'GPT-5.5 Codex',
+        family: 'gpt-5',
+        enabled: true,
+        recommended: true,
+        costInPerM: 5,
+        costOutPerM: 15,
+      },
+    ]);
+
+    render(<AcpModelSelector conversationId='conv-curated' backend='codex' />);
+
+    // The picker resolves to the default-model dropdown (not the dead-end
+    // first-connection tooltip): the curated registry is authoritative even
+    // before the agent reports its own models.
+    await waitFor(() => {
+      expect(screen.getAllByText('common.defaultModel').length).toBeGreaterThan(0);
+    });
+    expect(screen.queryByText(FIRST_CONNECTION_LABEL)).toBeNull();
+
+    // The dropdown is selectable and surfaces the curated model.
+    fireEvent.click(screen.getByRole('button'));
+    await waitFor(() => {
+      expect(screen.getByText('GPT-5.5 Codex')).toBeTruthy();
+    });
+  });
+
   it('shows the first-connection guidance only after the cache load completes with no models', async () => {
     // No cached catalog and no live models: a backend that has genuinely never
     // connected. After the cache lookup settles, the first-connection label shows.


### PR DESCRIPTION
## Summary
Fixes #345 — the in-chat model picker showed *"Model list will be available after first connection"* even for providers that are already connected with a populated catalog.

**Root cause** (per Overwatch triage): `AcpModelSelector` State 1b (`!modelInfo`) dead-ended on the `modelSwitchNotSupported` tooltip when the agent had not yet produced live model info — instead of falling back to the curated catalog. The other pickers were fixed in the catalog overhaul; the in-chat `AcpModelSelector` still had this gap.

**Fix:** mirror `GuidModelSelector`'s cold-start picker. In State 1b, when `hasCuratedModels` is true, render the curated flyout dropdown (driven off `curatedForAgent` via the existing `useModelSelectorViewModel`) so the picker is selectable. Keep the first-connection tooltip only when the curated catalog is genuinely empty (vendor CLIs / no provider connected). Selection routes through the existing `handleSelectModel -> setModel` path; the IPC result lands the real `modelInfo`.

No core change — `curatedForAgent` is the live models.dev-backed registry the desktop already owns.

## Test
- New case in `tests/unit/AcpModelSelector.dom.test.tsx`: with no live/cached model info but a non-empty curated catalog, the picker renders the selectable default-model dropdown (not the dead-end tooltip) and surfaces the curated model on open.
- Full suite green: AcpModelSelector 8/8, acpModelSelectorFlux 4/4.
- Cross-audit: `tsc --noEmit` clean, oxlint clean, oxfmt clean, i18n validation passes (no new keys).

Closes #345