### PR TITLE
0.11.6: restore built-in skills + workflows (fix packaging + add fail-hard resource gate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the Wayland Electron app are documented in this file. For
 
 ## [Unreleased]
 
+## [0.11.6] - 2026-06-29
+
+### Fixed
+
+- **Restored the entire built-in skills and workflows library.** 0.11.4 and 0.11.5 shipped without the bundled `skills-library` and `bundled-workflows` resources, so every built-in skill (2200+) and workflow showed up empty. The packed resources are now generated as a guaranteed part of every release build, and a fail-hard verification gate refuses to publish a build that is missing any critical bundled resource. Your skills and workflows are back, in full.
+
+### Build
+
+- The release build now stages the models.dev snapshot, the skill/workflow pack, and the Signal CLI runtime inside the build entrypoint itself, instead of relying on npm lifecycle hooks that CI bypassed. A new post-package check asserts every bundled resource is physically present in the shipped app before release.
+
 ## [0.11.5] - 2026-06-28
 
 ### Highlights

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Wayland",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "The local-first desktop AI agent that drives every AI CLI on your machine - Claude Code, Codex, Gemini and more, on your keys.",
   "keywords": [],
   "license": "AGPL-3.0-or-later",

--- a/scripts/build-with-builder.js
+++ b/scripts/build-with-builder.js
@@ -464,8 +464,16 @@ try {
   // This only affects packaging assets; runtime integration will be added in a future PR.
   prepareBundledBun();
 
-  // 5b. Prepare hub resources (index.json + extension zips for offline fallback)
-  execSync('node scripts/prepareHubResources.js', { stdio: 'inherit', env: process.env });
+  // 5b. Prepare hub resources (index.json + extension zips for offline fallback).
+  // Degradable: this downloads from the waylandHub repo and can 404/timeout if
+  // that source is unavailable. A hub-cache outage must NOT block a release -
+  // the app still fetches the hub online at runtime. Warn loudly; the post-pack
+  // gate reports hub as an (optional) warning so its absence is never silent.
+  try {
+    execSync('node scripts/prepareHubResources.js', { stdio: 'inherit', env: process.env });
+  } catch (e) {
+    console.warn(`⚠️  hub resource prep failed (offline hub fallback will be absent): ${e.message}`);
+  }
   // 5b. Prepare wayland-core binary (Rust CLI for agent integration)
   prepareWaylandCore();
   // 5c. Prepare the bundled voice STT model (Whisper-tiny ONNX, ~43 MB) so
@@ -475,6 +483,40 @@ try {
     stdio: 'inherit',
     env: process.env,
   });
+
+  // 5d. Stage build-time bundled resources that are NOT committed to the repo:
+  //  - resources/modelsdev-snapshot.json : models.dev catalog snapshot.
+  //  - .skill-pack/{skills-library,bundled-workflows} : the AV-safe packed blob
+  //    of every built-in skill + workflow (#316).
+  // These previously ran ONLY via npm `predist*` lifecycle hooks, which never
+  // fire when CI invokes this script directly (`node scripts/build-with-builder.js`).
+  // That gap shipped 0.11.4/0.11.5 with the entire skills-library +
+  // bundled-workflows missing -> every skill and workflow gone for all users.
+  // Run them here unconditionally so they ALWAYS run, however the build starts.
+  console.log('📦 Staging models.dev snapshot...');
+  execSync('bunx tsx scripts/bundle-modelsdev.ts', { stdio: 'inherit', env: process.env });
+  console.log('📦 Building skill/workflow pack (.skill-pack)...');
+  execSync('bunx tsx scripts/build-skill-pack.ts --out .skill-pack', { stdio: 'inherit', env: process.env });
+
+  // Optional Signal CLI runtime (degradable channel) - never fail the build on it.
+  try {
+    execSync('node scripts/install-signal-cli.mjs', { stdio: 'inherit', env: process.env });
+  } catch (e) {
+    console.warn(`⚠️  signal-cli install failed (Signal channel will be unavailable): ${e.message}`);
+  }
+
+  // Pre-pack assertion: the packed skill/workflow blobs MUST exist now, or the
+  // app would ship with 0 skills and 0 workflows (the 0.11.5 regression). Fail
+  // loud here, before electron-builder silently omits the missing extraResource.
+  for (const rel of ['skills-library/index.json', 'bundled-workflows/index.json']) {
+    const staged = path.resolve(__dirname, '..', '.skill-pack', rel);
+    if (!fs.existsSync(staged) || fs.statSync(staged).size === 0) {
+      throw new Error(
+        `Skill pack not staged: .skill-pack/${rel} is missing/empty - build:skill-pack did not produce it. ` +
+          `Aborting before electron-builder so we never ship an app with no skills/workflows.`
+      );
+    }
+  }
 
   // 6. Run electron-builder to create distributables (DMG/ZIP/EXE, etc.)
   // Always disable auto-publish to avoid electron-builder's implicit tag-based publishing
@@ -594,6 +636,14 @@ try {
       );
     }
   }
