### PR TITLE
fix(providers): bridge xAI Sign-in-with-X OAuth into the engine store so Grok chat stops 403ing (#379)

### DIFF
--- a/src/process/onboarding/xaiEngineAuthFile.ts
+++ b/src/process/onboarding/xaiEngineAuthFile.ts
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * The bridge between the desktop "Sign in with X (Grok)" OAuth flow and Wayland
+ * Core (the engine).
+ *
+ * #379: chatting with Grok returned `403 unauthenticated:bad-credentials` from
+ * `api.x.ai/v1/responses` despite a green "Signed in with X". Root cause: the
+ * engine's native `--provider xai` path only refreshes + presents a Grok OAuth
+ * bearer when refreshable credentials live in a store it reads — the engine's
+ * own `~/.wayland/oauth/xai.json` (which its `oauth/xai.rs` documents as
+ * "written by the Wayland app") or the Grok CLI's `~/.grok/auth.json`. Without
+ * either, the engine falls back to sending the raw, short-lived OAuth *access*
+ * token (registered as the `xai` provider key → injected as `XAI_API_KEY`)
+ * straight to `api.x.ai`, which rejects it (it expects either a real API key or
+ * a freshly-refreshed bearer) → 403.
+ *
+ * The desktop previously persisted the refresh token only to its own private
+ * cache (`xai-oauth.json`) + the model registry, never to the engine store. So
+ * after sign-in we WRITE `~/.wayland/oauth/xai.json` here — exactly mirroring
+ * how `writeCodexAuthFile` bridges the ChatGPT flow into `~/.codex/auth.json`
+ * (#243). The engine then owns refresh + presents a valid bearer to api.x.ai.
+ *
+ * Engine contract (read-only ref: `wcore-agent/src/oauth/storage.rs` +
+ * `oauth/flow.rs` `OAuthTokens`): `~/.wayland/oauth/{provider}.json` (or
+ * `$WAYLAND_HOME/oauth/...`) is `serde_json` of `OAuthTokens` —
+ * `access_token` (required), optional `refresh_token`, `expires_at_unix_secs`
+ * (epoch SECONDS), `token_type` (defaults "Bearer"), `scope`, `id_token`. The
+ * storage dir is created mode 0700; we write the file 0600.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { XAI_SCOPES, type XaiTokens } from './xaiOAuthCore';
+
+/** Engine OAuth provider id for xAI (matches `wcore-agent` `oauth::xai::PROVIDER`). */
+const XAI_ENGINE_PROVIDER = 'xai';
+
+/**
+ * Resolve the engine xAI OAuth store path: `$WAYLAND_HOME/oauth/xai.json`,
+ * default `~/.wayland/oauth/xai.json`. Mirrors the engine's
+ * `OAuthStorage` directory resolution so the desktop writes where the engine
+ * reads.
+ */
+export function xaiEngineAuthPath(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env.WAYLAND_HOME;
+  const waylandHome =
+    typeof override === 'string' && override.trim().length > 0 ? override.trim() : path.join(os.homedir(), '.wayland');
+  return path.join(waylandHome, 'oauth', `${XAI_ENGINE_PROVIDER}.json`);
+}
+
+/** The subset of the engine `OAuthTokens` document we write. */
+export type XaiEngineAuthDoc = {
+  access_token: string;
+  refresh_token?: string;
+  /** Epoch SECONDS (the engine's `expires_at_unix_secs`). XaiTokens.expiresAt is ms. */
+  expires_at_unix_secs?: number;
+  token_type: string;
+  scope?: string;
+};
+
+/** Build the engine `OAuthTokens` document from our token bundle. */
+export function buildXaiEngineAuthDoc(tokens: XaiTokens): XaiEngineAuthDoc {
+  const doc: XaiEngineAuthDoc = { access_token: tokens.accessToken, token_type: 'Bearer', scope: XAI_SCOPES };
+  if (tokens.refreshToken) doc.refresh_token = tokens.refreshToken;
+  if (typeof tokens.expiresAt === 'number' && Number.isFinite(tokens.expiresAt)) {
+    doc.expires_at_unix_secs = Math.floor(tokens.expiresAt / 1000);
+  }
+  return doc;
+}
+
+/**
+ * Write `~/.wayland/oauth/xai.json` (dir 0o700, file 0o600) so Wayland Core can
+ * read + refresh the Grok OAuth bearer instead of presenting the raw access
+ * token to api.x.ai. Atomic (temp + rename). Never throws — returns whether the
+ * write succeeded so the caller can log without failing sign-in.
+ */
+export async function writeXaiEngineAuthFile(
+  tokens: XaiTokens,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<boolean> {
+  try {
+    const file = xaiEngineAuthPath(env);
+    await fs.promises.mkdir(path.dirname(file), { recursive: true, mode: 0o700 });
+    const json = JSON.stringify(buildXaiEngineAuthDoc(tokens), null, 2);
+    const tmp = `${file}.tmp-${process.pid}`;
+    await fs.promises.writeFile(tmp, json, { mode: 0o600 });
+    await fs.promises.rename(tmp, file);
+    // rename preserves the temp file's mode, but chmod again defensively in case
+    // an existing target's perms lingered on some platforms.
+    await fs.promises.chmod(file, 0o600);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/process/onboarding/xaiOAuth.ts
+++ b/src/process/onboarding/xaiOAuth.ts
@@ -61,6 +61,7 @@ import {
   type XaiTokens,
 } from './xaiOAuthCore';
 import { loadXaiTokens, saveXaiTokens } from './xaiTokenStore';
+import { writeXaiEngineAuthFile } from './xaiEngineAuthFile';
 
 /** Registry provider id the obtained token is connected as. */
 const XAI_PROVIDER_ID: ProviderId = 'xai';
@@ -125,7 +126,10 @@ export async function xaiOAuthLogin(): Promise<XaiOAuthResult> {
       redirectUri,
       clientId,
     });
-    log.info('[xai] exchange result', { ok: !('error' in tokens), error: 'error' in tokens ? tokens.error : undefined });
+    log.info('[xai] exchange result', {
+      ok: !('error' in tokens),
+      error: 'error' in tokens ? tokens.error : undefined,
+    });
     if ('error' in tokens) return { ok: false, error: tokens.error };
 
     const result = await registerTokens(tokens, false);
@@ -273,7 +277,10 @@ function authorizeViaLoopback(
 
     const finish = (outcome: CallbackOutcome): void => {
       if (settled) return;
-      log.info('[xai] flow finish', { kind: outcome.kind, error: outcome.kind === 'error' ? outcome.error : undefined });
+      log.info('[xai] flow finish', {
+        kind: outcome.kind,
+        error: outcome.kind === 'error' ? outcome.error : undefined,
+      });
       settled = true;
       activeManualSubmit = null;
       if (timer) clearTimeout(timer);
@@ -382,10 +389,7 @@ async function refreshAccessToken(
 }
 
 /** POST a form-encoded token request and parse the response. Never throws. */
-async function postToken(
-  tokenUrl: string,
-  form: URLSearchParams
-): Promise<XaiTokens | { error: XaiOAuthError }> {
+async function postToken(tokenUrl: string, form: URLSearchParams): Promise<XaiTokens | { error: XaiOAuthError }> {
   let res: Response;
   try {
     res = await fetchWithTimeout(tokenUrl, {
@@ -426,6 +430,18 @@ async function postToken(
 async function registerTokens(tokens: XaiTokens, reused: boolean): Promise<XaiOAuthResult> {
   if (tokens.refreshToken) {
     await saveXaiTokens({ refreshToken: tokens.refreshToken, expiresAt: tokens.expiresAt });
+  }
+  // #379: bridge the OAuth credential into the engine's xAI OAuth store
+  // (~/.wayland/oauth/xai.json) so Wayland Core refreshes + presents a valid
+  // Grok bearer to api.x.ai, instead of falling back to the raw access token
+  // (→ 403 bad-credentials). Mirrors writeCodexAuthFile for ChatGPT (#243).
+  // Best-effort: a write failure is logged but must not fail an otherwise-good
+  // sign-in (the registry connect below is the user-facing success signal).
+  const wroteEngineStore = await writeXaiEngineAuthFile(tokens);
+  if (!wroteEngineStore) {
+    log.warn(
+      '[xai] failed to write engine OAuth store (~/.wayland/oauth/xai.json); Grok chat may 403 until next sign-in'
+    );
   }
   const connected = await connectModelRegistryProvider(XAI_PROVIDER_ID, { key: tokens.accessToken });
   if (!connected.ok) return { ok: false, error: narrowConnectError(connected.error) };

--- a/tests/unit/process/onboarding/xaiEngineAuthFile.test.ts
+++ b/tests/unit/process/onboarding/xaiEngineAuthFile.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  xaiEngineAuthPath,
+  buildXaiEngineAuthDoc,
+  writeXaiEngineAuthFile,
+} from '@/process/onboarding/xaiEngineAuthFile';
+import { XAI_SCOPES, type XaiTokens } from '@/process/onboarding/xaiOAuthCore';
+
+describe('xaiEngineAuthPath', () => {
+  it('defaults to ~/.wayland/oauth/xai.json', () => {
+    expect(xaiEngineAuthPath({})).toBe(path.join(os.homedir(), '.wayland', 'oauth', 'xai.json'));
+  });
+
+  it('honors $WAYLAND_HOME so the desktop writes where the engine reads', () => {
+    const home = path.join('/tmp', 'custom-wayland');
+    expect(xaiEngineAuthPath({ WAYLAND_HOME: home })).toBe(path.join(home, 'oauth', 'xai.json'));
+  });
+
+  it('ignores a blank $WAYLAND_HOME', () => {
+    expect(xaiEngineAuthPath({ WAYLAND_HOME: '   ' })).toBe(path.join(os.homedir(), '.wayland', 'oauth', 'xai.json'));
+  });
+});
+
+describe('buildXaiEngineAuthDoc', () => {
+  it('maps the token bundle onto the engine OAuthTokens shape (ms expiry → unix seconds)', () => {
+    const tokens: XaiTokens = { accessToken: 'acc', refreshToken: 'ref', expiresAt: 1_893_456_000_000 };
+    expect(buildXaiEngineAuthDoc(tokens)).toEqual({
+      access_token: 'acc',
+      refresh_token: 'ref',
+      expires_at_unix_secs: 1_893_456_000,
+      token_type: 'Bearer',
+      scope: XAI_SCOPES,
+    });
+  });
+
+  it('omits refresh_token and expires_at_unix_secs when the bundle lacks them', () => {
+    const doc = buildXaiEngineAuthDoc({ accessToken: 'acc' });
+    expect(doc).toEqual({ access_token: 'acc', token_type: 'Bearer', scope: XAI_SCOPES });
+    expect(doc.refresh_token).toBeUndefined();
+    expect(doc.expires_at_unix_secs).toBeUndefined();
+  });
+});
+
+describe('writeXaiEngineAuthFile', () => {
+  let dir: string;
+  let env: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wl-xai-'));
+    env = { WAYLAND_HOME: path.join(dir, '.wayland') };
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('writes ~/.wayland/oauth/xai.json (mode 0o600) with the engine schema', async () => {
+    const tokens: XaiTokens = { accessToken: 'acc', refreshToken: 'ref', expiresAt: 1_893_456_000_000 };
+    const ok = await writeXaiEngineAuthFile(tokens, env);
+    expect(ok).toBe(true);
+
+    const file = xaiEngineAuthPath(env);
+    expect(fs.existsSync(file)).toBe(true);
+    if (process.platform !== 'win32') {
+      expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+    }
+
+    const onDisk = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    expect(onDisk.access_token).toBe('acc');
+    expect(onDisk.refresh_token).toBe('ref');
+    expect(onDisk.expires_at_unix_secs).toBe(1_893_456_000);
+    expect(onDisk.token_type).toBe('Bearer');
+  });
+
+  it('returns false (never throws) when the target path cannot be written', async () => {
+    // Point WAYLAND_HOME at a FILE, so mkdir of the oauth dir underneath fails.
+    const filePath = path.join(dir, 'not-a-dir');
+    fs.writeFileSync(filePath, 'x');
+    const ok = await writeXaiEngineAuthFile({ accessToken: 'acc' }, { WAYLAND_HOME: filePath });
+    expect(ok).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #379.

## Symptom
Chatting with Grok returned `403 Forbidden: unauthenticated:bad-credentials: The OAuth2 access token could not be validated` from `https://api.x.ai/v1/responses`, **despite** Models settings showing a green "Signed in with X".

## Root cause (traced through desktop + engine)
The engine's native `--provider xai` path (`wayland-core` `bootstrap.rs` `xai_oauth_available()`) only refreshes + presents a Grok OAuth **bearer** to `api.x.ai` when refreshable credentials live in a store it reads:
- its own **`~/.wayland/oauth/xai.json`** — which `wcore-agent/src/oauth/xai.rs` documents as *"written by the Wayland app"*, or
- the Grok CLI's `~/.grok/auth.json`.

The desktop "Sign in with X" flow (`xaiOAuth.ts` `registerTokens`) persisted the refresh token only to its **private cache** (`xai-oauth.json`) and registered the **access token** in the model registry (→ injected as `XAI_API_KEY`). It wrote **neither** engine-readable store. So the engine never saw refreshable OAuth creds and fell back to sending the raw, short-lived OAuth **access** token straight to `api.x.ai` — which 403s once it expires. The sign-in-time registry connection probe succeeds (token still fresh), which is exactly why the check is green but chat later fails.

This is the **exact analog of the ChatGPT `writeCodexAuthFile` bridge (#243)** — that one exists; the xAI equivalent was simply missing.

## Fix
On sign-in / refresh / Grok-CLI-reuse, write `~/.wayland/oauth/xai.json` in the engine's `OAuthTokens` schema so Wayland Core owns refresh and presents a valid bearer:
- **new `src/process/onboarding/xaiEngineAuthFile.ts`** — path resolution honoring `$WAYLAND_HOME` (matches the engine's `OAuthStorage`), doc builder (`access_token` + `refresh_token` + `expires_at_unix_secs` (ms→unix-secs) + `token_type` + `scope`), atomic 0600 write, never throws.
- **wired into `registerTokens`** (single choke point for login, refresh, and CLI-reuse); best-effort with a warning log so a write failure never fails an otherwise-good sign-in.

## Tests
New `xaiEngineAuthFile.test.ts` (7): default path / `$WAYLAND_HOME` override / blank-ignored; doc mapping incl. ms→unix-secs and optional-field omission; write round-trip (0600) + the never-throws failure path.

## Verification
- `bun run typecheck` clean; `oxlint` / `oxfmt` clean; full **`prek`** green.
- Full unit suite: the only failures were two **pre-existing timing flakes** (`doctor/mcpChecksConcurrency`, `services/skills/skillLibrary` — wall-clock/concurrency assertions, non-deterministic across runs, unrelated to this onboarding change); both **pass in isolation** (27/27).

## ⚠️ Live-verification needed (cannot be done headless)
End-to-end confirmation (send a Grok message → real completion, no 403) requires a real signed-in X session; the OAuth browser flow can't run in automation. **Please verify on a clean launch:** sign in with X, then send a Grok Build message and confirm a completion with no 403. (Existing `~/.wayland/oauth/xai.json` will be (re)written on next sign-in/refresh.)