### PR TITLE
fix(observability): anchor turn timer to real start so it survives chat switches (#288)

### DIFF
--- a/src/renderer/components/chat/StatusFooter.tsx
+++ b/src/renderer/components/chat/StatusFooter.tsx
@@ -41,9 +41,15 @@ const PHRASES = [
 
 type StatusFooterProps = {
   isProcessing: boolean;
+  /**
+   * Epoch-ms timestamp of when the running turn actually started. When provided,
+   * the elapsed timer counts from here so it shows TOTAL running time and
+   * survives chat switches / remounts (#288). Falls back to mount time if absent.
+   */
+  startTime?: number;
 };
 
-const StatusFooter: React.FC<StatusFooterProps> = ({ isProcessing }) => {
+const StatusFooter: React.FC<StatusFooterProps> = ({ isProcessing, startTime }) => {
   const { t } = useTranslation();
   const [visible, setVisible] = useState(false);
   const [fading, setFading] = useState(false);
@@ -76,19 +82,20 @@ const StatusFooter: React.FC<StatusFooterProps> = ({ isProcessing }) => {
     return () => clearInterval(interval);
   }, [visible]);
 
-  // Elapsed time: start tracking when visible, update every 1s.
+  // Elapsed time: start tracking when visible, update every 1s. Anchored to the
+  // turn's real start (#288) so it shows TOTAL elapsed and survives remounts
+  // instead of resetting to 0 when switching chats and returning.
   useEffect(() => {
     if (!visible) {
       setElapsed(0);
       return;
     }
-    startTimeRef.current = Date.now();
-    setElapsed(0);
-    const interval = setInterval(() => {
-      setElapsed(Math.floor((Date.now() - startTimeRef.current) / 1000));
-    }, 1000);
+    startTimeRef.current = typeof startTime === 'number' ? startTime : Date.now();
+    const tick = () => setElapsed(Math.max(0, Math.floor((Date.now() - startTimeRef.current) / 1000)));
+    tick();
+    const interval = setInterval(tick, 1000);
     return () => clearInterval(interval);
-  }, [visible]);
+  }, [visible, startTime]);
 
   // Idle: render a spacer to preserve Virtuoso layout (no jump).
   if (!visible) return <div className={styles.spacer} />;

--- a/src/renderer/components/chat/observability/OrbitThinking.tsx
+++ b/src/renderer/components/chat/observability/OrbitThinking.tsx
@@ -42,9 +42,16 @@ const PHRASES = [
 type Props = {
   isProcessing: boolean;
   currentLabel?: string;
+  /**
+   * Epoch-ms timestamp of when the running turn actually started (the user's
+   * submission). When provided, the elapsed timer counts from here so it shows
+   * TOTAL running time and survives chat switches / remounts (#288). Falls back
+   * to the mount time when absent.
+   */
+  startTime?: number;
 };
 
-const OrbitThinking: React.FC<Props> = ({ isProcessing, currentLabel }) => {
+const OrbitThinking: React.FC<Props> = ({ isProcessing, currentLabel, startTime }) => {
   const { t } = useTranslation();
   const [phraseIndex, setPhraseIndex] = useState(0);
   const [elapsed, setElapsed] = useState(0);
@@ -60,19 +67,20 @@ const OrbitThinking: React.FC<Props> = ({ isProcessing, currentLabel }) => {
     return () => clearInterval(interval);
   }, [isProcessing]);
 
-  // Elapsed time: tracked only while processing, reset when idle.
+  // Elapsed time: tracked only while processing, reset when idle. Anchored to
+  // the turn's real start (#288) so returning to a still-running chat shows the
+  // TOTAL elapsed time, not time-since-reentry, and idle chats never tick.
   useEffect(() => {
     if (!isProcessing) {
       setElapsed(0);
       return;
     }
-    startTimeRef.current = Date.now();
-    setElapsed(0);
-    const interval = setInterval(() => {
-      setElapsed(Math.floor((Date.now() - startTimeRef.current) / 1000));
-    }, 1000);
+    startTimeRef.current = typeof startTime === 'number' ? startTime : Date.now();
+    const tick = () => setElapsed(Math.max(0, Math.floor((Date.now() - startTimeRef.current) / 1000)));
+    tick();
+    const interval = setInterval(tick, 1000);
     return () => clearInterval(interval);
-  }, [isProcessing]);
+  }, [isProcessing, startTime]);
 
   const sUnit = t('common.unit.second_short', { defaultValue: 's' });
   const hasRealLabel = typeof currentLabel === 'string' && currentLabel.length > 0;

--- a/src/renderer/pages/conversation/Messages/MessageList.tsx
+++ b/src/renderer/pages/conversation/Messages/MessageList.tsx
@@ -226,10 +226,14 @@ const ChatTimeMarkerRow: React.FC<{ marker: ChatTimeMarker }> = ({ marker }) => 
 // render). This is what keeps the orbit indicator MOUNTED across re-renders, so
 // its CSS animation runs continuously instead of restarting (= flashing) every
 // streamed token. The processing state reaches the footer via Virtuoso `context`.
-type MessageListContext = { isProcessing?: boolean; currentLabel?: string };
+type MessageListContext = { isProcessing?: boolean; currentLabel?: string; turnStartTime?: number };
 const ListHeader: React.FC = () => <div className='h-10px' />;
 const ListFooter: React.FC<{ context?: MessageListContext }> = ({ context }) => (
-  <OrbitThinking isProcessing={!!context?.isProcessing} currentLabel={context?.currentLabel} />
+  <OrbitThinking
+    isProcessing={!!context?.isProcessing}
+    currentLabel={context?.currentLabel}
+    startTime={context?.turnStartTime}
+  />
 );
 const LIST_COMPONENTS = { Header: ListHeader, Footer: ListFooter } as const;
 
@@ -499,6 +503,20 @@ const ConversationMessageList: React.FC<{
     return undefined;
   }, [processedList, isProcessing]);
 
