### PR TITLE
feat(thinking): render Flux reasoning_summary as the thinking-block subject (#318 desktop half)

### DIFF
--- a/src/process/agent/wcore/index.ts
+++ b/src/process/agent/wcore/index.ts
@@ -20,7 +20,7 @@ import type { WCoreEvent, WCoreCommand, WCoreCapabilities } from './protocol';
 
 const WCORE_PROJECT_CONFIG = '.wcore.toml';
 
-type StreamEventHandler = (event: { type: string; data: unknown; msg_id: string }) => void;
+type StreamEventHandler = (event: { type: string; data: unknown; msg_id: string; subject?: string }) => void;
 
 /**
  * Sanitize an existing `.wcore.toml` body and merge in the app's own provider
@@ -339,7 +339,7 @@ export class WCoreAgent {
         break;
 
       case 'thinking':
-        this.onStreamEvent({ type: 'thought', data: event.text, msg_id: event.msg_id });
+        this.onStreamEvent({ type: 'thought', data: event.text, msg_id: event.msg_id, subject: event.subject });
         break;
 
       case 'tool_request':

--- a/src/process/agent/wcore/protocol.ts
+++ b/src/process/agent/wcore/protocol.ts
@@ -98,7 +98,7 @@ export type WCoreEvent =
     }
   | { type: 'stream_start'; msg_id: string }
   | { type: 'text_delta'; text: string; msg_id: string }
-  | { type: 'thinking'; text: string; msg_id: string }
+  | { type: 'thinking'; text: string; msg_id: string; subject?: string }
   | {
       type: 'tool_request';
       msg_id: string;

--- a/src/process/task/WCoreManager.ts
+++ b/src/process/task/WCoreManager.ts
@@ -192,6 +192,9 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
    *  sending the full content every tick re-appended it and doubled the stored
    *  thought ("LetLet me think…"). */
   private lastFlushedThinkingLen = 0;
+  /** Per-turn reasoning subject (a short gerund phrase from the engine, #318).
+   *  Emitted once per reasoning turn; first one wins. Absent for non-reasoning turns. */
+  private thinkingSubject: string | undefined = undefined;
   private thinkingDbFlushTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly streamDbFlushIntervalMs: number = 120;
 
@@ -547,12 +550,18 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
     });
   }
 
-  private emitThinkingMessage(content: string, status: 'thinking' | 'done' = 'thinking'): void {
+  private emitThinkingMessage(content: string, status: 'thinking' | 'done' = 'thinking', subject?: string): void {
     if (!this.thinkingMsgId) {
       this.thinkingMsgId = uuid();
       this.thinkingStartTime = Date.now();
       this.thinkingContent = '';
       this.lastFlushedThinkingLen = 0;
+      this.thinkingSubject = undefined;
+    }
+
+    // First subject for this turn wins; the engine emits it once per turn (#318).
+    if (subject && !this.thinkingSubject) {
+      this.thinkingSubject = subject;
     }
 
     // The engine re-streams reasoning as cumulative restates, so emit/persist only
@@ -572,6 +581,7 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
       msg_id: this.thinkingMsgId,
       data: {
         content: delta,
+        subject: this.thinkingSubject,
         duration,
         status,
       },
@@ -603,6 +613,7 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
       conversation_id: this.conversation_id,
       content: {
         content: tail,
+        subject: this.thinkingSubject,
         duration,
         status,
       },
@@ -616,6 +627,7 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
     this.thinkingStartTime = null;
     this.thinkingContent = '';
     this.lastFlushedThinkingLen = 0;
+    this.thinkingSubject = undefined;
   }
 
   private queueBufferedStreamText(message: Extract<TMessage, { type: 'text' }>): void {
@@ -1074,12 +1086,16 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
         return;
       }
 
-      // Handle thought events - convert to thinking messages
+      // Handle thought events - convert to thinking messages.
+      // The engine emits an optional per-turn reasoning `subject` (a short gerund
+      // phrase) once, immediately before the first reasoning text. Thread it through
+      // so the live "Thinking" block header shows the model's own summary (#318).
       if (data.type === 'thought') {
         data.conversation_id = this.conversation_id;
         const content = typeof data.data === 'string' ? data.data : '';
-        if (content) {
-          this.emitThinkingMessage(content, 'thinking');
+        const subject = typeof data.subject === 'string' ? data.subject : undefined;
+        if (content || subject) {
+          this.emitThinkingMessage(content, 'thinking', subject);
         }
         return;
       }

--- a/src/process/task/WCoreManager.ts
+++ b/src/process/task/WCoreManager.ts
@@ -559,8 +559,10 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
       this.thinkingSubject = undefined;
     }
 
-    // First subject for this turn wins; the engine emits it once per turn (#318).
-    if (subject && !this.thinkingSubject) {
+    // Latest subject wins (#318 v2): Flux emits a generic header (Frame A) then a
+    // request-specific refinement (Frame B) within the same turn; replace in place
+    // so the refined subject upgrades the placeholder. Reset per turn (above).
+    if (subject) {
       this.thinkingSubject = subject;
     }
 

--- a/src/renderer/pages/conversation/Messages/MessageList.tsx
+++ b/src/renderer/pages/conversation/Messages/MessageList.tsx
@@ -488,6 +488,13 @@ const ConversationMessageList: React.FC<{
         const steps = toolSummaryToSteps(item.messages);
         return [...steps].reverse().find((s) => s.status === 'running')?.label;
       }
+      // #318: during the live reasoning phase (no tool activity yet) prefer the
+      // engine's own per-turn reasoning subject for the orbit footer; PHRASES stays
+      // the fallback for reasoning turns the engine gives no subject for.
+      if ('type' in item && item.type === 'thinking') {
+        const c = (item as TMessage & { type: 'thinking' }).content;
+        if (c.status !== 'done' && c.subject) return c.subject;
+      }
     }
     return undefined;
   }, [processedList, isProcessing]);

