### PR TITLE
fix(providers): curate ACP backend catalogs in home picker (grok→xai, codex cold-start) (#374)

### DIFF
--- a/src/process/providers/ipc/modelRegistryIpc.ts
+++ b/src/process/providers/ipc/modelRegistryIpc.ts
@@ -128,6 +128,23 @@ const CLI_UNDERLYING_PROVIDER: Record<CliAgentKey, ProviderId> = {
   gemini: 'google-gemini',
 };
 
+/**
+ * Vendor-locked ACP backends (#374): single-provider CLIs whose home-picker
+ * catalog is synthesized from the models.dev registry, exactly like a
+ * non-enumerable CLI. Each maps to the one provider it runs, so the picker
+ * surfaces real models BEFORE the first connection instead of dead-ending on
+ * the "available after first connection" tooltip. Multi-provider CLIs
+ * (opencode, goose, droid, auggie, cursor, …) are intentionally absent: they
+ * have no single underlying provider, so they keep returning an empty curated
+ * set (the picker then offers Flux Auto when the backend is Flux-routable).
+ */
+const ACP_BACKEND_UNDERLYING_PROVIDER: Record<string, ProviderId> = {
+  grok: 'xai',
+  kimi: 'moonshot',
+  qwen: 'qwen',
+  vibe: 'mistral',
+};
+
 // ─── Injectable dependencies ──────────────────────────────────────────────────
 
 /** A catalog source built from a connected cloud provider's registry slice. */
@@ -1025,29 +1042,47 @@ export function createModelRegistryHandlers(deps: ModelRegistryDeps): ModelRegis
           return all;
         }
 
-        if (CLI_AGENT_KEYS.has(agentKey)) {
-          const cliKey = agentKey as CliAgentKey;
-          if (isEnumerableCliAgent(cliKey)) {
-            // Enumerable CLI (Codex) - build straight from its CLI source.
-            const source = deps.makeCliSource(cliKey);
-            const registry = await modelsDevClient.getRegistry().catch(() => ({}) as ModelsDevRegistry);
-            const { models } = await assembler.assemble([source], registry);
-            return curator.curate(models);
-          }
-          // Non-enumerable CLI (e.g. Claude Code). When the underlying provider
-          // is connected with its own API key, use the persisted, override-aware
-          // catalog. When it is NOT connected - the common case for a CLI-login
-          // user (a Claude Pro/Max subscription, no Anthropic API key) - the
-          // picker used to come back EMPTY (#125). Synthesize the underlying
-          // provider's model families straight from the models.dev registry (the
-          // same keyless path cloud providers use), so Claude shows real models.
-          const underlying = CLI_UNDERLYING_PROVIDER[cliKey];
+        // Synthesize a provider's curated catalog from the persisted registry
+        // (connected, override-aware) or straight from models.dev (not
+        // connected) - the same keyless path cloud providers use. Lets a vendor
+        // CLI show real models before its first connection instead of an empty
+        // picker (#125 for Claude, #374 for Codex/Grok/…).
+        const synthesizeProvider = async (underlying: ProviderId): Promise<CuratedModel[]> => {
           if (repo.getRegistryProvider(underlying)) {
             return applyOverrides(underlying, curator.curate(repo.getRegistryCatalog(underlying)));
           }
           const registry = await modelsDevClient.getRegistry().catch(() => ({}) as ModelsDevRegistry);
           const { models } = await assembler.assemble([new CloudRegistrySource(underlying, registry)], registry);
           return curator.curate(models);
+        };
+
+        if (CLI_AGENT_KEYS.has(agentKey)) {
+          const cliKey = agentKey as CliAgentKey;
+          if (isEnumerableCliAgent(cliKey)) {
+            // Enumerable CLI (Codex) - prefer its live CLI source. In a fresh
+            // profile with no CLI installed / no cache this yields nothing; fall
+            // through to models.dev synthesis of the underlying provider (openai)
+            // so the picker still surfaces real GPT models instead of Flux-only
+            // (#374). A non-empty CLI enumeration always wins (it is the source
+            // of truth for the exact model ids that CLI accepts).
+            const source = deps.makeCliSource(cliKey);
+            const registry = await modelsDevClient.getRegistry().catch(() => ({}) as ModelsDevRegistry);
+            const { models } = await assembler.assemble([source], registry);
+            const enumerated = curator.curate(models);
+            if (enumerated.length > 0) return enumerated;
+          }
+          // Non-enumerable CLI (e.g. Claude Code), or an enumerable CLI whose
+          // source came back empty: synthesize from the underlying provider.
+          return synthesizeProvider(CLI_UNDERLYING_PROVIDER[cliKey]);
+        }
+
+        // Vendor-locked ACP backends (grok→xai, kimi→moonshot, …): synthesize
+        // their single provider's catalog so the home picker is never empty
+        // before first connection (#374). Unknown / multi-provider backends fall
+        // through to an empty set (the picker then offers Flux Auto if routable).
+        const acpUnderlying = ACP_BACKEND_UNDERLYING_PROVIDER[agentKey];
+        if (acpUnderlying) {
+          return synthesizeProvider(acpUnderlying);
         }
 
         return [];

--- a/tests/unit/process/providers/modelRegistryIpc.test.ts
+++ b/tests/unit/process/providers/modelRegistryIpc.test.ts
@@ -1324,6 +1324,85 @@ describe('modelRegistry IPC - curatedForAgent', () => {
   });
 });
 
