### PR TITLE
Remove Flux Router status widget from the sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ All notable changes to the Wayland Electron app are documented in this file. For
 - **Ollama (Local) connects keyless.** The Browse provider tile for Ollama (Local) no longer demands an API key — the key field is hidden and Connect works with nothing entered, matching how local models actually run.
 - **Cloud credential form padding.** The AWS Bedrock / Vertex / Azure credential form in the Browse modal now has proper inset and spacing instead of sitting flush against the window edges.
 
+### Changed
+
+- **Quieter sidebar.** Removed the Flux Router status widget from the left sidebar so the nav stays focused on your own work. Flux Router is still one click away in Settings → Models.
+
 ## [0.11.4] - 2026-06-28
 
 ### Highlights

--- a/src/renderer/components/layout/Sider/index.tsx
+++ b/src/renderer/components/layout/Sider/index.tsx
@@ -9,7 +9,6 @@ import { blurActiveElement } from '@renderer/utils/ui/focus';
 import { useThemeContext } from '@renderer/hooks/context/ThemeContext';
 import {
   SiderAssistantsEntry,
-  SiderFluxRouterEntry,
   SiderMemoryEntry,
   SiderProjectsEntry,
   SiderScheduledEntry,
@@ -242,12 +241,6 @@ const Sider: React.FC<SiderProps> = ({ onSessionClick, collapsed = false }) => {
           collapsed={collapsed}
           siderTooltipProps={siderTooltipProps}
           onClick={handleAssistantsClick}
-        />
-        <SiderFluxRouterEntry
-          isMobile={isMobile}
-          collapsed={collapsed}
-          siderTooltipProps={siderTooltipProps}
-          onClick={() => handleTopZoneNav('/settings/models')}
         />
         <SiderWorkflowsEntry
           isMobile={isMobile}


### PR DESCRIPTION
## Remove the Flux Router status widget from the sidebar

Per Sean: kill the persistent "Connect Flux Router" notice in the left nav.

The SiderFluxRouterEntry widget (connect / install / ollama / wired states) sat in the sidebar TopZone and, when Flux was not connected, showed an always-on "Connect Flux Router" nudge. Removed from the Sider so the nav stays focused on the user's own work.

- Removed the mount + import from Sider/index.tsx only. The component file, its unit test (SiderFluxRouterEntry.dom.test.tsx), the useFluxEntryDismissed hook, and the sider.json strings are left intact, so re-enabling later is a one-line change.
- Flux Router remains fully available in Settings -> Models (the hero + connect flow are unchanged).

### Verification
- typecheck clean, oxfmt clean, all 77 layout unit tests pass.
- Live-verified in the dev app: the "Connect Flux Router" entry is gone from the sidebar (no [data-testid=sider-flux-router-entry] in the DOM); all other nav items intact.

Folds into the not-yet-tagged 0.11.5 (CHANGELOG updated under a Changed section).