+
+  // 7. Fail-hard gate: assert the packaged app actually contains every critical
+  // bundled resource. electron-builder silently DROPS any extraResources whose
+  // source is absent (exit 0, no warning) - the exact failure that shipped
+  // 0.11.4/0.11.5 with no skills-library/bundled-workflows. This is the last
+  // line of defense: a structurally-incomplete app fails the build, never ships.
+  console.log('🔎 Verifying packaged resources are present in the built app...');
+  execSync('node scripts/verify-packaged-resources.js --out out', { stdio: 'inherit', env: process.env });
 
   console.log('✅ Build completed!');
 } catch (error) {

--- a/scripts/verify-packaged-resources.js
+++ b/scripts/verify-packaged-resources.js
@@ -1,0 +1,135 @@
+/**
+ * verify-packaged-resources.js
+ *
+ * Fail-hard gate run AFTER electron-builder packaging. Asserts that every
+ * bundled resource that the running app needs is physically present inside the
+ * packaged output. Exists because electron-builder SILENTLY skips any
+ * `extraResources` whose source folder is absent at pack time (exit 0, no
+ * warning) - which is exactly how 0.11.4/0.11.5 shipped with the entire
+ * skills-library + bundled-workflows missing, breaking all skills and
+ * workflows for every user.
+ *
+ * CRITICAL entries abort the build (exit 1) when missing - the app is broken
+ * without them. OPTIONAL entries only warn (degraded feature, app still works).
+ *
+ * Usage:
+ *   node scripts/verify-packaged-resources.js [--out <dir>]
+ *   (defaults to ./out, electron-builder's directories.output)
+ *
+ * Locates the unpacked app Resources dir under <out> across mac/win/linux
+ * layouts and checks each entry there.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const TAG = '[verify-packaged-resources]';
+
+// resource path (relative to the app Resources dir) -> {critical, kind}
+// kind 'file' = must exist and be non-empty; 'dir' = must exist and be non-empty.
+const REQUIRED = [
+  { rel: 'skills-library/index.json', critical: true, kind: 'file' },
+  { rel: 'bundled-workflows/index.json', critical: true, kind: 'file' },
+  { rel: 'bundled-wayland-core', critical: true, kind: 'dir' },
+  { rel: 'bundled-bun', critical: true, kind: 'dir' },
+  { rel: 'modelsdev-snapshot.json', critical: true, kind: 'file' },
+  { rel: 'voice-models', critical: true, kind: 'dir' },
+  // Degradable features - warn loudly but do not block the release.
+  { rel: 'hub', critical: false, kind: 'dir' },
+  { rel: 'whatsapp-bridge', critical: false, kind: 'dir' },
+  { rel: 'signal-cli-runtime', critical: false, kind: 'dir' },
+];
+
+function parseOutDir() {
+  const i = process.argv.indexOf('--out');
+  const raw = i !== -1 ? process.argv[i + 1] : 'out';
+  return path.resolve(process.cwd(), raw);
+}
+
+/**
+ * Find every app "Resources" directory under the electron-builder output.
+ * macOS:  <out>/<mac*>/<Name>.app/Contents/Resources
+ * win:    <out>/<*-unpacked>/resources
+ * linux:  <out>/<*-unpacked>/resources
+ */
+function findResourceDirs(outDir) {
+  const found = [];
+  if (!fs.existsSync(outDir)) return found;
+
+  for (const entry of fs.readdirSync(outDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const dir = path.join(outDir, entry.name);
+
+    // macOS: look for *.app/Contents/Resources
+    for (const sub of fs.readdirSync(dir, { withFileTypes: true }).filter((d) => d.isDirectory())) {
+      if (sub.name.endsWith('.app')) {
+        const res = path.join(dir, sub.name, 'Contents', 'Resources');
+        if (fs.existsSync(res)) found.push(res);
+      }
+    }
+
+    // win/linux: *-unpacked/resources
+    if (entry.name.endsWith('-unpacked')) {
+      const res = path.join(dir, 'resources');
+      if (fs.existsSync(res)) found.push(res);
+    }
+  }
+  return found;
+}
+
+function isNonEmpty(p, kind) {
+  try {
+    const st = fs.statSync(p);
+    if (kind === 'file') return st.isFile() && st.size > 0;
+    if (!st.isDirectory()) return false;
+    return fs.readdirSync(p).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function main() {
+  const outDir = parseOutDir();
+  const resourceDirs = findResourceDirs(outDir);
+
+  if (resourceDirs.length === 0) {
+    console.error(`${TAG} ERROR: no packaged app Resources dir found under ${outDir}`);
+    console.error(`${TAG} (expected <out>/<mac*>/<App>.app/Contents/Resources or <out>/*-unpacked/resources)`);
+    process.exit(1);
+  }
+
+  let criticalFailures = 0;
+  let warnings = 0;
+
+  for (const resDir of resourceDirs) {
+    console.log(`${TAG} checking ${resDir}`);
+    for (const req of REQUIRED) {
+      const target = path.join(resDir, req.rel);
+      const ok = isNonEmpty(target, req.kind);
+      if (ok) {
+        console.log(`${TAG}   OK   ${req.rel}`);
+      } else if (req.critical) {
+        console.error(`${TAG}   FAIL ${req.rel}  <-- CRITICAL, missing or empty`);
+        criticalFailures += 1;
+      } else {
+        console.warn(`${TAG}   WARN ${req.rel}  (optional, missing or empty)`);
+        warnings += 1;
+      }
+    }
+  }
+
+  if (criticalFailures > 0) {
+    console.error(
+      `\n${TAG} ${criticalFailures} CRITICAL resource(s) missing from the packaged app. ` +
+        `Refusing to ship a broken build. This is the guard that stops the 0.11.5 skills/workflows regression from recurring.`
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `\n${TAG} PASS - all critical bundled resources present${warnings ? ` (${warnings} optional warning(s))` : ''}.`
+  );
+}
+
+main();


### PR DESCRIPTION
## 0.11.6 — restore the built-in skills + workflows library (P0)

### Impact
0.11.4 and 0.11.5 shipped with **no skills-library and no bundled-workflows** in the packaged app. Every built-in skill (2200+) and every workflow showed as empty for all users. Confirmed on the installed 0.11.5: `ENOENT … Contents/Resources/skills-library/index.json`, and those folders do not exist in the .app.

### Root cause
`build:skill-pack` (which generates the AV-safe packed blob of skills/workflows) and `bundle:modelsdev` ran **only via npm `predist*` lifecycle hooks**. The release CI invokes `node scripts/build-with-builder.js` directly, so those hooks never fire and `.skill-pack/` was never generated. electron-builder then **silently omits** any `extraResources` whose source is absent (exit 0, no warning) — green build, broken app.

### Fix
- `build-with-builder.js` now stages models.dev + builds the skill pack (and installs signal-cli) **inside the build entrypoint**, before electron-builder, with a pre-pack assertion that the packed indexes exist.
- New `scripts/verify-packaged-resources.js` runs **after** packaging and **fails the build** if any critical bundled resource is missing from the shipped app. This makes a missing-skills release impossible to publish.
- `prepareHubResources` is now non-fatal (its source `waylandHub@dist-latest` currently 404s); the gate reports hub as an optional warning instead of letting it silently vanish. (Separate infra follow-up: fix the waylandHub publish.)

### Proof (the verification that was missing)
Real local packaged build (`out/mac-arm64/Wayland.app`):
- skills-library/index.json present — **2105 entries**, 57 MB blob
- bundled-workflows/index.json present — **70 entries**
- gate: `PASS - all critical bundled resources present`
- gate proven to exit non-zero on a missing/empty library (would have blocked 0.11.5)

Also audited the full extraResources set: the only things 0.11.5 dropped were skills-library, bundled-workflows, hub, signal-cli-runtime — all now covered by the prep + gate.
