### PR TITLE
ci(security-audit): pull electron from npmmirror to defeat egress truncation (#361)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -390,14 +390,6 @@ jobs:
     if: github.event.action != 'closed' && github.event.pull_request.draft == false && inputs.skip_build_test != true
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # TEMPORARY (0.11.4 cut): a temporal CI-infra issue is capping the ~100MB
-    # electron binary download to ~1MB on this runner (deterministic 678KB
-    # truncation since ~2026-06-26 11:00 UTC; the same job passed at 10:33), so
-    # the Playwright _electron e2e can't launch. This is environmental, not a
-    # regression in the 0.11.4 changeset, and is not fixable from the install
-    # script. Made non-blocking to unblock the cut; the job still runs and
-    # reports. REVERT once the download is fixed. Tracked in #361.
-    continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -465,8 +465,17 @@ jobs:
           key: electron-bin-${{ runner.os }}-${{ hashFiles('node_modules/electron/package.json') }}
 
       - name: Ensure Electron binary is installed
+        # ROOT CAUSE (#361): the default electron binary host
+        # (release-assets.githubusercontent.com) is egress-capped to ~678KB from
+        # the GitHub-hosted Azure runners since ~2026-06-26, truncating the
+        # ~117MB zip mid-stream so install.js only ever extracts
+        # v8_context_snapshot.bin and never writes path.txt. The cache could
+        # never warm (Save is gated on a complete install that never happened),
+        # so the job stayed red under continue-on-error. Fix: pull from
+        # npmmirror's CDN (a different host, not behind that cap, serving the
+        # complete zip + SHASUMS256.txt so install.js still verifies integrity),
+        # falling back to the default github host only if the mirror is down.
         env:
-          ELECTRON_MIRROR: ''
           npm_config_disturl: 'https://electronjs.org/headers'
         run: |
           set -ex
@@ -480,16 +489,21 @@ jobs:
           if electron_ok; then
             echo "electron already present (cache-warm); skipping download"
           else
-            for attempt in 1 2 3 4; do
-              export electron_config_cache="$(mktemp -d)"
-              rm -rf node_modules/electron/dist node_modules/electron/path.txt
-              node node_modules/electron/install.js || true
-              if electron_ok; then
-                echo "electron installed OK (attempt $attempt)"
-                break
-              fi
-              echo "electron install incomplete (attempt $attempt); retrying after backoff"
-              sleep $((attempt * 5))
+            # Mirrors tried in order. '' is electron's default github host, kept
+            # as a last resort so we never regress below the prior behaviour.
+            for mirror in 'https://npmmirror.com/mirrors/electron/' ''; do
+              for attempt in 1 2 3; do
+                export electron_config_cache="$(mktemp -d)"
+                export ELECTRON_MIRROR="$mirror"
+                rm -rf node_modules/electron/dist node_modules/electron/path.txt
+                node node_modules/electron/install.js || true
+                if electron_ok; then
+                  echo "electron installed OK (mirror='${mirror:-default-github}', attempt $attempt)"
+                  break 2
+                fi
+                echo "electron install incomplete (mirror='${mirror:-default-github}', attempt $attempt); retrying after backoff"
+                sleep $((attempt * 5))
+              done
             done
           fi
           ls -la node_modules/electron/dist | head -12

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -465,47 +465,72 @@ jobs:
           key: electron-bin-${{ runner.os }}-${{ hashFiles('node_modules/electron/package.json') }}
 
       - name: Ensure Electron binary is installed
-        # ROOT CAUSE (#361): the default electron binary host
-        # (release-assets.githubusercontent.com) is egress-capped to ~678KB from
-        # the GitHub-hosted Azure runners since ~2026-06-26, truncating the
-        # ~117MB zip mid-stream so install.js only ever extracts
-        # v8_context_snapshot.bin and never writes path.txt. The cache could
-        # never warm (Save is gated on a complete install that never happened),
-        # so the job stayed red under continue-on-error. Fix: pull from
-        # npmmirror's CDN (a different host, not behind that cap, serving the
-        # complete zip + SHASUMS256.txt so install.js still verifies integrity),
-        # falling back to the default github host only if the mirror is down.
+        # ROOT CAUSE (#361): "Ensure Electron binary is installed" has failed
+        # deterministically since ~2026-06-26 — dist/ ends up with only
+        # v8_context_snapshot.bin and no path.txt, identically whether
+        # ELECTRON_MIRROR points at npmmirror or the default github host. So it
+        # is NOT a host-specific egress cap (that hypothesis was tested and
+        # disproven on this PR). @electron/get's own failure is swallowed by a
+        # console.error()+process.exit() flush race, hiding whether the cause is
+        # a network truncation or extraction (disk).
+        #
+        # This step bypasses @electron/get: download the zip with curl (a client
+        # not subject to whatever truncates @electron/get) with retries, then
+        # HARD-ASSERT size + sha256 against electron's bundled checksums.json so a
+        # truncated download fails loudly with the real byte count instead of
+        # silently. Unzip into dist/ ourselves, with df before/after to surface
+        # any ENOSPC. npmmirror first, default github as fallback. A complete
+        # install here also finally lets the actions/cache Save warm for reuse.
         env:
           npm_config_disturl: 'https://electronjs.org/headers'
         run: |
-          set -ex
+          set -x
+          df -h /
           electron_ok() {
             [ -s node_modules/electron/path.txt ] \
               && [ -x "node_modules/electron/dist/$(cat node_modules/electron/path.txt)" ]
           }
-          # Idempotent (#361 fix): a cache-warm or already-good binary is reused
-          # as-is. Only (re)download when missing, so the per-attempt `rm -rf dist`
-          # never destroys a usable binary.
           if electron_ok; then
             echo "electron already present (cache-warm); skipping download"
-          else
-            # Mirrors tried in order. '' is electron's default github host, kept
-            # as a last resort so we never regress below the prior behaviour.
-            for mirror in 'https://npmmirror.com/mirrors/electron/' ''; do
-              for attempt in 1 2 3; do
-                export electron_config_cache="$(mktemp -d)"
-                export ELECTRON_MIRROR="$mirror"
-                rm -rf node_modules/electron/dist node_modules/electron/path.txt
-                node node_modules/electron/install.js || true
-                if electron_ok; then
-                  echo "electron installed OK (mirror='${mirror:-default-github}', attempt $attempt)"
-                  break 2
-                fi
-                echo "electron install incomplete (mirror='${mirror:-default-github}', attempt $attempt); retrying after backoff"
-                sleep $((attempt * 5))
-              done
-            done
+            exit 0
           fi
+          VER="$(node -p "require('./node_modules/electron/package.json').version")"
+          ZIP="electron-v${VER}-linux-x64.zip"
+          EXPECT="$(node -e "process.stdout.write((require('./node_modules/electron/checksums.json')['${ZIP}']||'').toLowerCase())")"
+          echo "electron ${VER}; expected sha256=${EXPECT:-<none>}"
+          for base in \
+            "https://npmmirror.com/mirrors/electron/v${VER}" \
+            "https://github.com/electron/electron/releases/download/v${VER}"; do
+            url="${base}/${ZIP}"
+            echo "::group::download ${url}"
+            rm -f "/tmp/${ZIP}"
+            if ! curl -fsSL --retry 5 --retry-all-errors --connect-timeout 30 -o "/tmp/${ZIP}" "${url}"; then
+              echo "curl failed: ${url}"; echo "::endgroup::"; continue
+            fi
+            sz="$(stat -c%s "/tmp/${ZIP}")"
+            echo "downloaded bytes=${sz} from ${url}"
+            if [ "${sz}" -lt 50000000 ]; then
+              echo "TRUNCATED (${sz} bytes < 50MB) from ${url}"; echo "::endgroup::"; continue
+            fi
+            actual="$(sha256sum "/tmp/${ZIP}" | cut -d' ' -f1)"
+            if [ -n "${EXPECT}" ] && [ "${EXPECT}" != "${actual}" ]; then
+              echo "SHA256 MISMATCH expect=${EXPECT} actual=${actual} from ${url}"; echo "::endgroup::"; continue
+            fi
+            echo "download verified (size+sha256); extracting"
+            df -h /
+            rm -rf node_modules/electron/dist
+            mkdir -p node_modules/electron/dist
+            if ! unzip -q "/tmp/${ZIP}" -d node_modules/electron/dist; then
+              echo "UNZIP FAILED from ${url}"; df -h /; echo "::endgroup::"; continue
+            fi
+            chmod +x node_modules/electron/dist/electron || true
+            printf 'electron' > node_modules/electron/path.txt
+            if electron_ok; then
+              echo "INSTALLED OK from ${url}"; echo "::endgroup::"; break
+            fi
+            echo "post-extract check failed from ${url}"; echo "::endgroup::"
+          done
+          df -h /
           ls -la node_modules/electron/dist | head -12
           electron_ok
           node -e "const p=require('electron'); require('node:fs').accessSync(p); console.log('electron binary OK:', p)"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -564,10 +564,15 @@ jobs:
       # properties under test (sandbox, contextIsolation, nodeIntegration:false,
       # IPC handler registration, electron version) are identical in dev and
       # packaged mode.
+      # Electron is a GUI app: on the headless runner it aborts at startup with
+      # "Missing X server or $DISPLAY -> The platform failed to initialize.
+      # Exiting", so Playwright's _electron.launch never gets a window and times
+      # out after 60s (#361, surfaced once the binary install was fixed). Run
+      # under xvfb (preinstalled on ubuntu runners) to give it a virtual display.
       - name: Run security-audit e2e spec
         env:
           E2E_DEV: '1'
-        run: bunx playwright test tests/e2e/specs/security-audit-verification.e2e.ts
+        run: xvfb-run -a bunx playwright test tests/e2e/specs/security-audit-verification.e2e.ts
 
       - name: Upload Playwright report on failure
         if: failure()


### PR DESCRIPTION
## #361 / #354 — Security Audit E2E

Two distinct root causes, each found and fixed by instrumented CI iterations on this PR. The job is now green on the real runner (7 passed / 5 intentional skips).

### 1. Binary install (the literal #361 title)
The inherited diagnosis was a github-host egress cap. That was disproven here: the binary truncated to the identical 694685 bytes from npmmirror AND github, so it is not host-specific — the truncation is specific to @electron/get's HTTP client. Its real error was being swallowed by a console.error()+process.exit() flush race, which is why prior logs showed nothing.

Fix: bypass @electron/get in the install step — download the zip with curl (retries), HARD-assert byte size > 50MB and sha256 against electron's bundled checksums.json (so any future truncation fails loudly with the real byte count), then unzip into dist/ and write path.txt. CI confirms curl pulls the full 117255354 bytes and the binary installs. A complete install also finally lets the actions/cache Save warm for reuse.

### 2. Launch (surfaced once install worked)
With the binary present, the spec then timed out: the headless runner has no X display, so electron aborts at startup ("Missing X server or $DISPLAY -> The platform failed to initialize. Exiting") and Playwright's _electron.launch never gets a window (60s timeout x7 specs).

Fix: run the spec under xvfb-run -a (preinstalled on ubuntu runners) for a virtual display.

### Gate re-armed
With the e2e green, the temporary continue-on-error guard (added during the 0.11.4 cut) is removed, so the job is a real blocker again.

### Known non-blocker
A non-fatal better-sqlite3 NODE_MODULE_VERSION 137-vs-145 ABI warning remains in the unpackaged dev e2e (native module not rebuilt for electron's ABI in this fast dev build). The DB degrades gracefully and the security assertions (version, sandbox, contextIsolation, IPC allowlist, asset:// traversal, error handlers, bridge shapes) do not need it. Out of scope for #361; can be tracked separately if we want the dev e2e DB-capable.

Tracks #361, #354. Not closing (release/Sean action).
