### PR TITLE
perf(test): cut unit shard 1/4 — gate BM25, fake-timer the real-timer error-path tests (#358)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -134,13 +134,14 @@ jobs:
     name: Unit Tests Shard (${{ matrix.os }} ${{ matrix.shard }}/4)
     if: github.event_name == 'workflow_dispatch' || (github.event.action != 'closed' && github.event.pull_request.draft == false)
     runs-on: ${{ matrix.os }}
-    # Stopgap headroom (#353): shard 1/4 grew to ~19m on ubuntu (vs the ~3.5m
-    # average) from slow real-timer error-path tests + the skillRecall release-gate
-    # BM25 full-corpus test (~16s), tipping over the old 20m cap (cancelled on all
-    # OS, ~2.7x worse on windows). Tests PASS — this is runtime, not a hang. Raised
-    # to 35m to unblock the 0.11.4 cut; the real fix (fake-timers for the error-path
-    # tests + moving the BM25 release-gate out of the PR shards) is tracked separately.
-    timeout-minutes: 35
+    # #358: shard 1/4 was ~19m on ubuntu (vs the ~3.5m average) from real-timer
+    # error-path tests + the skillRecall BM25 full-corpus gate. Those are now
+    # fixed — the BM25 gate is gated out of PR shards behind RUN_RELEASE_GATES
+    # (runs in release-gates.yml), and the iMessage delivery-poll / ConnectionTester
+    # retry / killChild escalation tests no longer wait real seconds. The 35m
+    # stopgap is dropped to 20m; tighten toward ~15m once this PR's CI run confirms
+    # the actual post-fix shard time.
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -138,10 +138,12 @@ jobs:
     # error-path tests + the skillRecall BM25 full-corpus gate. Those are now
     # fixed — the BM25 gate is gated out of PR shards behind RUN_RELEASE_GATES
     # (runs in release-gates.yml), and the iMessage delivery-poll / ConnectionTester
-    # retry / killChild escalation tests no longer wait real seconds. The 35m
-    # stopgap is dropped to 20m; tighten toward ~15m once this PR's CI run confirms
-    # the actual post-fix shard time.
-    timeout-minutes: 20
+    # retry / killChild escalation tests no longer wait real seconds. Post-fix CI
+    # on this PR: ubuntu/macos shards ~2min, windows shards 7.6-9.3min (windows
+    # runners are just slow; tracked separately). The 35m stopgap drops to 15m —
+    # ~1.6x over the slowest (windows, 9.3min). If windows variance trips the cap,
+    # raise toward 18-20m.
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release-gates.yml
+++ b/.github/workflows/release-gates.yml
@@ -1,0 +1,64 @@
+name: Release Gates
+
+# Runs the heavyweight "release gate" tests that guard a release decision
+# rather than the correctness of any single PR. These are gated behind
+# RUN_RELEASE_GATES=1 and skipped on every PR shard (they were the main driver
+# of the unit shard-1/4 time imbalance, #358). This nightly lane is where they
+# actually execute.
+#
+# Currently covers:
+#   - tests/unit/process/services/skills/skillRecall.test.ts
+#     (BM25 recall@20 over the full 2105-doc x 2003-query corpus)
+# Add new release-gate files to the `run:` step below as they are introduced.
+#
+# Security: no untrusted PR/issue text is interpolated into any run: step.
+
+on:
+  schedule:
+    # Nightly at 08:00 UTC.
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: release-gates-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  BUN_INSTALL_REGISTRY: 'https://registry.npmjs.org/'
+  WCORE_SKIP: '1'
+  CI: 'true'
+  NODE_OPTIONS: '--max-old-space-size=8192'
+
+jobs:
+  release-gates:
+    name: Release Gate Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+          cache: true
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run postinstall
+        run: npm run postinstall || true
+
+      - name: Run release-gate tests
+        env:
+          RUN_RELEASE_GATES: '1'
+        run: bunx vitest run tests/unit/process/services/skills/skillRecall.test.ts

--- a/src/process/agent/acp/utils.ts
+++ b/src/process/agent/acp/utils.ts
@@ -41,8 +41,13 @@ export async function waitForProcessExit(pid: number, timeoutMs: number): Promis
 /**
  * Kill a child process with platform-specific handling.
  * Windows: taskkill tree kill. POSIX: collect descendants → SIGTERM → SIGKILL escalation.
+ *
+ * `sigtermGraceMs` is how long to wait for a graceful SIGTERM exit before
+ * escalating to SIGKILL (default 3s). It is parameterised so tests that spawn a
+ * real SIGTERM-ignoring process can use a short grace instead of paying the full
+ * 3s real-time wait (#358).
  */
-export async function killChild(child: ChildProcess, isDetached: boolean): Promise<void> {
+export async function killChild(child: ChildProcess, isDetached: boolean, sigtermGraceMs = 3000): Promise<void> {
   const pid = child.pid;
   if (process.platform === 'win32' && pid) {
     try {
@@ -69,7 +74,7 @@ export async function killChild(child: ChildProcess, isDetached: boolean): Promi
   }
 
   if (pid) {
-    await waitForProcessExit(pid, 3000);
+    await waitForProcessExit(pid, sigtermGraceMs);
 
     // Escalate to SIGKILL if the process ignored SIGTERM
     if (isProcessAlive(pid)) {

--- a/tests/unit/acpKillChild.test.ts
+++ b/tests/unit/acpKillChild.test.ts
@@ -41,7 +41,9 @@ describeIfPosix('killChild', () => {
     await new Promise((r) => setTimeout(r, 200));
     expect(isProcessAlive(child.pid!)).toBe(true);
 
-    await killChild(child, false);
+    // Short SIGTERM grace (250ms) so this real-process escalation test does not
+    // pay the full 3s production default (#358); the SIGKILL path is identical.
+    await killChild(child, false, 250);
 
     // Should be dead via SIGKILL escalation
     expect(isProcessAlive(child.pid!)).toBe(false);

--- a/tests/unit/officeWatchBridge.test.ts
+++ b/tests/unit/officeWatchBridge.test.ts
@@ -168,9 +168,18 @@ function flush() {
  * race the spawn; poll until the child process has actually been spawned.
  */
 async function waitForSpawn(target: number) {
-  for (let i = 0; i < 50 && spawnMock.mock.calls.length < target; i++) {
-    await flush();
-  }
+  // confinePath does several real async hops (realpath walk + optional DB
+  // discovery) before spawn. A fixed-tick poll (the old 50x flush()) races and
+  // gives up early on slow/loaded CI runners — the start promise then never
+  // settles and the spec hits its 10s timeout (intermittent windows flake,
+  // #292). vi.waitFor polls against a real 5s budget so it tolerates a slow
+  // spawn deterministically without waiting when spawn is already done.
+  await vi.waitFor(
+    () => {
+      if (spawnMock.mock.calls.length < target) throw new Error(`spawn ${spawnMock.mock.calls.length}/${target}`);
+    },
+    { timeout: 5000, interval: 5 }
+  );
 }
 
 /**

--- a/tests/unit/process/channels/plugins/tier2/imessage/ImessagePlugin.deliveryAndService.test.ts
+++ b/tests/unit/process/channels/plugins/tier2/imessage/ImessagePlugin.deliveryAndService.test.ts
@@ -107,6 +107,20 @@ beforeEach(() => {
   plugin = new ImessagePlugin();
 });
 
+// F11 post-send delivery verification polls chat.db for a real
+// DELIVERY_POLL_CYCLES (5) x DELIVERY_POLL_INTERVAL_MS (600) = 3 s ceiling via
+// setTimeout. Under fake timers we advance past that budget instead of waiting
+// the real ~3 s (#358 - this was a top contributor to the shard-1/4 imbalance).
+// advanceTimersByTimeAsync (not runAllTimersAsync) is used deliberately: start()
+// installs a self-rescheduling inbound-poll setInterval that would make
+// runAllTimersAsync spin forever.
+const DELIVERY_BUDGET_MS = 3000;
+async function sendDrained(...args: Parameters<ImessagePlugin['sendMessage']>): Promise<string> {
+  const p = plugin.sendMessage(...args);
+  await vi.advanceTimersByTimeAsync(DELIVERY_BUDGET_MS);
+  return p;
+}
+
 // ---------------------------------------------------------------------------
 // F6 - attributedBody fallback
 // ---------------------------------------------------------------------------
@@ -180,16 +194,17 @@ describe('F6 - decodeAttributedBody fallback', () => {
 // ---------------------------------------------------------------------------
 
 describe('F8 - sendMessage picks iMessage vs SMS service from chat.service_name', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
   it('uses `service type = iMessage` when chat.service_name = "iMessage"', async () => {
     mockServiceLookupStmt.get.mockReturnValue({ service_name: 'iMessage' });
 
     await plugin.initialize(cfg());
     await plugin.start();
-    await plugin.sendMessage('+15551234567', { type: 'text', text: 'hi' });
+    await sendDrained('+15551234567', { type: 'text', text: 'hi' });
 
-    const sendCall = mockExecFileNoThrow.mock.calls.find((c) =>
-      String(c[1]?.[1] ?? '').includes('targetBuddy'),
-    );
+    const sendCall = mockExecFileNoThrow.mock.calls.find((c) => String(c[1]?.[1] ?? '').includes('targetBuddy'));
     expect(sendCall).toBeDefined();
     const script = String(sendCall![1]![1]);
     expect(script).toContain('service type = iMessage');
@@ -202,11 +217,9 @@ describe('F8 - sendMessage picks iMessage vs SMS service from chat.service_name'
 
     await plugin.initialize(cfg());
     await plugin.start();
-    await plugin.sendMessage('+15551234567', { type: 'text', text: 'hi' });
+    await sendDrained('+15551234567', { type: 'text', text: 'hi' });
 
-    const sendCall = mockExecFileNoThrow.mock.calls.find((c) =>
-      String(c[1]?.[1] ?? '').includes('targetBuddy'),
-    );
+    const sendCall = mockExecFileNoThrow.mock.calls.find((c) => String(c[1]?.[1] ?? '').includes('targetBuddy'));
     expect(sendCall).toBeDefined();
     expect(String(sendCall![1]![1])).toContain('service type = SMS');
     await plugin.stop();
@@ -217,11 +230,9 @@ describe('F8 - sendMessage picks iMessage vs SMS service from chat.service_name'
 
     await plugin.initialize(cfg());
     await plugin.start();
-    await plugin.sendMessage('+15551234567', { type: 'text', text: 'hi' });
+    await sendDrained('+15551234567', { type: 'text', text: 'hi' });
 
-    const sendCall = mockExecFileNoThrow.mock.calls.find((c) =>
-      String(c[1]?.[1] ?? '').includes('targetBuddy'),
-    );
+    const sendCall = mockExecFileNoThrow.mock.calls.find((c) => String(c[1]?.[1] ?? '').includes('targetBuddy'));
     expect(String(sendCall![1]![1])).toContain('service type = iMessage');
     await plugin.stop();
   });
@@ -232,12 +243,15 @@ describe('F8 - sendMessage picks iMessage vs SMS service from chat.service_name'
 // ---------------------------------------------------------------------------
 
 describe('F11 - sendMessage verifies delivery via chat.db', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
   it('returns a delivery-confirmed id when is_delivered=1 lands in chat.db', async () => {
     mockDeliveryStmt.get.mockReturnValue({ rowid: 99, is_delivered: 1, error: 0, date_delivered: 1 });
 
     await plugin.initialize(cfg());
     await plugin.start();
-    const id = await plugin.sendMessage('+15551234567', { type: 'text', text: 'hi' });
+    const id = await sendDrained('+15551234567', { type: 'text', text: 'hi' });
 
     // suffix-encoded confirmation: `d` for delivered
     expect(id).toMatch(/^imessage-sent-d-/);
@@ -249,9 +263,13 @@ describe('F11 - sendMessage verifies delivery via chat.db', () => {
 
     await plugin.initialize(cfg());
     await plugin.start();
-    await expect(plugin.sendMessage('+15551234567', { type: 'text', text: 'hi' })).rejects.toThrow(
-      /not delivered.*error=22/i,
+    // Attach the rejection expectation BEFORE advancing timers so the promise is
+    // never momentarily unhandled while the fake delivery-poll budget elapses.
+    const rejection = expect(plugin.sendMessage('+15551234567', { type: 'text', text: 'hi' })).rejects.toThrow(
+      /not delivered.*error=22/i
     );
+    await vi.advanceTimersByTimeAsync(DELIVERY_BUDGET_MS);
+    await rejection;
     await plugin.stop();
   });
 
@@ -260,8 +278,8 @@ describe('F11 - sendMessage verifies delivery via chat.db', () => {
 
     await plugin.initialize(cfg());
     await plugin.start();
-    const id = await plugin.sendMessage('+15551234567', { type: 'text', text: 'hi' });
+    const id = await sendDrained('+15551234567', { type: 'text', text: 'hi' });
     expect(id).toMatch(/^imessage-sent-p-/);
     await plugin.stop();
-  }, 10_000);
+  });
 });

--- a/tests/unit/process/providers/connectionTester.test.ts
+++ b/tests/unit/process/providers/connectionTester.test.ts
@@ -30,6 +30,23 @@ afterEach(() => {
 describe('ConnectionTester', () => {
   const tester = new ConnectionTester();
 
+  // fetchWithRetry does 3 bounded attempts with a 400ms + ~800ms setTimeout
+  // backoff between them, so retryable-error cases (network / abort / 429 / 5xx)
+  // otherwise wait the real ~1.2s+ — a top contributor to the shard-1/4
+  // imbalance (#358). Drive fake timers past the backoff instead. 3000ms covers
+  // the jittered backoffs and stays under the 15s per-attempt abort timeout, so
+  // those abort timers never fire.
+  async function testWithRetries(...args: Parameters<ConnectionTester['test']>): ReturnType<ConnectionTester['test']> {
+    vi.useFakeTimers();
+    try {
+      const p = tester.test(...args);
+      await vi.advanceTimersByTimeAsync(3_000);
+      return await p;
+    } finally {
+      vi.useRealTimers();
+    }
+  }
+
   it('returns ok for a successful minimal completion (OpenAI)', async () => {
     const fetchMock = vi.fn().mockResolvedValue(response({ choices: [{ message: { content: 'hi' } }] }));
     vi.stubGlobal('fetch', fetchMock);
@@ -105,7 +122,7 @@ describe('ConnectionTester', () => {
       'fetch',
       vi.fn().mockResolvedValue(response({ error: { message: 'You exceeded your current quota' } }, 429))
     );
-    const result = await tester.test('openai', { key: 'sk-test' });
+    const result = await testWithRetries('openai', { key: 'sk-test' });
     expect(result).toEqual({ ok: false, error: 'no-credit' });
   });
 
@@ -120,19 +137,19 @@ describe('ConnectionTester', () => {
 
   it('maps a network throw to offline', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('fetch failed')));
-    const result = await tester.test('openai', { key: 'sk-test' });
+    const result = await testWithRetries('openai', { key: 'sk-test' });
     expect(result).toEqual({ ok: false, error: 'offline' });
   });
 
   it('maps an abort/timeout to offline', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(Object.assign(new Error('aborted'), { name: 'AbortError' })));
-    const result = await tester.test('openai', { key: 'sk-test' });
+    const result = await testWithRetries('openai', { key: 'sk-test' });
     expect(result).toEqual({ ok: false, error: 'offline' });
   });
 
   it('maps an unclassifiable 500 to unknown', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({ error: 'server error' }, 500)));
-    const result = await tester.test('openai', { key: 'sk-test' });
+    const result = await testWithRetries('openai', { key: 'sk-test' });
     expect(result).toEqual({ ok: false, error: 'unknown' });
   });
 
@@ -277,7 +294,7 @@ describe('ConnectionTester', () => {
         throw new Error('sync explosion');
       })
     );
-    const result = await tester.test('openai', { key: 'sk-test' });
+    const result = await testWithRetries('openai', { key: 'sk-test' });
     expect(result.ok).toBe(false);
     expect(result.error).toBe('offline');
   });

--- a/tests/unit/process/services/skills/skillRecall.test.ts
+++ b/tests/unit/process/services/skills/skillRecall.test.ts
@@ -52,7 +52,15 @@ const QUERIES_PATH = path.join(LIBRARY_DIR, 'discovery-queries.json');
 // Gate
 // ---------------------------------------------------------------------------
 
-describe('BM25 recall gate (release gate)', () => {
+// This is a CPU-bound full-corpus gate (2105 docs x 2003 queries, ~16s on a
+// loaded CI runner) and it was the single biggest contributor to the unit
+// shard-1/4 imbalance (#358). It does not need to run on every PR shard — it
+// guards a release decision (whether BM25 recall is still good enough), not the
+// correctness of a changeset. It runs only when RUN_RELEASE_GATES=1, which the
+// nightly `release-gates.yml` workflow sets; PR shards skip it.
+const RUN_RELEASE_GATES = process.env.RUN_RELEASE_GATES === '1';
+
+describe.skipIf(!RUN_RELEASE_GATES)('BM25 recall gate (release gate)', () => {
   it('recall@20 >= 0.80 over the full discovery-queries corpus', async () => {
     const [indexRaw, queriesRaw] = await Promise.all([readFile(INDEX_PATH, 'utf-8'), readFile(QUERIES_PATH, 'utf-8')]);
 


### PR DESCRIPTION
## #358 — unit shard 1/4 perf

Shard 1/4 ran ~19m on ubuntu (vs the ~3.5m average). Before changing anything I measured shard 1/4 locally to find the real offenders — and the issue's named suspect was wrong: RemoteAgentCore/Manager error-path tests run in 134ms total (already fast). The actual hot tests, with the fix applied to each:

| Test file | Before | After | Fix |
|---|---|---|---|
| skillRecall.test.ts (BM25 full-corpus gate) | ~16s on CI | skipped on PR shards | Gated behind RUN_RELEASE_GATES; runs in a new nightly release-gates.yml lane |
| ImessagePlugin.deliveryAndService.test.ts | ~12s (4x ~3s) | ~150ms | Fake-timer the F8/F11 sends (production pollDeliveryStatus = 5x600ms setTimeout loop) |
| connectionTester.test.ts | ~7s (5x ~1.3s) | ~150ms | Fake-timer the retryable cases (fetchWithRetry 400ms+800ms backoff) |
| acpKillChild.test.ts (SIGKILL escalation) | ~3.3s | ~530ms | Real-process test — made killChild's SIGTERM grace an optional param (default unchanged) and pass 250ms |

Local full shard 1/4: ~impacted files cut ~38s of guaranteed wall time plus the BM25 CPU gate.

## Notes

- The BM25 gate is moved, not dropped: release-gates.yml runs it nightly with RUN_RELEASE_GATES=1 (no silent loss of coverage).
- ImessagePlugin uses advanceTimersByTimeAsync (not runAllTimersAsync) because start() installs a self-rescheduling inbound-poll setInterval.
- killChild's signature gains an optional sigtermGraceMs=3000; all existing callers are unaffected.
- The 35m stopgap cap is dropped to 20m. I deliberately did not go straight to ~15m: I want this PR's own CI run to confirm the real post-fix shard-1/4 time first, then tighten in a follow-up commit (or flag for review per the ruling). Shard rebalancing was not needed locally; will revisit if CI still shows 1/4 hot.

Base main, PR -> main. Tracks #358 (follow-up to #353). Not closing (release/Sean action).
