### PR TITLE
feat(guid): restore per-assistant suggested prompts as a prompt-cards grid (#375)

### DIFF
--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -50,7 +50,7 @@ import type { SpeechToTextRequest, SpeechToTextResult } from '../types/speech';
 import type { DownloadResult, VoiceAsset } from '../types/voiceAsset';
 import type { SkillSecurityReport, SkillIndexEntry, SkillSource, SkillVerdict } from '../types/skillTypes';
 import type { ImportResult } from '../../process/services/skills/SkillImport';
-import type { KickoffResult, KickoffTelemetryEvent } from '../../process/services/kickoff/types';
+import type { KickoffGridResult, KickoffResult, KickoffTelemetryEvent } from '../../process/services/kickoff/types';
 import type {
   AskRecord,
   ResolvedSkill,
@@ -2309,6 +2309,11 @@ export const storage = {
 // (e.g. `extensions.list`) instead of the early `:` form.
 export const kickoff = {
   suggest: buildProvider<KickoffResult, { assistantId: string }>('kickoff.suggest'),
+  // #375 - per-assistant suggested-prompts grid (assistant detail view). Returns
+  // up to `max` ranked starters; `locale` selects the promptsI18n fallback.
+  suggestMany: buildProvider<KickoffGridResult, { assistantId: string; max?: number; locale?: string }>(
+    'kickoff.suggestMany'
+  ),
   telemetry: buildProvider<void, KickoffTelemetryEvent>('kickoff.telemetry'),
 };
 

--- a/src/process/bridge/kickoffBridge.ts
+++ b/src/process/bridge/kickoffBridge.ts
@@ -8,7 +8,13 @@ import { ipcBridge } from '@/common';
 import { waitForCronReady } from '@process/services/cron/cronReadiness';
 import { ExtensionRegistry } from '@process/extensions/ExtensionRegistry';
 import { getKickoffEngine } from '@process/services/kickoff/kickoffSingleton';
-import type { KickoffResult, KickoffTelemetryEvent, NotRenderedReason } from '@process/services/kickoff/types';
+import type {
+  KickoffGridResult,
+  KickoffResult,
+  KickoffTelemetryEvent,
+  NotRenderedReason,
+} from '@process/services/kickoff/types';
+import { KICKOFF_GRID_MAX } from '@process/services/kickoff/types';
 
 /**
  * IPC surface for the Kickoff system.
@@ -62,9 +68,31 @@ export function initKickoffBridge(): void {
       // legitimate cascade misses. Never include err.message (PII risk).
       const errorName =
         err && typeof err === 'object' && typeof (err as { name?: unknown }).name === 'string'
-          ? ((err as { name: string }).name || 'Error')
+          ? (err as { name: string }).name || 'Error'
           : 'Error';
       console.warn('[kickoff.suggest] failed; returning notRendered/engine-error', err);
+      return { notRendered: 'engine-error', errorName };
+    }
+  });
+
+  // #375 - per-assistant suggested-prompts grid. Same registry/cron readiness
+  // gating as `suggest`; returns up to `max` ranked starters (kickoffs, else a
+  // legacy-prompts fallback). Bad input is coerced to a safe default rather
+  // than thrown, matching the `suggest` "fall through to bare surface" contract.
+  ipcBridge.kickoff.suggestMany.provider(async (raw: unknown): Promise<KickoffGridResult> => {
+    const params = parseSuggestManyParams(raw);
+    if (!params) return { notRendered: 'error' };
+    const [registryReady] = await Promise.all([waitForRegistry(), waitForCron()]);
+    if (!registryReady) return { notRendered: 'registry-not-ready' };
+
+    try {
+      return await getKickoffEngine().suggestN(params.assistantId, params.max, params.locale);
+    } catch (err) {
+      const errorName =
+        err && typeof err === 'object' && typeof (err as { name?: unknown }).name === 'string'
+          ? (err as { name: string }).name || 'Error'
+          : 'Error';
+      console.warn('[kickoff.suggestMany] failed; returning notRendered/engine-error', err);
       return { notRendered: 'engine-error', errorName };
     }
   });
@@ -118,6 +146,24 @@ function isSuggestParams(raw: unknown): raw is { assistantId: string } {
   return ASSISTANT_ID_REGEX.test(id);
 }
 
+// #375 - locale tags are short (`en-US`, `zh-CN`); bound defensively so a
+// pathological payload can't reach the engine's promptsI18n index.
+const LOCALE_MAX_LEN = 35;
+
+function parseSuggestManyParams(raw: unknown): { assistantId: string; max?: number; locale?: string } | null {
+  if (!isSuggestParams(raw)) return null;
+  const r = raw as { assistantId: string; max?: unknown; locale?: unknown };
+  let max: number | undefined;
+  if (typeof r.max === 'number' && Number.isFinite(r.max)) {
+    max = Math.max(1, Math.min(Math.floor(r.max), KICKOFF_GRID_MAX));
+  }
+  let locale: string | undefined;
+  if (typeof r.locale === 'string' && r.locale.length > 0 && r.locale.length <= LOCALE_MAX_LEN) {
+    locale = r.locale;
+  }
+  return { assistantId: r.assistantId, max, locale };
+}
+
 const TELEMETRY_EVENT_NAMES = new Set<KickoffTelemetryEvent['event']>([
   'accepted',
   'redirected',
@@ -139,10 +185,7 @@ const NOT_RENDERED_REASONS = new Set<NotRenderedReason>([
   'error',
 ]);
 const VALID_CASCADE_LEVELS = new Set<number>([1, 2, 3, 4]);
-const DISMISS_REASONS = new Set<NonNullable<KickoffTelemetryEvent['dismissReason']>>([
-  'interaction',
-  'typing',
-]);
+const DISMISS_REASONS = new Set<NonNullable<KickoffTelemetryEvent['dismissReason']>>(['interaction', 'typing']);
 
 function isTelemetryEvent(raw: unknown): raw is KickoffTelemetryEvent {
   if (!raw || typeof raw !== 'object') return false;

--- a/src/process/services/kickoff/SuggestionEngine.ts
+++ b/src/process/services/kickoff/SuggestionEngine.ts
@@ -8,6 +8,7 @@ import type { SignalCollector } from './SignalCollector';
 import { findAssistantInRegistry } from './SignalCollector';
 import { dateKey, hashSeed, seededShuffle } from './seededShuffle';
 import {
+  KICKOFF_GRID_MAX,
   THREAD_MIN_DURATION_MS,
   THREAD_MIN_MESSAGES,
   THREAD_RECENT_WINDOW_MS,
@@ -15,6 +16,8 @@ import {
   type KickoffCascadeLevel,
   type KickoffCascadeReason,
   type KickoffEntry,
+  type KickoffGridItem,
+  type KickoffGridResult,
   type KickoffResult,
   type KickoffSignals,
   type KickoffSuggestion,
@@ -104,6 +107,104 @@ export class SuggestionEngine {
 
     return { notRendered: 'all-levels-missed' };
   }
+
+  /**
+   * #375 - per-assistant suggested-prompts GRID. Returns up to `max` browseable
+   * starters for the assistant detail view (below the composer), each prefilling
+   * the composer on click.
+   *
+   * Ranking (Sean-approved): beginner-safe first, then entries matching the
+   * current time bucket, then a daily-stable seeded shuffle for the remainder
+   * (same install + assistant + day → same order). Unlike `suggest`, this does
+   * NOT walk the 5-level cascade: the grid is a flat browse surface, not a
+   * single confident offer.
+   *
+   * Fallback: assistants that ship no `kickoffs` (the ASSISTANT_PRESETS like
+   * `cowork`, which carry localized `promptsI18n`, and a few catalog rows with
+   * only the legacy flat `prompts`) fall back to those prompt strings. This is
+   * why the grid (and the previously-empty Cowork detail view) renders at all
+   * for kickoff-less assistants. `locale` selects the `promptsI18n` variant;
+   * flat `prompts` are locale-agnostic.
+   */
+  async suggestN(
+    assistantId: string,
+    max: number = KICKOFF_GRID_MAX,
+    locale: string = 'en-US'
+  ): Promise<KickoffGridResult> {
+    const cap = Math.max(1, Math.min(max, KICKOFF_GRID_MAX));
+    const assistant = this.registryFinder(assistantId);
+    if (!assistant) return { notRendered: 'unknown-assistant' };
+    if ((assistant as { _kickoffsExcluded?: unknown })._kickoffsExcluded === true) {
+      return { notRendered: 'kickoffs-excluded' };
+    }
+
+    const kickoffs = readKickoffArray(assistant);
+    if (kickoffs.length > 0) {
+      const signals = await this.signalCollector.collect(assistantId);
+      const items = rankGridKickoffs(kickoffs, signals, assistantId)
+        .slice(0, cap)
+        .map<KickoffGridItem>((k) => ({ kickoffId: k.id, text: k.text, prefill: k.prefill, source: 'kickoff' }));
+      return { items };
+    }
+
+    // Fallback: legacy prompt strings (presets carry localized promptsI18n;
+    // some catalog rows carry only a flat prompts array).
+    const prompts = readPromptsFallback(assistant, locale).slice(0, cap);
+    if (prompts.length > 0) {
+      return { items: prompts.map<KickoffGridItem>((p) => ({ text: p, prefill: p, source: 'prompts' })) };
+    }
+
+    return { notRendered: 'no-kickoffs-defined' };
+  }
+}
+
+/**
+ * #375 - grid ordering. Stable across a day for one install: seed the base
+ * shuffle with `installUuid:assistantId:dateKey`, then stable-sort so
+ * beginner-safe entries lead and current-time-bucket entries follow, with the
+ * shuffled order breaking ties. De-dupes by id defensively (readKickoffArray
+ * already drops malformed rows, but a bundle could repeat an id).
+ */
+function rankGridKickoffs(kickoffs: KickoffEntry[], signals: KickoffSignals, assistantId: string): KickoffEntry[] {
+  const seed = hashSeed(`${signals.installUuid}:${assistantId}:${dateKey(signals.now)}`);
+  const shuffled = seededShuffle(kickoffs, seed);
+  const seen = new Set<string>();
+  const deduped = shuffled.filter((k) => (seen.has(k.id) ? false : (seen.add(k.id), true)));
+  const score = (k: KickoffEntry): number =>
+    (k.beginnerSafe === true ? 2 : 0) + (k.timeBucket === signals.timeBucket ? 1 : 0);
+  // Stable sort: Array.prototype.sort is stable in V8, so equal scores keep the
+  // seeded-shuffle order.
+  return deduped.toSorted((a, b) => score(b) - score(a));
+}
+
+/**
+ * #375 - read legacy prompt strings for the grid fallback. Prefers the flat
+ * `prompts` array (catalog rows), then `promptsI18n[locale]` with an `en-US`
+ * backstop (ASSISTANT_PRESETS like cowork). Returns trimmed, non-empty,
+ * de-duplicated strings; never throws on a malformed shape.
+ */
+function readPromptsFallback(raw: Record<string, unknown>, locale: string): string[] {
+  const out: string[] = [];
+  const push = (v: unknown): void => {
+    if (typeof v === 'string') {
+      const t = v.trim();
+      if (t.length > 0) out.push(t);
+    }
+  };
+
+  const flat = (raw as { prompts?: unknown }).prompts;
+  if (Array.isArray(flat)) flat.forEach(push);
+
+  if (out.length === 0) {
+    const i18n = (raw as { promptsI18n?: unknown }).promptsI18n;
+    if (i18n && typeof i18n === 'object') {
+      const byLocale = i18n as Record<string, unknown>;
+      const chosen = byLocale[locale] ?? byLocale['en-US'] ?? Object.values(byLocale)[0];
+      if (Array.isArray(chosen)) chosen.forEach(push);
+    }
+  }
+
+  return Array.from(new Set(out));
 }
 
 function pickQualityThread(signals: KickoffSignals): KickoffSignals['assistantRecentConversations'][number] | null {

--- a/src/process/services/kickoff/types.ts
+++ b/src/process/services/kickoff/types.ts
@@ -75,6 +75,28 @@ export type KickoffNotRendered = {
 export type KickoffResult = KickoffSuggestion | KickoffNotRendered;
 
 /**
+ * #375 - a single card in the per-assistant suggested-prompts GRID rendered
+ * below the composer in the assistant detail view. Distinct from the single
+ * yes-bias KickoffSuggestion: the grid shows several browseable starters, each
+ * of which prefills (not auto-sends) the composer on click.
+ *
+ * `source` records where the entry came from so the renderer + tests can tell
+ * a ranked kickoff from a legacy-prompt fallback. `kickoffId` is only set for
+ * `source: 'kickoff'` (legacy prompts have no stable id).
+ */
+export type KickoffGridItem = {
+  kickoffId?: string;
+  text: string;
+  prefill: string;
+  source: 'kickoff' | 'prompts';
+};
+
+export type KickoffGridResult = { items: KickoffGridItem[] } | KickoffNotRendered;
+
+/** #375 - default + hard cap on grid card count (Sean-approved 4-6 range). */
+export const KICKOFF_GRID_MAX = 6;
+
+/**
  * v0.4.7.1 (D-M-3) - `reason` discriminator on dismiss lets v2 analytics
  * separate "user clicked ×" from "user just started typing past the card."
  * Both are dismissals but they mean very different things for cold-start

--- a/src/renderer/hooks/kickoff/useKickoffGrid.ts
+++ b/src/renderer/hooks/kickoff/useKickoffGrid.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useEffect, useState } from 'react';
+import { ipcBridge } from '@/common';
+import type { KickoffGridItem, KickoffGridResult } from '@process/services/kickoff/types';
+
+/**
+ * #375 - hook for the per-assistant suggested-prompts GRID rendered below the
+ * composer in the assistant detail view. Unlike `useKickoff` (the single
+ * yes-bias card), this is a flat browse surface: it fetches up to N ranked
+ * starters and the caller renders them as clickable cards that PREFILL the
+ * composer (not auto-send).
+ *
+ * Behavior:
+ *  - Re-fetches whenever `assistantId` or `locale` changes. An undefined
+ *    assistantId (no preset selected) clears the grid.
+ *  - A `notRendered` result or an IPC failure resolves to an empty grid - the
+ *    detail view simply shows nothing, matching the pre-#375 behavior for
+ *    assistants with no suggestions.
+ *  - No telemetry / no per-session dismiss: the grid is a passive,
+ *    always-available browse surface, not a one-shot offer.
+ */
+
+function isItems(result: KickoffGridResult): result is { items: KickoffGridItem[] } {
+  return Array.isArray((result as { items?: unknown }).items);
+}
+
+export type UseKickoffGridReturn = {
+  items: KickoffGridItem[];
+  visible: boolean;
+};
+
+export function useKickoffGrid(assistantId: string | undefined, locale?: string): UseKickoffGridReturn {
+  const [items, setItems] = useState<KickoffGridItem[]>([]);
+
+  useEffect(() => {
+    if (!assistantId) {
+      setItems([]);
+      return;
+    }
+    let cancelled = false;
+    void ipcBridge.kickoff.suggestMany
+      .invoke({ assistantId, locale })
+      .then((result) => {
+        if (cancelled) return;
+        setItems(isItems(result) ? result.items : []);
+      })
+      .catch((err) => {
+        console.warn('[useKickoffGrid] suggestMany IPC failed', err);
+        if (!cancelled) setItems([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [assistantId, locale]);
+
+  return { items, visible: items.length > 0 };
+}

--- a/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
+++ b/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
@@ -28,6 +28,8 @@ import { isImageAvatar } from '@/renderer/utils/avatar';
 import { getLucideIcon } from '@/renderer/utils/lucideAvatar';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
+import { useKickoffGrid } from '@/renderer/hooks/kickoff/useKickoffGrid';
+import KickoffGrid from './kickoffGrid/KickoffGrid';
 
 type AssistantSelectionAreaProps = {
   isPresetAgent: boolean;
@@ -207,6 +209,20 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
     onRegisterOpenDetails(openAssistantDetails);
   }, [onRegisterOpenDetails, openAssistantDetails]);
 
+  // #375 - per-assistant suggested-prompts grid for the selected-assistant
+  // detail view. Same id source as GuidPage's single-card wiring
+  // (selectedAgentInfo.customAgentId). Clicking a card prefills the composer
+  // (editable, not auto-send) via the onSetInput/onFocusInput props.
+  const kickoffGridAssistantId = isPresetAgent ? selectedAgentInfo?.customAgentId : undefined;
+  const kickoffGrid = useKickoffGrid(kickoffGridAssistantId, localeKey);
+  const handleKickoffSelect = useCallback(
+    (prefill: string) => {
+      onSetInput(prefill);
+      onFocusInput();
+    },
+    [onSetInput, onFocusInput]
+  );
+
   // Only render if there are preset agents
   if (!customAgents || !customAgents.some((a) => a.isPreset)) return null;
 
@@ -238,7 +254,10 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
               </span>
             </div>
           )}
-          {/* Per-assistant example prompts removed - intent pills above cover discovery. */}
+          {/* #375 - per-assistant suggested prompts, restored as a prompt-cards
+              grid (replaces the v0.9.6 removal). Reuses the assistant's kickoffs
+              (ranked) or legacy prompts; clicking a card prefills the composer. */}
+          {kickoffGrid.visible ? <KickoffGrid items={kickoffGrid.items} onSelect={handleKickoffSelect} /> : null}
         </div>
         {modalTree}
       </div>
@@ -265,8 +284,7 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
           .map((assistant) => {
             const avatarValue = assistant.avatar?.trim();
             const LucideIconComponent = getLucideIcon(avatarValue);
-            const mappedAvatar =
-              !LucideIconComponent && avatarValue ? CUSTOM_AVATAR_IMAGE_MAP[avatarValue] : undefined;
+            const mappedAvatar = !LucideIconComponent && avatarValue ? CUSTOM_AVATAR_IMAGE_MAP[avatarValue] : undefined;
             const resolvedAvatar =
               !LucideIconComponent && avatarValue ? resolveExtensionAssetUrl(avatarValue) : undefined;
             const avatarImage = mappedAvatar || resolvedAvatar;

--- a/src/renderer/pages/guid/components/kickoffGrid/KickoffGrid.module.css
+++ b/src/renderer/pages/guid/components/kickoffGrid/KickoffGrid.module.css
@@ -1,0 +1,56 @@
+/* #375 - per-assistant suggested-prompts grid (assistant detail view). */
+
+.wrap {
+  margin: 12px auto 0;
+  width: 100%;
+}
+
+.heading {
+  margin: 0 0 8px 2px;
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--text-secondary);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+/* Single column on narrow layouts so card text never truncates awkwardly. */
+@media (max-width: 560px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.card {
+  /* Mirrors KickoffCard's elevated surface so the grid reads as the same family. */
+  display: block;
+  width: 100%;
+  margin: 0;
+  padding: 12px 14px;
+  text-align: left;
+  font-size: 14px;
+  line-height: 1.4;
+  color: var(--text-primary);
+  background-color: var(--bg-elevated);
+  border: 1px solid var(--border-light);
+  border-radius: 12px;
+  cursor: pointer;
+  transition:
+    background-color 0.12s ease,
+    border-color 0.12s ease,
+    box-shadow 0.12s ease;
+}
+
+.card:hover,
+.card:focus-visible {
+  background-color: var(--bg-hover);
+  border-color: var(--color-border-3);
+  box-shadow:
+    0 1px 0 rgba(0, 0, 0, 0.02),
+    0 8px 24px rgba(0, 0, 0, 0.04);
+  outline: none;
+}

--- a/src/renderer/pages/guid/components/kickoffGrid/KickoffGrid.tsx
+++ b/src/renderer/pages/guid/components/kickoffGrid/KickoffGrid.tsx
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import type { KickoffGridItem } from '@process/services/kickoff/types';
+import styles from './KickoffGrid.module.css';
+
+export type KickoffGridProps = {
+  items: KickoffGridItem[];
+  /** Click handler - receives the prefill text to drop (editable) into the composer. */
+  onSelect: (prefill: string) => void;
+};
+
+/**
+ * #375 - per-assistant suggested-prompts grid for the assistant detail view
+ * (restores the pre-v0.9.6 per-assistant starters, redesigned). Renders 4-6
+ * capability-based starter cards below the composer; clicking a card prefills
+ * the composer (editable, not auto-send) so the user can tweak before sending.
+ *
+ * Card styling mirrors KickoffCard (same elevated surface tokens) so the grid
+ * reads as the same family as the single yes-bias card. Raw <button> is used
+ * intentionally (lint-disabled) - an Arco Button forces a filled/outlined
+ * visual that competes with the composer's primary send affordance, the same
+ * precedent KickoffCard set for its peer-weighted controls.
+ */
+const KickoffGrid: React.FC<KickoffGridProps> = ({ items, onSelect }) => {
+  const { t } = useTranslation();
+
+  if (items.length === 0) return null;
+
+  return (
+    <div className={styles.wrap} data-testid='assistant-kickoff-grid'>
+      <div className={styles.heading}>
+        {t('guid.assistantDetail.kickoffGrid.heading', { defaultValue: 'Try one of these' })}
+      </div>
+      <div className={styles.grid}>
+        {items.map((item, index) => (
+          /* eslint-disable-next-line wayland/no-raw-button */
+          <button
+            type='button'
+            key={item.kickoffId ?? `${item.source}-${index}`}
+            className={styles.card}
+            data-testid='assistant-kickoff-card'
+            onClick={() => onSelect(item.prefill)}
+          >
+            {item.text}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default KickoffGrid;

--- a/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/src/renderer/services/i18n/i18n-keys.d.ts
@@ -872,6 +872,7 @@ export type I18nKey =
   | 'guid.agentFallbackNotice'
   | 'guid.agentSwitcherLabel'
   | 'guid.agentTabAutoSwitch'
+  | 'guid.assistantDetail.kickoffGrid.heading'
   | 'guid.autoSwitchToAgent'
   | 'guid.autoSwitchedAgent'
   | 'guid.hint.backend'

--- a/src/renderer/services/i18n/locales/en-US/guid.json
+++ b/src/renderer/services/i18n/locales/en-US/guid.json
@@ -27,31 +27,11 @@
     "greeting": {
       "withName": "{{timeLabel}}, {{name}}",
       "labels": {
-        "lateNight": [
-          "Working late",
-          "Burning the midnight oil",
-          "Up late"
-        ],
-        "morning": [
-          "Morning",
-          "Good morning",
-          "Rise and shine"
-        ],
-        "afternoon": [
-          "Afternoon",
-          "Good afternoon",
-          "Welcome back"
-        ],
-        "evening": [
-          "Evening",
-          "Good evening",
-          "Welcome back"
-        ],
-        "night": [
-          "Evening",
-          "Good evening",
-          "Winding down"
-        ]
+        "lateNight": ["Working late", "Burning the midnight oil", "Up late"],
+        "morning": ["Morning", "Good morning", "Rise and shine"],
+        "afternoon": ["Afternoon", "Good afternoon", "Welcome back"],
+        "evening": ["Evening", "Good evening", "Welcome back"],
+        "night": ["Evening", "Good evening", "Winding down"]
       }
     },
     "intent": {
@@ -80,6 +60,11 @@
       "redirect": "Something else",
       "dismissAria": "Dismiss suggestion",
       "regionAria": "Suggested first message"
+    }
+  },
+  "assistantDetail": {
+    "kickoffGrid": {
+      "heading": "Try one of these"
     }
   }
 }

--- a/tests/unit/process/bridge/kickoffBridge.test.ts
+++ b/tests/unit/process/bridge/kickoffBridge.test.ts
@@ -23,12 +23,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // ----------------------------------------------------------------------------
 
 vi.mock('@/common', () => {
-  const suggestProvider = (globalThis as any).__suggestProviderMock ?? ((globalThis as any).__suggestProviderMock = vi.fn());
-  const telemetryProvider = (globalThis as any).__telemetryProviderMock ?? ((globalThis as any).__telemetryProviderMock = vi.fn());
+  const suggestProvider =
+    (globalThis as any).__suggestProviderMock ?? ((globalThis as any).__suggestProviderMock = vi.fn());
+  const suggestManyProvider =
+    (globalThis as any).__suggestManyProviderMock ?? ((globalThis as any).__suggestManyProviderMock = vi.fn());
+  const telemetryProvider =
+    (globalThis as any).__telemetryProviderMock ?? ((globalThis as any).__telemetryProviderMock = vi.fn());
   return {
     ipcBridge: {
       kickoff: {
         suggest: { provider: suggestProvider },
+        suggestMany: { provider: suggestManyProvider },
         telemetry: { provider: telemetryProvider },
       },
     },
@@ -37,13 +42,16 @@ vi.mock('@/common', () => {
 
 vi.mock('@process/services/kickoff/kickoffSingleton', () => {
   const engineSuggest = (globalThis as any).__engineSuggestMock ?? ((globalThis as any).__engineSuggestMock = vi.fn());
+  const engineSuggestN =
+    (globalThis as any).__engineSuggestNMock ?? ((globalThis as any).__engineSuggestNMock = vi.fn());
   return {
-    getKickoffEngine: () => ({ suggest: engineSuggest }),
+    getKickoffEngine: () => ({ suggest: engineSuggest, suggestN: engineSuggestN }),
   };
 });
 
 vi.mock('@process/extensions/ExtensionRegistry', () => {
-  const whenInitialized = (globalThis as any).__whenInitializedMock ?? ((globalThis as any).__whenInitializedMock = vi.fn());
+  const whenInitialized =
+    (globalThis as any).__whenInitializedMock ?? ((globalThis as any).__whenInitializedMock = vi.fn());
   return {
     ExtensionRegistry: {
       getInstance: () => ({ whenInitialized }),
@@ -52,20 +60,23 @@ vi.mock('@process/extensions/ExtensionRegistry', () => {
 });
 
 vi.mock('@process/services/cron/cronReadiness', () => {
-  const waitForCronReady = (globalThis as any).__waitForCronReadyMock ?? ((globalThis as any).__waitForCronReadyMock = vi.fn());
+  const waitForCronReady =
+    (globalThis as any).__waitForCronReadyMock ?? ((globalThis as any).__waitForCronReadyMock = vi.fn());
   return {
     waitForCronReady: (...args: unknown[]) => waitForCronReady(...args),
   };
 });
 
 const suggestProviderMock: ReturnType<typeof vi.fn> = (globalThis as any).__suggestProviderMock;
+const suggestManyProviderMock: ReturnType<typeof vi.fn> = (globalThis as any).__suggestManyProviderMock;
 const telemetryProviderMock: ReturnType<typeof vi.fn> = (globalThis as any).__telemetryProviderMock;
 const engineSuggestMock: ReturnType<typeof vi.fn> = (globalThis as any).__engineSuggestMock;
+const engineSuggestNMock: ReturnType<typeof vi.fn> = (globalThis as any).__engineSuggestNMock;
 const whenInitializedMock: ReturnType<typeof vi.fn> = (globalThis as any).__whenInitializedMock;
 const waitForCronReadyMock: ReturnType<typeof vi.fn> = (globalThis as any).__waitForCronReadyMock;
 
 import { initKickoffBridge } from '@process/bridge/kickoffBridge';
-import type { KickoffResult, KickoffTelemetryEvent } from '@process/services/kickoff/types';
+import type { KickoffGridResult, KickoffResult, KickoffTelemetryEvent } from '@process/services/kickoff/types';
 
 // Pulls the most-recently-registered handler from a `.provider` mock. The
 // bridge calls `.provider(fn)` once at init; we re-init in `beforeEach`
@@ -82,10 +93,18 @@ function getTelemetryHandler(): (raw: unknown) => Promise<void> {
   return last[0] as (raw: unknown) => Promise<void>;
 }
 
+function getSuggestManyHandler(): (raw: unknown) => Promise<KickoffGridResult> {
+  const last = suggestManyProviderMock.mock.calls.at(-1);
+  if (!last) throw new Error('suggestMany provider was never registered');
+  return last[0] as (raw: unknown) => Promise<KickoffGridResult>;
+}
+
 beforeEach(() => {
   suggestProviderMock.mockReset();
+  suggestManyProviderMock.mockReset();
   telemetryProviderMock.mockReset();
   engineSuggestMock.mockReset();
+  engineSuggestNMock.mockReset();
   whenInitializedMock.mockReset();
   waitForCronReadyMock.mockReset();
   // Sensible defaults - most tests want registry ready + cron ready.
@@ -209,12 +228,13 @@ describe('kickoffBridge.suggest - registry readiness', () => {
       ipcBridge: {
         kickoff: {
           suggest: { provider: suggestProviderMock },
+          suggestMany: { provider: suggestManyProviderMock },
           telemetry: { provider: telemetryProviderMock },
         },
       },
     }));
     vi.doMock('@process/services/kickoff/kickoffSingleton', () => ({
-      getKickoffEngine: () => ({ suggest: engineSuggestMock }),
+      getKickoffEngine: () => ({ suggest: engineSuggestMock, suggestN: engineSuggestNMock }),
     }));
     vi.doMock('@process/services/cron/cronReadiness', () => ({
       waitForCronReady: () => Promise.resolve('ready' as const),
@@ -301,9 +321,7 @@ describe('kickoffBridge.telemetry - validation', () => {
   it("silently drops payload with notRenderedReason: 'unknown'", async () => {
     const handler = getTelemetryHandler();
     const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
-    await expect(
-      handler({ event: 'not_rendered', notRenderedReason: 'unknown' })
-    ).resolves.toBeUndefined();
+    await expect(handler({ event: 'not_rendered', notRenderedReason: 'unknown' })).resolves.toBeUndefined();
     expect(debugSpy).not.toHaveBeenCalled();
     debugSpy.mockRestore();
   });
@@ -311,9 +329,7 @@ describe('kickoffBridge.telemetry - validation', () => {
   it('silently drops payload with notRenderedReason longer than 128 chars', async () => {
     const handler = getTelemetryHandler();
     const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
-    await expect(
-      handler({ event: 'not_rendered', notRenderedReason: 'a'.repeat(129) })
-    ).resolves.toBeUndefined();
+    await expect(handler({ event: 'not_rendered', notRenderedReason: 'a'.repeat(129) })).resolves.toBeUndefined();
     expect(debugSpy).not.toHaveBeenCalled();
     debugSpy.mockRestore();
   });
@@ -329,9 +345,7 @@ describe('kickoffBridge.telemetry - validation', () => {
   it('silently drops payload with invalid dismissReason', async () => {
     const handler = getTelemetryHandler();
     const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
-    await expect(
-      handler({ event: 'dismissed', dismissReason: 'rage-quit' })
-    ).resolves.toBeUndefined();
+    await expect(handler({ event: 'dismissed', dismissReason: 'rage-quit' })).resolves.toBeUndefined();
     expect(debugSpy).not.toHaveBeenCalled();
     debugSpy.mockRestore();
   });
@@ -396,5 +410,54 @@ describe('kickoffBridge.telemetry - validation', () => {
     await expect(handler('hi')).resolves.toBeUndefined();
     expect(debugSpy).not.toHaveBeenCalled();
     debugSpy.mockRestore();
+  });
+});
+
+// ============================================================================
+// #375 - suggestMany (per-assistant suggested-prompts grid)
+// ============================================================================
+
+describe('kickoffBridge.suggestMany', () => {
+  it('rejects a malformed assistantId with notRendered=error and never reaches the engine', async () => {
+    const handler = getSuggestManyHandler();
+    const result = await handler({ assistantId: 'Bad Id!' });
+    expect(result).toEqual({ notRendered: 'error' });
+    expect(engineSuggestNMock).not.toHaveBeenCalled();
+  });
+
+  it('returns notRendered=registry-not-ready when the registry never initializes', async () => {
+    whenInitializedMock.mockReturnValue(new Promise(() => {})); // never resolves → race loses to timeout
+    vi.useFakeTimers();
+    const handler = getSuggestManyHandler();
+    const pending = handler({ assistantId: 'helm' });
+    await vi.advanceTimersByTimeAsync(3000);
+    const result = await pending;
+    vi.useRealTimers();
+    expect(result).toEqual({ notRendered: 'registry-not-ready' });
+    expect(engineSuggestNMock).not.toHaveBeenCalled();
+  });
+
+  it('forwards clamped max + locale to the engine and returns its items', async () => {
+    engineSuggestNMock.mockResolvedValue({ items: [{ text: 'Go', prefill: 'Go', source: 'prompts' }] });
+    const handler = getSuggestManyHandler();
+    const result = await handler({ assistantId: 'cowork', max: 99, locale: 'zh-CN' });
+    expect(engineSuggestNMock).toHaveBeenCalledWith('cowork', 6, 'zh-CN');
+    expect(result).toEqual({ items: [{ text: 'Go', prefill: 'Go', source: 'prompts' }] });
+  });
+
+  it('drops a non-positive max so the engine applies its own default', async () => {
+    engineSuggestNMock.mockResolvedValue({ items: [] });
+    const handler = getSuggestManyHandler();
+    await handler({ assistantId: 'helm', max: 0 });
+    expect(engineSuggestNMock).toHaveBeenCalledWith('helm', 1, undefined);
+  });
+
+  it('maps an engine throw to notRendered=engine-error with a sanitized errorName', async () => {
+    engineSuggestNMock.mockRejectedValue(Object.assign(new Error('boom /Users/x'), { name: 'RangeError' }));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const handler = getSuggestManyHandler();
+    const result = await handler({ assistantId: 'helm' });
+    expect(result).toEqual({ notRendered: 'engine-error', errorName: 'RangeError' });
+    warnSpy.mockRestore();
   });
 });

--- a/tests/unit/process/services/kickoff/SuggestionEngine.test.ts
+++ b/tests/unit/process/services/kickoff/SuggestionEngine.test.ts
@@ -244,10 +244,7 @@ describe('SuggestionEngine - deterministic shuffle', () => {
     const result = await engine.suggest('helm');
     if ('notRendered' in result) throw new Error('expected suggestion');
     const morningColdStarts = FIXTURE_ASSISTANT.kickoffs.filter(
-      (k) =>
-        k.scenario === 'cold-start' &&
-        k.beginnerSafe !== true &&
-        (!k.timeBucket || k.timeBucket === 'morning')
+      (k) => k.scenario === 'cold-start' && k.beginnerSafe !== true && (!k.timeBucket || k.timeBucket === 'morning')
     );
     const expectedSeed = hashSeed(`${signals.installUuid}:helm:${dateKey(now)}`);
     const expectedPrimary = seededShuffle(morningColdStarts, expectedSeed)[0]!;
@@ -333,9 +330,7 @@ describe('SuggestionEngine - readKickoffArray malformed-entry filter', () => {
     if ('notRendered' in result) throw new Error('expected suggestion');
     // Only the valid one survives → it must be the chosen primary.
     expect(result.kickoffId).toBe('good-1');
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('invalid scenario "oops"')
-    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('invalid scenario "oops"'));
     warnSpy.mockRestore();
   });
 
@@ -359,9 +354,7 @@ describe('SuggestionEngine - readKickoffArray malformed-entry filter', () => {
     // eligible for any bucket → present at Level 3.
     if ('notRendered' in result) throw new Error('expected suggestion');
     expect(result.kickoffId).toBe('good-1');
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('invalid timeBucket "gibberish"')
-    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('invalid timeBucket "gibberish"'));
     warnSpy.mockRestore();
   });
 });
@@ -418,5 +411,99 @@ describe('SuggestionEngine - kickoffs-excluded opt-out sentinel', () => {
     const engine = makeEngine(signalsBase(), record);
     const result = await engine.suggest('helm');
     expect(result).toEqual({ notRendered: 'kickoffs-excluded' });
+  });
+});
+
+// ============================================================================
+// #375 - suggestN: per-assistant suggested-prompts grid
+// ============================================================================
+
+describe('SuggestionEngine.suggestN - grid', () => {
+  it('returns notRendered=unknown-assistant when the registry has no match', async () => {
+    const engine = makeEngine(signalsBase(), null);
+    const result = await engine.suggestN('ghost');
+    expect(result).toEqual({ notRendered: 'unknown-assistant' });
+  });
+
+  it('returns notRendered=kickoffs-excluded for an opted-out assistant', async () => {
+    const record = { id: 'helm', _kickoffsExcluded: true, kickoffs: FIXTURE_ASSISTANT.kickoffs };
+    const engine = makeEngine(signalsBase(), record);
+    const result = await engine.suggestN('helm');
+    expect(result).toEqual({ notRendered: 'kickoffs-excluded' });
+  });
+
+  it('returns up to `max` kickoff-sourced items, never more than the data holds', async () => {
+    const engine = makeEngine(signalsBase());
+    const result = await engine.suggestN('helm', 4);
+    if ('notRendered' in result) throw new Error(`expected items, got ${result.notRendered}`);
+    expect(result.items).toHaveLength(4);
+    expect(result.items.every((i) => i.source === 'kickoff')).toBe(true);
+    expect(result.items.every((i) => i.kickoffId && i.text && i.prefill)).toBe(true);
+  });
+
+  it('clamps an over-large `max` to the data size (6 entries → 6 items)', async () => {
+    const engine = makeEngine(signalsBase());
+    const result = await engine.suggestN('helm', 99);
+    if ('notRendered' in result) throw new Error('expected items');
+    expect(result.items).toHaveLength(6);
+  });
+
+  it('ranks beginner-safe first, then current time-bucket matches', async () => {
+    const engine = makeEngine(signalsBase()); // timeBucket: 'morning'
+    const result = await engine.suggestN('helm', 6);
+    if ('notRendered' in result) throw new Error('expected items');
+    // The single beginnerSafe entry must lead.
+    expect(result.items[0]!.kickoffId).toBe('beginner');
+    // The two morning (non-beginner) entries must outrank the lone afternoon one.
+    const ids = result.items.map((i) => i.kickoffId);
+    expect(ids.indexOf('morning-cold')).toBeLessThan(ids.indexOf('afternoon-cold'));
+    expect(ids.indexOf('morning-cold-2')).toBeLessThan(ids.indexOf('afternoon-cold'));
+  });
+
+  it('is deterministic for the same install + assistant + day', async () => {
+    const engineA = makeEngine(signalsBase());
+    const engineB = makeEngine(signalsBase());
+    const a = await engineA.suggestN('helm', 6);
+    const b = await engineB.suggestN('helm', 6);
+    if ('notRendered' in a || 'notRendered' in b) throw new Error('expected items');
+    expect(a.items.map((i) => i.kickoffId)).toEqual(b.items.map((i) => i.kickoffId));
+  });
+
+  it('falls back to the flat legacy prompts array when no kickoffs are defined', async () => {
+    const record = { id: 'doc', kickoffs: [], prompts: ['Make a deck', 'Draft a memo', 'Make a deck'] };
+    const engine = makeEngine(signalsBase(), record);
+    const result = await engine.suggestN('doc', 6);
+    if ('notRendered' in result) throw new Error('expected items');
+    // De-duped, prompt-sourced, prefill mirrors text.
+    expect(result.items).toEqual([
+      { text: 'Make a deck', prefill: 'Make a deck', source: 'prompts' },
+      { text: 'Draft a memo', prefill: 'Draft a memo', source: 'prompts' },
+    ]);
+  });
+
+  it('falls back to promptsI18n for the requested locale (cowork-style preset)', async () => {
+    const record = {
+      id: 'cowork',
+      promptsI18n: { 'en-US': ['Organize my files'], 'zh-CN': ['整理我的文件'] },
+    };
+    const engine = makeEngine(signalsBase(), record);
+    const result = await engine.suggestN('cowork', 6, 'zh-CN');
+    if ('notRendered' in result) throw new Error('expected items');
+    expect(result.items).toEqual([{ text: '整理我的文件', prefill: '整理我的文件', source: 'prompts' }]);
+  });
+
+  it('falls back to en-US promptsI18n when the requested locale is absent', async () => {
+    const record = { id: 'cowork', promptsI18n: { 'en-US': ['Organize my files'] } };
+    const engine = makeEngine(signalsBase(), record);
+    const result = await engine.suggestN('cowork', 6, 'fr-FR');
+    if ('notRendered' in result) throw new Error('expected items');
+    expect(result.items[0]!.text).toBe('Organize my files');
+  });
+
+  it('returns notRendered=no-kickoffs-defined when neither kickoffs nor prompts exist', async () => {
+    const record = { id: 'empty', kickoffs: [] };
+    const engine = makeEngine(signalsBase(), record);
+    const result = await engine.suggestN('empty', 6);
+    expect(result).toEqual({ notRendered: 'no-kickoffs-defined' });
   });
 });

--- a/tests/unit/renderer/KickoffGrid.dom.test.tsx
+++ b/tests/unit/renderer/KickoffGrid.dom.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import type { KickoffGridItem } from '@process/services/kickoff/types';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? _key,
+  }),
+}));
+
+vi.mock('@/renderer/pages/guid/components/kickoffGrid/KickoffGrid.module.css', () => ({ default: {} }));
+
+import KickoffGrid from '@/renderer/pages/guid/components/kickoffGrid/KickoffGrid';
+
+const items: KickoffGridItem[] = [
+  { kickoffId: 'k1', text: 'Organize my project files', prefill: 'Organize my files now', source: 'kickoff' },
+  { text: 'Process a batch of PDFs', prefill: 'Process these PDFs', source: 'prompts' },
+];
+
+describe('<KickoffGrid>', () => {
+  it('renders the heading and one card per item', () => {
+    render(<KickoffGrid items={items} onSelect={vi.fn()} />);
+    expect(screen.getByText('Try one of these')).toBeTruthy();
+    expect(screen.getAllByTestId('assistant-kickoff-card')).toHaveLength(2);
+    expect(screen.getByText('Organize my project files')).toBeTruthy();
+    expect(screen.getByText('Process a batch of PDFs')).toBeTruthy();
+  });
+
+  it("clicking a card invokes onSelect with that card's prefill (not its display text)", () => {
+    const onSelect = vi.fn();
+    render(<KickoffGrid items={items} onSelect={onSelect} />);
+    fireEvent.click(screen.getByText('Organize my project files'));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith('Organize my files now');
+  });
+
+  it('renders nothing when there are no items (empty assistant)', () => {
+    const { container } = render(<KickoffGrid items={[]} onSelect={vi.fn()} />);
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByTestId('assistant-kickoff-grid')).toBeNull();
+  });
+});

--- a/tests/unit/renderer/useKickoffGrid.dom.test.ts
+++ b/tests/unit/renderer/useKickoffGrid.dom.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const suggestManyMock = vi.fn();
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    kickoff: {
+      suggestMany: { invoke: (...a: unknown[]) => suggestManyMock(...a) },
+    },
+  },
+}));
+
+import { useKickoffGrid } from '@/renderer/hooks/kickoff/useKickoffGrid';
+
+beforeEach(() => {
+  suggestManyMock.mockReset();
+});
+
+describe('useKickoffGrid', () => {
+  it('fetches the grid on mount, forwarding assistantId + locale', async () => {
+    suggestManyMock.mockResolvedValue({
+      items: [{ kickoffId: 'k1', text: 'A', prefill: 'a', source: 'kickoff' }],
+    });
+    const { result } = renderHook(() => useKickoffGrid('cowork', 'zh-CN'));
+    await waitFor(() => expect(result.current.visible).toBe(true));
+    expect(result.current.items).toHaveLength(1);
+    expect(suggestManyMock).toHaveBeenCalledWith({ assistantId: 'cowork', locale: 'zh-CN' });
+  });
+
+  it('does not call IPC and stays empty when assistantId is undefined', async () => {
+    const { result } = renderHook(() => useKickoffGrid(undefined, 'en-US'));
+    expect(suggestManyMock).not.toHaveBeenCalled();
+    expect(result.current.visible).toBe(false);
+    expect(result.current.items).toEqual([]);
+  });
+
+  it('treats a notRendered result as an empty (hidden) grid', async () => {
+    suggestManyMock.mockResolvedValue({ notRendered: 'no-kickoffs-defined' });
+    const { result } = renderHook(() => useKickoffGrid('ghost', 'en-US'));
+    await waitFor(() => expect(suggestManyMock).toHaveBeenCalled());
+    expect(result.current.visible).toBe(false);
+    expect(result.current.items).toEqual([]);
+  });
+
+  it('swallows an IPC rejection and stays empty (no throw to the view)', async () => {
+    suggestManyMock.mockRejectedValue(new Error('ipc down'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { result } = renderHook(() => useKickoffGrid('helm', 'en-US'));
+    await waitFor(() => expect(warn).toHaveBeenCalled());
+    expect(result.current.visible).toBe(false);
+    expect(result.current.items).toEqual([]);
+    warn.mockRestore();
+  });
+
+  it('re-fetches when the assistantId changes', async () => {
+    suggestManyMock.mockResolvedValue({ items: [{ text: 'A', prefill: 'a', source: 'prompts' }] });
+    const { rerender } = renderHook(({ id }) => useKickoffGrid(id, 'en-US'), {
+      initialProps: { id: 'a1' },
+    });
+    await waitFor(() => expect(suggestManyMock).toHaveBeenCalledWith({ assistantId: 'a1', locale: 'en-US' }));
+    rerender({ id: 'a2' });
+    await waitFor(() => expect(suggestManyMock).toHaveBeenCalledWith({ assistantId: 'a2', locale: 'en-US' }));
+  });
+});


### PR DESCRIPTION
Closes #375.

## What
Restores the per-assistant starter prompts removed in ~v0.9.6, redesigned per Sean's approved spec: a **4-6 card grid below the composer in the assistant detail view**. Clicking a card **prefills** the composer (editable, not auto-send).

## How
- **Engine** — `SuggestionEngine.suggestN(assistantId, max, locale)`: ranks the assistant's `kickoffs` (beginner-safe first → current time-bucket → daily-stable seeded shuffle) and returns up to `max`. Falls back to the legacy flat `prompts` / localized `promptsI18n` when an assistant ships no kickoffs.
- **IPC** — `kickoff.suggestMany` provider with the same registry/cron readiness gating + input validation as `suggest` (assistantId regex, clamped `max`, bounded `locale`).
- **Renderer** — `useKickoffGrid` hook + `KickoffGrid` component (mirrors `KickoffCard` styling), wired into `AssistantSelectionArea`'s selected-assistant view; click prefills via the existing `onSetInput`/`onFocusInput` props.
- **i18n** — `guid.assistantDetail.kickoffGrid.heading`.

## Cowork "nothing below the composer" fix
Root cause confirmed: the **Cowork** assistant (and the other `ASSISTANT_PRESETS`) carry `promptsI18n`, **not** `kickoffs`, while `SuggestionEngine` previously read only `kickoffs` → always `notRendered`. The new `suggestN` legacy-prompts fallback makes the grid render for Cowork (and any kickoff-less preset).

## Notes for the reviewer
- The issue's "82/88 kickoffs populated" refers to the `builtin-catalog` specialists; the **detail-view assistants are `ASSISTANT_PRESETS`** (cowork, doc-creators) which use `promptsI18n`. The unified engine path (kickoffs → prompts/promptsI18n fallback) covers both systems, so the grid is correct regardless of which an assistant uses.
- Disjoint from #374 (BH1's curated-picker work) — touches only the kickoff engine/IPC + the kickoff grid UI.

## Verification
- `bun run typecheck` clean
- `oxlint` / `oxfmt --check` clean on changed files
- `bun run i18n:types` + `node scripts/check-i18n.js` in sync
- Full unit suite green (**11256 passed, 0 failed**); 16 new tests across engine ranking/fallback/clamp/determinism, bridge validation/error paths, and grid + hook DOM coverage.