### PR TITLE
fix(mcp): WebUI MCP OAuth/config routes read servers via ProcessConfig (#283/#397)

### DIFF
--- a/src/process/webserver/routes/mcpConfigRoutes.ts
+++ b/src/process/webserver/routes/mcpConfigRoutes.ts
@@ -26,7 +26,7 @@
  *    plain HTTP from the public internet.
  *
  * Server records and the target agent list are resolved SERVER-SIDE
- * (`ConfigStorage.get('mcp.config')` + `agentRegistry.getDetectedAgents()`): the
+ * (`ProcessConfig.get('mcp.config')` + `agentRegistry.getDetectedAgents()`): the
  * remote body carries only ids, so a remote caller can never inject an arbitrary
  * `command` / `cliPath` for the agent CLIs to execute. It does NOT route through
  * the WS bridge (R2: the `mcpService.*` IPC channels remain denied to remote
@@ -38,7 +38,6 @@ import { apiRateLimiter } from '../middleware/security';
 import { redactSecrets, requireSecureConfigWrite } from './configWriteGuards';
 import { detectNetworkContext } from '../middleware/detectNetworkContext';
 import { appendAudit } from '../audit/auditLog';
-import { ConfigStorage } from '@/common/config/storage';
 import type { IMcpServer } from '@/common/config/storage';
 import { mcpService } from '@process/services/mcpServices/McpService';
 import { agentRegistry } from '@process/agent/AgentRegistry';
@@ -57,9 +56,16 @@ function detectedAgents(): Array<{ backend: string; name: string; cliPath?: stri
   }));
 }
 
-/** Look up a stored MCP server record by id - never trusts a client-supplied spec. */
+/**
+ * Look up a stored MCP server record by id - never trusts a client-supplied spec.
+ *
+ * #283/#397: read via `ProcessConfig` (direct main-process accessor), NOT the
+ * renderer-facing `ConfigStorage`, which round-trips over IPC and HANGS when
+ * called from the main process (this webserver). Mirrors the desktop-bridge fix.
+ */
 async function findServerById(serverId: string): Promise<IMcpServer | undefined> {
-  const servers: IMcpServer[] = (await ConfigStorage.get('mcp.config').catch(() => [] as IMcpServer[])) ?? [];
+  const { ProcessConfig } = await import('@process/utils/initStorage');
+  const servers: IMcpServer[] = (await ProcessConfig.get('mcp.config').catch(() => [] as IMcpServer[])) ?? [];
   return servers.find((s) => s.id === serverId);
 }
 

--- a/src/process/webserver/routes/mcpOAuthRoutes.ts
+++ b/src/process/webserver/routes/mcpOAuthRoutes.ts
@@ -55,9 +55,12 @@ import { apiRateLimiter } from '../middleware/security';
 import { redactSecrets, requireSecureConfigWrite } from './configWriteGuards';
 import { detectNetworkContext } from '../middleware/detectNetworkContext';
 import { appendAudit } from '../audit/auditLog';
-import { ConfigStorage } from '@/common/config/storage';
 import type { IMcpServer } from '@/common/config/storage';
-import { mcpOAuthService, WAYLAND_OAUTH_CALLBACK_PORT, WAYLAND_OAUTH_REDIRECT_URI } from '@process/services/mcpServices/McpOAuthService';
+import {
+  mcpOAuthService,
+  WAYLAND_OAUTH_CALLBACK_PORT,
+  WAYLAND_OAUTH_REDIRECT_URI,
+} from '@process/services/mcpServices/McpOAuthService';
 
 /** The path the vendor redirects the remote browser back to (our public origin). */
 const REMOTE_CALLBACK_PATH = '/api/mcp/oauth/callback';
