### PR TITLE
fix(sider): unclip chat context menu + visible recents scrollbar

### DIFF
--- a/src/renderer/components/layout/Sider/Sider.module.css
+++ b/src/renderer/components/layout/Sider/Sider.module.css
@@ -28,16 +28,45 @@
   }
 }
 
-/* Overlay-style scroll area: scrollbar takes zero layout width so icons in the
-   fixed top nav and the scrollable list stay on the same vertical center line.
-   Mimics macOS native overlay scrollbars. */
+/* Overlay-style scroll area. Previously the scrollbar was fully hidden
+   (width:0), so when the recents/accordions overflowed there was no affordance
+   that more chats existed and no drag target to reach them - they "scrolled off
+   the page". Use a thin overlay scrollbar that only shows on hover: it stays out
+   of the way (overlay, no layout width reserved) but gives a clear, draggable
+   indicator when there is more to see. */
 .scrollArea {
-  scrollbar-width: none; /* Firefox */
+  scrollbar-width: thin; /* Firefox */
+  scrollbar-color: transparent transparent;
+}
+
+.scrollArea:hover {
+  scrollbar-color: var(--color-fill-3) transparent; /* Firefox: show on hover */
 }
 
 .scrollArea::-webkit-scrollbar {
-  width: 0;
-  height: 0;
+  width: 8px;
+  height: 8px;
+}
+
+.scrollArea::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.scrollArea::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: 4px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+
+.scrollArea:hover::-webkit-scrollbar-thumb {
+  background: var(--color-fill-3);
+  background-clip: padding-box;
+}
+
+.scrollArea::-webkit-scrollbar-thumb:hover {
+  background: var(--color-fill-4);
+  background-clip: padding-box;
 }
 
 /* Pinned sidebar row - reserve a dedicated 28px slot on the right for the

--- a/src/renderer/pages/conversation/GroupedHistory/ConversationRow.tsx
+++ b/src/renderer/pages/conversation/GroupedHistory/ConversationRow.tsx
@@ -226,6 +226,7 @@ const ConversationRow: React.FC<ConversationRowProps> = (props) => {
             <Dropdown
               droplist={
                 <Menu
+                  style={{ maxHeight: 'min(60vh, 360px)', overflowY: 'auto' }}
                   onClickMenuItem={(key) => {
                     if (key === 'pin') {
                       onTogglePin(conversation);


### PR DESCRIPTION
## Two sidebar niggles

### 1. Chat context menu clipped "Delete"
Right-clicking / opening the ⋮ menu on a recent chat near the top of a short window let the menu (Pin / Rename / Schedule / Export / Add to project / Delete) run past the bottom edge, hiding Delete with no way to reach it. Cap the menu at `min(60vh, 360px)` with `overflow-y: auto` so it scrolls instead of clipping. Arco's default `autoFitPosition` already flips it up near the viewport edge.

### 2. Recent chats "scrolled off the page"
The sider scroll area hid its scrollbar entirely (`::-webkit-scrollbar { width: 0 }`), so with many chats there was no visual affordance that more existed and no drag target to reach them. Replaced with a thin overlay scrollbar that appears on hover. It only reserves width when content actually overflows, so the top-nav icon centering is unchanged in the normal (non-scrolling) case.

### Verified
- typecheck clean, oxfmt clean.
- Live (dev app): context menu renders the full list incl. Delete; nav icons stay aligned with the scrollbar change in the non-overflow case.
- Note: the many-chats scroll case is best confirmed on a profile with a long chat list (couldn't repro locally on an empty profile).

Targets the next release after 0.11.6.