--- a/tests/unit/WCoreManagerThinking.test.ts
+++ b/tests/unit/WCoreManagerThinking.test.ts
@@ -439,6 +439,88 @@ describe('GAP-1: WCoreManager Thinking Message Display & Persistence', () => {
     });
   });
 
+  // ── #318: per-turn reasoning subject ────────────────────────────
+
+  describe('#318: reasoning subject flows from thought event to thinking message', () => {
+    it('threads the subject from a thought event into the thinking emission', () => {
+      emitEvent(manager, { type: 'start', data: '', msg_id: 'msg-1' });
+      emitEvent(manager, {
+        type: 'thought',
+        data: 'reasoning text',
+        msg_id: 'msg-1',
+        subject: 'Reasoning through the problem',
+      });
+
+      const thinkingEmissions = findEmissions('thinking');
+      expect(thinkingEmissions[0]).toMatchObject({
+        type: 'thinking',
+        data: expect.objectContaining({
+          content: 'reasoning text',
+          subject: 'Reasoning through the problem',
+          status: 'thinking',
+        }),
+      });
+    });
+
+    it('keeps the first subject across subsequent subject-less thought events', () => {
+      emitEvent(manager, { type: 'start', data: '', msg_id: 'msg-1' });
+      emitEvent(manager, { type: 'thought', data: 'a', msg_id: 'msg-1', subject: 'Analyzing inputs' });
+      emitEvent(manager, { type: 'thought', data: ' b', msg_id: 'msg-1' });
+
+      const thinkingEmissions = findEmissions('thinking');
+      // every emission for this turn carries the first subject
+      for (const e of thinkingEmissions as any[]) {
+        expect(e.data.subject).toBe('Analyzing inputs');
+      }
+    });
+
+    it('accepts a subject-only thought event (no reasoning text yet)', () => {
+      emitEvent(manager, { type: 'start', data: '', msg_id: 'msg-1' });
+      emitEvent(manager, { type: 'thought', data: '', msg_id: 'msg-1', subject: 'Planning the approach' });
+
+      const thinkingEmissions = findEmissions('thinking');
+      expect(thinkingEmissions.length).toBeGreaterThanOrEqual(1);
+      expect(thinkingEmissions[0].data.subject).toBe('Planning the approach');
+    });
+
+    it('persists the subject to the DB thinking message', () => {
+      emitEvent(manager, { type: 'start', data: '', msg_id: 'msg-1' });
+      emitEvent(manager, { type: 'thought', data: 'reasoning', msg_id: 'msg-1', subject: 'Synthesizing' });
+      emitEvent(manager, { type: 'content', data: 'response', msg_id: 'msg-1' });
+
+      expect(mockAddOrUpdateMessage).toHaveBeenCalledWith(
+        'conv-think-1',
+        expect.objectContaining({
+          type: 'thinking',
+          content: expect.objectContaining({ subject: 'Synthesizing' }),
+        }),
+        'wcore'
+      );
+    });
+
+    it('leaves subject undefined for a reasoning turn with no subject (no regression)', () => {
+      emitEvent(manager, { type: 'start', data: '', msg_id: 'msg-1' });
+      emitEvent(manager, { type: 'thought', data: 'reasoning', msg_id: 'msg-1' });
+
+      const thinkingEmissions = findEmissions('thinking');
+      expect(thinkingEmissions[0].data.subject).toBeUndefined();
+    });
+
+    it('resets subject between turns', () => {
+      emitEvent(manager, { type: 'start', data: '', msg_id: 'msg-1' });
+      emitEvent(manager, { type: 'thought', data: 't1', msg_id: 'msg-1', subject: 'First subject' });
+      emitEvent(manager, { type: 'finish', data: '', msg_id: 'msg-1' });
+
+      vi.clearAllMocks();
+
+      emitEvent(manager, { type: 'start', data: '', msg_id: 'msg-2' });
+      emitEvent(manager, { type: 'thought', data: 't2', msg_id: 'msg-2' });
+
+      const thinkingEmissions = findEmissions('thinking');
+      expect(thinkingEmissions[0].data.subject).toBeUndefined();
+    });
+  });
+
   // ── White-box: boundary cases ───────────────────────────────────
 
   describe('Edge cases', () => {

--- a/tests/unit/WCoreManagerThinking.test.ts
+++ b/tests/unit/WCoreManagerThinking.test.ts
@@ -462,16 +462,23 @@ describe('GAP-1: WCoreManager Thinking Message Display & Persistence', () => {
       });
     });
 
