### PR TITLE
feat(mcp): per-conversation MCP server scoping (#348 — closes the user-scoping lever)

### DIFF
--- a/src/common/config/storage.ts
+++ b/src/common/config/storage.ts
@@ -423,6 +423,8 @@ export type TChatConversation =
         presetRules?: string; // System rules, injected at initialization
         /** Enabled skills list for filtering SkillManager skills */
         enabledSkills?: string[];
+        /** Per-conversation active MCP server ids (#348): undefined = all enabled servers, [] = none. */
+        activeMcpServers?: string[];
         /** Snapshot of actually loaded skills (persisted on first message) */
         loadedSkills?: Array<{ name: string; description: string }>;
         /** Preset assistant ID for displaying name and avatar in the conversation panel */
@@ -454,6 +456,8 @@ export type TChatConversation =
           presetContext?: string; // Preset context/rules from smart assistant
           /** Enabled skills list for filtering SkillManager skills */
           enabledSkills?: string[];
+          /** Per-conversation active MCP server ids (#348): undefined = all enabled servers, [] = none. */
+          activeMcpServers?: string[];
           /** Builtin auto-injected skills to exclude */
           excludeBuiltinSkills?: string[];
           /** Snapshot of actually loaded skills */
@@ -512,6 +516,8 @@ export type TChatConversation =
           presetContext?: string; // Preset context/rules from smart assistant
           /** Enabled skills list for filtering SkillManager skills */
           enabledSkills?: string[];
+          /** Per-conversation active MCP server ids (#348): undefined = all enabled servers, [] = none. */
+          activeMcpServers?: string[];
           /** Snapshot of actually loaded skills */
           loadedSkills?: Array<{ name: string; description: string }>;
           /** Preset assistant ID for displaying name and avatar in the conversation panel */
@@ -567,6 +573,8 @@ export type TChatConversation =
           };
           /** Enabled skills list */
           enabledSkills?: string[];
+          /** Per-conversation active MCP server ids (#348): undefined = all enabled servers, [] = none. */
+          activeMcpServers?: string[];
           /** Snapshot of actually loaded skills */
           loadedSkills?: Array<{ name: string; description: string }>;
           /** Preset assistant ID */
@@ -593,6 +601,8 @@ export type TChatConversation =
           customWorkspace?: boolean;
           /** Enabled skills list */
           enabledSkills?: string[];
+          /** Per-conversation active MCP server ids (#348): undefined = all enabled servers, [] = none. */
+          activeMcpServers?: string[];
           /** Snapshot of actually loaded skills */
           loadedSkills?: Array<{ name: string; description: string }>;
           /** Preset assistant ID */
@@ -623,6 +633,8 @@ export type TChatConversation =
           sessionKey?: string;
           /** Enabled skills list */
           enabledSkills?: string[];
+          /** Per-conversation active MCP server ids (#348): undefined = all enabled servers, [] = none. */
+          activeMcpServers?: string[];
           /** Snapshot of actually loaded skills */
           loadedSkills?: Array<{ name: string; description: string }>;
           /** Preset assistant ID */
@@ -652,6 +664,8 @@ export type TChatConversation =
         presetRules?: string;
         /** Enabled skills list */
         enabledSkills?: string[];
+        /** Per-conversation active MCP server ids (#348): undefined = all enabled servers, [] = none. */
+        activeMcpServers?: string[];
         /** Snapshot of actually loaded skills */
         loadedSkills?: Array<{ name: string; description: string }>;
         /** Preset assistant ID */

--- a/src/process/agent/acp/index.ts
+++ b/src/process/agent/acp/index.ts
@@ -134,6 +134,8 @@ export class AcpAgent {
     teamMcpStdioConfig?: { name: string; command: string; args: string[]; env: Array<{ name: string; value: string }> };
     /** Pending config option selections from Guid page (applied after session creation) */
     pendingConfigOptions?: Record<string, string>;
+    /** Per-conversation active MCP server ids (#348): undefined = all enabled, [] = none. */
+    activeMcpServers?: string[];
   };
   private connection: AcpConnection;
   private adapter: AcpAdapter;
