### PR TITLE
fix(signal): manual receive-mode + single-account receive params so inbound polling works (#387)

### DIFF
--- a/src/process/channels/plugins/tier1/signal/SignalDaemon.ts
+++ b/src/process/channels/plugins/tier1/signal/SignalDaemon.ts
@@ -287,6 +287,13 @@ export class SignalDaemon {
       '--http',
       `${this.opts.httpHost}:${this.opts.httpPort}`,
       '--no-receive-stdout',
+      // #387: the daemon defaults to `--receive-mode on-connection` (auto-receive
+      // in the background), which makes a manual `receive` RPC fail with
+      // `-1 Receive command cannot be used if messages are already being received`.
+      // Wayland's design is manual polling (pollReceive), so run the daemon in
+      // manual receive mode so those polls are accepted (signal-cli 0.13.x/0.14.x).
+      '--receive-mode',
+      'manual',
     ];
 
     // stdin is `ignore` - RPC travels over HTTP, not stdio.  stdout/stderr
@@ -469,7 +476,13 @@ export class SignalDaemon {
     try {
       const result = await this.postRpc(
         'receive',
-        { account: this.opts.phoneNumber, ignoreAttachments: false },
+        // #387: a single-account daemon (`-a <number>`) accepts ONLY
+        // { maxMessages?, timeout? } for `receive`. `account` is implicit under
+        // `-a`, and `ignoreAttachments` is a daemon SPAWN flag
+        // (`--ignore-attachments`), not a per-call param - sending either is
+        // rejected with `-32600 Unrecognized field`. `timeout` is the per-poll
+        // receive window in seconds (we re-poll every RECEIVE_POLL_INTERVAL_MS).
+        { timeout: 1 },
         RECEIVE_RPC_TIMEOUT_MS
       );
       const envelopes = Array.isArray(result) ? result : [];

--- a/tests/unit/process/channels/plugins/tier1/signal/SignalDaemon.restart.test.ts
+++ b/tests/unit/process/channels/plugins/tier1/signal/SignalDaemon.restart.test.ts
@@ -125,7 +125,7 @@ beforeEach(() => {
         return new Response('', { status: 200 });
       }
       return jsonRpcOk(1, []);
-    }),
+    })
   );
 });
 
@@ -145,17 +145,17 @@ describe('SignalDaemon restart behaviour', () => {
     expect(args).toContain('--http');
     expect(args).toContain('+14155551234');
     expect(args).toContain('--no-receive-stdout');
+    // #387: manual receive-mode so the daemon does not auto-receive (which would
+    // reject our manual `receive` polls with -1 "already being received").
+    expect(args).toContain('--receive-mode');
+    expect(args).toContain('manual');
     await daemon.stop();
   });
 
   it('spawns child with stdin ignored (RPC travels via HTTP)', async () => {
     const daemon = new SignalDaemon({ phoneNumber: '+14155551234' });
     await daemon.start();
-    const [, , spawnOpts] = mockSpawn.mock.calls[0] as [
-      string,
-      string[],
-      { stdio: [string, string, string] },
-    ];
+    const [, , spawnOpts] = mockSpawn.mock.calls[0] as [string, string[], { stdio: [string, string, string] }];
     expect(spawnOpts.stdio).toEqual(['ignore', 'pipe', 'pipe']);
     await daemon.stop();
   });
@@ -276,7 +276,7 @@ describe('SignalDaemon HTTP transport', () => {
           return jsonRpcOk(body.id, { timestamp: 1_700_000_000_000 });
         }
         return new Response('', { status: 404 });
-      }),
+      })
     );
 
     const daemon = new SignalDaemon({ phoneNumber: '+14155551234' });
@@ -291,10 +291,7 @@ describe('SignalDaemon HTTP transport', () => {
     expect(result).toEqual({ timestamp: 1_700_000_000_000 });
 
     const sendCall = captured.find(
-      (c) =>
-        c.url.endsWith('/api/v1/rpc') &&
-        typeof c.init?.body === 'string' &&
-        c.init.body.includes('"send"'),
+      (c) => c.url.endsWith('/api/v1/rpc') && typeof c.init?.body === 'string' && c.init.body.includes('"send"')
     );
     expect(sendCall).toBeDefined();
     expect(sendCall!.url).toBe('http://127.0.0.1:8080/api/v1/rpc');
@@ -321,9 +318,9 @@ describe('SignalDaemon HTTP transport', () => {
             id: body.id,
             error: { code: -32601, message: 'method not found' },
           }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } },
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
         );
