### PR TITLE
fix(onboarding,preview): selected-item hover + file-viewer error button colors (#249 #253)

### DIFF
--- a/src/renderer/components/onboarding/Onboarding.module.css
+++ b/src/renderer/components/onboarding/Onboarding.module.css
@@ -572,6 +572,13 @@
   border-color: rgba(var(--accent), 0.65);
   background: rgba(var(--accent), 0.1);
 }
+/* #249: hovering the SELECTED option must brighten the selected style, not fall
+   back to the unselected `.persona:hover`. Same specificity as `.persona:hover`
+   but declared later, so it wins for the `.persona.personaSel:hover` element. */
+.personaSel:hover {
+  border-color: rgba(var(--accent), 0.85);
+  background: rgba(var(--accent), 0.16);
+}
 .pIc {
   width: 36px;
   height: 36px;

--- a/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx
+++ b/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx
@@ -824,7 +824,7 @@ const PreviewPanel: React.FC = () => {
                 })}
               </div>
               <div
-                className='flex items-center gap-4px px-12px py-6px rd-4px cursor-pointer bg-bg-3 hover:bg-bg-4 transition-colors'
+                className='flex items-center gap-4px px-12px py-6px rd-4px cursor-pointer bg-primary text-white hover:opacity-85 transition-opacity'
                 onClick={reset}
               >
                 {t('preview.viewerError.retry', { defaultValue: 'Try again' })}


### PR DESCRIPTION
Two small desktop-UI presentational fixes.

### #249 — onboarding selected-item hover
On the "What are you working on" screen, hovering the **selected** persona made its highlight disappear and revert to the plain unselected hover. Cause: `.persona:hover` (class + pseudo-class) outranks `.personaSel` (single class), so on the `.persona.personaSel:hover` element the unselected hover won.

Fix: add `.personaSel:hover` — equal specificity to `.persona:hover` but declared later, so it wins — brightening the selected style on hover instead of dropping it.

### #253 — file-viewer error button color
The viewer-error fallback **"Try again"** button used neutral `bg-bg-3` with no text color, so it read as disabled (one of the "wrong colors on button" sub-bugs). Fix: use the primary action style (`bg-primary` / `text-white`) already used by the other Preview action buttons (`PreviewConfirmModals`, `CodeViewer`).

> The viewer **crash-containment** for #253 (error boundary so a viewer module error no longer breaks the conversation route / back button) already landed in `155882f2a`. This PR only addresses the remaining cosmetic button-color sub-bug.

### Verification
CSS/className-only changes; `oxfmt` + `oxlint` clean (no new warnings). Visual live-verify of the onboarding hover state is being routed to Overwatch — the #253 error state only reproduces on a packaged Windows build (syntax-highlighter dynamic-import failure), so it is not locally reproducible on macOS dev.

Closes #249
Closes #253