@@ -1686,7 +1688,9 @@ export class AcpAgent {
       if (Array.isArray(mcpConfig) && mcpConfig.length > 0) {
         const mcpCaps = this.connection.getAgentCapabilities()?.mcpCapabilities;
         if (mcpCaps) {
-          servers.push(...buildAcpSessionMcpServers(mcpConfig as IMcpServer[], mcpCaps));
+          // Per-conversation scoping (#348): only inject the MCP servers active
+          // for this chat (undefined ⇒ all). Builtins always pass.
+          servers.push(...buildAcpSessionMcpServers(mcpConfig as IMcpServer[], mcpCaps, this.extra.activeMcpServers));
         }
       }
 

--- a/src/process/agent/acp/mcpSessionConfig.ts
+++ b/src/process/agent/acp/mcpSessionConfig.ts
@@ -61,9 +61,24 @@ export function shouldInjectSessionMcpServer(server: IMcpServer): boolean {
   return server.status === 'connected';
 }
 
+/**
+ * Per-conversation MCP scoping (#348): is this server active for the chat?
+ * Builtins (image-gen, skill-search) always inject — they're infrastructure,
+ * not user-scopable. A user server passes when the chat has no selection
+ * (`activeServerIds === undefined` ⇒ all enabled servers) or the selection
+ * includes it. `[]` scopes out every user server. The user's per-server
+ * `allowedTools` still trims tools within whatever servers stay active.
+ */
+export function isServerActiveForSession(server: IMcpServer, activeServerIds?: readonly string[]): boolean {
+  if (server.builtin === true) return true;
+  if (activeServerIds === undefined) return true;
+  return activeServerIds.includes(server.id);
+}
+
 export function buildAcpSessionMcpServers(
   mcpServers: IMcpServer[] | undefined | null,
-  capabilities: AcpMcpCapabilities
+  capabilities: AcpMcpCapabilities,
+  activeServerIds?: readonly string[]
 ): AcpSessionMcpServer[] {
   if (!Array.isArray(mcpServers) || mcpServers.length === 0) {
     return [];
@@ -71,6 +86,7 @@ export function buildAcpSessionMcpServers(
 
   return mcpServers
     .filter(shouldInjectSessionMcpServer)
+    .filter((server) => isServerActiveForSession(server, activeServerIds))
     .map((server): AcpSessionMcpServer | null => {
       switch (server.transport.type) {
         case 'stdio':

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -107,6 +107,8 @@ interface AcpAgentManagerData {
   pendingConfigOptions?: Record<string, string>;
   /** Per-conversation reasoning effort (codex/claude). Absent => backend default. */
   effort?: 'low' | 'medium' | 'high';
+  /** Per-conversation active MCP server ids (#348): undefined = all enabled, [] = none. */
+  activeMcpServers?: string[];
 }
 
 type BufferedStreamTextMessage = {
@@ -1346,6 +1348,8 @@ ${collectedResponses.join('\n')}`;
           currentModelId: this.persistedModelId ?? undefined,
           sessionMode: this.currentMode,
           pendingConfigOptions: data.pendingConfigOptions,
+          // Per-conversation MCP scoping (#348): forward to loadBuiltinSessionMcpServers.
+          activeMcpServers: data.activeMcpServers,
           // Forward team MCP stdio config so AcpAgent.loadBuiltinSessionMcpServers() can inject it
           teamMcpStdioConfig: (data as unknown as Record<string, unknown>).teamMcpStdioConfig as
             | { name: string; command: string; args: string[]; env: Array<{ name: string; value: string }> }

--- a/src/renderer/pages/conversation/components/composerMenu/ComposerAddMenu.tsx
+++ b/src/renderer/pages/conversation/components/composerMenu/ComposerAddMenu.tsx
@@ -66,10 +66,12 @@ const ComposerAddMenuPanel: React.FC<{
   const navigate = useNavigate();
   const [pane, setPane] = useState<Pane>('skills');
 
-  // The target model drives the connectors count-vs-cap nudge (#348). Live mode
-  // only — a staged (home) composer has no conversation/model yet. Read-only:
-  // no write, mirrors useModelEffort's conversation.get usage.
+  // The target model drives the connectors count-vs-cap nudge, and the chat's
+  // per-conversation MCP selection drives the scoping toggles (#348). Live mode
+  // only — a staged (home) composer has no conversation yet. Mirrors
+  // useModelEffort's conversation.get usage.
   const [targetModel, setTargetModel] = useState<{ cap?: number; label?: string }>({});
+  const [activeServerIds, setActiveServerIds] = useState<string[] | undefined>(undefined);
   useEffect(() => {
     if (!conversationId) return;
     let alive = true;
@@ -82,12 +84,28 @@ const ComposerAddMenuPanel: React.FC<{
         // (nudge hidden) for those rather than guessing.
         const model = 'model' in conv ? conv.model : undefined;
         setTargetModel({ cap: resolveModelToolCap(model?.id, model?.useModel), label: model?.useModel });
+        setActiveServerIds((conv.extra as { activeMcpServers?: string[] } | undefined)?.activeMcpServers);
       })
       .catch(() => {});
     return () => {
       alive = false;
     };
   }, [conversationId]);
+
+  // Persist the per-conversation MCP selection (#348). Read-modify-write the full
+  // extra so we never clobber sibling fields (skills, effort, workspace).
+  const setActiveServers = (ids: string[] | undefined) => {
+    if (!conversationId) return;
+    setActiveServerIds(ids); // optimistic
+    void ipcBridge.conversation.get
+      .invoke({ id: conversationId })
+      .then((conv) => {
+        if (!conv) return;
+        const extra = { ...(conv.extra as Record<string, unknown> | undefined), activeMcpServers: ids };
+        return ipcBridge.conversation.update.invoke({ id: conversationId, updates: { extra } });
+      })
+      .catch(() => {});
+  };
 
   // Anchor the panes to the "+". Arco may open the popup above OR below the
   // trigger (and its position class is unreliable - it reports "tl" even when
@@ -214,6 +232,8 @@ const ComposerAddMenuPanel: React.FC<{
           onManageConnectors={goConnectors}
           modelCap={targetModel.cap}
           modelLabel={targetModel.label}
+          onScopeChange={conversationId ? setActiveServers : undefined}
+          activeServerIds={activeServerIds}
         />
       )}
     </div>

--- a/src/renderer/pages/conversation/components/composerMenu/ConnectorsFlyout.tsx
+++ b/src/renderer/pages/conversation/components/composerMenu/ConnectorsFlyout.tsx
@@ -11,15 +11,15 @@ import { useTranslation } from 'react-i18next';
 import { iconColors } from '@/renderer/styles/colors';
 import type { IMcpServer } from '@/common/config/storage';
 import styles from './ComposerAddMenu.module.css';
-import { countEnabledMcpTools, toolBudgetStatus } from './toolBudget';
+import { countEnabledMcpTools, nextActiveSelection, toolBudgetStatus } from './toolBudget';
 
 type Props = {
   /** Installed MCP servers (user-configured + extension-contributed). */
   servers: IMcpServer[];
   /**
-   * Toggle a connector. NOTE: this flips the server's GLOBAL `enabled` flag -
-   * MCP enablement is not yet per-conversation, so toggling here affects the
-   * connector everywhere. True per-chat connector scoping is a follow-up.
+   * Toggle a connector's GLOBAL `enabled` flag. Used in staged (home) mode where
+   * there is no conversation to scope. In live mode `onScopeChange` takes over
+   * and the toggle becomes per-conversation.
    */
   onToggle: (id: string, enabled: boolean) => void;
   /** Open the MCP Library to add a new connector. */
@@ -34,13 +34,23 @@ type Props = {
   modelCap?: number;
   /** Display name of the target model, used in the nudge text. */
   modelLabel?: string;
+  /**
+   * Per-conversation scoping (#348). When provided (live mode), the toggle
+   * controls whether each server is active for THIS chat (not the global
+   * `enabled` flag). `activeServerIds === undefined` ⇒ all enabled servers
+   * active. The flyout writes the next selection back through this callback.
+   */
+  onScopeChange?: (ids: string[] | undefined) => void;
+  /** Current per-conversation selection (undefined = all enabled active). */
+  activeServerIds?: string[];
 };
 
-const ConnectorRow: React.FC<{ server: IMcpServer; onToggle: Props['onToggle']; toolsLabel: string }> = ({
-  server,
-  onToggle,
-  toolsLabel,
-}) => {
+const ConnectorRow: React.FC<{
+  server: IMcpServer;
+  checked: boolean;
+  onChange: (on: boolean) => void;
+  toolsLabel: string;
+}> = ({ server, checked, onChange, toolsLabel }) => {
   const connected = server.status === 'connected';
   return (
     <div className={styles.row}>
@@ -52,12 +62,7 @@ const ConnectorRow: React.FC<{ server: IMcpServer; onToggle: Props['onToggle']; 
         </div>
         <div className={styles.desc}>{server.description || toolsLabel}</div>
       </div>
-      <Switch
-        size='small'
-        checked={server.enabled !== false}
-        onChange={(v) => onToggle(server.id, v)}
-        aria-label={server.name}
-      />
+      <Switch size='small' checked={checked} onChange={onChange} aria-label={server.name} />
     </div>
   );
 };
@@ -69,6 +74,8 @@ const ConnectorsFlyout: React.FC<Props> = ({
   onManageConnectors,
   modelCap,
   modelLabel,
+  onScopeChange,
+  activeServerIds,
 }) => {
   const { t } = useTranslation();
 
@@ -77,6 +84,19 @@ const ConnectorsFlyout: React.FC<Props> = ({
   const toolCount = countEnabledMcpTools(servers);
   const budget = modelCap ? toolBudgetStatus(toolCount, modelCap) : 'ok';
   const showNudge = modelCap !== undefined && budget !== 'ok';
+
+  // Per-conversation scoping (#348): in live mode (onScopeChange given) the
+  // toggle reflects "active for THIS chat" over the enabled servers; in staged
+  // mode it flips the global `enabled` flag (legacy behaviour).
+  const scoping = onScopeChange !== undefined;
+  const candidates = scoping ? servers.filter((s) => s.enabled !== false) : servers;
+  const enabledIds = candidates.map((s) => s.id);
+  const isActiveForChat = (id: string) => activeServerIds === undefined || activeServerIds.includes(id);
+  const rowChecked = (server: IMcpServer) => (scoping ? isActiveForChat(server.id) : server.enabled !== false);
+  const rowOnChange = (server: IMcpServer) => (on: boolean) =>
+    scoping
+      ? onScopeChange?.(nextActiveSelection(activeServerIds, enabledIds, server.id, on))
+      : onToggle(server.id, on);
 
   return (
     <div className={styles.flyout}>
@@ -119,16 +139,19 @@ const ConnectorsFlyout: React.FC<Props> = ({
             </span>
           </div>
         )}
-        {servers.length > 0 ? (
+        {candidates.length > 0 ? (
           <>
             <div className={styles.sectionLabel}>
-              {t('conversation.composerMenu.connectorsConnected', { defaultValue: 'Connected' })}
+              {scoping
+                ? t('conversation.composerMenu.connectorsForChat', { defaultValue: 'Active in this chat' })
+                : t('conversation.composerMenu.connectorsConnected', { defaultValue: 'Connected' })}
             </div>
-            {servers.map((server) => (
+            {candidates.map((server) => (
               <ConnectorRow
                 key={server.id}
                 server={server}
-                onToggle={onToggle}
+                checked={rowChecked(server)}
+                onChange={rowOnChange(server)}
                 toolsLabel={
                   server.tools && server.tools.length > 0
                     ? t('conversation.composerMenu.toolCount', {

--- a/src/renderer/pages/conversation/components/composerMenu/toolBudget.ts
+++ b/src/renderer/pages/conversation/components/composerMenu/toolBudget.ts
@@ -22,6 +22,25 @@ export function countEnabledMcpTools(servers: IMcpServer[]): number {
   return total;
 }
 
+/**
+ * Compute the next per-conversation active-server selection (#348) after the
+ * user toggles one server. `current === undefined` means "all enabled servers".
+ * Returns `undefined` when the result is once again every enabled server (the
+ * clean default, so we don't persist a redundant explicit list), else the
+ * explicit id list. Toggling the only-active server off yields `[]` (none).
+ */
+export function nextActiveSelection(
+  current: string[] | undefined,
+  allEnabledIds: string[],
+  serverId: string,
+  active: boolean
+): string[] | undefined {
+  const base = current ?? allEnabledIds;
+  const next = active ? Array.from(new Set([...base, serverId])) : base.filter((id) => id !== serverId);
+  const isAll = next.length === allEnabledIds.length && allEnabledIds.every((id) => next.includes(id));
+  return isAll ? undefined : next;
+}
+
 export type ToolBudgetStatus = 'ok' | 'near' | 'over';
 
 /**

--- a/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/src/renderer/services/i18n/i18n-keys.d.ts
@@ -411,6 +411,7 @@ export type I18nKey =
   | 'conversation.composerMenu.addConnector'
   | 'conversation.composerMenu.connectors'
   | 'conversation.composerMenu.connectorsConnected'
+  | 'conversation.composerMenu.connectorsForChat'
   | 'conversation.composerMenu.connectorsSub'
   | 'conversation.composerMenu.connectorsTitle'
   | 'conversation.composerMenu.countOn'

--- a/src/renderer/services/i18n/locales/en-US/conversation.json
+++ b/src/renderer/services/i18n/locales/en-US/conversation.json
@@ -436,6 +436,7 @@
     "connectorsTitle": "Connectors",
     "connectorsSub": "Turn a connected MCP server on or off.",
     "connectorsConnected": "Connected",
+    "connectorsForChat": "Active in this chat",
     "toolCount": "{{count}} tools",
     "noConnectors": "No connectors installed yet.",
     "addConnector": "Add a connector",

--- a/tests/unit/process/agent/acp/mcpSessionConfig.activeServers.test.ts
+++ b/tests/unit/process/agent/acp/mcpSessionConfig.activeServers.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * #348 — per-conversation MCP scoping at the ACP injection chokepoint. A chat's
+ * `activeMcpServers` selection filters which user servers are injected; builtins
+ * always pass; `undefined` = all (unchanged behaviour), `[]` = only builtins.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isServerActiveForSession, buildAcpSessionMcpServers } from '@process/agent/acp/mcpSessionConfig';
+import type { IMcpServer } from '@/common/config/storage';
+
+const caps = { stdio: true, http: true, sse: true };
+
+const server = (over: Partial<IMcpServer>): IMcpServer =>
+  ({
+    id: 'srv',
+    name: 'srv',
+    enabled: true,
+    status: 'connected',
+    transport: { type: 'stdio', command: 'x', args: [] },
+    originalJson: '{}',
+    createdAt: 1,
+    updatedAt: 1,
+    ...over,
+  }) as IMcpServer;
+
+describe('isServerActiveForSession (#348)', () => {
+  it('passes a builtin regardless of the selection', () => {
+    expect(isServerActiveForSession(server({ builtin: true }), [])).toBe(true);
+    expect(isServerActiveForSession(server({ builtin: true }), ['other'])).toBe(true);
+  });
+
+  it('passes any user server when no selection is set (undefined = all)', () => {
+    expect(isServerActiveForSession(server({ id: 'a' }), undefined)).toBe(true);
+  });
+
+  it('passes a user server only when the selection includes it', () => {
+    expect(isServerActiveForSession(server({ id: 'a' }), ['a', 'b'])).toBe(true);
+    expect(isServerActiveForSession(server({ id: 'c' }), ['a', 'b'])).toBe(false);
+  });
+
+  it('scopes out every user server on an empty selection', () => {
+    expect(isServerActiveForSession(server({ id: 'a' }), [])).toBe(false);
+  });
+});
+
+describe('buildAcpSessionMcpServers active-server filter (#348)', () => {
+  const builtin = server({ id: 'img', name: 'image-gen', builtin: true, status: undefined });
+  const userA = server({ id: 'a', name: 'alpha' });
+  const userB = server({ id: 'b', name: 'beta' });
+
+  it('injects all enabled servers when no selection is given (back-compat)', () => {
+    const out = buildAcpSessionMcpServers([builtin, userA, userB], caps);
+    expect(out.map((s) => s.name).sort()).toEqual(['alpha', 'beta', 'image-gen']);
+  });
+
+  it('injects only selected user servers plus builtins', () => {
+    const out = buildAcpSessionMcpServers([builtin, userA, userB], caps, ['a']);
+    expect(out.map((s) => s.name).sort()).toEqual(['alpha', 'image-gen']);
+  });
+
+  it('injects only builtins when the selection is empty', () => {
+    const out = buildAcpSessionMcpServers([builtin, userA, userB], caps, []);
+    expect(out.map((s) => s.name)).toEqual(['image-gen']);
+  });
+});

--- a/tests/unit/renderer/composerMenu/ConnectorsFlyout.dom.test.tsx
+++ b/tests/unit/renderer/composerMenu/ConnectorsFlyout.dom.test.tsx
@@ -14,7 +14,7 @@
 
 import React from 'react';
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { IMcpServer } from '@/common/config/storage';
 
 vi.mock('react-i18next', () => ({
@@ -91,5 +91,46 @@ describe('ConnectorsFlyout count-vs-cap nudge (#348)', () => {
       modelLabel: 'gpt-5',
     });
     expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+});
+
+describe('ConnectorsFlyout per-conversation scoping (#348)', () => {
+  const a = srv(1, { id: 'a', name: 'alpha' });
+  const b = srv(1, { id: 'b', name: 'beta' });
+
+  it('in live mode (onScopeChange) all enabled servers show as active by default', () => {
+    renderFlyout({ servers: [a, b], onScopeChange: noop, activeServerIds: undefined });
+    expect(screen.getByText('Active in this chat')).toBeInTheDocument();
+    expect(screen.getByRole('switch', { name: 'alpha' }).getAttribute('aria-checked')).toBe('true');
+    expect(screen.getByRole('switch', { name: 'beta' }).getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('toggling one off from "all" materializes the rest (writes the explicit set)', () => {
+    const onScopeChange = vi.fn();
+    renderFlyout({ servers: [a, b], onScopeChange, activeServerIds: undefined });
+    fireEvent.click(screen.getByRole('switch', { name: 'alpha' }));
+    expect(onScopeChange).toHaveBeenCalledWith(['b']);
+  });
+
+  it('reflects an explicit selection and toggles the missing one back to "all" (undefined)', () => {
+    const onScopeChange = vi.fn();
+    renderFlyout({ servers: [a, b], onScopeChange, activeServerIds: ['b'] });
+    expect(screen.getByRole('switch', { name: 'alpha' }).getAttribute('aria-checked')).toBe('false');
+    fireEvent.click(screen.getByRole('switch', { name: 'alpha' }));
+    expect(onScopeChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it('excludes globally-disabled servers from the per-chat candidate list', () => {
+    renderFlyout({ servers: [a, srv(1, { id: 'c', name: 'gamma', enabled: false })], onScopeChange: noop });
+    expect(screen.getByText('alpha')).toBeInTheDocument();
+    expect(screen.queryByText('gamma')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the global toggle in staged mode (no onScopeChange)', () => {
+    const onToggle = vi.fn();
+    renderFlyout({ servers: [a], onToggle });
+    expect(screen.getByText('Connected')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('switch', { name: 'alpha' }));
+    expect(onToggle).toHaveBeenCalledWith('a', false);
   });
 });

--- a/tests/unit/renderer/composerMenu/toolBudget.test.ts
+++ b/tests/unit/renderer/composerMenu/toolBudget.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   countEnabledMcpTools,
+  nextActiveSelection,
   toolBudgetStatus,
 } from '@renderer/pages/conversation/components/composerMenu/toolBudget';
 import type { IMcpServer } from '@/common/config/storage';
@@ -49,6 +50,34 @@ describe('countEnabledMcpTools (#348)', () => {
 
   it('treats a connected server with no tools yet as zero', () => {
     expect(countEnabledMcpTools([server({ tools: undefined })])).toBe(0);
+  });
+});
+
+describe('nextActiveSelection (#348)', () => {
+  const all = ['a', 'b', 'c'];
+
+  it('toggling one off from "all" (undefined) materializes the rest', () => {
+    expect(nextActiveSelection(undefined, all, 'b', false)).toEqual(['a', 'c']);
+  });
+
+  it('toggling the last one back on returns undefined (clean "all")', () => {
+    expect(nextActiveSelection(['a', 'c'], all, 'b', true)).toBeUndefined();
+  });
+
+  it('toggling off from a defined set removes that id', () => {
+    expect(nextActiveSelection(['a', 'b'], all, 'a', false)).toEqual(['b']);
+  });
+
+  it('toggling the only-active server off yields [] (none)', () => {
+    expect(nextActiveSelection(['a'], all, 'a', false)).toEqual([]);
+  });
+
+  it('toggling on from [] adds just that id', () => {
+    expect(nextActiveSelection([], all, 'b', true)).toEqual(['b']);
+  });
+
+  it('does not duplicate an id already present', () => {
+    expect(nextActiveSelection(['a'], all, 'a', true)).toEqual(['a']);
   });
 });
 


### PR DESCRIPTION
## Summary
Second + final half of #348 — the **per-conversation server selection** that pairs with the count-vs-cap nudge (#370, merged). Together with per-server `allowedTools` (#351) and #347's overview, this completes the ratified #344 user-scoping lever for MCP tool overflow.

In an active chat, the composer **Connectors** flyout now scopes **per-conversation**: each toggle controls whether a server is active **for this chat** (not the global `enabled` flag). The selection persists to `conversation.extra.activeMcpServers` and is honoured at the ACP injection chokepoint, so a scoped-down chat actually sends fewer tools. The home (staged) composer keeps the global toggle.

## Changes
**Data + injection (committed first):**
- `activeMcpServers?: string[]` on the conversation extra (undefined = all enabled, [] = none) + the ACP manager's `this.extra`.
- `buildAcpSessionMcpServers(…, activeServerIds)` + `isServerActiveForSession` (builtins always inject; user servers scoped to the selection).
- End-to-end wiring: forwarded through `AcpAgentManager.agentConfig.extra` so the persisted value reaches the filter.

**UI:**
- `ComposerAddMenu`: reads `activeMcpServers` (alongside the target model) + a read-modify-write setter via `conversation.update` (never clobbers sibling extra fields).
- `ConnectorsFlyout`: scoping-aware toggles over the enabled-server candidates; "Active in this chat" section; `nextActiveSelection` normalizes "all" back to `undefined`.

## Scope / boundaries
- **No WCore per-session engine-config writes** — Core owns per-session filtering (#344). WCore chats still get the nudge + per-server `allowedTools`.
- **Gemini** injection path unchanged (a noted follow-up; the ACP path — Claude/Codex/Wayland — is wired).

## Test plan
- [x] `mcpSessionConfig.activeServers.test.ts` (7) — filter + `isServerActiveForSession`.
- [x] `toolBudget.test.ts` `nextActiveSelection` (6) — materialize/normalize/empty semantics.
- [x] `ConnectorsFlyout.dom.test.tsx` scoping (5) — default-all, toggle-off materializes, explicit→all, disabled excluded, staged fallback.
- [x] Existing composer/ComposerAddMenu suites green; `tsc`/`oxlint`/`oxfmt`/i18n clean.

Closes #348. Builds on #370 (nudge), #351 (allowedTools), #347 (overview). Does not gate the 0.11.4 cut.