-      }),
+      })
     );
 
     const daemon = new SignalDaemon({ phoneNumber: '+14155551234' });
@@ -353,7 +350,7 @@ describe('SignalDaemon HTTP transport', () => {
           return jsonRpcOk(body.id, receiveCalls === 1 ? [envelope] : []);
         }
         return jsonRpcOk(body.id, null);
-      }),
+      })
     );
 
     const daemon = new SignalDaemon({ phoneNumber: '+14155551234' });
@@ -371,6 +368,37 @@ describe('SignalDaemon HTTP transport', () => {
     await daemon.stop();
   });
 
+  it('polls `receive` with single-account params (timeout only; no account / ignoreAttachments) (#387)', async () => {
+    const captured: FetchCall[] = [];
+    vi.stubGlobal(
+      'fetch',
+      makeFetchMock((call) => {
+        captured.push(call);
+        if (call.url.endsWith('/api/v1/check')) return new Response('', { status: 200 });
+        const body = JSON.parse(String(call.init?.body ?? '{}')) as { id: number };
+        return jsonRpcOk(body.id, []);
+      })
+    );
+
+    const daemon = new SignalDaemon({ phoneNumber: '+14155551234' });
+    await daemon.start();
+
+    const isReceive = (c: FetchCall): boolean => typeof c.init?.body === 'string' && c.init.body.includes('"receive"');
+    await vi.waitFor(() => expect(captured.some(isReceive)).toBe(true), { timeout: 2_000 });
+
+    const body = JSON.parse(String(captured.find(isReceive)!.init!.body)) as {
+      params: Record<string, unknown>;
+    };
+    // A single-account daemon (`-a <number>`) rejects `account` /
+    // `ignoreAttachments` for `receive` with -32600; only maxMessages?/timeout?
+    // are accepted.
+    expect(body.params).not.toHaveProperty('account');
+    expect(body.params).not.toHaveProperty('ignoreAttachments');
+    expect(body.params).toHaveProperty('timeout');
+
+    await daemon.stop();
+  });
+
   it('offMessage removes a handler so it no longer fires', async () => {
     const envelope = {
       envelope: { source: '+12125550100', timestamp: 1, dataMessage: { message: 'x' } },
@@ -383,7 +411,7 @@ describe('SignalDaemon HTTP transport', () => {
         const body = JSON.parse(String(init?.body ?? '{}')) as { id: number; method: string };
         if (body.method === 'receive') return jsonRpcOk(body.id, [envelope]);
         return jsonRpcOk(body.id, null);
-      }),
+      })
     );
 
     const daemon = new SignalDaemon({ phoneNumber: '+14155551234' });


### PR DESCRIPTION
## #387 — Signal channel never receives inbound messages

The Signal channel connects and passes "Test connection" but never receives inbound messages — `SignalDaemon`'s receive poll fails every cycle against signal-cli **0.13.x AND 0.14.x** (reporter verified 0.13.24 + 0.14.5, so pinning an older signal-cli doesn't help). Two independent bugs:

### Bug 1 — wrong `receive` params (`-32600`)
`pollReceive()` sent `{ account, ignoreAttachments }`, but a single-account daemon (`-a <number>`) accepts only `{ maxMessages?, timeout? }` for `receive`. `account` is implicit under `-a`, and `ignoreAttachments` is a daemon **spawn flag** (`--ignore-attachments`), not a per-call param → every poll rejected with `Unrecognized field "account"`.
**Fix:** send only `{ timeout: 1 }` (a 1s receive window per poll). Not adding `--ignore-attachments` preserves the prior `ignoreAttachments:false` intent.

### Bug 2 — wrong receive mode (`-1`)
The daemon defaults to `--receive-mode on-connection` (auto-receive), so a manual `receive` RPC is rejected with `Receive command cannot be used if messages are already being received`. Wayland's design is manual polling.
**Fix:** spawn the daemon with `--receive-mode manual`.

### Tests
`SignalDaemon.restart.test.ts`: spawn args include `--receive-mode manual`; the `receive` poll body carries `{ timeout }` with **no** `account` / `ignoreAttachments`. Full Signal suite (65) green; typecheck + oxfmt + oxlint clean.

### Verification routed to Overwatch
Full live receive needs a registered Signal account + a running signal-cli daemon — routed to Overwatch / the reporter. The JSON-RPC contract is verified against the reporter's direct 0.13.24/0.14.5 repro; the params + spawn args are unit-locked.
