### PR TITLE
fix(chat): persist composer drafts across reload/restart (#412)

### DIFF
--- a/src/renderer/hooks/chat/useSendBoxDraft.ts
+++ b/src/renderer/hooks/chat/useSendBoxDraft.ts
@@ -69,6 +69,15 @@ const store: SendBoxDraftStore = {
   wcore: new Map(),
 };
 
+/**
+ * Test-only: drop every in-memory draft (localStorage is left intact). Lets a
+ * test simulate a renderer reload - the in-memory store is gone but the durable
+ * copy survives, which is exactly the scenario #412 fixes.
+ */
+export function __clearInMemoryDraftsForTests(): void {
+  for (const map of Object.values(store)) map.clear();
+}
+
 // ── Durable persistence (#412) ───────────────────────────────────────────────
 // The in-memory `store` above survives navigation and component remounts within
 // a single renderer session, but is wiped whenever the renderer reloads or the

--- a/src/renderer/hooks/chat/useSendBoxDraft.ts
+++ b/src/renderer/hooks/chat/useSendBoxDraft.ts
@@ -1,5 +1,5 @@
 import type { TChatConversation } from '@/common/config/storage';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import useSWR from 'swr';
 import type { FileOrFolderItem } from '@/renderer/utils/file/fileTypes';
 export type { FileOrFolderItem } from '@/renderer/utils/file/fileTypes';
@@ -69,6 +69,65 @@ const store: SendBoxDraftStore = {
   wcore: new Map(),
 };
 
+// ── Durable persistence (#412) ───────────────────────────────────────────────
+// The in-memory `store` above survives navigation and component remounts within
+// a single renderer session, but is wiped whenever the renderer reloads or the
+// app restarts/crashes - which is exactly when users reported losing typed-but-
+// unsent text ("the system jumps and all my words are lost"). Mirror each draft
+// into localStorage (synchronous, renderer-local, survives reload/restart) so a
+// half-written message is never dropped. Failures here are non-fatal: the
+// in-memory store keeps working if storage is unavailable or over quota.
+const DRAFT_STORAGE_PREFIX = 'wayland:sendbox-draft:';
+
+function draftStorageKey(type: string, conversation_id: string): string {
+  return `${DRAFT_STORAGE_PREFIX}${type}:${conversation_id}`;
+}
+
+/** A draft worth persisting has typed content or attached files; anything else is noise. */
+function isDraftPersistable(draft: Draft | undefined): boolean {
+  if (!draft) return false;
+  const content = (draft as { content?: unknown }).content;
+  if (typeof content === 'string' && content.length > 0) return true;
+  const atPath = (draft as { atPath?: unknown[] }).atPath;
+  if (Array.isArray(atPath) && atPath.length > 0) return true;
+  const uploadFile = (draft as { uploadFile?: unknown[] }).uploadFile;
+  if (Array.isArray(uploadFile) && uploadFile.length > 0) return true;
+  return false;
+}
+
+/** Read a persisted draft from localStorage. Returns undefined on miss, parse error, or type drift. */
+function readPersistedDraft<K extends TChatConversation['type']>(
+  type: K,
+  conversation_id: string
+): Extract<Draft, { _type: K }> | undefined {
+  if (typeof localStorage === 'undefined') return undefined;
+  try {
+    const raw = localStorage.getItem(draftStorageKey(type, conversation_id));
+    if (!raw) return undefined;
+    const parsed = JSON.parse(raw) as Draft;
+    // Guard against schema drift across releases: only accept a matching _type.
+    if (!parsed || parsed._type !== type) return undefined;
+    return parsed as Extract<Draft, { _type: K }>;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Write-through a draft to localStorage, or clear it once the draft is empty (e.g. after send). */
+function writePersistedDraft(type: string, conversation_id: string, draft: Draft | undefined): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    const key = draftStorageKey(type, conversation_id);
+    if (isDraftPersistable(draft)) {
+      localStorage.setItem(key, JSON.stringify(draft));
+    } else {
+      localStorage.removeItem(key);
+    }
+  } catch {
+    // Quota exceeded / serialization failure: in-memory draft still works.
+  }
+}
+
 const setDraft = <K extends TChatConversation['type']>(
   type: K,
   conversation_id: string,
@@ -128,9 +187,11 @@ const setDraft = <K extends TChatConversation['type']>(
     default:
       break;
   }
+  // Mirror the change to durable storage so the draft survives reload/restart (#412).
+  writePersistedDraft(type, conversation_id, draft);
 };
 
-const getDraft = <K extends TChatConversation['type']>(
+const getInMemoryDraft = <K extends TChatConversation['type']>(
   type: K,
   conversation_id: string
 ): Extract<Draft, { _type: K }> | undefined => {
@@ -155,6 +216,22 @@ const getDraft = <K extends TChatConversation['type']>(
   }
 };
 
+const getDraft = <K extends TChatConversation['type']>(
+  type: K,
+  conversation_id: string
+): Extract<Draft, { _type: K }> | undefined => {
+  const inMemory = getInMemoryDraft(type, conversation_id);
+  if (inMemory !== undefined) return inMemory;
+  // Cold session (post reload/restart): rehydrate from durable storage and warm
+  // the in-memory store so subsequent reads are cheap (#412).
+  const persisted = readPersistedDraft(type, conversation_id);
+  if (persisted !== undefined) {
+    setDraft(type, conversation_id, persisted);
+    return persisted;
+  }
+  return undefined;
+};
+
 /**
  * React Hook for conversation draft operations of a given type.
  */
@@ -163,16 +240,36 @@ export const getSendBoxDraftHook = <K extends TChatConversation['type']>(
   initialValue: Extract<Draft, { _type: K }>
 ) => {
   function useDraft(conversation_id: string) {
-    const swrRet = useSWR([`/send-box/${type}/draft/${conversation_id}`, conversation_id], ([_, id]) => {
-      return getDraft(type, id);
-    });
+    // Synchronously seed SWR with the persisted draft so `data` is the saved
+    // value on the VERY FIRST render after a reload/restart - never undefined.
+    // Without this, a mount-time partial update (e.g. setAtPath) would run while
+    // `data` is still undefined, rebuild the draft from the empty `initialValue`,
+    // and clobber the persisted text before async hydration lands (#412). This
+    // is a pure read (no side effects during render); the fetcher below performs
+    // the actual in-memory hydration.
+    const fallbackData = useMemo(
+      () => getInMemoryDraft(type, conversation_id) ?? readPersistedDraft(type, conversation_id),
+      [conversation_id]
+    );
+    const swrRet = useSWR(
+      [`/send-box/${type}/draft/${conversation_id}`, conversation_id],
+      ([_, id]) => {
+        return getDraft(type, id);
+      },
+      { fallbackData }
+    );
 
     const mutateDraft = useCallback(
       (draft: (k: Extract<Draft, { _type: K }>) => typeof k | undefined): void => {
         swrRet
           .mutate(
             (prev) => {
-              const newDraft = draft(prev ?? initialValue);
+              // SWR's cached `prev` is undefined until the fetcher commits, so on
+              // the first mutate after a reload we must fall back to the persisted
+              // draft (not the empty initialValue) - otherwise a partial update
+              // would rebuild from empty and wipe the saved text (#412).
+              const base = prev ?? getDraft(type, conversation_id) ?? initialValue;
+              const newDraft = draft(base);
               setDraft(type, conversation_id, newDraft);
               return newDraft;
             },

--- a/tests/unit/sendBoxDraftPersistence.dom.test.tsx
+++ b/tests/unit/sendBoxDraftPersistence.dom.test.tsx
@@ -15,7 +15,7 @@
  */
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { getSendBoxDraftHook } from '@/renderer/hooks/chat/useSendBoxDraft';
+import { __clearInMemoryDraftsForTests, getSendBoxDraftHook } from '@/renderer/hooks/chat/useSendBoxDraft';
 
 const STORAGE_PREFIX = 'wayland:sendbox-draft:';
 const emptyWcoreDraft = { _type: 'wcore' as const, content: '', atPath: [], uploadFile: [] };
@@ -23,6 +23,7 @@ const useWcoreDraft = getSendBoxDraftHook('wcore', emptyWcoreDraft);
 
 beforeEach(() => {
   localStorage.clear();
+  __clearInMemoryDraftsForTests();
 });
 
 describe('send-box draft persistence (#412)', () => {
@@ -66,6 +67,25 @@ describe('send-box draft persistence (#412)', () => {
       result.current.mutate((prev) => ({ ...prev, content: '' }));
     });
     expect(localStorage.getItem(`${STORAGE_PREFIX}wcore:${id}`)).toBeNull();
+  });
+
+  it('survives a full reload: typed via the hook, unmounted, in-memory wiped, then restored on remount', () => {
+    const id = 'conv-reload-roundtrip';
+
+    // Session 1: type through the real hook (write-through to localStorage + in-memory).
+    const session1 = renderHook(() => useWcoreDraft(id));
+    act(() => {
+      session1.result.current.mutate((prev) => ({ ...prev, content: 'a half-finished thought' }));
+    });
+    session1.unmount();
+
+    // Simulate a renderer reload: the in-memory store is gone, localStorage remains.
+    __clearInMemoryDraftsForTests();
+    expect(localStorage.getItem(`${STORAGE_PREFIX}wcore:${id}`)).toBeTruthy();
+
+    // Session 2 (cold in-memory): remounting the same conversation restores the text.
+    const session2 = renderHook(() => useWcoreDraft(id));
+    expect(session2.result.current.data?.content).toBe('a half-finished thought');
   });
 
   it('exposes the persisted draft synchronously so a mount-time partial update cannot clobber it', () => {

--- a/tests/unit/sendBoxDraftPersistence.dom.test.tsx
+++ b/tests/unit/sendBoxDraftPersistence.dom.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #412 - composer draft persistence. The send-box draft store kept typed-but-
+ * unsent text only in a module-level in-memory Map, so a renderer reload / app
+ * restart / crash dropped it ("the system jumps and all my words are lost").
+ * These tests pin the durable-storage behavior: drafts are mirrored to
+ * localStorage, rehydrated on a cold read, and cleared once emptied.
+ *
+ * Each test uses a unique conversation id so the in-memory Map has no entry for
+ * it - that forces getDraft down the persisted (localStorage) path, which is
+ * what a post-restart session exercises.
+ */
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { getSendBoxDraftHook } from '@/renderer/hooks/chat/useSendBoxDraft';
+
+const STORAGE_PREFIX = 'wayland:sendbox-draft:';
+const emptyWcoreDraft = { _type: 'wcore' as const, content: '', atPath: [], uploadFile: [] };
+const useWcoreDraft = getSendBoxDraftHook('wcore', emptyWcoreDraft);
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('send-box draft persistence (#412)', () => {
+  it('mirrors typed content to localStorage on mutate (write-through)', async () => {
+    const id = 'conv-write-through';
+    const { result } = renderHook(() => useWcoreDraft(id));
+
+    act(() => {
+      result.current.mutate((prev) => ({ ...prev, content: 'half-written message' }));
+    });
+
+    const raw = localStorage.getItem(`${STORAGE_PREFIX}wcore:${id}`);
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw as string).content).toBe('half-written message');
+  });
+
+  it('rehydrates a persisted draft on a cold read (simulates restart)', async () => {
+    const id = 'conv-rehydrate';
+    // Seed storage as if a prior session had saved a draft; the in-memory Map
+    // has no entry for this id (fresh session), so getDraft must read storage.
+    localStorage.setItem(
+      `${STORAGE_PREFIX}wcore:${id}`,
+      JSON.stringify({ _type: 'wcore', content: 'survived the restart', atPath: [], uploadFile: [] })
+    );
+
+    const { result } = renderHook(() => useWcoreDraft(id));
+
+    await waitFor(() => expect(result.current.data?.content).toBe('survived the restart'));
+  });
+
+  it('clears the persisted draft once the content is emptied (e.g. after send)', async () => {
+    const id = 'conv-clear';
+    const { result } = renderHook(() => useWcoreDraft(id));
+
+    act(() => {
+      result.current.mutate((prev) => ({ ...prev, content: 'about to send' }));
+    });
+    expect(localStorage.getItem(`${STORAGE_PREFIX}wcore:${id}`)).toBeTruthy();
+
+    act(() => {
+      result.current.mutate((prev) => ({ ...prev, content: '' }));
+    });
+    expect(localStorage.getItem(`${STORAGE_PREFIX}wcore:${id}`)).toBeNull();
+  });
+
+  it('exposes the persisted draft synchronously so a mount-time partial update cannot clobber it', () => {
+    const id = 'conv-race';
+    localStorage.setItem(
+      `${STORAGE_PREFIX}wcore:${id}`,
+      JSON.stringify({ _type: 'wcore', content: 'precious unsent text', atPath: [], uploadFile: [] })
+    );
+
+    const { result } = renderHook(() => useWcoreDraft(id));
+    // fallbackData makes the saved draft present on the FIRST render - there is
+    // no undefined window where a partial update would rebuild from empty.
+    expect(result.current.data?.content).toBe('precious unsent text');
+
+    // A partial update (the kind a mount effect fires, e.g. setAtPath) must
+    // preserve the typed content rather than wipe it.
+    act(() => {
+      result.current.mutate((prev) => ({ ...prev, atPath: ['/some/file'] }));
+    });
+    expect(JSON.parse(localStorage.getItem(`${STORAGE_PREFIX}wcore:${id}`) as string).content).toBe(
+      'precious unsent text'
+    );
+  });
+
+  it('ignores a persisted entry whose _type does not match (schema drift guard)', async () => {
+    const id = 'conv-drift';
+    localStorage.setItem(`${STORAGE_PREFIX}wcore:${id}`, JSON.stringify({ _type: 'gemini', content: 'wrong type' }));
+
+    const { result } = renderHook(() => useWcoreDraft(id));
+    // Give SWR a tick; the mismatched entry must NOT surface as wcore data.
+    await waitFor(() => expect(result.current.data).toBeUndefined());
+  });
+});


### PR DESCRIPTION
Part 1 of the #412 memory cluster (Overwatch ruling: split composer draft persistence into its own PR).

## Problem
Typed-but-unsent composer text was held only in a module-level in-memory Map (useSendBoxDraft). That survives in-session navigation and remounts, but is wiped on any renderer reload / app restart / crash — exactly when the reporter lost work: "the system tends to jump every so often and all my words in chat box are lost… came to the end of the chat and it seems all was lost."

## Fix
Make the per-conversation draft durable via localStorage, in the single shared hook so every platform send box (wcore / gemini / acp / codex / openclaw / nanobot / remote) benefits:
- Write-through to localStorage on every draft change; clear the entry once the draft is emptied (e.g. after send).
- Rehydrate from localStorage on a cold read and warm the in-memory store.
- Seed SWR synchronously via fallbackData, and fall back to the persisted draft inside mutate, so a mount-time partial update (e.g. setAtPath) cannot rebuild from the empty initialValue and clobber the saved text. This race was caught live during verification and is pinned by a regression test.
- Failures (no storage / quota) are swallowed — the in-memory store keeps working.

## Verification
- Unit: tests/unit/sendBoxDraftPersistence.dom.test.tsx — 5 tests (write-through, cold-read rehydrate, clear-on-empty, schema-drift guard, no-clobber-on-partial-update). All green.
- Live (packaged build, electromcp): typed a draft into a real wcore conversation, confirmed it persisted to localStorage, reloaded the renderer (the actual failure mode), and the composer restored the full text. Screenshot-confirmed.

Scope: src/renderer/hooks/chat/useSendBoxDraft.ts + the new test. The recall/store-on-drop half of #412/#256 is a separate follow-up PR.
