### PR TITLE
fix(providers): codex home picker uses connected chatgpt-subscription catalog (#374)

### DIFF
--- a/src/process/providers/ipc/modelRegistryIpc.ts
+++ b/src/process/providers/ipc/modelRegistryIpc.ts
@@ -121,11 +121,28 @@ const CLOUD_REQUIRED_FIELDS: Record<string, readonly string[]> = {
 /** The CLI agent keys, mirrored from `CliAgentSource`. */
 const CLI_AGENT_KEYS: ReadonlySet<string> = new Set<CliAgentKey>(['claude', 'codex', 'gemini']);
 
-/** The provider each CLI agent runs (used for the non-enumerable fallback). */
+/** The provider each CLI agent runs (used for the not-connected models.dev
+ * fallback - must be a models.dev-keyed provider). */
 const CLI_UNDERLYING_PROVIDER: Record<CliAgentKey, ProviderId> = {
   claude: 'anthropic',
   codex: 'openai',
   gemini: 'google-gemini',
+};
+
+/**
+ * OAuth/subscription providers a CLI may be authenticated through, BEYOND its
+ * primary `CLI_UNDERLYING_PROVIDER` API-key provider (#374). Codex authenticates
+ * via a ChatGPT subscription (`chatgpt-subscription`, OAuth) far more often than
+ * an `openai` API key, and that connection persists its OWN live Codex-backend
+ * catalog (`buildChatGptSubscriptionCatalogLive`). When one of these is
+ * connected the home picker must use its real catalog instead of synthesizing
+ * the (unconnected, therefore empty) API-key provider - the gap #377 missed,
+ * which made the Codex picker fall back to Flux-only for subscription users.
+ */
+const CLI_OAUTH_PROVIDERS: Record<CliAgentKey, ProviderId[]> = {
+  claude: [],
+  codex: [CHATGPT_SUBSCRIPTION_PROVIDER_ID],
+  gemini: [],
 };
 
 /**
@@ -1058,6 +1075,21 @@ export function createModelRegistryHandlers(deps: ModelRegistryDeps): ModelRegis
 
         if (CLI_AGENT_KEYS.has(agentKey)) {
           const cliKey = agentKey as CliAgentKey;
+
+          // A CLI may be authenticated via an OAuth subscription rather than an
+          // API key (Codex via a ChatGPT subscription -> `chatgpt-subscription`).
+          // That connection persists its own real, live-fetched catalog, so when
+          // it is connected prefer it over CLI enumeration / models.dev synthesis
+          // -> the subscription user sees their actual GPT models. This is the
+          // path #377 missed: a ChatGPT-subscription user has no `openai`
+          // provider connected, so synthesizing `openai` came back empty and the
+          // picker fell to Flux-only (#374 reopen).
+          for (const providerId of CLI_OAUTH_PROVIDERS[cliKey]) {
+            if (!repo.getRegistryProvider(providerId)) continue;
+            const connected = applyOverrides(providerId, curator.curate(repo.getRegistryCatalog(providerId)));
+            if (connected.length > 0) return connected;
+          }
+
           if (isEnumerableCliAgent(cliKey)) {
             // Enumerable CLI (Codex) - prefer its live CLI source. In a fresh
             // profile with no CLI installed / no cache this yields nothing; fall

--- a/tests/unit/process/providers/modelRegistryIpc.test.ts
+++ b/tests/unit/process/providers/modelRegistryIpc.test.ts
@@ -1403,6 +1403,97 @@ describe('modelRegistry IPC - curatedForAgent ACP backends (#374)', () => {
   });
 });
 
+describe('modelRegistry IPC - curatedForAgent codex via ChatGPT subscription (#374 reopen)', () => {
+  it('uses the connected chatgpt-subscription catalog for codex (not the empty openai synth)', async () => {
+    // The #377 gap: a ChatGPT-subscription user has no `openai` provider, so
+    // synthesizing `openai` returned empty and the picker fell to Flux-only.
+    const { deps, repo, cliListModels } = makeFakes();
+    cliListModels.mockResolvedValue([]); // no codex CLI installed
+    repo.upsertRegistryProvider({
+      providerId: 'chatgpt-subscription',
+      connectedVia: 'oauth',
+      state: 'connected',
+      creds: { key: 'tok' },
+    });
+    repo.replaceRegistryCatalog('chatgpt-subscription', [
+      catalogModel({ id: 'gpt-5.5', providerId: 'chatgpt-subscription' }),
+      catalogModel({ id: 'gpt-5.4', providerId: 'chatgpt-subscription' }),
+    ]);
+    const h = createModelRegistryHandlers(deps);
+
+    const ids = (await h.curatedForAgent({ agentKey: 'codex' })).map((m) => m.id).toSorted();
+
+    expect(ids).toEqual(['gpt-5.4', 'gpt-5.5']);
+  });
+
+  it('prefers the chatgpt-subscription catalog over codex CLI enumeration', async () => {
+    const { deps, repo, cliListModels } = makeFakes();
+    cliListModels.mockResolvedValue([{ id: 'gpt-5-codex', providerId: 'openai' }]); // CLI present
+    repo.upsertRegistryProvider({
+      providerId: 'chatgpt-subscription',
+      connectedVia: 'oauth',
+      state: 'connected',
+      creds: { key: 'tok' },
+    });
+    repo.replaceRegistryCatalog('chatgpt-subscription', [
+      catalogModel({ id: 'gpt-5.5', providerId: 'chatgpt-subscription' }),
+    ]);
+    const h = createModelRegistryHandlers(deps);
+
+    const ids = (await h.curatedForAgent({ agentKey: 'codex' })).map((m) => m.id);
+
+    expect(ids).toEqual(['gpt-5.5']);
+  });
+
+  it('falls through to CLI enumeration when chatgpt-subscription is connected but its catalog is empty', async () => {
+    const { deps, repo, cliListModels } = makeFakes();
+    cliListModels.mockResolvedValue([{ id: 'gpt-5-codex', providerId: 'openai' }]);
+    repo.upsertRegistryProvider({
+      providerId: 'chatgpt-subscription',
+      connectedVia: 'oauth',
+      state: 'connected',
+      creds: { key: 'tok' },
+    });
+    repo.replaceRegistryCatalog('chatgpt-subscription', []); // connected but no models persisted
+    const h = createModelRegistryHandlers(deps);
+
+    const ids = (await h.curatedForAgent({ agentKey: 'codex' })).map((m) => m.id);
+
+    expect(ids).toEqual(['gpt-5-codex']);
+  });
+
+  it('still serves the openai API-key catalog for codex when no subscription is connected (#377 path intact)', async () => {
+    const { deps, repo, cliListModels } = makeFakes();
+    cliListModels.mockResolvedValue([]); // no CLI
+    repo.upsertRegistryProvider({
+      providerId: 'openai',
+      connectedVia: 'api-key',
+      state: 'connected',
+      creds: { key: 'sk' },
+    });
+    repo.replaceRegistryCatalog('openai', [catalogModel({ id: 'gpt-4o', providerId: 'openai' })]);
+    const h = createModelRegistryHandlers(deps);
+
+    const ids = (await h.curatedForAgent({ agentKey: 'codex' })).map((m) => m.id);
+
+    expect(ids).toEqual(['gpt-4o']);
+  });
+
+  it('leaves claude unaffected by the codex OAuth-provider preference (empty OAuth list)', async () => {
+    const { deps, repo } = makeFakes();
+    repo.upsertRegistryProvider({
+      providerId: 'anthropic',
+      connectedVia: 'api-key',
+      state: 'connected',
+      creds: { key: 'k' },
+    });
+    repo.replaceRegistryCatalog('anthropic', [catalogModel({ id: 'claude-3-5', providerId: 'anthropic' })]);
+    const h = createModelRegistryHandlers(deps);
+
+    expect((await h.curatedForAgent({ agentKey: 'claude' })).map((m) => m.id)).toEqual(['claude-3-5']);
+  });
+});
+
 describe('modelRegistry IPC - defensive behavior', () => {
   beforeEach(() => {
     vi.restoreAllMocks();


### PR DESCRIPTION
## Summary

Follow-up to #377 (which was incomplete). Reopens/fixes #374 — the home **Default Model** picker showed **Codex Flux-only even with ChatGPT connected**.

**Root cause #377 missed:** `curatedForAgent('codex')` synthesized provider `openai`. But a ChatGPT-subscription user is connected as provider id **`chatgpt-subscription`** (OAuth), NOT `openai` — there is no `openai` provider connected, so the synthesis came back empty and the picker fell to Flux-only. #377 only covered the API-key path.

## Fix (surgical, backend-only)

- New `CLI_OAUTH_PROVIDERS` map (`codex → [chatgpt-subscription]`) in `modelRegistryIpc.ts`.
- `curatedForAgent`, for CLI agents, now FIRST prefers a connected OAuth/subscription provider's persisted (override-aware) catalog before CLI enumeration / models.dev synthesis.
- Every #377 path is unchanged (grok→xai, codex API-key, fresh-profile openai synth); only the subscription case is added. `claude`/`gemini` have empty OAuth lists → no behavior change.

**Code-proof:** `connectChatGptSubscriptionProvider` (`modelRegistryIpc.ts:2160`) **synchronously** writes the static GPT catalog (`buildChatGptSubscriptionCatalog` → gpt-5.5 / gpt-5.4 / gpt-5.4-mini / gpt-5.3-codex-spark) into the same `_repo` that `curatedForAgent` reads. So a connected `chatgpt-subscription` can never return empty now. `GuidModelSelector` already renders off `curatedForAgent` (the `showAcpFlux || acpModels.length > 0` gate).

## Automated checks (done)

- [x] `bunx tsc --noEmit` clean
- [x] `bun run lint` 0 errors
- [x] **5 new unit tests using the REAL `chatgpt-subscription` provider id** — closes the exact gap (fakes used `openai`) that fooled the prior two gatings. 93 pass.

## ⚠️ MANDATORY LIVE-VERIFY — handed to Overwatch (gate before merge)

Per the #374 reopen, unit/review proof is NOT sufficient — this must be confirmed in the running app on a **ChatGPT-subscription-connected profile** (the desktop agent cannot obtain real ChatGPT OAuth credentials autonomously). Overwatch to run/coordinate:

- [ ] Launch this branch (`cd /tmp/wt-374 && bun run start`, or build) on a profile where ChatGPT is connected ("Signed in with ChatGPT" green in Models settings).
- [ ] Home screen → select the **Codex** agent → open the **Default Model** picker.
- [ ] **PASS = the picker lists GPT models (gpt-5.5 / gpt-5.4 / …), not Flux-only.**

Do not merge until the live check passes.