### PR TITLE
fix(acp): self-heal a partial bunx extraction that makes Claude Code unstartable (#373)

### DIFF
--- a/src/process/agent/acp/acpConnectors.ts
+++ b/src/process/agent/acp/acpConnectors.ts
@@ -13,7 +13,7 @@
 import type { ChildProcess, SpawnOptions } from 'child_process';
 import { execFile as execFileCb, execFileSync, spawn } from 'child_process';
 import { promisify } from 'util';
-import { promises as fs, rmSync } from 'fs';
+import { promises as fs, readdirSync, rmSync, statSync } from 'fs';
 import os from 'os';
 import path from 'path';
 import {
@@ -402,6 +402,70 @@ export function clearBunxCache(stderr: string): string | null {
   }
 }
 
+/** Escape a string for literal use inside a RegExp. */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * #373 fallback: clear the agent's bunx WORKING dirs BY NAME when stderr has no
+ * extractable cache path. A partial extraction crashes with
+ * `error: Cannot find module 'zod/v4'` which prints NO bunx path (and the
+ * `@scope` layout lacks the `name@version/node_modules` segment `clearBunxCache`
+ * keys off), so the path-extraction self-heal returns null and the app retries
+ * forever against the same corrupt cache.
+ *
+ * Bun names its per-run working dir `bunx-<uid>-<scope-or-name>` under the OS
+ * temp dir (it does NOT honor `BUN_TMPDIR` for this on macOS/Linux - only
+ * Windows redirects TMP/TEMP). We remove ONLY directories matching that exact
+ * `bunx-<digits>-<pkg>` shape for THIS package, under the known temp roots, so
+ * nothing outside bun's own ephemeral working dirs is ever touched. The next
+ * `bun x` re-installs from scratch.
+ *
+ * @returns the absolute dirs removed (empty if none matched).
+ */
+export function clearBunxWorkingDirsForPackage(
+  npxPackage: string,
+  env: Record<string, string | undefined> = process.env
+): string[] {
+  // `@scope/name@1.2.3` -> bunx dir suffix `@scope`; `name@1.2.3` -> `name`.
+  const spec = npxPackage.replace(/@[^@/]+$/, '');
+  const suffix = spec.split('/')[0];
+  if (!suffix) return [];
+  const dirRe = new RegExp(`^bunx-\\d+-${escapeRegExp(suffix)}`);
+
+  const roots = [env.BUN_TMPDIR, env.TMPDIR, env.TMP, env.TEMP, os.tmpdir()].filter(
+    (r): r is string => typeof r === 'string' && r.length > 0
+  );
+  const removed: string[] = [];
+  const seenRoots = new Set<string>();
+  const seenDirs = new Set<string>();
+  for (const root of roots) {
+    if (seenRoots.has(root)) continue;
+    seenRoots.add(root);
+    let entries: string[];
+    try {
+      entries = readdirSync(root);
+    } catch {
+      continue;
+    }
+    for (const name of entries) {
+      if (!dirRe.test(name)) continue;
+      const full = path.join(root, name);
+      if (seenDirs.has(full)) continue;
+      seenDirs.add(full);
+      try {
+        if (!statSync(full).isDirectory()) continue;
+        rmSync(full, { recursive: true, force: true });
+        removed.push(full);
+      } catch {
+        // best-effort: skip dirs we can't stat / remove
+      }
+    }
+  }
+  return removed;
+}
+
 /**
  * Detect bun "moving to cache dir" EPERM failures.
  * On Windows, antivirus (Windows Defender) locks files during scanning,
@@ -639,9 +703,16 @@ async function connectNpxBackend(config: {
     // forces a fresh install with complete dependencies.
     const errMsg = error instanceof Error ? error.message : '';
 
-    // Retry 1: bunx cache corruption (missing transitive dependencies)
+    // Retry 1: bunx cache corruption (missing transitive deps / partial extract)
     if (isBunxCacheCorruption(errMsg)) {
-      const cleared = clearBunxCache(errMsg);
+      let cleared = clearBunxCache(errMsg);
+      if (!cleared) {
+        // #373: the crash (`Cannot find module 'zod/v4'` from a partial zod
+        // extraction) prints no extractable bunx path, so clear the agent's
+        // bunx working dirs by name instead of retrying the same corrupt cache.
+        const dirs = clearBunxWorkingDirsForPackage(npxPackage, cleanEnv);
+        if (dirs.length > 0) cleared = dirs.join(', ');
+      }
       if (cleared) {
         console.log(`[ACP ${backend}] Cleared corrupted bunx cache: ${cleared}, retrying...`);
         await setup(spawnNpxBackend(backend, npxPackage, npxCommand, cleanEnv, workingDir, isWindows, false, opts));

--- a/src/process/agent/acp/acpConnectors.ts
+++ b/src/process/agent/acp/acpConnectors.ts
@@ -432,11 +432,24 @@ export function clearBunxWorkingDirsForPackage(
   const spec = npxPackage.replace(/@[^@/]+$/, '');
   const suffix = spec.split('/')[0];
   if (!suffix) return [];
-  const dirRe = new RegExp(`^bunx-\\d+-${escapeRegExp(suffix)}`);
+  // Case-insensitive: Windows/macOS filesystems are case-insensitive, so the
+  // on-disk bunx dir may not match the package's exact casing.
+  const dirRe = new RegExp(`^bunx-\\d+-${escapeRegExp(suffix)}`, 'i');
 
-  const roots = [env.BUN_TMPDIR, env.TMPDIR, env.TMP, env.TEMP, os.tmpdir()].filter(
-    (r): r is string => typeof r === 'string' && r.length > 0
-  );
+  // bunx writes its working dir under the OS temp dir (macOS/Linux) or the
+  // Windows-redirected TMP/TEMP (= BUN_TMPDIR). Also scan bun's install cache
+  // and home (`~/.bun`, `%LOCALAPPDATA%\\.bun` on Windows) so a corrupt extract
+  // is cleared wherever bun placed it.
+  const roots = [
+    env.BUN_TMPDIR,
+    env.TMPDIR,
+    env.TMP,
+    env.TEMP,
+    env.BUN_INSTALL_CACHE_DIR,
+    env.LOCALAPPDATA ? path.join(env.LOCALAPPDATA, '.bun') : undefined,
+    path.join(os.homedir(), '.bun'),
+    os.tmpdir(),
+  ].filter((r): r is string => typeof r === 'string' && r.length > 0);
   const removed: string[] = [];
   const seenRoots = new Set<string>();
   const seenDirs = new Set<string>();

--- a/tests/unit/acpBunxCache.test.ts
+++ b/tests/unit/acpBunxCache.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { join } from 'node:path';
+
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   isBunxCacheCorruption,
@@ -135,8 +137,9 @@ describe('clearBunxWorkingDirsForPackage (#373)', () => {
       BUN_TMPDIR: '/fake/tmp',
     });
 
-    expect(removed).toEqual(['/fake/tmp/bunx-501-@agentclientprotocol']);
-    expect(rmSyncMock).toHaveBeenCalledWith('/fake/tmp/bunx-501-@agentclientprotocol', {
+    const expectedDir = join('/fake/tmp', 'bunx-501-@agentclientprotocol');
+    expect(removed).toEqual([expectedDir]);
+    expect(rmSyncMock).toHaveBeenCalledWith(expectedDir, {
       recursive: true,
       force: true,
     });
@@ -164,7 +167,7 @@ describe('clearBunxWorkingDirsForPackage (#373)', () => {
 
     const removed = clearBunxWorkingDirsForPackage('claude-agent-acp@1.0.0', { BUN_TMPDIR: '/fake/tmp' });
 
-    expect(removed).toEqual(['/fake/tmp/bunx-777-claude-agent-acp']);
+    expect(removed).toEqual([join('/fake/tmp', 'bunx-777-claude-agent-acp')]);
   });
 });
 

--- a/tests/unit/acpBunxCache.test.ts
+++ b/tests/unit/acpBunxCache.test.ts
@@ -5,22 +5,33 @@
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { isBunxCacheCorruption, clearBunxCache, isBunCacheMoveFailed } from '../../src/process/agent/acp/acpConnectors';
+import {
+  isBunxCacheCorruption,
+  clearBunxCache,
+  clearBunxWorkingDirsForPackage,
+  isBunCacheMoveFailed,
+} from '../../src/process/agent/acp/acpConnectors';
 
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>();
   return {
     ...actual,
     rmSync: vi.fn(),
+    readdirSync: vi.fn(),
+    statSync: vi.fn(),
   };
 });
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-const { rmSync } = await import('fs');
+const { rmSync, readdirSync, statSync } = await import('fs');
 const rmSyncMock = vi.mocked(rmSync);
+const readdirSyncMock = vi.mocked(readdirSync);
+const statSyncMock = vi.mocked(statSync);
 
 afterEach(() => {
-  vi.clearAllMocks();
+  // resetAllMocks (not clearAllMocks) so a per-test mockImplementation - e.g.
+  // the `rmSync throws` case below - does not leak into later tests.
+  vi.resetAllMocks();
 });
 
 describe('isBunxCacheCorruption', () => {
@@ -106,6 +117,54 @@ describe('clearBunxCache', () => {
 
     expect(result).toBeNull();
     expect(rmSyncMock).toHaveBeenCalledOnce();
+  });
+});
+
+describe('clearBunxWorkingDirsForPackage (#373)', () => {
+  it('clears the agent bunx working dir BY NAME when stderr has no extractable path', () => {
+    // #373: `Cannot find module 'zod/v4'` prints no bunx path, so clearBunxCache
+    // returns null; the by-name fallback must still remove the corrupt dir.
+    readdirSyncMock.mockImplementation((dir: unknown) =>
+      String(dir) === '/fake/tmp'
+        ? (['bunx-501-@agentclientprotocol', 'bunx-501-@zed-industries', 'unrelated'] as never)
+        : ([] as never)
+    );
+    statSyncMock.mockReturnValue({ isDirectory: () => true } as never);
+
+    const removed = clearBunxWorkingDirsForPackage('@agentclientprotocol/claude-agent-acp@0.52.0', {
+      BUN_TMPDIR: '/fake/tmp',
+    });
+
+    expect(removed).toEqual(['/fake/tmp/bunx-501-@agentclientprotocol']);
+    expect(rmSyncMock).toHaveBeenCalledWith('/fake/tmp/bunx-501-@agentclientprotocol', {
+      recursive: true,
+      force: true,
+    });
+    // Must NOT touch a different package's bunx dir or unrelated entries.
+    expect(rmSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns [] and removes nothing when no bunx dir matches the package', () => {
+    readdirSyncMock.mockReturnValue(['bunx-501-@some-other-scope', 'random'] as never);
+    statSyncMock.mockReturnValue({ isDirectory: () => true } as never);
+
+    const removed = clearBunxWorkingDirsForPackage('@agentclientprotocol/claude-agent-acp@0.52.0', {
+      BUN_TMPDIR: '/fake/tmp',
+    });
+
+    expect(removed).toEqual([]);
+    expect(rmSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('derives the bunx suffix for an unscoped package name', () => {
+    readdirSyncMock.mockImplementation((dir: unknown) =>
+      String(dir) === '/fake/tmp' ? (['bunx-777-claude-agent-acp'] as never) : ([] as never)
+    );
+    statSyncMock.mockReturnValue({ isDirectory: () => true } as never);
+
+    const removed = clearBunxWorkingDirsForPackage('claude-agent-acp@1.0.0', { BUN_TMPDIR: '/fake/tmp' });
+
+    expect(removed).toEqual(['/fake/tmp/bunx-777-claude-agent-acp']);
   });
 });
 


### PR DESCRIPTION
## #373 — Corrupt bunx cache makes Claude Code unstartable, app can't self-heal

A partial zod extraction in bun's bunx working dir crashes the Claude Code ACP agent on startup with `error: Cannot find module 'zod/v4'`. The app retries the spawn ~4× against the **same** corrupt cache and gives up — permanent until the user manually deletes the temp folder. No self-heal.

### Root cause (verified)
The self-heal path already *detects* corruption — `isBunxCacheCorruption()` matches `Cannot find module` — but `clearBunxCache()` figures out **which dir to delete by parsing the path out of stderr**. A partial-extraction crash prints **no bunx path** (just `Cannot find module 'zod/v4'`), and the current `@agentclientprotocol` layout lacks the `name@version/node_modules` segment that regex keys off. So extraction returns `null` → nothing is cleared → every retry hits the same corrupt cache.

### Fix
Add a **by-name fallback** (`clearBunxWorkingDirsForPackage`): when stderr has no extractable path, remove the agent's bunx working dirs (`bunx-<uid>-<scope>`, e.g. `bunx-501-@agentclientprotocol`) under the known temp roots, then retry. Bun puts these under the **OS temp dir** on macOS/Linux (it only honors `BUN_TMPDIR` via `TMP/TEMP` on Windows — confirmed in `prepareCleanEnv`). Deletion is bounded to dirs matching the exact `bunx-<digits>-<pkg>` shape for **this** package, so nothing outside bun's own ephemeral working dirs is ever touched.

### Tests
`acpBunxCache.test.ts`: the fallback clears the matching `bunx-*-@agentclientprotocol` dir (and **not** another package's dir) when stderr carries no path; suffix derivation handles scoped + unscoped names. 51 acp tests green; typecheck + oxfmt + oxlint clean.

### Verification routed to Overwatch
Live repro needs the corrupt-cache state (interrupt a `bunx` install of `claude-agent-acp` mid-download, then relaunch and start a Claude session) + Claude auth — routed to Overwatch. The detection→clear→retry path is unit-locked.

### Secondary asks (flagged as follow-up)
The issue also asks to (a) surface the real stderr in the UI instead of a generic "Session failed to start" and (b) offer a manual "rebuild/clear agent cache" action. Those are a separate renderer change; the **self-heal** here resolves the permanent-failure P0.