+  // #288: the orbit's elapsed timer is anchored to the turn's actual start - the
+  // last user submission (createdAt is epoch-ms). This makes elapsed = TOTAL
+  // running time that survives chat switches (the timer no longer resets to 0 on
+  // remount), and it is undefined while idle so the timer never ticks with no
+  // task running.
+  const turnStartTime = useMemo<number | undefined>(() => {
+    if (!isProcessing) return undefined;
+    for (let i = list.length - 1; i >= 0; i--) {
+      const m = list[i];
+      if (m.position === 'right' && typeof m.createdAt === 'number') return m.createdAt;
+    }
+    return undefined;
+  }, [list, isProcessing]);
+
   const renderItem = (_index: number, item: (typeof processedList)[0]) => {
     const highlighted = matchesTargetMessage(item, highlightedMessageId);
     const marker = timeMarkers?.[_index] ?? null;
@@ -574,7 +592,7 @@ const ConversationMessageList: React.FC<{
             // resting static when done. Stable components + context avoid remounts
             // (= flashing). See LIST_COMPONENTS above.
             components={LIST_COMPONENTS}
-            context={{ isProcessing, currentLabel }}
+            context={{ isProcessing, currentLabel, turnStartTime }}
           />
         </ImagePreviewContext.Provider>
       </Image.PreviewGroup>

--- a/tests/unit/OrbitThinkingElapsed.dom.test.tsx
+++ b/tests/unit/OrbitThinkingElapsed.dom.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/// <reference types="@testing-library/jest-dom/vitest" />
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render } from '@testing-library/react';
+import React from 'react';
+
+// CSS module + i18n + glyph are irrelevant to the timer behaviour under test.
+vi.mock('@/renderer/components/chat/observability/OrbitThinking.module.css', () => ({
+  default: {
+    container: 'container',
+    activeStep: 'activeStep',
+    label: 'label',
+    labelReal: 'labelReal',
+    elapsed: 'elapsed',
+  },
+}));
+vi.mock('@/renderer/components/chat/observability/OrbitGlyph', () => ({ default: () => null }));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? key }),
+}));
+
+import OrbitThinking from '@/renderer/components/chat/observability/OrbitThinking';
+
+const FIXED_NOW = 1_700_000_000_000;
+
+describe('OrbitThinking elapsed timer (#288)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ now: FIXED_NOW });
+  });
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('shows TOTAL elapsed from the turn start, not from mount', () => {
+    // Turn started 65s before this (late) mount - emulates returning to a chat
+    // whose task is still running.
+    const { container } = render(<OrbitThinking isProcessing startTime={FIXED_NOW - 65_000} />);
+    expect(container.textContent).toContain('65s');
+  });
+
+  it('does not reset to 0 when the component remounts mid-turn (chat switch)', () => {
+    const start = FIXED_NOW - 30_000;
+    const first = render(<OrbitThinking isProcessing startTime={start} />);
+    expect(first.container.textContent).toContain('30s');
+    // Switch away (unmount) and back (fresh mount) at the same wall-clock time.
+    first.unmount();
+    const second = render(<OrbitThinking isProcessing startTime={start} />);
+    // Still 30s after remount - the timer is anchored to the turn start, not the
+    // (new) mount time, so it does not restart from 0.
+    expect(second.container.textContent).toContain('30s');
+  });
+
+  it('ticks forward once per second while processing', () => {
+    const { container } = render(<OrbitThinking isProcessing startTime={FIXED_NOW - 10_000} />);
+    expect(container.textContent).toContain('10s');
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(container.textContent).toContain('12s');
+  });
+
+  it('renders no elapsed timer when idle', () => {
+    const { container } = render(<OrbitThinking isProcessing={false} startTime={FIXED_NOW - 99_000} />);
+    expect(container.textContent ?? '').not.toMatch(/\d+s/);
+  });
+});


### PR DESCRIPTION
## What

Fixes #288 — the chat turn-timer reset to **0** when switching chats and returning, and showed *time-since-reentry* instead of total run time.

## Root cause

`OrbitThinking` (the live message-list footer) and its sibling `StatusFooter` seeded their elapsed start from `Date.now()` whenever the component became visible/processing. Switching chats remounts the message list, so on return the effect re-ran and reset the start to "now" — even for a task that had been running for a while, and even briefly when no task was running.

## Fix

Anchor the elapsed timer to the **turn's actual start** — the last user submission's `createdAt` (epoch-ms) — threaded through the Virtuoso footer `context` as `turnStartTime`. Now:

- Elapsed = **total** running time, computed as `now - turnStartTime`.
- Survives remounts (chat switch and return shows the correct accumulated time).
- Stays absent when idle: `turnStartTime` is `undefined` unless a turn is processing, and the timer only renders while `isProcessing`.

`StatusFooter` receives the same optional `startTime` anchor for parity (prevents the latent bug if it gets wired up).

## Tests

New `tests/unit/OrbitThinkingElapsed.dom.test.tsx` (fake timers):
- shows total elapsed from turn start, not from mount
- does not reset on remount mid-turn (the #288 repro)
- ticks forward 1/s while processing
- renders no timer when idle

All pass. `check-i18n.js` passes (no new keys).

Closes #288