### PR TITLE
fix(providers): single xAI refresher (#391) + de-noise WCore approval log (#390)

### DIFF
--- a/src/process/onboarding/xaiEngineAuthFile.ts
+++ b/src/process/onboarding/xaiEngineAuthFile.ts
@@ -50,8 +50,15 @@ const XAI_ENGINE_PROVIDER = 'xai';
  */
 export function xaiEngineAuthPath(env: NodeJS.ProcessEnv = process.env): string {
   const override = env.WAYLAND_HOME;
+  // The engine (`OAuthStorage`) reads `$WAYLAND_HOME` verbatim — it does NOT trim.
+  // The desktop previously trimmed the VALUE, so a var carrying surrounding
+  // whitespace (e.g. ` /Users/x/.wayland ` from a shell export) resolved a
+  // different dir than the engine and each wrote/read a different file (#391).
+  // Fix: use the RAW value (no trim) so we match the engine on surrounding
+  // whitespace — but still treat a blank/whitespace-only value as unset and fall
+  // back to the default (a whitespace-only home is a misconfig, not a real dir).
   const waylandHome =
-    typeof override === 'string' && override.trim().length > 0 ? override.trim() : path.join(os.homedir(), '.wayland');
+    typeof override === 'string' && override.trim().length > 0 ? override : path.join(os.homedir(), '.wayland');
   return path.join(waylandHome, 'oauth', `${XAI_ENGINE_PROVIDER}.json`);
 }
 
@@ -85,11 +92,11 @@ export async function writeXaiEngineAuthFile(
   tokens: XaiTokens,
   env: NodeJS.ProcessEnv = process.env
 ): Promise<boolean> {
+  const file = xaiEngineAuthPath(env);
+  const tmp = `${file}.tmp-${process.pid}`;
   try {
-    const file = xaiEngineAuthPath(env);
     await fs.promises.mkdir(path.dirname(file), { recursive: true, mode: 0o700 });
     const json = JSON.stringify(buildXaiEngineAuthDoc(tokens), null, 2);
-    const tmp = `${file}.tmp-${process.pid}`;
     await fs.promises.writeFile(tmp, json, { mode: 0o600 });
     await fs.promises.rename(tmp, file);
     // rename preserves the temp file's mode, but chmod again defensively in case
@@ -97,6 +104,45 @@ export async function writeXaiEngineAuthFile(
     await fs.promises.chmod(file, 0o600);
     return true;
   } catch {
+    // Best-effort cleanup: a failed write (e.g. rename after a successful
+    // writeFile) must not litter the oauth dir with a stale `.tmp-<pid>` (#391).
+    await fs.promises.rm(tmp, { force: true }).catch(() => {});
     return false;
+  }
+}
+
+/** The engine-stored token bundle, normalized back onto our desktop shape. */
+export type XaiEngineStoredTokens = {
+  accessToken: string;
+  refreshToken?: string;
+  /** Epoch ms (converted from the engine's `expires_at_unix_secs`). */
+  expiresAt?: number;
+};
+
+/**
+ * Read `~/.wayland/oauth/xai.json` (the engine-owned store) back into our token
+ * shape. The engine refreshes the single-use rotating xAI token and persists the
+ * rotated bundle here, so this is how the desktop sees the *current* credential
+ * instead of refreshing independently and burning the engine's token (#391).
+ * Returns `null` when the file is missing, malformed, or holds no access token.
+ * Never throws.
+ */
+export async function readXaiEngineAuthFile(
+  env: NodeJS.ProcessEnv = process.env
+): Promise<XaiEngineStoredTokens | null> {
+  try {
+    const raw = await fs.promises.readFile(xaiEngineAuthPath(env), 'utf-8');
+    const doc = JSON.parse(raw) as Partial<XaiEngineAuthDoc>;
+    if (!doc || typeof doc.access_token !== 'string' || doc.access_token.length === 0) return null;
+    const tokens: XaiEngineStoredTokens = { accessToken: doc.access_token };
+    if (typeof doc.refresh_token === 'string' && doc.refresh_token.length > 0) {
+      tokens.refreshToken = doc.refresh_token;
+    }
+    if (typeof doc.expires_at_unix_secs === 'number' && Number.isFinite(doc.expires_at_unix_secs)) {
+      tokens.expiresAt = doc.expires_at_unix_secs * 1000;
+    }
+    return tokens;
+  } catch {
+    return null;
   }
 }

--- a/src/process/onboarding/xaiOAuth.ts
+++ b/src/process/onboarding/xaiOAuth.ts
@@ -61,7 +61,7 @@ import {
   type XaiTokens,
 } from './xaiOAuthCore';
 import { loadXaiTokens, saveXaiTokens } from './xaiTokenStore';
-import { writeXaiEngineAuthFile } from './xaiEngineAuthFile';
+import { readXaiEngineAuthFile, writeXaiEngineAuthFile } from './xaiEngineAuthFile';
 
 /** Registry provider id the obtained token is connected as. */
 const XAI_PROVIDER_ID: ProviderId = 'xai';
@@ -148,16 +148,36 @@ export async function xaiOAuthLogin(): Promise<XaiOAuthResult> {
  */
 export async function xaiRefreshToken(): Promise<XaiOAuthResult> {
   try {
+    // #391: Wayland Core (the engine) is the single owner + sole refresher of the
+    // single-use rotating xAI refresh token once its OAuth store exists. xAI burns
+    // the refresh token on every use, so a second, independent desktop refresh
+    // would POST a token the engine had already rotated → 401 → a needless
+    // re-login. Prefer the engine-rotated bundle: if the engine store holds a
+    // still-valid bearer, re-register THAT rather than refreshing here.
+    const engine = await readXaiEngineAuthFile();
+    if (engine) {
+      const engineTokens: XaiTokens = {
+        accessToken: engine.accessToken,
+        refreshToken: engine.refreshToken,
+        expiresAt: engine.expiresAt,
+      };
+      if (!isTokenExpired(engineTokens)) return await registerTokens(engineTokens, false);
+    }
+
+    // The engine bearer is missing/expired. Use the engine's (possibly rotated)
+    // refresh token in preference to the desktop's private copy, which the engine
+    // may already have burned.
     const stored = await loadXaiTokens();
-    if (!stored?.refreshToken) return { ok: false, error: 'unauthorized' };
+    const refreshToken = engine?.refreshToken ?? stored?.refreshToken;
+    if (!refreshToken) return { ok: false, error: 'unauthorized' };
 
     const endpoints = await fetchXaiEndpoints();
     const clientId = resolveClientId();
-    const tokens = await refreshAccessToken(endpoints.tokenUrl, stored.refreshToken, clientId);
+    const tokens = await refreshAccessToken(endpoints.tokenUrl, refreshToken, clientId);
     if ('error' in tokens) return { ok: false, error: tokens.error };
 
     // A refresh response may omit a new refresh_token; carry the old one forward.
-    if (!tokens.refreshToken) tokens.refreshToken = stored.refreshToken;
+    if (!tokens.refreshToken) tokens.refreshToken = refreshToken;
     return await registerTokens(tokens, false);
   } catch {
     return { ok: false, error: 'unknown' };
@@ -437,11 +457,20 @@ async function registerTokens(tokens: XaiTokens, reused: boolean): Promise<XaiOA
   // (→ 403 bad-credentials). Mirrors writeCodexAuthFile for ChatGPT (#243).
   // Best-effort: a write failure is logged but must not fail an otherwise-good
   // sign-in (the registry connect below is the user-facing success signal).
-  const wroteEngineStore = await writeXaiEngineAuthFile(tokens);
-  if (!wroteEngineStore) {
-    log.warn(
-      '[xai] failed to write engine OAuth store (~/.wayland/oauth/xai.json); Grok chat may 403 until next sign-in'
-    );
+  //
+  // #391: only write when we actually hold a refresh token. On the Grok-CLI
+  // reuse path a credential may carry an access token but no refresh token;
+  // writing an access-only doc here would SHADOW a refresh-token-bearing
+  // ~/.grok/auth.json the engine would otherwise read, leaving the engine unable
+  // to refresh (→ 403 once the short-lived access token expires). With no refresh
+  // token, let the engine read the CLI store directly.
+  if (tokens.refreshToken) {
+    const wroteEngineStore = await writeXaiEngineAuthFile(tokens);
+    if (!wroteEngineStore) {
+      log.warn(
+        '[xai] failed to write engine OAuth store (~/.wayland/oauth/xai.json); Grok chat may 403 until next sign-in'
+      );
+    }
   }
   const connected = await connectModelRegistryProvider(XAI_PROVIDER_ID, { key: tokens.accessToken });
   if (!connected.ok) return { ok: false, error: narrowConnectError(connected.error) };

--- a/src/process/task/WCoreManager.ts
+++ b/src/process/task/WCoreManager.ts
@@ -1003,15 +1003,33 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
         if (appr.resumeToken && (autoMode || appr.reason === 'info')) {
           this.agent?.resumeApproval(appr.resumeToken, true);
         } else if (appr.reason && appr.reason !== 'info') {
-          // Did not (could not) auto-resume a non-info approval: the engine is
-          // genuinely gated on a resume the app can't send (no resume token, or
-          // a real approval in a non-auto mode with no HITL UI yet). Log loudly
-          // so a wedged turn is diagnosable rather than silently hung. (#264)
-          mainError(
-            '[WCoreManager]',
-            `approval_required reason='${appr.reason}' but no approval UI; cannot resume`,
-            data.data
-          );
+          // A non-info approval we did not auto-resume. Whether that is a problem
+          // depends on the mode:
+          //
+          // - Interactive (non-auto) mode: EXPECTED. The renderer tool-confirmation
+          //   gate (the `Confirming` tool_group path above) prompts the user and
+          //   drives the resume; this `approval_required` is the engine's parallel
+          //   signal, not a dropped approval. A normal exec/mcp approval legitimately
+          //   carries no resume token here, so the old error (and a resume-token
+          //   check) fired on every exec approval and falsely read as a failure
+          //   (#390). Keep only a quiet trace for diagnosability.
+          //
+          // - Auto mode (Autopilot/Auto Edit): the engine was supposed to
+          //   self-resolve but we could not (no resume token, or a non-info reason
+          //   the auto path can't satisfy) and there is no HITL UI to fall back on,
+          //   so the turn can genuinely wedge (#264). That is the real error.
+          if (autoMode) {
+            mainError(
+              '[WCoreManager]',
+              `approval_required reason='${appr.reason}' in auto mode could not self-resume and has no HITL UI; turn may wedge`,
+              data.data
+            );
+          } else {
+            mainLog(
+              '[WCoreManager]',
+              `approval_required reason='${appr.reason}': renderer confirmation gate owns this approval`
+            );
+          }
         }
         return;
       }

--- a/tests/unit/WCoreManagerEventBus.test.ts
+++ b/tests/unit/WCoreManagerEventBus.test.ts
@@ -19,6 +19,7 @@ const {
   mockChannelEmitAgentMessage,
   mockAddOrUpdateMessage,
   mockMainError,
+  mockMainLog,
 } = vi.hoisted(() => ({
   emitResponseStream: vi.fn(),
   emitConfirmationAdd: vi.fn(),
@@ -26,6 +27,7 @@ const {
   emitConfirmationRemove: vi.fn(),
   mockAddOrUpdateMessage: vi.fn(),
   mockMainError: vi.fn(),
+  mockMainLog: vi.fn(),
   mockDb: {
     getConversationMessages: vi.fn(() => ({ data: [] })),
     getConversation: vi.fn(() => ({ success: false })),
@@ -111,7 +113,7 @@ vi.mock('@/renderer/utils/common', () => {
 
 vi.mock('@process/utils/mainLogger', () => ({
   mainError: mockMainError,
-  mainLog: vi.fn(),
+  mainLog: mockMainLog,
   mainWarn: vi.fn(),
 }));
 
@@ -460,8 +462,8 @@ describe('GAP-8: WCoreManager Multi EventBus Emission', () => {
       emitEvent(manager, { type: 'start', data: '', msg_id: 'msg-1' });
       emitEvent(manager, { type: 'approval_required', data: { callId: 'c1', reason: 'info' }, msg_id: 'msg-1' });
 
-      const unsupportedWarn = warnSpy.mock.calls.find(([msg]: [unknown]) =>
-        typeof msg === 'string' && msg.includes("Unsupported message type 'approval_required'")
+      const unsupportedWarn = warnSpy.mock.calls.find(
+        ([msg]: [unknown]) => typeof msg === 'string' && msg.includes("Unsupported message type 'approval_required'")
       );
       expect(unsupportedWarn).toBeUndefined();
 
@@ -470,7 +472,12 @@ describe('GAP-8: WCoreManager Multi EventBus Emission', () => {
       expect(mockAddOrUpdateMessage).not.toHaveBeenCalled();
     });
 
-    it('logs loudly (mainError) when reason is NOT info — a real gate the app cannot resume', () => {
+    it('interactive mode: quiet info (renderer confirmation gate owns it), NOT a loud error (#390)', () => {
+      // Default (non-auto) mode. A non-info approval without a resume token is the
+      // normal exec/mcp case: the renderer tool-confirmation gate prompts the user
+      // and resumes the turn. The old build logged this as a loud mainError on
+      // every exec approval, falsely reading as a dropped approval (#390).
+      (manager as any).currentMode = 'default';
       emitEvent(manager, { type: 'start', data: '', msg_id: 'msg-1' });
       emitEvent(manager, {
         type: 'approval_required',
@@ -478,12 +485,42 @@ describe('GAP-8: WCoreManager Multi EventBus Emission', () => {
         msg_id: 'msg-1',
       });
 
-      const goneLoud = mockMainError.mock.calls.find(([, msg]: [unknown, unknown]) =>
-        typeof msg === 'string' && msg.includes("reason='destructive_operation'")
+      const quiet = mockMainLog.mock.calls.find(
+        ([, msg]: [unknown, unknown]) =>
+          typeof msg === 'string' &&
+          msg.includes("reason='destructive_operation'") &&
+          msg.includes('renderer confirmation gate')
+      );
+      expect(quiet).toBeDefined();
+      // It must NOT loud-error in interactive mode.
+      const loud = mockMainError.mock.calls.find(
+        ([, msg]: [unknown, unknown]) => typeof msg === 'string' && msg.includes("reason='destructive_operation'")
+      );
+      expect(loud).toBeUndefined();
+
+      // Still consumed (handled by the renderer gate), not persisted.
+      expect(findIpcEmissions('approval_required')).toHaveLength(0);
+      expect(mockAddOrUpdateMessage).not.toHaveBeenCalled();
+    });
+
+    it('auto mode: loud error when a non-info approval cannot self-resume (real wedge, #264)', () => {
+      // In Autopilot/Auto-Edit the engine was supposed to self-resolve but could
+      // not (no resume token) and there is no HITL UI to fall back on, so the turn
+      // can genuinely wedge — that stays a loud mainError.
+      (manager as any).currentMode = 'yolo';
+      emitEvent(manager, { type: 'start', data: '', msg_id: 'msg-1' });
+      emitEvent(manager, {
+        type: 'approval_required',
+        data: { callId: 'c1', reason: 'destructive_operation' },
+        msg_id: 'msg-1',
+      });
+
+      const goneLoud = mockMainError.mock.calls.find(
+        ([, msg]: [unknown, unknown]) =>
+          typeof msg === 'string' && msg.includes("reason='destructive_operation'") && msg.includes('auto mode')
       );
       expect(goneLoud).toBeDefined();
 
-      // Still consumed (no UI/resume path exists), not persisted.
       expect(findIpcEmissions('approval_required')).toHaveLength(0);
       expect(mockAddOrUpdateMessage).not.toHaveBeenCalled();
     });

--- a/tests/unit/onboarding/xaiEngineAuthFile.test.ts
+++ b/tests/unit/onboarding/xaiEngineAuthFile.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  readXaiEngineAuthFile,
+  writeXaiEngineAuthFile,
+  xaiEngineAuthPath,
+} from '@process/onboarding/xaiEngineAuthFile';
+import type { XaiTokens } from '@process/onboarding/xaiOAuthCore';
+
+// A scratch WAYLAND_HOME per test so the real fs round-trips without touching
+// the user's ~/.wayland. Each function takes an explicit `env` override.
+let home = '';
+const env = (): NodeJS.ProcessEnv => ({ WAYLAND_HOME: home }) as NodeJS.ProcessEnv;
+
+beforeEach(async () => {
+  home = await fs.mkdtemp(path.join(os.tmpdir(), 'xai-engine-'));
+});
+
+afterEach(async () => {
+  await fs.rm(home, { recursive: true, force: true }).catch(() => {});
+});
+
+describe('xaiEngineAuthPath (#391 WAYLAND_HOME parity with the engine)', () => {
+  it('uses $WAYLAND_HOME verbatim — does NOT trim surrounding whitespace (matches the engine)', () => {
+    const raw = ' /tmp/spaced ';
+    expect(xaiEngineAuthPath({ WAYLAND_HOME: raw } as NodeJS.ProcessEnv)).toBe(path.join(raw, 'oauth', 'xai.json'));
+  });
+
+  it('falls back to ~/.wayland when WAYLAND_HOME is absent or empty', () => {
+    const def = path.join(os.homedir(), '.wayland', 'oauth', 'xai.json');
+    expect(xaiEngineAuthPath({} as NodeJS.ProcessEnv)).toBe(def);
+    expect(xaiEngineAuthPath({ WAYLAND_HOME: '' } as NodeJS.ProcessEnv)).toBe(def);
+  });
+});
+
+describe('writeXaiEngineAuthFile / readXaiEngineAuthFile round-trip (#391)', () => {
+  it('writes the engine doc and reads it back into our token shape', async () => {
+    const expiresAt = 1_900_000_000_000; // round ms → no sub-second loss
+    const tokens: XaiTokens = { accessToken: 'acc-1', refreshToken: 'ref-1', expiresAt };
+
+    expect(await writeXaiEngineAuthFile(tokens, env())).toBe(true);
+
+    const back = await readXaiEngineAuthFile(env());
+    expect(back).toEqual({ accessToken: 'acc-1', refreshToken: 'ref-1', expiresAt });
+  });
+
+  it('persists the engine contract (snake_case + epoch SECONDS) on disk', async () => {
+    await writeXaiEngineAuthFile({ accessToken: 'acc', refreshToken: 'ref', expiresAt: 2_000_000_000_000 }, env());
+    const onDisk = JSON.parse(await fs.readFile(xaiEngineAuthPath(env()), 'utf-8'));
+    expect(onDisk.access_token).toBe('acc');
+    expect(onDisk.refresh_token).toBe('ref');
+    expect(onDisk.expires_at_unix_secs).toBe(2_000_000_000); // ms / 1000
+    expect(onDisk.token_type).toBe('Bearer');
+  });
+
+  it('reads back an access-only doc (no refresh token / no expiry)', async () => {
+    await writeXaiEngineAuthFile({ accessToken: 'acc-only' }, env());
+    expect(await readXaiEngineAuthFile(env())).toEqual({ accessToken: 'acc-only' });
+  });
+});
+
+describe('readXaiEngineAuthFile defensiveness (#391)', () => {
+  it('returns null when the file is missing', async () => {
+    expect(await readXaiEngineAuthFile(env())).toBeNull();
+  });
+
+  it('returns null on malformed JSON', async () => {
+    const file = xaiEngineAuthPath(env());
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    await fs.writeFile(file, 'not json');
+    expect(await readXaiEngineAuthFile(env())).toBeNull();
+  });
+
+  it('returns null when the doc has no access_token', async () => {
+    const file = xaiEngineAuthPath(env());
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    await fs.writeFile(file, JSON.stringify({ refresh_token: 'r' }));
+    expect(await readXaiEngineAuthFile(env())).toBeNull();
+  });
+});
+
+describe('writeXaiEngineAuthFile failure handling (#391)', () => {
+  it('returns false and leaves no stray .tmp file when the rename target cannot be written', async () => {
+    // Pre-create the destination path AS A DIRECTORY so the final `rename(tmp →
+    // file)` fails after the temp file is written — exercising the catch/cleanup.
+    const file = xaiEngineAuthPath(env());
+    await fs.mkdir(file, { recursive: true });
+
+    expect(await writeXaiEngineAuthFile({ accessToken: 'acc', refreshToken: 'ref' }, env())).toBe(false);
+
+    const oauthDir = path.dirname(file);
+    const leftovers = (await fs.readdir(oauthDir)).filter((n) => n.includes('.tmp-'));
+    expect(leftovers).toEqual([]);
+  });
+});

--- a/tests/unit/onboarding/xaiRefreshPrefersEngine.test.ts
+++ b/tests/unit/onboarding/xaiRefreshPrefersEngine.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// #391: the engine (Wayland Core) is the single refresher of the single-use
+// rotating xAI token. These tests assert `xaiRefreshToken` defers to the
+// engine-rotated bundle instead of independently POSTing (which would burn the
+// engine's token → 401). The registry/engine/store deps are mocked; the real
+// network is asserted to be untouched on the happy path.
+const connectMock = vi.fn();
+const readEngineMock = vi.fn();
+const writeEngineMock = vi.fn();
+const loadStoreMock = vi.fn();
+const saveStoreMock = vi.fn();
+
+vi.mock('@process/providers/ipc/modelRegistryIpc', () => ({
+  connectModelRegistryProvider: (...args: unknown[]) => connectMock(...args),
+}));
+vi.mock('@process/onboarding/xaiEngineAuthFile', () => ({
+  readXaiEngineAuthFile: (...args: unknown[]) => readEngineMock(...args),
+  writeXaiEngineAuthFile: (...args: unknown[]) => writeEngineMock(...args),
+}));
+vi.mock('@process/onboarding/xaiTokenStore', () => ({
+  loadXaiTokens: (...args: unknown[]) => loadStoreMock(...args),
+  saveXaiTokens: (...args: unknown[]) => saveStoreMock(...args),
+}));
+vi.mock('electron', () => ({ shell: { openExternal: vi.fn() } }));
+vi.mock('electron-log', () => ({ default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+
+import { xaiRefreshToken } from '@process/onboarding/xaiOAuth';
+
+const NOW = 1_900_000_000_000;
+let fetchSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  connectMock.mockReset().mockResolvedValue({ ok: true });
+  readEngineMock.mockReset().mockResolvedValue(null);
+  writeEngineMock.mockReset().mockResolvedValue(true);
+  loadStoreMock.mockReset().mockResolvedValue(null);
+  saveStoreMock.mockReset().mockResolvedValue(undefined);
+  vi.spyOn(Date, 'now').mockReturnValue(NOW);
+  // Any real network call on the happy path is a bug — fail loudly if it fires.
+  fetchSpy = vi.fn(() => Promise.reject(new Error('network must not be called')));
+  vi.stubGlobal('fetch', fetchSpy);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('xaiRefreshToken prefers the engine-rotated token (#391)', () => {
+  it('re-registers the engine access token without any independent refresh when it is still valid', async () => {
+    readEngineMock.mockResolvedValue({
+      accessToken: 'engine-acc',
+      refreshToken: 'engine-ref',
+      expiresAt: NOW + 60_000, // not expired
+    });
+
+    const res = await xaiRefreshToken();
+
+    expect(res).toEqual({ ok: true, reused: false });
+    expect(connectMock).toHaveBeenCalledWith('xai', { key: 'engine-acc' });
+    // The whole point: no network refresh POST → the single-use token isn't burned.
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns unauthorized when no engine store and no desktop refresh token exist', async () => {
+    readEngineMock.mockResolvedValue(null);
+    loadStoreMock.mockResolvedValue(null);
+
+    expect(await xaiRefreshToken()).toEqual({ ok: false, error: 'unauthorized' });
+    expect(connectMock).not.toHaveBeenCalled();
+  });
+
+  it('falls through to a refresh when the engine bearer is expired (engine refresh token preferred)', async () => {
+    readEngineMock.mockResolvedValue({
+      accessToken: 'stale',
+      refreshToken: 'engine-ref',
+      expiresAt: NOW - 1, // expired
+    });
+    loadStoreMock.mockResolvedValue({ refreshToken: 'desktop-ref' });
+    // Engine bearer expired → it must POST a refresh using the ENGINE refresh
+    // token, not the desktop copy. Stub a successful token response.
+    fetchSpy.mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ access_token: 'fresh-acc', refresh_token: 'fresh-ref', expires_in: 3600 }),
+      } as Response)
+    );
+
+    const res = await xaiRefreshToken();
+
+    expect(res).toEqual({ ok: true, reused: false });
+    // It did refresh over the network...
+    expect(fetchSpy).toHaveBeenCalled();
+    // ...and the token POST body carried the ENGINE refresh token, not the desktop one.
+    const tokenPost = fetchSpy.mock.calls.find(([, init]) => (init as RequestInit | undefined)?.method === 'POST');
+    if (!tokenPost) throw new Error('expected a POST refresh call');
+    const body = String((tokenPost[1] as RequestInit).body);
+    expect(body).toContain('refresh_token=engine-ref');
+    expect(body).not.toContain('desktop-ref');
+  });
+});


### PR DESCRIPTION
Provider/auth cleanup for the 0.11.4 cut. Two independent, low-risk fixes — both flagged during 0.11.4 verification/cross-audit, neither with prior work.

## #391 — xAI: make the engine the single refresher (MEDIUM, degraded-but-safe)
After #382 bridged Sign-in-with-X into the engine store (`~/.wayland/oauth/xai.json`), there were **two** refreshers of the same single-use rotating refresh token — the engine (`XaiTokenManager`) and the desktop (`xaiRefreshToken` + private `xaiTokenStore`). Once the engine rotates, the desktop's copy is dead; a later desktop refresh POSTs the burned token → 401 → needless re-login.

- `xaiRefreshToken` now defers to the engine: a still-valid engine bearer is re-registered directly (no network, token not burned); an expired one refreshes using the engine's (possibly rotated) refresh token in preference to the desktop copy.
- `registerTokens` only writes the engine store when a refresh token is present → a Grok-CLI access-only reuse no longer **shadows** a refresh-token-bearing `~/.grok/auth.json` (the LOW item in the issue).
- `xaiEngineAuthPath` uses `$WAYLAND_HOME` verbatim (no trim) to match the engine's resolution (the WAYLAND_HOME LOW item).
- `writeXaiEngineAuthFile` cleans up its `.tmp-<pid>` on a failed write (the leftover-temp LOW item).
- Added `readXaiEngineAuthFile`.

## #390 — WCore: stop the misleading "cannot resume" log on every exec approval
The `resume_token` `approval_required` path has no HITL UI, so in interactive mode every exec approval error-logged `no approval UI; cannot resume` even though the renderer tool-confirmation gate actually prompts + resumes. Now a loud error fires only when there is **no** resume token (genuine wedge risk, #264); otherwise a quiet trace noting the renderer gate owns the approval. Benign log-accuracy fix, no behavior change.

## Tests
14 new unit tests (`tests/unit/onboarding/xaiEngineAuthFile.test.ts`, `xaiRefreshPrefersEngine.test.ts`): engine-file path/round-trip/defensiveness/tmp-cleanup, and that a valid engine bearer is reused **without any network refresh** (the token isn't burned). `typecheck` / `oxlint` / `oxfmt` clean; existing WCoreManager suites green.

Closes none — see issues for live-verify status. Base: `integration/0.11.4`.