+describe('modelRegistry IPC - curatedForAgent ACP backends (#374)', () => {
+  it('synthesizes xAI models for the grok backend before first connection (cut blocker)', async () => {
+    // Grok Build is vendor-locked (grok.com) and not connected as an API
+    // provider, so the home picker used to dead-end on the "available after
+    // first connection" tooltip. It must instead synthesize xAI's catalog.
+    const { deps, getRegistry } = makeFakes();
+    getRegistry.mockResolvedValue({
+      xai: { models: { 'grok-4': { name: 'Grok 4' }, 'grok-3-mini': { name: 'Grok 3 Mini' } } },
+    });
+    const h = createModelRegistryHandlers(deps);
+
+    const ids = (await h.curatedForAgent({ agentKey: 'grok' })).map((m) => m.id).toSorted();
+
+    expect(ids).toEqual(['grok-3-mini', 'grok-4']);
+  });
+
+  it('prefers the connected xAI catalog for grok when the provider is connected', async () => {
+    const { deps, repo } = makeFakes();
+    repo.upsertRegistryProvider({
+      providerId: 'xai',
+      connectedVia: 'api-key',
+      state: 'connected',
+      creds: { key: 'k' },
+    });
+    repo.replaceRegistryCatalog('xai', [catalogModel({ id: 'grok-4', providerId: 'xai' })]);
+    const h = createModelRegistryHandlers(deps);
+
+    const curated = await h.curatedForAgent({ agentKey: 'grok' });
+
+    expect(curated.map((m) => m.id)).toEqual(['grok-4']);
+  });
+
+  it('falls back to openai synthesis for codex when the CLI enumerates nothing (Flux-only fix)', async () => {
+    // Fresh profile: codex CLI not installed -> enumeration is empty. The picker
+    // must still surface GPT models from models.dev instead of Flux-only.
+    const { deps, cliListModels, getRegistry } = makeFakes();
+    cliListModels.mockResolvedValue([]);
+    getRegistry.mockResolvedValue({ openai: { models: { 'gpt-5.5-codex': { name: 'GPT-5.5 Codex' } } } });
+    const h = createModelRegistryHandlers(deps);
+
+    const ids = (await h.curatedForAgent({ agentKey: 'codex' })).map((m) => m.id);
+
+    expect(ids).toEqual(['gpt-5.5-codex']);
+  });
+
+  it('keeps the live CLI enumeration for codex when it is non-empty (no synthesis override)', async () => {
+    const { deps, cliListModels, getRegistry } = makeFakes();
+    cliListModels.mockResolvedValue([{ id: 'gpt-5-codex', providerId: 'openai' }]);
+    // If synthesis wrongly ran it would surface this id instead - it must NOT.
+    getRegistry.mockResolvedValue({ openai: { models: { 'should-not-appear': {} } } });
+    const h = createModelRegistryHandlers(deps);
+
+    const ids = (await h.curatedForAgent({ agentKey: 'codex' })).map((m) => m.id);
+
+    expect(ids).toEqual(['gpt-5-codex']);
+  });
+
+  it('synthesizes moonshot models for the kimi backend', async () => {
+    const { deps, getRegistry } = makeFakes();
+    getRegistry.mockResolvedValue({ moonshotai: { models: { 'kimi-k2': { name: 'Kimi K2' } } } });
+    const h = createModelRegistryHandlers(deps);
+
+    const ids = (await h.curatedForAgent({ agentKey: 'kimi' })).map((m) => m.id);
+
+    expect(ids).toEqual(['kimi-k2']);
+  });
+
+  it('returns [] for a multi-provider ACP backend with no single underlying provider (goose)', async () => {
+    // goose/opencode/droid/… run any connected provider, so there is no single
+    // catalog to synthesize - the picker offers Flux Auto (when routable) rather
+    // than a misleading vendor catalog.
+    const { deps, getRegistry } = makeFakes();
+    getRegistry.mockResolvedValue({ xai: { models: { 'grok-4': {} } } });
+    const h = createModelRegistryHandlers(deps);
+
+    expect(await h.curatedForAgent({ agentKey: 'goose' })).toEqual([]);
+  });
+});
+
 describe('modelRegistry IPC - defensive behavior', () => {
   beforeEach(() => {
     vi.restoreAllMocks();


### PR DESCRIPTION
## Summary

Fixes #374 — the home **Default Model** picker showed no curated catalog for ACP agents (Grok empty → "available after first connection" tooltip; Codex Flux-only in a fresh profile). 0.11.4-cut blocker.

Root cause: `curatedForAgent` (modelRegistryIpc.ts) hardcoded `CLI_AGENT_KEYS = ['claude','codex','gemini']` and `return []` for every other ACP backend → empty curated set → the picker dead-ended. Codex's enumerable path collapsed to empty when the CLI isn't installed (fresh profile), leaving only Flux.

## Fix (backend-only)

- New `ACP_BACKEND_UNDERLYING_PROVIDER` map for vendor-locked single-provider ACP CLIs: `grok→xai`, `kimi→moonshot`, `qwen→qwen`, `vibe→mistral`. Each synthesizes its provider's catalog from the models.dev registry (connected → persisted override-aware catalog; not connected → keyless models.dev synthesis), exactly like the existing non-enumerable CLI path (#125).
- Codex (enumerable): a non-empty CLI enumeration still wins; when the CLI yields nothing (no CLI/cache), fall through to `openai` models.dev synthesis so GPT models always show instead of Flux-only.
- Shared `synthesizeProvider` helper (dedups the connected-vs-models.dev logic).
- Multi-provider CLIs (opencode, goose, droid, auggie, cursor, …) intentionally still return `[]` — they have no single underlying provider, so the picker correctly offers Flux Auto when routable rather than a misleading vendor catalog.

## Why no frontend change

`GuidModelSelector` already renders off `curatedForAgent`: the gate `if (showAcpFlux || acpModels.length > 0)` (line 491) surfaces the picker whenever curated models exist, and `acpModels` falls back to `curated`. The issue's suggested #364-style frontend fallback was already present from the cold-start fix — so once the backend returns real models, Grok shows xAI models + Codex shows GPT + Flux Auto with no UI change. Backend-only = lowest risk for a held cut.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun run lint` 0 errors
- [x] 6 new unit tests in `modelRegistryIpc.test.ts` (88 pass): grok not-connected → xAI synthesis; grok connected → persisted catalog; codex CLI-empty → openai synthesis; codex CLI non-empty → enumeration wins (no override); kimi → moonshot; goose (multi-provider) → `[]`.
- [ ] **LIVE (Overwatch/Sean):** fresh profile — Codex picker shows gpt-5.5-codex + Flux Auto; Grok picker shows xAI models + (no Flux, vendor) — both before sending a message.