-    it('keeps the first subject across subsequent subject-less thought events', () => {
+    it('upgrades to the latest subject within a turn, then preserves it (v2 placeholder-then-refine)', () => {
       emitEvent(manager, { type: 'start', data: '', msg_id: 'msg-1' });
-      emitEvent(manager, { type: 'thought', data: 'a', msg_id: 'msg-1', subject: 'Analyzing inputs' });
-      emitEvent(manager, { type: 'thought', data: ' b', msg_id: 'msg-1' });
+      // Frame A: generic placeholder.
+      emitEvent(manager, { type: 'thought', data: 'a', msg_id: 'msg-1', subject: 'Planning the approach' });
+      // Frame B (a beat later): request-specific refinement REPLACES the placeholder.
+      emitEvent(manager, {
+        type: 'thought',
+        data: ' b',
+        msg_id: 'msg-1',
+        subject: 'Analyzing query performance regression',
+      });
+      // Subsequent subject-less thought events preserve the latest subject.
+      emitEvent(manager, { type: 'thought', data: ' c', msg_id: 'msg-1' });
 
-      const thinkingEmissions = findEmissions('thinking');
-      // every emission for this turn carries the first subject
-      for (const e of thinkingEmissions as any[]) {
-        expect(e.data.subject).toBe('Analyzing inputs');
-      }
+      const thinkingEmissions = findEmissions('thinking') as any[];
+      const last = thinkingEmissions[thinkingEmissions.length - 1];
+      expect(last.data.subject).toBe('Analyzing query performance regression');
     });
 
     it('accepts a subject-only thought event (no reasoning text yet)', () => {


### PR DESCRIPTION
Desktop half of #318. Threads the per-turn reasoning subject from the wcore stdio thinking event (subject field) through WCoreManager into the thinking message; MessageThinking renders it as the live header (subject || 'Thinking…'), collapsing to 'Thought for Ns'. Inert/forward-compatible until the engine ships the #318 decode (wayland-core 0.12.12) — when subject is absent (today, 0.12.10), behavior is unchanged. Typecheck clean; 72 unit tests pass. Cross-audit in progress; e2e verification pends the Flux reasoning_summary fix.