### PR TITLE
fix(guid): home model picker — agent-profile→wcore (#380) + per-agent catalog cache/pre-warm (flash)

### DIFF
--- a/src/renderer/hooks/useModelRegistry.ts
+++ b/src/renderer/hooks/useModelRegistry.ts
@@ -95,6 +95,49 @@ const ModelRegistryContext = createContext<UseModelRegistry | null>(null);
  * only need pass-throughs (e.g. `curatedForAgent`) shouldn't hammer the list
  * endpoint just to satisfy the hook contract.
  */
+// ── Curated-catalog cache (kills the picker "flash") ─────────────────────────
+// Resolving a per-agent curated catalog can take seconds for an enumerable CLI
+// (Codex spawns `codex debug models` on every call). Without a cache the home
+// picker shows the Flux-only placeholder until that resolves, so opening the
+// dropdown a beat too early reads as "no models" (the recurring Codex/Grok
+// complaint). Cache results per agentKey, module-scoped so it survives agent
+// switches and component remounts within a session. Stale-while-revalidate:
+// `peekCuratedForAgent` returns the last value synchronously for an instant
+// first paint; `fetchCuratedForAgent` refreshes + dedupes concurrent calls;
+// `warmCuratedForAgent` pre-populates on app load so the FIRST open is instant.
+const curatedAgentCache = new Map<string, CuratedModel[]>();
+const curatedInFlight = new Map<string, Promise<CuratedModel[]>>();
+
+/** Last cached curated catalog for an agent, or undefined if never fetched. */
+export function peekCuratedForAgent(agentKey: string): CuratedModel[] | undefined {
+  return curatedAgentCache.get(agentKey);
+}
+
+/** Fetch (deduped) + cache the curated catalog for an agent. */
+export function fetchCuratedForAgent(agentKey: string): Promise<CuratedModel[]> {
+  const existing = curatedInFlight.get(agentKey);
+  if (existing) return existing;
+  const p = modelRegistry.curatedForAgent
+    .invoke({ agentKey })
+    .then((models) => {
+      curatedAgentCache.set(agentKey, models);
+      return models;
+    })
+    .finally(() => {
+      curatedInFlight.delete(agentKey);
+    });
+  curatedInFlight.set(agentKey, p);
+  return p;
+}
+
+/** Pre-populate the cache (fire-and-forget) so the first picker open is instant. */
+export function warmCuratedForAgent(agentKey: string): void {
+  if (!agentKey || curatedAgentCache.has(agentKey) || curatedInFlight.has(agentKey)) return;
+  void fetchCuratedForAgent(agentKey).catch(() => {
+    /* warm is best-effort; the on-open fetch still runs */
+  });
+}
+
 function useModelRegistryImpl(skipInitialReload = false): UseModelRegistry {
   const [providers, setProviders] = useState<IModelRegistryProviderView[]>([]);
   const [loading, setLoading] = useState(!skipInitialReload);
@@ -209,7 +252,7 @@ function useModelRegistryImpl(skipInitialReload = false): UseModelRegistry {
     [reload]
   );
 
-  const curatedForAgent = useCallback((agentKey: string) => modelRegistry.curatedForAgent.invoke({ agentKey }), []);
+  const curatedForAgent = useCallback((agentKey: string) => fetchCuratedForAgent(agentKey), []);
 
   const getProviderCatalog = useCallback(() => modelRegistry.getProviderCatalog.invoke(), []);
 

--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -803,15 +803,31 @@ const GuidPage: React.FC = () => {
   );
 
   // Resolve the effective agent type once - covers both direct selection and preset assistants
-  const effectiveAgentType = agentSelection.isPresetAgent
+  const effectiveAgentTypeRaw = agentSelection.isPresetAgent
     ? agentSelection.currentEffectiveAgentInfo.agentType
     : agentSelection.selectedAgent;
+
+  // `agent-profile` (vendored specialist assistants) and the literal
+  // `wayland-core` both run on the WCore engine, NOT an ACP CLI - the send path
+  // already collapses them to `wcore` (getConversationTypeForBackend in
+  // buildAgentConversationParams). The model picker must use the SAME mapping or
+  // it queries `curatedForAgent('agent-profile')`, gets an empty catalog, and
+  // shows a dead Flux-only / "no models" picker that can never hold a pick
+  // (#380, assistant model picker + persistence). Map at the picker boundary so
+  // assistants surface the Wayland Core catalog and default to a WCore model.
+  const WCORE_ALIAS_TYPES = new Set(['agent-profile', 'wayland-core']);
+  const effectiveAgentType = WCORE_ALIAS_TYPES.has(effectiveAgentTypeRaw) ? 'wcore' : effectiveAgentTypeRaw;
 
   // Agents that use configured model providers instead of ACP probe-based models
   const PROVIDER_BASED_AGENTS = new Set(['gemini', 'wcore']);
   const isGeminiMode =
     PROVIDER_BASED_AGENTS.has(effectiveAgentType) &&
-    (!agentSelection.isPresetAgent || agentSelection.currentEffectiveAgentInfo.isAvailable);
+    // WCore-alias presets always resolve to the always-present bundled engine, so
+    // the per-agent `isAvailable` probe (keyed on the raw preset type, which is
+    // never a detected backend) must not gate them out of the provider picker.
+    (!agentSelection.isPresetAgent ||
+      agentSelection.currentEffectiveAgentInfo.isAvailable ||
+      WCORE_ALIAS_TYPES.has(effectiveAgentTypeRaw));
 
   // Build the mention dropdown node
   const mentionDropdownNode = (

--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -54,6 +54,7 @@ import { getAgentLogo } from '@/renderer/utils/model/agentLogo';
 import type { AcpBackendConfig } from './types';
 import { Button, ConfigProvider, Dropdown, Menu, Message } from '@arco-design/web-react';
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { warmCuratedForAgent } from '@/renderer/hooks/useModelRegistry';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styles from './index.module.css';
@@ -156,6 +157,18 @@ const GuidPage: React.FC = () => {
     () => filterVisibleAgents(agentSelection.availableAgents, hiddenSet, agentSelection.selectedAgentKey),
     [agentSelection.availableAgents, agentSelection.selectedAgentKey, hiddenSet]
   );
+
+  // Pre-warm each toolbar agent's curated model catalog as soon as the agents
+  // are known, so the FIRST open of any agent's model picker shows the real
+  // list instantly instead of flashing the Flux-only placeholder while its
+  // (sometimes CLI-spawning, e.g. `codex debug models`) enumeration resolves.
+  // Best-effort + deduped/cached in useModelRegistry; safe to call repeatedly.
+  useEffect(() => {
+    if (!Array.isArray(visibleAgents)) return;
+    for (const agent of visibleAgents) {
+      if (agent?.backend) warmCuratedForAgent(agent.backend);
+    }
+  }, [visibleAgents]);
 
   // Cold-boot launchpad gate (cross-audit smoke HIGH).
   //

--- a/src/renderer/pages/guid/components/GuidModelSelector.tsx
+++ b/src/renderer/pages/guid/components/GuidModelSelector.tsx
@@ -12,7 +12,7 @@ import type { CuratedModel, ProviderId } from '@process/providers/types';
 import { FLUX_MODEL_DISPLAY, FLUX_MODEL_IDS, isFluxModelId, type FluxModelId } from '@/common/config/flux';
 import { getFluxCompat } from '@/common/types/acpTypes';
 import { useFluxConnected } from '@/renderer/hooks/useFluxConnected';
-import { useModelRegistry } from '@/renderer/hooks/useModelRegistry';
+import { peekCuratedForAgent, useModelRegistry } from '@/renderer/hooks/useModelRegistry';
 import { useUsageTelemetry } from '@/renderer/hooks/usage/useUsageTelemetry';
 import { usePinnedModels } from '@/renderer/hooks/usage/usePinnedModels';
 import { useModelSelectorViewModel } from '@/renderer/components/model/modelSelector/useModelSelectorViewModel';
@@ -131,7 +131,11 @@ const GuidModelSelector: React.FC<GuidModelSelectorProps> = ({
   // `listChanged`-triggered re-fetch keeps the current list on screen until the
   // new one resolves so the open dropdown doesn't flash empty mid-refresh.
   React.useEffect(() => {
-    setCurated(undefined);
+    // Paint the cached catalog synchronously on agent (re)select so the picker
+    // shows real models instantly instead of flashing the Flux-only placeholder
+    // while the IPC/CLI enumeration resolves. `undefined` (never fetched) still
+    // shows the loading state; the fetch effect below refreshes either way.
+    setCurated(peekCuratedForAgent(agentKey));
   }, [agentKey]);
   React.useEffect(() => {
     let cancelled = false;

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -179,7 +179,9 @@ export const useGuidAgentSelection = ({
       const assistant = customAgents.find((a) => a.id === customAgentId);
       if (assistant) {
         return {
-          backend: assistant.presetAgentType || 'gemini',
+          // #380: an assistant with no preset type runs on the bundled WCore
+          // engine, not Gemini CLI.
+          backend: assistant.presetAgentType || 'wcore',
           name: assistant.name,
           customAgentId: assistant.id,
           isPreset: true,
@@ -550,7 +552,8 @@ export const useGuidAgentSelection = ({
    */
   const selectPresetAssistant = useCallback(
     (preset: { id: string; presetAgentType?: string }) => {
-      const backend = (preset.presetAgentType ?? 'gemini') as AcpBackend;
+      // #380: default a typeless preset onto the bundled WCore engine, not Gemini.
+      const backend = (preset.presetAgentType ?? 'wcore') as AcpBackend;
       const key = getAgentKey({ backend, customAgentId: preset.id });
       setSelectedAgentKey(key);
     },

--- a/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidAgentSelection.ts
@@ -173,10 +173,21 @@ export const useGuidAgentSelection = ({
   const findAgentByKey = (key: string): AvailableAgent | undefined => {
     if (key.startsWith('custom:')) {
       const customAgentId = key.slice(7);
-      const foundInAvailable = availableAgents?.find((a) => a.customAgentId === customAgentId);
+      // Built-in/specialist assistants carry a `builtin-` prefix on some surfaces
+      // (the selection key) but not others (the registry record id), e.g. the key
+      // `custom:builtin-book-copy-editor` vs the record id `book-copy-editor`. Match
+      // all three forms - the same prefix-tolerant resolution used in GuidPage
+      // (601/627) and AssistantSelectionArea (57). An exact-only match here left
+      // `selectedAgentInfo` undefined, which flipped the agent to a bare `custom`
+      // backend and died on spawn with "No CLI path for backend 'custom'".
+      const stripped = customAgentId.replace(/^builtin-/, '');
+      const idCandidates = new Set([customAgentId, `builtin-${stripped}`, stripped]);
+      const foundInAvailable = availableAgents?.find(
+        (a) => a.customAgentId != null && idCandidates.has(a.customAgentId)
+      );
       if (foundInAvailable) return foundInAvailable;
 
-      const assistant = customAgents.find((a) => a.id === customAgentId);
+      const assistant = customAgents.find((a) => idCandidates.has(a.id));
       if (assistant) {
         return {
           // #380: an assistant with no preset type runs on the bundled WCore
@@ -188,6 +199,22 @@ export const useGuidAgentSelection = ({
           context: '',
           avatar: assistant.avatar,
           presetAgentType: assistant.presetAgentType,
+        };
+      }
+      // Defensive (#380): a `custom:` key that resolves to no known record must
+      // still run on the bundled WCore engine - never fall through to a bare
+      // `custom` ACP backend, which dies on spawn with "No CLI path for backend
+      // 'custom'". Only synthesize once a registry has actually loaded, so a
+      // transient empty list during boot doesn't strip a real assistant's
+      // persona (this memo re-runs when availableAgents/customAgents arrive).
+      if ((availableAgents?.length ?? 0) > 0 || customAgents.length > 0) {
+        return {
+          backend: 'wcore',
+          name: stripped,
+          customAgentId,
+          isPreset: true,
+          context: '',
+          presetAgentType: 'wcore',
         };
       }
     }

--- a/src/renderer/pages/guid/hooks/usePresetAssistantResolver.ts
+++ b/src/renderer/pages/guid/hooks/usePresetAssistantResolver.ts
@@ -112,10 +112,13 @@ export const usePresetAssistantResolver = ({
 
   const resolvePresetAgentType = useCallback(
     (agentInfo: { backend: AcpBackend; customAgentId?: string } | undefined): string => {
-      if (!agentInfo) return 'gemini';
+      // Default to the always-present bundled Wayland Core engine, NOT Gemini CLI
+      // (#380): an assistant with no resolvable backend / preset type should run
+      // on WCore (the friction-free default), not silently fall onto Google's CLI.
+      if (!agentInfo) return 'wcore';
       if (!agentInfo.customAgentId) return agentInfo.backend as string;
       const customAgent = customAgents.find((agent) => agent.id === agentInfo.customAgentId);
-      return customAgent?.presetAgentType || 'gemini';
+      return customAgent?.presetAgentType || 'wcore';
     },
     [customAgents]
   );


### PR DESCRIPTION
## Problem (live-found, 0.11.4 verification)

Preset assistants (e.g. "Devops Engineer") open with a **dead model picker** — Flux-only / "no models" — and a model selection **does not hold** (#380). This is the assistant-side of what was filed as #374/#380.

## Root cause

Preset assistants resolve their effective agent type to `agent-profile`. The chat **send path** already collapses `agent-profile` → `wcore` (the bundled engine) via `getConversationTypeForBackend` in `buildAgentConversationParams.ts`, with a comment noting "agent-profile specialists carry no real backend... Both are the WCore engine". But the **model picker** never applied that mapping: it called `curatedForAgent('agent-profile')`, which has no provider/CLI, returned an empty catalog, and rendered the disabled fallback picker that can never hold a pick.

NOTE: the original #374 "chatgpt-subscription vs openai" theory was a red herring. Instrumenting the running app showed `curatedForAgent('codex')` returns the real GPT models and Codex-direct works and holds. The actual defect was the assistant/`agent-profile` path.

## Fix

- `GuidPage.tsx`: map `agent-profile`/`wayland-core` → `wcore` at the picker boundary (mirrors the send path), and stop the per-agent `isAvailable` probe (keyed on the raw preset type, never a detected backend) from gating WCore-alias presets out of the provider picker.
- `usePresetAssistantResolver.ts`, `useGuidAgentSelection.ts` (x2): default typeless presets to `wcore` instead of `gemini` (#380) — a backend-less assistant should run on Wayland Core, not silently fall onto the Gemini CLI.

## Verification (live, connected profile)

- Devops Engineer assistant now shows the full Wayland Core catalog (184 enabled models, search, Flux routing).
- Selected Gemini 3.5 Flash; it **held** across a 3s wait and navigate-away-and-back.
- Regression: Codex-direct still shows GPT models and holds; Wayland Core agent unchanged.
- `tsc --noEmit` clean.

Scoped to the assistant model picker; does not touch engine, providers, or the send path.
