### PR TITLE
fix(guid): default assistants to Wayland Core instead of Gemini CLI (#380)

### DIFF
--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -546,7 +546,7 @@ const GuidPage: React.FC = () => {
       } else {
         // Extension-bundle assistants follow the same Rory rule. When no user
         // backend pill is active, presetAgentType is left undefined and
-        // selectPresetAssistant defaults to gemini (Phase 1 fallback).
+        // selectPresetAssistant defaults to wcore (Wayland Core, the native engine).
         agentSelection.selectPresetAssistant({
           id: prompt.targetAssistantId,
           presetAgentType: userBackend,
@@ -741,7 +741,7 @@ const GuidPage: React.FC = () => {
     return () => observer.disconnect();
   }, [agentSelection.isPresetAgent, selectedAssistantDescription]);
 
-  const currentPresetAgentType = selectedAssistantRecord?.presetAgentType || 'gemini';
+  const currentPresetAgentType = selectedAssistantRecord?.presetAgentType || 'wcore';
   const agentSwitcherItems = useMemo(() => {
     if (!agentSelection.availableAgents) return [];
     // Build from detected execution engines, excluding preset assistants and remote agents

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -179,7 +179,7 @@ export const useGuidAgentSelection = ({
       const assistant = customAgents.find((a) => a.id === customAgentId);
       if (assistant) {
         return {
-          backend: assistant.presetAgentType || 'gemini',
+          backend: assistant.presetAgentType || 'wcore',
           name: assistant.name,
           customAgentId: assistant.id,
           isPreset: true,
@@ -550,7 +550,7 @@ export const useGuidAgentSelection = ({
    */
   const selectPresetAssistant = useCallback(
     (preset: { id: string; presetAgentType?: string }) => {
-      const backend = (preset.presetAgentType ?? 'gemini') as AcpBackend;
+      const backend = (preset.presetAgentType ?? 'wcore') as AcpBackend;
       const key = getAgentKey({ backend, customAgentId: preset.id });
       setSelectedAgentKey(key);
     },

--- a/src/renderer/pages/guid/hooks/useGuidModelSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidModelSelection.ts
@@ -173,9 +173,9 @@ export type GuidModelSelectionResult = {
 
 /**
  * Hook that manages Gemini model list and selection state for the Guid page.
- * @param agentKey - current provider-based agent ('gemini' | 'wcore'), defaults to 'gemini'
+ * @param agentKey - current provider-based agent ('gemini' | 'wcore'), defaults to 'wcore'
  */
-export const useGuidModelSelection = (agentKey: ProviderAgentKey = 'gemini'): GuidModelSelectionResult => {
+export const useGuidModelSelection = (agentKey: ProviderAgentKey = 'wcore'): GuidModelSelectionResult => {
   const { geminiModeOptions, isGoogleAuth } = useGeminiGoogleAuthModels();
   const { data: modelConfig, mutate: mutateModelConfig } = useSWR('model.config.welcome', () => {
     return ipcBridge.mode.getModelConfig.invoke().then((data) => {

--- a/src/renderer/pages/guid/hooks/usePresetAssistantResolver.ts
+++ b/src/renderer/pages/guid/hooks/usePresetAssistantResolver.ts
@@ -112,10 +112,10 @@ export const usePresetAssistantResolver = ({
 
   const resolvePresetAgentType = useCallback(
     (agentInfo: { backend: AcpBackend; customAgentId?: string } | undefined): string => {
-      if (!agentInfo) return 'gemini';
+      if (!agentInfo) return 'wcore';
       if (!agentInfo.customAgentId) return agentInfo.backend as string;
       const customAgent = customAgents.find((agent) => agent.id === agentInfo.customAgentId);
-      return customAgent?.presetAgentType || 'gemini';
+      return customAgent?.presetAgentType || 'wcore';
     },
     [customAgents]
   );

--- a/tests/unit/guidAgentHooks.dom.test.ts
+++ b/tests/unit/guidAgentHooks.dom.test.ts
@@ -219,16 +219,16 @@ describe('usePresetAssistantResolver', () => {
     expect(result.current.resolvePresetAgentType({ backend: 'qwen', customAgentId: 'agent-beta' })).toBe('qwen');
   });
 
-  it('resolvePresetAgentType defaults to gemini for unknown preset agent', () => {
+  it('resolvePresetAgentType defaults to wcore for unknown preset agent', () => {
     const { result } = renderHook(() => usePresetAssistantResolver({ customAgents, localeKey: 'en-US' }));
 
-    expect(result.current.resolvePresetAgentType({ backend: 'claude', customAgentId: 'unknown-id' })).toBe('gemini');
+    expect(result.current.resolvePresetAgentType({ backend: 'claude', customAgentId: 'unknown-id' })).toBe('wcore');
   });
 
-  it('resolvePresetAgentType returns gemini when agentInfo is undefined', () => {
+  it('resolvePresetAgentType returns wcore when agentInfo is undefined', () => {
     const { result } = renderHook(() => usePresetAssistantResolver({ customAgents, localeKey: 'en-US' }));
 
-    expect(result.current.resolvePresetAgentType(undefined)).toBe('gemini');
+    expect(result.current.resolvePresetAgentType(undefined)).toBe('wcore');
   });
 
   // -- resolveEnabledSkills ---------------------------------------------------


### PR DESCRIPTION
## #380 — Assistants default backend to Gemini CLI instead of Wayland Core

Found in live verification of the 0.11.4 cut candidate. Assistants with no explicit `presetAgentType` fell back to `'gemini'`, so the agent dropdown defaulted to **Gemini CLI** (an external dependency that may not be installed) instead of the native, always-available **Wayland Core** engine.

### Fix
Flip the unset/fallback backend default `'gemini'` → `'wcore'` at the preset resolution + selection sites:
- `usePresetAssistantResolver.ts` — `resolvePresetAgentType` fallbacks (:115, :118)
- `useGuidAgentSelection.ts` — `findAgentByKey` custom: branch (:182) + `selectPresetAssistant` (:553)
- `GuidPage.tsx` — `currentPresetAgentType` agent-switcher current-pill marker (:744) + stale comment (:549)
- `useGuidModelSelection.ts` — default param (dead default; only caller passes explicit `providerAgentKey`; aligned for consistency)

Assistants that set an explicit `presetAgentType` keep theirs.

### Deliberately NOT changed
`useGuidSend.ts:201` `backend: 'gemini'` — although the issue listed it, it sits inside the confirmed **gemini execution branch** (guarded at :184, builds the gemini placeholder model). Its wcore counterpart at :376 handles wcore-resolved presets (traced: a preset resolving to `'wcore'` produces `selectedAgent='custom'` + `finalEffectiveAgentType='wcore'`, skips the gemini branch, hits :376). Changing :201 would build wcore params inside the gemini branch and break gemini sends — a regression. Left intact per the issue's own caution about legitimate provider-path refs.

### Verification
- `tsc --noEmit`: clean (exit 0)
- `oxlint` on changed files: 0 new warnings (2 pre-existing `no-unused-vars` in usePresetAssistantResolver unrelated to this change)
- `oxfmt --check`: clean
- **Cross-audit** (code-reviewer subagent): confirmed the 4 flips are correctly-scoped fallbacks, the `:201` skip is correct (traced the wcore branch is hit), the default-param change is safe — and **caught the GuidPage.tsx:744 site** which an initial hooks/-only pass had missed. Now included.
- LIVE fix-verification (open assistants, confirm dropdown shows Wayland Core by default) rides the next cut-candidate build in Sean's E2E pass — the running CDP app is the pre-fix cut candidate.

Refs #380. Overwatch to gate into integration/0.11.4.