### PR TITLE
fix(providers): surface connected opencode-go catalog in OpenCode agent picker (#407)

### DIFF
--- a/src/process/providers/ipc/modelRegistryIpc.ts
+++ b/src/process/providers/ipc/modelRegistryIpc.ts
@@ -150,16 +150,24 @@ const CLI_OAUTH_PROVIDERS: Record<CliAgentKey, ProviderId[]> = {
  * catalog is synthesized from the models.dev registry, exactly like a
  * non-enumerable CLI. Each maps to the one provider it runs, so the picker
  * surfaces real models BEFORE the first connection instead of dead-ending on
- * the "available after first connection" tooltip. Multi-provider CLIs
- * (opencode, goose, droid, auggie, cursor, …) are intentionally absent: they
- * have no single underlying provider, so they keep returning an empty curated
- * set (the picker then offers Flux Auto when the backend is Flux-routable).
+ * the "available after first connection" tooltip. Truly multi-provider CLIs
+ * (goose, droid, auggie, cursor, …) are intentionally absent: they have no
+ * single underlying provider, so they keep returning an empty curated set (the
+ * picker then offers Flux Auto when the backend is Flux-routable).
+ *
+ * `opencode` is mapped to the `opencode-go` gateway it is vendored alongside
+ * (#407): the OpenCode agent's picker dead-ended on the tooltip even with
+ * opencode-go "Connected · N models", because nothing surfaced that connected
+ * catalog. When opencode-go is connected, `synthesizeProvider` returns its real
+ * catalog; when it is not, opencode-go has no models.dev slice so the result is
+ * empty (cold-start parity with the old behavior, no misleading vendor list).
  */
 const ACP_BACKEND_UNDERLYING_PROVIDER: Record<string, ProviderId> = {
   grok: 'xai',
   kimi: 'moonshot',
   qwen: 'qwen',
   vibe: 'mistral',
+  opencode: 'opencode-go',
 };
 
 // ─── Injectable dependencies ──────────────────────────────────────────────────

--- a/tests/unit/AcpModelSelector.dom.test.tsx
+++ b/tests/unit/AcpModelSelector.dom.test.tsx
@@ -365,6 +365,46 @@ describe('AcpModelSelector', () => {
     });
   });
 
+  it('renders the connected opencode-go catalog for the OpenCode agent instead of the first-connection tooltip (#407)', async () => {
+    // #407: the OpenCode agent picker permanently showed "available after first
+    // connection" even with opencode-go "Connected · N models". The process now
+    // maps opencode->opencode-go so curatedForAgent('opencode') returns that
+    // connected catalog; the picker must surface it as a selectable dropdown
+    // (State 1b) rather than dead-ending on the tooltip.
+    ipcMock.getModelInfo.mockResolvedValue({
+      success: true,
+      data: { modelInfo: null },
+    });
+    configGetMock.mockResolvedValue(null);
+    ipcMock.curatedForAgent.mockResolvedValue([
+      {
+        id: 'deepseek-v4-pro',
+        providerId: 'opencode-go',
+        displayName: 'DeepSeek V4 Pro',
+        family: 'deepseek',
+        enabled: true,
+        recommended: true,
+        costInPerM: 1,
+        costOutPerM: 2,
+      },
+    ]);
+
+    render(<AcpModelSelector conversationId='conv-opencode' backend='opencode' />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('common.defaultModel').length).toBeGreaterThan(0);
+    });
+    expect(screen.queryByText(FIRST_CONNECTION_LABEL)).toBeNull();
+
+    fireEvent.click(screen.getByRole('button'));
+    await waitFor(() => {
+      expect(screen.getByText('DeepSeek V4 Pro')).toBeTruthy();
+    });
+
+    // The backend is forwarded so the process derives the opencode catalog.
+    expect(ipcMock.curatedForAgent).toHaveBeenCalledWith(expect.objectContaining({ agentKey: 'opencode' }));
+  });
+
   it('shows the first-connection guidance only after the cache load completes with no models', async () => {
     // No cached catalog and no live models: a backend that has genuinely never
     // connected. After the cache lookup settles, the first-connection label shows.

--- a/tests/unit/process/providers/modelRegistryIpc.test.ts
+++ b/tests/unit/process/providers/modelRegistryIpc.test.ts
@@ -1392,7 +1392,7 @@ describe('modelRegistry IPC - curatedForAgent ACP backends (#374)', () => {
   });
 
   it('returns [] for a multi-provider ACP backend with no single underlying provider (goose)', async () => {
-    // goose/opencode/droid/… run any connected provider, so there is no single
+    // goose/droid/… run any connected provider, so there is no single
     // catalog to synthesize - the picker offers Flux Auto (when routable) rather
     // than a misleading vendor catalog.
     const { deps, getRegistry } = makeFakes();
@@ -1400,6 +1400,30 @@ describe('modelRegistry IPC - curatedForAgent ACP backends (#374)', () => {
     const h = createModelRegistryHandlers(deps);
 
     expect(await h.curatedForAgent({ agentKey: 'goose' })).toEqual([]);
+  });
+
+  it('surfaces the connected opencode-go catalog for the opencode backend (#407)', async () => {
+    // #407: the OpenCode agent picker dead-ended on "available after first
+    // connection" even with opencode-go "Connected · 20 models", because
+    // curatedForAgent('opencode') returned []. opencode pairs with the
+    // opencode-go gateway (vendored together), so surface its connected catalog
+    // exactly like a vendor-locked backend (grok→xai).
+    const { deps, repo } = makeFakes();
+    repo.upsertRegistryProvider({
+      providerId: 'opencode-go',
+      connectedVia: 'api-key',
+      state: 'connected',
+      creds: { key: 'k' },
+    });
+    repo.replaceRegistryCatalog('opencode-go', [
+      catalogModel({ id: 'deepseek-v4-pro', providerId: 'opencode-go' }),
+      catalogModel({ id: 'qwen3-coder', providerId: 'opencode-go' }),
+    ]);
+    const h = createModelRegistryHandlers(deps);
+
+    const ids = (await h.curatedForAgent({ agentKey: 'opencode' })).map((m) => m.id).toSorted();
+
+    expect(ids).toEqual(['deepseek-v4-pro', 'qwen3-coder']);
   });
 });
 


### PR DESCRIPTION
## #407 — OpenCode agent model picker never populates

The OpenCode ACP agent's in-chat model picker permanently showed "Model list will be available after first connection" even when the opencode-go gateway provider was connected ("Connected · 20 models"). No model could be selected in-app; the only workaround was hand-editing ~/.config/opencode/opencode.json.

### Root cause
curatedForAgent('opencode') returned an empty list. opencode was bucketed with truly multi-provider CLIs (goose, droid, auggie, …) as having "no single underlying provider", so nothing surfaced the connected opencode-go catalog to the picker. The renderer's curated fallback (State 1b) therefore had no models and dead-ended on the first-connection tooltip.

opencode is, however, vendored alongside the opencode-go gateway, and opencode-go is the provider users actually connect for it — exactly the vendor-locked shape #374 handled for grok→xai.

### Change
Map opencode → opencode-go in ACP_BACKEND_UNDERLYING_PROVIDER. When opencode-go is connected, synthesizeProvider returns its real catalog; when it is not, opencode-go has no models.dev slice so the result stays empty (cold-start parity — no misleading vendor list). The renderer's existing curated-dropdown fallback then renders the catalog as a selectable picker instead of the tooltip.

One line of behavior change + doc; goose/droid/etc. remain intentionally empty.

### Tests
- Handler: the connected opencode-go catalog now surfaces for the opencode backend (RED→GREEN); existing curatedForAgent cases unaffected (23 pass).
- Renderer DOM: the OpenCode picker renders the curated dropdown (DeepSeek V4 Pro), shows no first-connection tooltip, and forwards agentKey='opencode'.
- Full modelRegistryIpc suite (94) + AcpModelSelector DOM suite (9) green; typecheck + oxfmt + oxlint clean on changed files.

### Scope + verification routed to Overwatch
This fixes the primary symptom: the picker populates and is selectable. Two follow-on questions need a live opencode-go account to settle (I don't have one; routing to Overwatch / the reporter):
1. Does selecting a populated-picker model now route to opencode via ACP setModel, or does opencode still honor only opencode.json "model"? The reporter's "only opencode.json is honored" finding was made against a permanently-empty picker, so it's untested against a populated one.
2. If selection does not route, a follow-up should persist the chosen model into opencode.json top-level "model" + respawn (the connector already owns atomic opencode.json writes).

Not marking the issue fixed-pending-release until that live end-to-end is confirmed.