@@ -70,9 +73,16 @@ function bodyString(value: unknown): string {
  * Load the persisted MCP servers (same backing key the desktop bridge reads).
  * A storage failure is allowed to propagate to the route's catch so the error is
  * redacted before it reaches the client (R6).
+ *
+ * #283/#397: the read MUST go through `ProcessConfig` (direct main-process file
+ * accessor), NOT the renderer-facing `ConfigStorage`, which round-trips over IPC
+ * and HANGS when called from the main process (the webserver runs in main). The
+ * desktop bridge was fixed in #283; this is the same hang on the remote-WebUI
+ * GitHub MCP OAuth surface, which wedged "Save & Sign In" with no resolution.
  */
 async function loadServers(): Promise<IMcpServer[]> {
-  return (await ConfigStorage.get('mcp.config')) ?? [];
+  const { ProcessConfig } = await import('@process/utils/initStorage');
+  return (await ProcessConfig.get('mcp.config')) ?? [];
 }
 
 /**

--- a/tests/unit/webserver/mcpConfigRoutes.test.ts
+++ b/tests/unit/webserver/mcpConfigRoutes.test.ts
@@ -30,8 +30,11 @@ vi.mock('@process/agent/AgentRegistry', () => ({
 vi.mock('@process/bridge/mcpBridge', () => ({
   persistMcpByoOAuthCredentials: mockPersistByo,
 }));
-vi.mock('@/common/config/storage', () => ({
-  ConfigStorage: { get: mockGet },
+// #283/#397 regression guard: findServerById must read through ProcessConfig
+// (direct main-process accessor), never the renderer-facing ConfigStorage, which
+// hangs when called from the main-process webserver.
+vi.mock('@process/utils/initStorage', () => ({
+  ProcessConfig: { get: mockGet },
 }));
 vi.mock('../../../src/process/webserver/audit/auditLog', () => ({
   appendAudit: mockAppendAudit,
@@ -190,7 +193,10 @@ describe('mcp config routes (W3.D write-only MCP config)', () => {
   });
 
   it('remove audits with action mcp.remove', async () => {
-    await captureHandlers()['/api/mcp/remove-from-agents'](makeReq({ body: { name: 'raindrop' }, userId: 'u1' }), makeRes());
+    await captureHandlers()['/api/mcp/remove-from-agents'](
+      makeReq({ body: { name: 'raindrop' }, userId: 'u1' }),
+      makeRes()
+    );
     expect(mockAppendAudit.mock.calls[0][0]).toMatchObject({ action: 'mcp.remove', target: 'raindrop' });
   });
 

--- a/tests/unit/webserver/mcpOAuthRoutes.test.ts
+++ b/tests/unit/webserver/mcpOAuthRoutes.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Express, Request, RequestHandler, Response } from 'express';
 
-// The connect route loads servers via ConfigStorage, starts the flow via the
-// mcpOAuthService singleton, and captures the auth URL off the core feedback
-// event. All three are hoisted mocks so the route runs in isolation.
+// The connect route loads servers via ProcessConfig (#283/#397: NOT the
+// renderer-facing ConfigStorage, which hangs when called from the main-process
+// webserver), starts the flow via the mcpOAuthService singleton, and captures
+// the auth URL off the core feedback event. All hoisted mocks so the route runs
+// in isolation.
 const { mockLogin, mockGet, mockAppendAudit, emitter, servers } = vi.hoisted(() => {
   const { EventEmitter } = require('node:events');
   const feedbackEmitter = new EventEmitter();
@@ -36,8 +38,10 @@ vi.mock('@process/services/mcpServices/McpOAuthService', () => ({
   WAYLAND_OAUTH_CALLBACK_PORT: '57000',
   WAYLAND_OAUTH_REDIRECT_URI: 'http://localhost:57000/oauth/callback',
 }));
-vi.mock('@/common/config/storage', () => ({
-  ConfigStorage: { get: mockGet },
+// #283/#397 regression guard: the route must read servers through ProcessConfig
+// (direct main-process accessor), never the renderer-facing ConfigStorage.
+vi.mock('@process/utils/initStorage', () => ({
+  ProcessConfig: { get: mockGet },
 }));
 vi.mock('../../../src/process/webserver/audit/auditLog', () => ({
   appendAudit: mockAppendAudit,
@@ -164,7 +168,10 @@ describe('MCP OAuth connect route (W4a write-only DCR connect)', () => {
   });
 
   it('connect keeps the desktop loopback redirect unchanged for a loopback peer', async () => {
-    await captureHandlers()['POST /api/mcp/oauth/connect'](makeReq({ body: { serverId: 'srv-1' }, peer: '127.0.0.1' }), makeRes());
+    await captureHandlers()['POST /api/mcp/oauth/connect'](
+      makeReq({ body: { serverId: 'srv-1' }, peer: '127.0.0.1' }),
+      makeRes()
+    );
 
     expect(mockLogin).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'srv-1' }),


### PR DESCRIPTION
## #283 / #397 — GitHub MCP OAuth "Save & Sign In" hang (WebUI surface)

### Background
#283 root-caused the desktop hang: main-process code read `mcp.config` through the renderer-facing `ConfigStorage`, which round-trips over IPC and **hangs when called from the main process**. The fix swapped the desktop bridge to `ProcessConfig` (a direct main-process file accessor). That shipped in 0.11.4 → forward-merged into 0.11.6, so the **desktop** hang (#242 on 0.11.2, #397 on 0.11.3 — both predate the fix) is resolved on current main.

### What this PR fixes
The remote-**WebUI** surface was missed. The webserver also runs in the main process, and two of its MCP routes still read `mcp.config` via the hanging `ConfigStorage`:
- `mcpOAuthRoutes.ts` `loadServers()` — the GitHub MCP OAuth **connect** path
- `mcpConfigRoutes.ts` `findServerById()` — sync-to-agents / remove-from-agents

A remote-WebUI user signing into GitHub MCP would hit the same indefinite hang #397 describes. Both are swapped to `ProcessConfig` via dynamic import, mirroring the proven mcpBridge fix. Pure read-path change — route behavior is otherwise identical.

### Tests
The two webserver route suites (29 tests) now feed servers through a `ProcessConfig` mock instead of `ConfigStorage`, so they fail if either route regresses to the hanging accessor. Full suites green; typecheck + oxfmt + oxlint clean on changed files.

### Verification routed to Overwatch
Live end-to-end of the remote-WebUI GitHub MCP OAuth flow needs a remote session + a real GitHub OAuth App — routing that to Overwatch. The desktop hang is already fixed in 0.11.6; recommend asking the #242/#397 reporters to retest on 0.11.6.

### Related (out of scope, flagged)
`src/process/bridge/voiceSynthBridge.ts:14` has the same `ConfigStorage`-from-main read for `tools.textToSpeech` (non-MCP). Same one-line class of fix; left for a separate change.
