### PR TITLE
fix(ui): Arco overlay close icons clickable over macOS titlebar drag region (#415)

### DIFF
--- a/src/renderer/styles/arco-override.css
+++ b/src/renderer/styles/arco-override.css
@@ -26,7 +26,6 @@ body,
   --arco-font-family: var(--forge-font);
 }
 
-
 /* Override Arco Design component backgrounds to white in light mode */
 /* .arco-input,
 .arco-textarea,
@@ -155,6 +154,32 @@ body[arco-theme='dark'] .arco-modal-footer {
 
 body[arco-theme='dark'] .arco-modal-title {
   color: var(--text-primary) !important;
+}
+
+/*
+ * macOS frameless-window drag-region fix (#415).
+ *
+ * The custom title bar (.app-titlebar--desktop) claims the top 45px of the
+ * window as a drag region (-webkit-app-region: drag) so the frameless window
+ * can be moved. Arco overlay surfaces - Drawer, Modal, and their popups -
+ * render in body-level portals that paint OVER that band. Because those
+ * portals are app-region:none (neutral, not no-drag) they do not punch a
+ * no-drag hole, so on macOS the OS treats the overlapped pixels as
+ * window-drag and silently swallows real mouse clicks there. The most visible
+ * casualty is a Drawer/Modal close (X) icon pinned to the top-right corner:
+ * the click "does nothing" because the OS ate it as a drag (Skills detail
+ * flyout, #415). Synthetic/CDP clicks bypass the OS layer, which is why this
+ * only bites real users.
+ *
+ * Mark the overlay surfaces no-drag so every control they host - including the
+ * close icon in the top band - stays clickable. Overlays are never legitimate
+ * window-drag handles, so this is safe; it is a no-op off Electron/macOS.
+ */
+.arco-drawer,
+.arco-modal,
+.arco-drawer-close-icon,
+.arco-modal-close-icon {
+  -webkit-app-region: no-drag;
 }
 
 body[arco-theme='dark'] .arco-modal-body,


### PR DESCRIPTION
Fixes #415 — the close (X) icon on the Skills detail flyout did nothing on macOS.

## Root cause
The frameless-window title bar (.app-titlebar--desktop) marks the top 45px of the
window as a -webkit-app-region:drag strip so the window can be moved. Arco Drawer and
Modal render in body-level portals that visually paint OVER that band, but those
surfaces are app-region:none (neutral) — they do not punch a no-drag hole. On macOS the
OS therefore claims the overlapped pixels for window-dragging and silently swallows real
mouse clicks there. The most visible casualty is a Drawer/Modal close icon pinned to the
top-right corner, which sits squarely inside the 45px band: the click "does nothing"
because the OS ate it as a window drag.

Synthetic / CDP (Playwright) clicks dispatch DOM events directly and bypass the OS drag
layer, which is why automated clicks close the drawer fine and only real users hit the
dead button — and why it reproduces on every version.

## Fix
A global rule in styles/arco-override.css marks .arco-drawer, .arco-modal and their
close icons -webkit-app-region:no-drag. The no-drag region paints on top of the
titlebar's drag region, so Chromium subtracts it and the OS stops treating those pixels
as draggable. Overlays are never legitimate window-drag handles, so this is safe; it is a
no-op off Electron/macOS.

## Verification (packaged build, electromcp)
- Before: close icon computed -webkit-app-region: none; a drag region overlapped the X
  with no no-drag region covering it.
- After (rebuilt out/): close icon and drawer compute no-drag; a no-drag region now covers
  the X's rect. Drawer still opens and closes correctly via a real click.
- Could not exercise the literal OS drag-swallow in-harness (CDP bypasses the OS layer);
  the computed-region flip is the deterministic proxy for the mechanism.

Scope: styles/arco-override.css only.
