### PR TITLE
Release 0.11.5 — keyless local models (wayland-core v0.12.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,28 @@ All notable changes to the Wayland Electron app are documented in this file. For
 
 ## [0.11.4] - 2026-06-28
 
+### Highlights
+
+- **Greatly improved chat streaming.** A ground-up rework of how responses stream and render: a real-time JSON progress stream drives a smooth, live activity view — an inline "orbit" indicator that animates while the assistant works and settles when it's done, a unified step-by-step timeline with plain-English labels for every backend, live reasoning summaries in the thinking block, and a per-message action toolbar that appears the moment a turn completes. Chat finally feels alive, legible, and fast (#337, #318, #288, and the observability rework series).
+- **Real tool-use on Windows — safely sandboxed.** Wayland now runs real shell commands and tools on Windows inside a locked-down AppContainer sandbox — so the assistant doesn't just talk, it does the work, even on a clean non-developer machine. Live-verified on Windows. (wayland-core v0.12.14)
+- **Your local models just work with tools.** Wayland detects tool support up front and transparently retries without tools for any backend that rejects them — so Ollama and llama.cpp models answer instead of erroring.
+
 ### Wayland Core engine
 
-- Bundled engine updated to v0.12.13. Local models that don't support function calling now just work: Wayland detects tool support up front (an Ollama capability probe) and, for any backend that still rejects a tools request, automatically retries without tools and remembers the result — so Ollama and llama.cpp models answer instead of erroring (#389).
+- Bundled engine updated to **v0.12.14**. Windows AppContainer shell tools now work end to end: absent developer-cache paths are skipped when applying the sandbox filesystem grant (no more hard-fail before the command runs), and the sandbox reaps its full job tree before draining output so commands return promptly instead of timing out (wayland-core #99, #100).
+- Local models that don't support function calling now just work: Wayland detects tool support up front (an Ollama capability probe) and, for any backend that still rejects a tools request, automatically retries without tools and remembers the result — so Ollama and llama.cpp models answer instead of erroring (#389).
 - Billing errors are classified more accurately, so a transient or unrelated provider error is no longer reported as "out of credit" (#329).
 - Tighter control over which environment variables and secrets reach sandboxed subprocesses, with a fail-closed sandbox toggle (#325–#327).
+- xAI / Grok sign-in uses a single, engine-preferred OAuth refresher so Grok sessions stay authenticated without token races (#390, #391).
 
-### Thinking & reasoning
+### Chat streaming & live activity (headline)
 
-- Reasoning models now show a short, live summary of what they're working through as the heading of the thinking block, updated turn by turn (#318).
+- Responses now stream over a real-time JSON progress channel and render through a reworked live activity view, so chat updates feel immediate and smooth (#337).
+- An inline "orbit" indicator animates while the assistant is working and settles to a static state when the turn is done — a single, calm signal of what's happening (replaces the old flashing/duplicated indicators).
+- A unified, step-by-step activity timeline projects every backend's events into clean, human-readable labels, so you can follow exactly what the assistant is doing regardless of which model or tool is in play.
+- Reasoning models show a short, live summary of what they're working through as the heading of the thinking block, updated turn by turn (#318).
+- A per-message action toolbar (copy, retry, and more) appears the moment a turn completes — consolidated into one clean row.
+- The turn timer is anchored to the turn's real start, so elapsed time stays accurate even when you switch chats mid-response (#288).
 
 ### Models & providers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to the Wayland Electron app are documented in this file. For
 
 ## [Unreleased]
 
+## [0.11.5] - 2026-06-28
+
+### Highlights
+
+- **Local models connect with zero setup.** Ollama (Local) and other self-hosted models now run with no API key at all — the engine recognizes loopback and private-network endpoints and connects cleanly, and the desktop connect form drops the key field for local providers entirely. No more "OpenAI API key is required" when you're running a model that lives entirely on your own machine (#398, wayland-core keyless self-hosted support).
+
+### Wayland Core engine
+
+- Bundled engine updated to **v0.12.15**. Keyless self-hosted endpoints are now first-class: when no API key is set and the endpoint is local (loopback, 0.0.0.0, `*.local`, private RFC1918, or Tailscale-CGNAT), the engine connects with a benign placeholder instead of failing — so local Ollama and other OpenAI-compatible local servers work out of the box. Public endpoints still require a key, as they should.
+
+### Fixed
+
+- **Ollama (Local) connects keyless.** The Browse provider tile for Ollama (Local) no longer demands an API key — the key field is hidden and Connect works with nothing entered, matching how local models actually run.
+- **Cloud credential form padding.** The AWS Bedrock / Vertex / Azure credential form in the Browse modal now has proper inset and spacing instead of sitting flush against the window edges.
+
 ## [0.11.4] - 2026-06-28
 
 ### Highlights

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Wayland",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "The local-first desktop AI agent that drives every AI CLI on your machine - Claude Code, Codex, Gemini and more, on your keys.",
   "keywords": [],
   "license": "AGPL-3.0-or-later",

--- a/scripts/bundled-wcore-shasums.json
+++ b/scripts/bundled-wcore-shasums.json
@@ -1,5 +1,13 @@
 {
   "_comment": "Authoritative SHA-256 checksums for bundled wayland-core release archives (the downloaded .tar.gz / .zip assets), keyed by release tag then asset filename. Mirrors scripts/bundled-bun-shasums.json. Source of truth: the SHASUMS published alongside each signed FerroxLabs/wayland-core release. The downloaded archive is verified against this file BEFORE it is extracted, copied, or executed. Update this file in lockstep with DEFAULT_WCORE_VERSION in scripts/prepareWaylandCore.js and regenerate on every engine version bump.",
+  "v0.12.15": {
+    "wayland-core-v0.12.15-aarch64-apple-darwin.tar.gz": "sha256:1344513ca0642b1430e13e43cc549b089350cf4f52988f40abc24236f12778c0",
+    "wayland-core-v0.12.15-x86_64-apple-darwin.tar.gz": "sha256:0cf828480b29cbdb301932e3200584646109af7b4915cdf313817ff8ade118f3",
+    "wayland-core-v0.12.15-aarch64-unknown-linux-gnu.tar.gz": "sha256:843c86633c9819fe1a76750a360685430f150f8d512002af56d8e2e154dd72f8",
+    "wayland-core-v0.12.15-x86_64-unknown-linux-gnu.tar.gz": "sha256:594ed9f019c30391750b5b7799540e4e021d67034d519304ada5853b3f742d9a",
+    "wayland-core-v0.12.15-aarch64-pc-windows-msvc.zip": "sha256:b540910001dcf33870a34889650a5cd7b532c39d538b919d6d8d1f47054b739d",
+    "wayland-core-v0.12.15-x86_64-pc-windows-msvc.zip": "sha256:a7e7b9e9b771edb2d158de1ce3e9508e970e69724dcb0006ae755ead00825de3"
+  },
   "v0.12.14": {
     "wayland-core-v0.12.14-aarch64-apple-darwin.tar.gz": "sha256:17e42009fd5b0d46563aa96aeccbab45c3e6d4d00fe1687b76919260e16e8ed1",
     "wayland-core-v0.12.14-x86_64-apple-darwin.tar.gz": "sha256:adee4b80cc695b2ad6d3419c0e564bd778c994b8a30265f815c0695b1340a0c0",

--- a/scripts/prepareWaylandCore.js
+++ b/scripts/prepareWaylandCore.js
@@ -184,7 +184,7 @@ function verifyArchiveChecksum(archivePath, expectedHex, assetName, tag) {
 // FerroxLabs/wayland-core; Desktop integrates against a specific tag rather
 // than tracking `latest` so version drift can't sneak in via a release made
 // while a CI build is mid-flight. Override with WCORE_VERSION=... when bumping.
-const DEFAULT_WCORE_VERSION = 'v0.12.14';
+const DEFAULT_WCORE_VERSION = 'v0.12.15';
 
 function getVersion() {
   return (process.env.WCORE_VERSION || DEFAULT_WCORE_VERSION).trim();

--- a/src/renderer/pages/settings/ModelsSettings/BrowseModal.module.css
+++ b/src/renderer/pages/settings/ModelsSettings/BrowseModal.module.css
@@ -423,6 +423,15 @@
   padding: 14px 20px 20px;
 }
 
+/* ---- Cloud credential form view ----
+   Bedrock/Vertex/Azure render CloudCredentialForm raw inside the modal, whose
+   Arco content padding is zeroed. Without this wrapper the multi-field form sat
+   flush against the modal edges with no breathing room. Mirrors .keyForm so it
+   gets the same inset and vertical rhythm as the single-key view. */
+.cloudForm {
+  padding: 14px 20px 20px;
+}
+
 .keyLabel {
   font-size: 11px;
   font-weight: 600;

--- a/src/renderer/pages/settings/ModelsSettings/BrowseModal.tsx
+++ b/src/renderer/pages/settings/ModelsSettings/BrowseModal.tsx
@@ -80,6 +80,16 @@ type CatalogState =
  * A successful connect closes the modal; `useModelRegistry.connect` reloads the
  * connected list on its own.
  */
+/**
+ * Providers that connect WITHOUT an API key. A local Ollama daemon needs no
+ * credential (the backend explicitly accepts an empty key for `ollama-local`),
+ * so the connect view hides the key field and connects against the canonical
+ * `localhost:11434` default. Without this the tile rendered a key-only form that
+ * rejected every input ("OpenAI API key is required" / "Couldn't connect").
+ */
+const KEYLESS_PROVIDER_IDS = new Set<ProviderId>(['ollama-local']);
+const isKeylessProvider = (id: ProviderId): boolean => KEYLESS_PROVIDER_IDS.has(id);
+
 const BrowseModal: React.FC<Props> = ({ visible, onClose, initialProvider, connectKey }) => {
   const { t } = useTranslation();
   const { providers, connect, getProviderCatalog } = useModelRegistry();
@@ -209,7 +219,9 @@ const BrowseModal: React.FC<Props> = ({ visible, onClose, initialProvider, conne
   const handleKeyConnect = useCallback(async () => {
     if (view.kind !== 'key') return;
     const key = keyValue.trim();
-    if (!key) return;
+    // Keyless providers (local Ollama) connect with an empty key; everyone else
+    // needs one before the request is worth sending.
+    if (!key && !isKeylessProvider(view.provider.id)) return;
     // Ship-gate Fix B2: `openai-compatible` accepts an optional `baseUrl`. A
     // non-empty value is submitted as `creds.baseUrl`; an empty value falls
     // back to the canonical default at chat-start time (no harm in sending
@@ -260,7 +272,9 @@ const BrowseModal: React.FC<Props> = ({ visible, onClose, initialProvider, conne
       : view.kind === 'catalog'
         ? t('settings.modelsPage.browse.catalog.subtitle')
         : view.kind === 'key'
-          ? t('settings.modelsPage.browse.keySubtitle', { provider: view.provider.displayName })
+          ? isKeylessProvider(view.provider.id)
+            ? t('settings.modelsPage.browse.keylessSubtitle', { provider: view.provider.displayName })
+            : t('settings.modelsPage.browse.keySubtitle', { provider: view.provider.displayName })
           : undefined;
 
   // ---- Tile renderer -----------------------------------------------------
@@ -527,18 +541,22 @@ const BrowseModal: React.FC<Props> = ({ visible, onClose, initialProvider, conne
 
       {view.kind === 'key' && (
         <div className={styles.keyForm}>
-          <div className={styles.keyLabel}>{t('settings.modelsPage.browse.keyLabel')}</div>
-          <Input.Password
-            value={keyValue}
-            onChange={(v) => {
-              setKeyValue(v);
-              setErrorKey(null);
-            }}
-            onPressEnter={() => void handleKeyConnect()}
-            placeholder={t('settings.modelsPage.browse.keyPlaceholder')}
-            aria-label={t('settings.modelsPage.browse.keyLabel')}
-            disabled={connecting}
-          />
+          {!isKeylessProvider(view.provider.id) && (
+            <>
+              <div className={styles.keyLabel}>{t('settings.modelsPage.browse.keyLabel')}</div>
+              <Input.Password
+                value={keyValue}
+                onChange={(v) => {
+                  setKeyValue(v);
+                  setErrorKey(null);
+                }}
+                onPressEnter={() => void handleKeyConnect()}
+                placeholder={t('settings.modelsPage.browse.keyPlaceholder')}
+                aria-label={t('settings.modelsPage.browse.keyLabel')}
+                disabled={connecting}
+              />
+            </>
+          )}
           {/* Ship-gate Fix B2: `openai-compatible` connect collects an optional
               `baseUrl` alongside the api key so the user can point at a custom
               endpoint (the backend already routes `creds.baseUrl` through to
@@ -572,7 +590,7 @@ const BrowseModal: React.FC<Props> = ({ visible, onClose, initialProvider, conne
             type='primary'
             long
             loading={connecting}
-            disabled={!keyValue.trim()}
+            disabled={!isKeylessProvider(view.provider.id) && !keyValue.trim()}
             onClick={() => void handleKeyConnect()}
             className={styles.keySubmit}
           >

--- a/src/renderer/pages/settings/ModelsSettings/BrowseModal.tsx
+++ b/src/renderer/pages/settings/ModelsSettings/BrowseModal.tsx
@@ -600,7 +600,9 @@ const BrowseModal: React.FC<Props> = ({ visible, onClose, initialProvider, conne
       )}
 
       {view.kind === 'cloud' && (
-        <CloudCredentialForm providerId={view.provider} onSubmit={handleCloudConnect} mode='connect' />
+        <div className={styles.cloudForm}>
+          <CloudCredentialForm providerId={view.provider} onSubmit={handleCloudConnect} mode='connect' />
+        </div>
       )}
     </Modal>
   );

--- a/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/src/renderer/services/i18n/i18n-keys.d.ts
@@ -3335,6 +3335,7 @@ export type I18nKey =
   | 'settings.modelsPage.browse.keyLabel'
   | 'settings.modelsPage.browse.keyPlaceholder'
   | 'settings.modelsPage.browse.keySubtitle'
+  | 'settings.modelsPage.browse.keylessSubtitle'
   | 'settings.modelsPage.browse.noMatch'
   | 'settings.modelsPage.browse.searchPlaceholder'
   | 'settings.modelsPage.browse.subtitle'

--- a/src/renderer/services/i18n/locales/de-DE/settings.json
+++ b/src/renderer/services/i18n/locales/de-DE/settings.json
@@ -1901,6 +1901,7 @@
         "voice": "Sprache & Transkription"
       },
       "keySubtitle": "Füge einen API-Schlüssel für {{provider}} ein, um dich zu verbinden.",
+      "keylessSubtitle": "{{provider}} runs locally, so no API key is needed.",
       "keyLabel": "API-Schlüssel",
       "keyPlaceholder": "Füge deinen API-Schlüssel ein…",
       "baseUrlLabel": "Basis-URL (optional)",

--- a/src/renderer/services/i18n/locales/en-US/settings.json
+++ b/src/renderer/services/i18n/locales/en-US/settings.json
@@ -1942,6 +1942,7 @@
         "voice": "Voice & transcription"
       },
       "keySubtitle": "Paste an API key for {{provider}} to connect.",
+      "keylessSubtitle": "{{provider}} runs locally, so no API key is needed.",
       "keyLabel": "API key",
       "keyPlaceholder": "Paste your API key…",
       "baseUrlLabel": "Base URL (optional)",

--- a/src/renderer/services/i18n/locales/es-ES/settings.json
+++ b/src/renderer/services/i18n/locales/es-ES/settings.json
@@ -1901,6 +1901,7 @@
         "voice": "Voz y transcripción"
       },
       "keySubtitle": "Pega una clave de API de {{provider}} para conectarte.",
+      "keylessSubtitle": "{{provider}} runs locally, so no API key is needed.",
       "keyLabel": "Clave de API",
       "keyPlaceholder": "Pega tu clave de API…",
       "baseUrlLabel": "URL base (opcional)",

--- a/src/renderer/services/i18n/locales/fr-FR/settings.json
+++ b/src/renderer/services/i18n/locales/fr-FR/settings.json
@@ -1901,6 +1901,7 @@
         "voice": "Voix et transcription"
       },
       "keySubtitle": "Collez une clé API pour {{provider}} afin de vous connecter.",
+      "keylessSubtitle": "{{provider}} runs locally, so no API key is needed.",
       "keyLabel": "Clé API",
       "keyPlaceholder": "Collez votre clé API…",
       "baseUrlLabel": "URL de base (facultatif)",

--- a/src/renderer/services/i18n/locales/ja-JP/settings.json
+++ b/src/renderer/services/i18n/locales/ja-JP/settings.json
@@ -1868,6 +1868,7 @@
         "voice": "音声と文字起こし"
       },
       "keySubtitle": "{{provider}} の API キーを貼り付けて接続します。",
+      "keylessSubtitle": "{{provider}} runs locally, so no API key is needed.",
       "keyLabel": "API キー",
       "keyPlaceholder": "API キーを貼り付け…",
       "connect": "接続してテスト",

--- a/src/renderer/services/i18n/locales/ko-KR/settings.json
+++ b/src/renderer/services/i18n/locales/ko-KR/settings.json
@@ -1868,6 +1868,7 @@
         "voice": "음성 및 전사"
       },
       "keySubtitle": "{{provider}}의 API 키를 붙여넣어 연결하세요.",
+      "keylessSubtitle": "{{provider}} runs locally, so no API key is needed.",
       "keyLabel": "API 키",
       "keyPlaceholder": "API 키 붙여넣기…",
       "connect": "연결 및 테스트",

--- a/src/renderer/services/i18n/locales/pt-BR/settings.json
+++ b/src/renderer/services/i18n/locales/pt-BR/settings.json
@@ -1901,6 +1901,7 @@
         "voice": "Voz e transcrição"
       },
       "keySubtitle": "Cole uma chave de API do {{provider}} para conectar.",
+      "keylessSubtitle": "{{provider}} runs locally, so no API key is needed.",
       "keyLabel": "Chave de API",
       "keyPlaceholder": "Cole sua chave de API…",
       "baseUrlLabel": "URL Base (opcional)",

--- a/src/renderer/services/i18n/locales/ru-RU/settings.json
+++ b/src/renderer/services/i18n/locales/ru-RU/settings.json
@@ -1868,6 +1868,7 @@
         "voice": "Голос и транскрипция"
       },
       "keySubtitle": "Вставьте API-ключ для {{provider}}, чтобы подключиться.",
+      "keylessSubtitle": "{{provider}} runs locally, so no API key is needed.",
       "keyLabel": "API-ключ",
       "keyPlaceholder": "Вставьте ваш API-ключ…",
       "connect": "Подключить и проверить",

--- a/src/renderer/services/i18n/locales/tr-TR/settings.json
+++ b/src/renderer/services/i18n/locales/tr-TR/settings.json
@@ -1866,6 +1866,7 @@
         "voice": "Ses ve transkripsiyon"
       },
       "keySubtitle": "Bağlanmak için {{provider}} API anahtarını yapıştırın.",
+      "keylessSubtitle": "{{provider}} runs locally, so no API key is needed.",
       "keyLabel": "API anahtarı",
       "keyPlaceholder": "API anahtarınızı yapıştırın…",
       "connect": "Bağlan ve test et",

--- a/src/renderer/services/i18n/locales/uk-UA/settings.json
+++ b/src/renderer/services/i18n/locales/uk-UA/settings.json
@@ -1833,6 +1833,7 @@
         "voice": "Голос і транскрипція"
       },
       "keySubtitle": "Вставте API-ключ для {{provider}}, щоб підключитися.",
+      "keylessSubtitle": "{{provider}} runs locally, so no API key is needed.",
       "keyLabel": "API-ключ",
       "keyPlaceholder": "Вставте ваш API-ключ…",
       "connect": "Підключити та перевірити",

--- a/src/renderer/services/i18n/locales/zh-CN/settings.json
+++ b/src/renderer/services/i18n/locales/zh-CN/settings.json
@@ -1867,6 +1867,7 @@
         "voice": "语音与转写"
       },
       "keySubtitle": "粘贴 {{provider}} 的 API 密钥以进行连接。",
+      "keylessSubtitle": "{{provider}} runs locally, so no API key is needed.",
       "keyLabel": "API 密钥",
       "keyPlaceholder": "粘贴你的 API 密钥…",
       "connect": "连接并测试",

--- a/src/renderer/services/i18n/locales/zh-TW/settings.json
+++ b/src/renderer/services/i18n/locales/zh-TW/settings.json
@@ -1868,6 +1868,7 @@
         "voice": "語音與轉錄"
       },
       "keySubtitle": "貼上 {{provider}} 的 API 金鑰以進行連接。",
+      "keylessSubtitle": "{{provider}} runs locally, so no API key is needed.",
       "keyLabel": "API 金鑰",
       "keyPlaceholder": "貼上你的 API 金鑰…",
       "connect": "連接並測試",

--- a/tests/unit/renderer/browseModal.dom.test.tsx
+++ b/tests/unit/renderer/browseModal.dom.test.tsx
@@ -229,9 +229,7 @@ describe('BrowseModal', () => {
     fireEvent.click(document.querySelector('[data-provider="ollama-local"]') as HTMLElement);
 
     // A keyless provider shows NO API-key field...
-    expect(
-      screen.queryByPlaceholderText('settings.modelsPage.browse.keyPlaceholder'),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('settings.modelsPage.browse.keyPlaceholder')).not.toBeInTheDocument();
 
     // ...and Connect works with no key, sending an empty credential and no baseUrl
     // (the engine resolves the canonical localhost:11434 default).

--- a/tests/unit/renderer/browseModal.dom.test.tsx
+++ b/tests/unit/renderer/browseModal.dom.test.tsx
@@ -220,6 +220,26 @@ describe('BrowseModal', () => {
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 
+  it('connects Ollama (Local) keyless, with no API-key field', async () => {
+    const onClose = vi.fn();
+    renderModal(onClose);
+    await screen.findByText('settings.modelsPage.browse.group.frontier');
+
+    // Pick the keyless local-Ollama tile from the BYO section.
+    fireEvent.click(document.querySelector('[data-provider="ollama-local"]') as HTMLElement);
+
+    // A keyless provider shows NO API-key field...
+    expect(
+      screen.queryByPlaceholderText('settings.modelsPage.browse.keyPlaceholder'),
+    ).not.toBeInTheDocument();
+
+    // ...and Connect works with no key, sending an empty credential and no baseUrl
+    // (the engine resolves the canonical localhost:11434 default).
+    fireEvent.click(screen.getByText('settings.modelsPage.browse.connect'));
+    await waitFor(() => expect(mockConnectKey).toHaveBeenCalledWith('ollama-local', '', undefined));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
   it('shows the inline error when a single-key connect fails', async () => {
     mockConnectKey.mockResolvedValue({ ok: false, error: 'unauthorized' });
     renderModal();


### PR DESCRIPTION
## Wayland desktop 0.11.5

Bundles wayland-core v0.12.15 and fixes the customer-reported "OpenAI API key is required" failure on fully local Ollama models.

### What ships
- Engine bumped to v0.12.15 (keyless self-hosted endpoints: loopback / 0.0.0.0 / *.local / RFC1918 / Tailscale-CGNAT connect with no API key; public hosts still require a key).
- Ollama (Local) Browse tile is now keyless: hides the key field, shows "runs locally, so no API key is needed", connects with empty credentials (#398).
- Cloud credential form (Bedrock / Vertex / Azure) padding fixed: wrapped in .cloudForm so fields no longer sit flush against the modal edges.

### Verification
- Pre-flight green: i18n up to date, lint 0 errors, typecheck clean, 11295 tests pass / 0 fail (was 11294 + the new keyless test).
- Live-verified on the OFFICIAL 0.12.15 bundle (fresh dev profile, Mac):
  - Onboarding auto-connected Ollama (Local) keyless, no key prompt.
  - gemma3:4b "say hello" answered, engine log shows zero MissingApiKey and the #389 tools-unsupported retry firing (customer's exact case).
  - Browse Ollama (Local) tile: no key field, "runs locally, so no API key is needed", Connect and test.
  - Browse AWS Bedrock: credential form properly inset.

Closes #398.
