### PR TITLE
fix(memory): index dropped memories into IJFW FTS5 so the agent can recall them (#256) [lane: BH1]

### DIFF
--- a/src/process/bridge/importBridge.ts
+++ b/src/process/bridge/importBridge.ts
@@ -25,6 +25,7 @@ import {
 } from '@process/services/import/dropFolderWatcher';
 import type { DropFolderWatcherHandle } from '@process/services/import/dropFolderWatcher';
 import { indexDroppedMemory } from '@process/services/import/memoryIndexer';
+import { deriveSummary, deriveTitle, stripBom } from '@process/services/import/memoryFrontmatter';
 
 // ── Schemas ──────────────────────────────────────────────────────────────────
 
@@ -39,6 +40,60 @@ const ingestFileItemSchema = z.object({
 const ingestFilesSchema = z.object({
   files: z.array(ingestFileItemSchema).min(1).max(50),
 });
+
+// name/content are required by ingestFileItemSchema (`.min(1)`); they are typed
+// optional here only to match zod's inferred element type at the call site.
+type DragDropFile = { name?: string; content?: string; scope?: 'project' | 'global' };
+
+/**
+ * Assemble the persisted .md (frontmatter + body) and store payload for one
+ * drag-dropped memory. Pure + exported so the BOM / CRLF derivation that the
+ * drag-drop path got wrong (#256 B1) is unit-testable without the IPC harness.
+ * Derivation runs through the shared `memoryFrontmatter` helpers so this path
+ * and the drop-folder watcher cannot diverge again.
+ */
+export function buildDragDropMemoryFile(
+  file: DragDropFile,
+  timestamp: number
+): { destName: string; fileContent: string; summary: string; title: string; indexedContent: string } {
+  const name = file.name ?? 'memory.md';
+  // Strip a leading BOM up front so the written body, the dedup hash, the
+  // derived title/description, and the FTS5 store content all see clean text.
+  // Without this a Windows-authored file (BOM before the first `#`) lost its
+  // title to the filename fallback and stored mangled metadata.
+  const cleaned = stripBom(file.content ?? '');
+  const hash = crypto.createHash('sha1').update(cleaned).digest('hex').slice(0, 8);
+  const safeName = name.replace(/[^a-zA-Z0-9._-]/g, '_').replace(/\.(?:md|txt|json)$/i, '.md');
+  const destName = `dropped-${timestamp}-${safeName}`;
+  const scope = file.scope ?? 'global';
+  const summary = deriveSummary(cleaned, name);
+  const title = deriveTitle(cleaned, name);
+  const hasFrontmatter = cleaned.trimStart().startsWith('---');
+
+  let fileContent: string;
+  if (hasFrontmatter) {
+    fileContent = cleaned;
+  } else {
+    // title + description let the IJFW reader tier surface a real label/desc
+    // instead of falling back to the generated filename.
+    const frontmatter = [
+      '---',
+      `id: ${hash}`,
+      `title: ${title}`,
+      `description: ${summary}`,
+      `type: observation`,
+      `created: ${timestamp}`,
+      `source: drag-drop`,
+      `scope: ${scope}`,
+      `summary: ${summary}`,
+      '---',
+      '',
+    ].join('\n');
+    fileContent = `${frontmatter}${cleaned}\n`;
+  }
+
+  return { destName, fileContent, summary, title, indexedContent: cleaned };
+}
 
 // ── Drop folder watcher handle (singleton) ───────────────────────────────────
 
@@ -177,51 +232,8 @@ export function initImportBridge(): void {
         continue;
       }
 
-      const timestamp = Date.now();
-      const hash = crypto.createHash('sha1').update(file.content).digest('hex').slice(0, 8);
-      const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_').replace(/\.(?:md|txt|json)$/i, '.md');
-      const destName = `dropped-${timestamp}-${safeName}`;
+      const { destName, fileContent, summary, indexedContent } = buildDragDropMemoryFile(file, Date.now());
       const destPath = path.join(memDir, destName);
-
-      const scope = file.scope ?? 'global';
-      // Prefer the first real body line over a leading heading so the
-      // description is distinct from the title (#256).
-      const contentLines = file.content
-        .split('\n')
-        .map((l) => l.trim())
-        .filter((l) => l.length > 0);
-      const firstBodyLine = contentLines.find((l) => !l.startsWith('#'));
-      const firstHeadingLine = contentLines[0]?.replace(/^#+\s*/, '');
-      const summary = (
-        (firstBodyLine || firstHeadingLine || file.name).replace(/[\r\n]+/g, ' ').trim() || file.name
-      ).slice(0, 200);
-      const headingMatch = file.content.match(/^#\s+(.+)$/m);
-      const title = (headingMatch ? headingMatch[1].trim() : file.name.replace(/\.(?:md|txt|json)$/i, ''))
-        .replace(/[\r\n]+/g, ' ')
-        .slice(0, 200);
-      const hasFrontmatter = file.content.trimStart().startsWith('---');
-
-      let fileContent: string;
-      if (hasFrontmatter) {
-        fileContent = file.content;
-      } else {
-        // title + description let the IJFW reader tier surface a real label/desc
-        // instead of falling back to the generated filename (#256).
-        const frontmatter = [
-          '---',
-          `id: ${hash}`,
-          `title: ${title}`,
-          `description: ${summary}`,
-          `type: observation`,
-          `created: ${timestamp}`,
-          `source: drag-drop`,
-          `scope: ${scope}`,
-          `summary: ${summary}`,
-          '---',
-          '',
-        ].join('\n');
-        fileContent = `${frontmatter}${file.content}\n`;
-      }
 
       try {
         await fs.promises.writeFile(destPath, fileContent, 'utf8');
@@ -229,7 +241,7 @@ export function initImportBridge(): void {
         log.info('[import] ingestFiles wrote', { destName });
         // Index into the IJFW FTS5 store so the agent can recall it, not just
         // see it in the Memory UI (#256). Fire-and-forget.
-        void indexDroppedMemory({ content: file.content, summary, sourceFile: file.name });
+        void indexDroppedMemory({ content: indexedContent, summary, sourceFile: file.name });
       } catch (err) {
         log.warn('[import] ingestFiles write failed', { destName, err });
         errors.push(`${file.name}: ${String(err)}`);

--- a/src/process/bridge/importBridge.ts
+++ b/src/process/bridge/importBridge.ts
@@ -184,13 +184,17 @@ export function initImportBridge(): void {
       const destPath = path.join(memDir, destName);
 
       const scope = file.scope ?? 'global';
-      const firstLine = file.content
+      // Prefer the first real body line over a leading heading so the
+      // description is distinct from the title (#256).
+      const contentLines = file.content
         .split('\n')
-        .find((l) => l.trim().length > 0)
-        ?.replace(/^#+\s*/, '')
-        .replace(/[\r\n]+/g, ' ')
-        .trim();
-      const summary = (firstLine || file.name).slice(0, 200);
+        .map((l) => l.trim())
+        .filter((l) => l.length > 0);
+      const firstBodyLine = contentLines.find((l) => !l.startsWith('#'));
+      const firstHeadingLine = contentLines[0]?.replace(/^#+\s*/, '');
+      const summary = (
+        (firstBodyLine || firstHeadingLine || file.name).replace(/[\r\n]+/g, ' ').trim() || file.name
+      ).slice(0, 200);
       const headingMatch = file.content.match(/^#\s+(.+)$/m);
       const title = (headingMatch ? headingMatch[1].trim() : file.name.replace(/\.(?:md|txt|json)$/i, ''))
         .replace(/[\r\n]+/g, ' ')

--- a/src/process/bridge/importBridge.ts
+++ b/src/process/bridge/importBridge.ts
@@ -24,6 +24,7 @@ import {
   getDropFolderStatus,
 } from '@process/services/import/dropFolderWatcher';
 import type { DropFolderWatcherHandle } from '@process/services/import/dropFolderWatcher';
+import { indexDroppedMemory } from '@process/services/import/memoryIndexer';
 
 // ── Schemas ──────────────────────────────────────────────────────────────────
 
@@ -183,19 +184,30 @@ export function initImportBridge(): void {
       const destPath = path.join(memDir, destName);
 
       const scope = file.scope ?? 'global';
-      const summary = file.content
-        .split('\n')[0]
-        .slice(0, 200)
-        .replace(/[\r\n]+/g, ' ');
+      const firstLine = file.content
+        .split('\n')
+        .find((l) => l.trim().length > 0)
+        ?.replace(/^#+\s*/, '')
+        .replace(/[\r\n]+/g, ' ')
+        .trim();
+      const summary = (firstLine || file.name).slice(0, 200);
+      const headingMatch = file.content.match(/^#\s+(.+)$/m);
+      const title = (headingMatch ? headingMatch[1].trim() : file.name.replace(/\.(?:md|txt|json)$/i, ''))
+        .replace(/[\r\n]+/g, ' ')
+        .slice(0, 200);
       const hasFrontmatter = file.content.trimStart().startsWith('---');
 
       let fileContent: string;
       if (hasFrontmatter) {
         fileContent = file.content;
       } else {
+        // title + description let the IJFW reader tier surface a real label/desc
+        // instead of falling back to the generated filename (#256).
         const frontmatter = [
           '---',
           `id: ${hash}`,
+          `title: ${title}`,
+          `description: ${summary}`,
           `type: observation`,
           `created: ${timestamp}`,
           `source: drag-drop`,
@@ -211,6 +223,9 @@ export function initImportBridge(): void {
         await fs.promises.writeFile(destPath, fileContent, 'utf8');
         ingested++;
         log.info('[import] ingestFiles wrote', { destName });
+        // Index into the IJFW FTS5 store so the agent can recall it, not just
+        // see it in the Memory UI (#256). Fire-and-forget.
+        void indexDroppedMemory({ content: file.content, summary, sourceFile: file.name });
       } catch (err) {
         log.warn('[import] ingestFiles write failed', { destName, err });
         errors.push(`${file.name}: ${String(err)}`);

--- a/src/process/bridge/importBridge.ts
+++ b/src/process/bridge/importBridge.ts
@@ -25,6 +25,7 @@ import {
 } from '@process/services/import/dropFolderWatcher';
 import type { DropFolderWatcherHandle } from '@process/services/import/dropFolderWatcher';
 import { indexDroppedMemory } from '@process/services/import/memoryIndexer';
+import { backfillMemoryIndex } from '@process/services/import/memoryBackfill';
 import { deriveSummary, deriveTitle, stripBom } from '@process/services/import/memoryFrontmatter';
 
 // ── Schemas ──────────────────────────────────────────────────────────────────
@@ -253,6 +254,13 @@ export function initImportBridge(): void {
 
   // Auto-start the live drop folder watcher at bridge init (no-deferment #10).
   startDropWatcherIfNeeded();
+
+  // One-time backfill: index memories that predate store-on-drop so they become
+  // recallable without the user having to re-drop them (#256). Fire-and-forget -
+  // guarded by a marker so it runs once, and best-effort so it never blocks init.
+  void backfillMemoryIndex({ ijfwMemoryDir: resolveMemoryDir() }).catch((err: unknown) => {
+    log.warn('[import] memory backfill failed', { err });
+  });
 }
 
 /**

--- a/src/process/services/import/dropFolderWatcher.ts
+++ b/src/process/services/import/dropFolderWatcher.ts
@@ -114,6 +114,18 @@ function destFilename(timestamp: number, basename: string): string {
   return `dropped-${timestamp}-${safe}`;
 }
 
+/**
+ * Strip a leading UTF-8 BOM (U+FEFF). Windows editors (Notepad, PowerShell
+ * redirects, etc.) prefix one; left in place it sits before the first `#`, which
+ * (a) defeats deriveTitle's `^#` heading match so the title silently falls back
+ * to the filename, (b) is written verbatim into the stored .md body, and (c) is
+ * handed to the FTS5 store as content, corrupting its own title/description
+ * derivation. Stripping once at read time fixes all three (#256 B1).
+ */
+function stripBom(raw: string): string {
+  return raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw;
+}
+
 /** Strip a YAML frontmatter block (if any) so derived title/summary read the real body. */
 function stripFrontmatter(raw: string): string {
   return raw.replace(/^﻿?\s*---\r?\n[\s\S]*?\r?\n---\r?\n?/, '');
@@ -145,7 +157,9 @@ function deriveTitle(raw: string, basename: string): string {
 async function ingestFile(filePath: string, ijfwMemoryDir: string): Promise<void> {
   const ext = path.extname(filePath).toLowerCase();
   const basename = path.basename(filePath);
-  const rawContent = await fs.promises.readFile(filePath, 'utf8');
+  // Strip a leading BOM at the source so the title heading-match, the written
+  // body, and the FTS5 store content all see clean text (#256 B1).
+  const rawContent = stripBom(await fs.promises.readFile(filePath, 'utf8'));
   const timestamp = Date.now();
 
   let fileContent: string;

--- a/src/process/services/import/dropFolderWatcher.ts
+++ b/src/process/services/import/dropFolderWatcher.ts
@@ -16,6 +16,7 @@ import * as path from 'node:path';
 import chokidar from 'chokidar';
 import log from 'electron-log';
 import { indexDroppedMemory } from './memoryIndexer';
+import { deriveSummary, deriveTitle, stripBom } from './memoryFrontmatter';
 
 const DEFAULT_DROP_FOLDER = path.join(os.homedir(), 'Documents', 'Wayland-Memory');
 
@@ -112,46 +113,6 @@ function buildFrontmatter(fields: Record<string, string | string[] | number>): s
 function destFilename(timestamp: number, basename: string): string {
   const safe = basename.replace(/[^a-zA-Z0-9._-]/g, '_');
   return `dropped-${timestamp}-${safe}`;
-}
-
-/**
- * Strip a leading UTF-8 BOM (U+FEFF). Windows editors (Notepad, PowerShell
- * redirects, etc.) prefix one; left in place it sits before the first `#`, which
- * (a) defeats deriveTitle's `^#` heading match so the title silently falls back
- * to the filename, (b) is written verbatim into the stored .md body, and (c) is
- * handed to the FTS5 store as content, corrupting its own title/description
- * derivation. Stripping once at read time fixes all three (#256 B1).
- */
-function stripBom(raw: string): string {
-  return raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw;
-}
-
-/** Strip a YAML frontmatter block (if any) so derived title/summary read the real body. */
-function stripFrontmatter(raw: string): string {
-  return raw.replace(/^﻿?\s*---\r?\n[\s\S]*?\r?\n---\r?\n?/, '');
-}
-
-/**
- * One-line description for frontmatter + the FTS5 store summary (<=200 chars
- * here, capped again downstream). Prefers the first real body line over a
- * leading markdown heading, so the description is distinct from the title.
- */
-function deriveSummary(raw: string, basename: string): string {
-  const lines = stripFrontmatter(raw)
-    .split('\n')
-    .map((l) => l.trim())
-    .filter((l) => l.length > 0);
-  const firstBodyLine = lines.find((l) => !l.startsWith('#'));
-  const firstHeading = lines[0]?.replace(/^#+\s*/, '');
-  const cleaned = (firstBodyLine || firstHeading || basename).replace(/[\r\n]+/g, ' ').trim();
-  return (cleaned || basename).slice(0, 200);
-}
-
-/** Human title: a leading markdown heading if present, else the source filename (sans extension). */
-function deriveTitle(raw: string, basename: string): string {
-  const heading = stripFrontmatter(raw).match(/^#\s+(.+)$/m);
-  const title = heading ? heading[1].trim() : basename.replace(/\.(?:md|txt|json)$/i, '');
-  return title.replace(/[\r\n]+/g, ' ').slice(0, 200);
 }
 
 async function ingestFile(filePath: string, ijfwMemoryDir: string): Promise<void> {

--- a/src/process/services/import/dropFolderWatcher.ts
+++ b/src/process/services/import/dropFolderWatcher.ts
@@ -15,6 +15,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import chokidar from 'chokidar';
 import log from 'electron-log';
+import { indexDroppedMemory } from './memoryIndexer';
 
 const DEFAULT_DROP_FOLDER = path.join(os.homedir(), 'Documents', 'Wayland-Memory');
 
@@ -98,7 +99,9 @@ function buildFrontmatter(fields: Record<string, string | string[] | number>): s
     if (Array.isArray(val)) {
       lines.push(`${key}: [${val.map((v) => String(v)).join(', ')}]`);
     } else {
-      const escaped = String(val).replace(/[\r\n]+/g, ' ').slice(0, 500);
+      const escaped = String(val)
+        .replace(/[\r\n]+/g, ' ')
+        .slice(0, 500);
       lines.push(`${key}: ${escaped}`);
     }
   }
@@ -111,10 +114,30 @@ function destFilename(timestamp: number, basename: string): string {
   return `dropped-${timestamp}-${safe}`;
 }
 
-async function ingestFile(
-  filePath: string,
-  ijfwMemoryDir: string,
-): Promise<void> {
+/** Strip a YAML frontmatter block (if any) so derived title/summary read the real body. */
+function stripFrontmatter(raw: string): string {
+  return raw.replace(/^﻿?\s*---\r?\n[\s\S]*?\r?\n---\r?\n?/, '');
+}
+
+/** One-line description for frontmatter + the FTS5 store summary (<=200 chars here, capped again downstream). */
+function deriveSummary(raw: string, basename: string): string {
+  const body = stripFrontmatter(raw).trimStart();
+  const firstLine = body.split('\n').find((l) => l.trim().length > 0) ?? '';
+  const cleaned = firstLine
+    .replace(/^#+\s*/, '')
+    .replace(/[\r\n]+/g, ' ')
+    .trim();
+  return (cleaned || basename).slice(0, 200);
+}
+
+/** Human title: a leading markdown heading if present, else the source filename (sans extension). */
+function deriveTitle(raw: string, basename: string): string {
+  const heading = stripFrontmatter(raw).match(/^#\s+(.+)$/m);
+  const title = heading ? heading[1].trim() : basename.replace(/\.(?:md|txt|json)$/i, '');
+  return title.replace(/[\r\n]+/g, ' ').slice(0, 200);
+}
+
+async function ingestFile(filePath: string, ijfwMemoryDir: string): Promise<void> {
   const ext = path.extname(filePath).toLowerCase();
   const basename = path.basename(filePath);
   const rawContent = await fs.promises.readFile(filePath, 'utf8');
@@ -122,14 +145,21 @@ async function ingestFile(
 
   let fileContent: string;
 
+  // Title + summary feed both the on-disk frontmatter (so the IJFW reader tier
+  // surfaces a real title/description, not just the filename) and the FTS5
+  // index call below. Prefer a leading markdown heading, else the source name.
+  const summary = deriveSummary(rawContent, basename);
+  const title = deriveTitle(rawContent, basename);
+
   if (ext === '.md') {
     // Already markdown - prepend source frontmatter if not already present.
     const hasFrontmatter = rawContent.trimStart().startsWith('---');
     if (hasFrontmatter) {
       fileContent = rawContent;
     } else {
-      const summary = rawContent.split('\n')[0].slice(0, 200).replace(/[\r\n]+/g, ' ');
       const frontmatter = buildFrontmatter({
+        title,
+        description: summary,
         type: 'observation',
         summary,
         stored: new Date(timestamp).toISOString(),
@@ -142,8 +172,9 @@ async function ingestFile(
     }
   } else {
     // .txt or .json - wrap body.
-    const summary = rawContent.split('\n')[0].slice(0, 200).replace(/[\r\n]+/g, ' ');
     const frontmatter = buildFrontmatter({
+      title,
+      description: summary,
       type: 'observation',
       summary,
       stored: new Date(timestamp).toISOString(),
@@ -158,6 +189,10 @@ async function ingestFile(
   const destName = destFilename(timestamp, basename.replace(/\.(?:md|txt|json)$/i, '.md'));
   const destPath = path.join(ijfwMemoryDir, destName);
   await fs.promises.writeFile(destPath, fileContent, 'utf8');
+
+  // Populate the IJFW FTS5 index so the agent can recall this memory, not just
+  // see it in the Memory UI (#256). Fire-and-forget - never blocks the ingest.
+  void indexDroppedMemory({ content: rawContent, summary, sourceFile: basename });
 
   // Only unlink after a successful write. If unlink fails, log and continue -
   // the file will be seen again on next event but the dedup window will skip it.
@@ -248,8 +283,7 @@ export async function runDropFolderProcess(opts?: {
   ijfwMemoryDir?: string;
 }): Promise<DropFolderProcessResult> {
   const dropFolder = opts?.dropFolder ?? DEFAULT_DROP_FOLDER;
-  const ijfwMemoryDir =
-    opts?.ijfwMemoryDir ?? path.join(os.homedir(), '.ijfw', 'memory');
+  const ijfwMemoryDir = opts?.ijfwMemoryDir ?? path.join(os.homedir(), '.ijfw', 'memory');
   const result: DropFolderProcessResult = { count: 0, errors: [] };
 
   try {

--- a/src/process/services/import/dropFolderWatcher.ts
+++ b/src/process/services/import/dropFolderWatcher.ts
@@ -119,14 +119,19 @@ function stripFrontmatter(raw: string): string {
   return raw.replace(/^﻿?\s*---\r?\n[\s\S]*?\r?\n---\r?\n?/, '');
 }
 
-/** One-line description for frontmatter + the FTS5 store summary (<=200 chars here, capped again downstream). */
+/**
+ * One-line description for frontmatter + the FTS5 store summary (<=200 chars
+ * here, capped again downstream). Prefers the first real body line over a
+ * leading markdown heading, so the description is distinct from the title.
+ */
 function deriveSummary(raw: string, basename: string): string {
-  const body = stripFrontmatter(raw).trimStart();
-  const firstLine = body.split('\n').find((l) => l.trim().length > 0) ?? '';
-  const cleaned = firstLine
-    .replace(/^#+\s*/, '')
-    .replace(/[\r\n]+/g, ' ')
-    .trim();
+  const lines = stripFrontmatter(raw)
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+  const firstBodyLine = lines.find((l) => !l.startsWith('#'));
+  const firstHeading = lines[0]?.replace(/^#+\s*/, '');
+  const cleaned = (firstBodyLine || firstHeading || basename).replace(/[\r\n]+/g, ' ').trim();
   return (cleaned || basename).slice(0, 200);
 }
 

--- a/src/process/services/import/memoryBackfill.ts
+++ b/src/process/services/import/memoryBackfill.ts
@@ -1,0 +1,134 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #256 - one-time backfill of pre-existing memories into the IJFW FTS5 index.
+ *
+ * Store-on-drop (`memoryIndexer.indexDroppedMemory`) only exists from this
+ * version on, so any memory already sitting in ~/.ijfw/memory - dropped or
+ * imported before the upgrade - was written to disk (and shows in the Memory UI)
+ * but was never indexed into the FTS5 store free-text recall reads. Those
+ * entries can never be recalled and do NOT self-heal. On first run after upgrade
+ * we sweep the memory dir once and index each entry.
+ *
+ * Guarded by a version marker so it runs exactly once: `ijfw_memory_store` is an
+ * INSERT, so re-running would duplicate entries. The marker lives one level above
+ * the memory dir so neither the Memory UI archive scanner nor the drop watcher
+ * ever sees it.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import log from 'electron-log';
+import { deriveSummary, stripFrontmatter } from './memoryFrontmatter';
+import { indexDroppedMemory } from './memoryIndexer';
+
+const MARKER_BASENAME = '.memory-fts5-backfill-v1';
+
+/** Once-only marker path, kept beside (not inside) the memory dir. */
+export function backfillMarkerPath(ijfwMemoryDir: string): string {
+  return path.join(path.dirname(ijfwMemoryDir), MARKER_BASENAME);
+}
+
+export type BackfillResult = {
+  /** Number of memories handed to the FTS5 store this run. */
+  indexed: number;
+  /** True when the marker already existed and the sweep was skipped. */
+  skipped: boolean;
+  errors: string[];
+};
+
+/**
+ * Index every top-level .md memory currently in `ijfwMemoryDir` into the IJFW
+ * FTS5 store, exactly once per install. Best-effort: a failure on any single
+ * file (or the whole sweep) is logged and swallowed - it must never break app
+ * startup, and the on-disk memories remain untouched.
+ */
+export async function backfillMemoryIndex(opts: {
+  ijfwMemoryDir: string;
+  markerPath?: string;
+}): Promise<BackfillResult> {
+  const { ijfwMemoryDir } = opts;
+  const markerPath = opts.markerPath ?? backfillMarkerPath(ijfwMemoryDir);
+  const result: BackfillResult = { indexed: 0, skipped: false, errors: [] };
+
+  // Already swept once - never run again (store is an INSERT; re-running dupes).
+  // If the marker can't be stat'd, fail safe by skipping to avoid duplicate risk.
+  try {
+    if (fs.existsSync(markerPath)) {
+      result.skipped = true;
+      return result;
+    }
+  } catch {
+    result.skipped = true;
+    return result;
+  }
+
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(ijfwMemoryDir, { withFileTypes: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      // No memory dir yet (fresh install) - nothing to strand. Lay the marker so
+      // we don't re-scan on every boot, then stop.
+      await writeMarker(markerPath, result);
+      return result;
+    }
+    // Transient failure (EACCES / EBUSY / EMFILE / home volume syncing). Do NOT
+    // write the marker - retry the sweep on the next boot rather than burning the
+    // once-only guard and permanently stranding every pre-existing memory.
+    log.warn('[memoryBackfill] readdir failed, will retry next boot', { ijfwMemoryDir, err });
+    result.errors.push(`readdir: ${String(err)}`);
+    return result;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    if (!entry.name.toLowerCase().endsWith('.md')) continue;
+
+    const filePath = path.join(ijfwMemoryDir, entry.name);
+    try {
+      const raw = await fs.promises.readFile(filePath, 'utf8');
+      // Index the body only. The persisted file carries synthetic frontmatter
+      // (title/description/type/...); the live drop paths store the pre-frontmatter
+      // body, so strip it here too - otherwise backfilled entries would be polluted
+      // with YAML and burn the store's content cap on metadata. stripFrontmatter
+      // also strips a BOM and normalizes newlines.
+      const body = stripFrontmatter(raw);
+      if (!body.trim()) continue;
+      const summary = deriveSummary(raw, entry.name);
+      await indexDroppedMemory({
+        content: body,
+        summary,
+        sourceFile: entry.name,
+        tags: ['dropped', 'backfill'],
+      });
+      result.indexed++;
+    } catch (err) {
+      log.warn('[memoryBackfill] failed to index existing memory', { file: entry.name, err });
+      result.errors.push(`${entry.name}: ${String(err)}`);
+    }
+  }
+
+  await writeMarker(markerPath, result);
+  log.info('[memoryBackfill] one-time FTS5 backfill complete', {
+    indexed: result.indexed,
+    errorCount: result.errors.length,
+  });
+  return result;
+}
+
+/** Persist the once-only marker. A marker-write failure is recorded but never thrown. */
+async function writeMarker(markerPath: string, result: BackfillResult): Promise<void> {
+  try {
+    await fs.promises.mkdir(path.dirname(markerPath), { recursive: true });
+    await fs.promises.writeFile(
+      markerPath,
+      JSON.stringify({ version: 1, indexed: result.indexed, at: new Date().toISOString() }),
+      'utf8'
+    );
+  } catch (err) {
+    log.warn('[memoryBackfill] failed to write backfill marker', { markerPath, err });
+    result.errors.push(`marker: ${String(err)}`);
+  }
+}

--- a/src/process/services/import/memoryFrontmatter.ts
+++ b/src/process/services/import/memoryFrontmatter.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Shared title/description derivation for ingested memories.
+ *
+ * Two ingest paths feed the memory store: the Drop folder watcher
+ * (`dropFolderWatcher.ingestFile`) and the drag-drop IPC
+ * (`importBridge.ingestFiles`). They previously each reimplemented title/summary
+ * derivation inline, and the drag-drop path never stripped a leading UTF-8 BOM.
+ * On a Windows-authored file (BOM + CRLF, or lone-CR line endings) that path
+ * produced `title = <filename fallback>` and a mashed description, while the
+ * drop-folder path produced clean output for the same bytes (#256 B1).
+ *
+ * Both paths now derive through these helpers so identical input yields
+ * identical metadata regardless of entry point, and the two implementations
+ * cannot drift again. Every function tolerates a BOM and CRLF / lone-CR endings.
+ */
+
+const FIELD_MAX = 200;
+
+/** Strip a single leading UTF-8 BOM (U+FEFF), which Windows editors prepend. */
+export function stripBom(raw: string): string {
+  return raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw;
+}
+
+/** Normalize CRLF and lone-CR line endings to LF. */
+export function normalizeNewlines(raw: string): string {
+  return raw.replace(/\r\n?/g, '\n');
+}
+
+/** Strip a leading BOM and normalize newlines in one pass. Idempotent. */
+export function cleanText(raw: string): string {
+  return normalizeNewlines(stripBom(raw));
+}
+
+/** Strip a leading YAML frontmatter block (if any) so derivation reads the real body. */
+export function stripFrontmatter(raw: string): string {
+  return cleanText(raw).replace(/^\s*---\n[\s\S]*?\n---\n?/, '');
+}
+
+/**
+ * Human title: a leading markdown heading if present, else the source filename
+ * (sans extension). Falls back to the filename when no heading is found.
+ */
+export function deriveTitle(raw: string, basename: string): string {
+  const heading = stripFrontmatter(raw).match(/^#\s+(.+)$/m);
+  const title = heading ? heading[1].trim() : basename.replace(/\.(?:md|txt|json)$/i, '');
+  return title
+    .replace(/[\r\n]+/g, ' ')
+    .trim()
+    .slice(0, FIELD_MAX);
+}
+
+/**
+ * One-line description. Prefers the first real body line over a leading markdown
+ * heading, so the description stays distinct from the title; falls back to the
+ * heading text and finally the filename.
+ */
+export function deriveSummary(raw: string, basename: string): string {
+  const lines = stripFrontmatter(raw)
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+  const firstBodyLine = lines.find((l) => !l.startsWith('#'));
+  const firstHeading = lines[0]?.replace(/^#+\s*/, '');
+  const cleaned = (firstBodyLine || firstHeading || basename).replace(/[\r\n]+/g, ' ').trim();
+  return (cleaned || basename).slice(0, FIELD_MAX);
+}

--- a/src/process/services/import/memoryIndexer.ts
+++ b/src/process/services/import/memoryIndexer.ts
@@ -27,6 +27,8 @@ type IndexDroppedMemoryOpts = {
   summary: string;
   /** Original source filename, used as a summary fallback. */
   sourceFile?: string;
+  /** Tags for the stored entry. Defaults to ['dropped']; the backfill adds 'backfill'. */
+  tags?: string[];
 };
 
 /**
@@ -48,7 +50,7 @@ export async function indexDroppedMemory(opts: IndexDroppedMemoryOpts): Promise<
       content: content.slice(0, MAX_CONTENT),
       type: 'observation',
       summary,
-      tags: ['dropped'],
+      tags: opts.tags ?? ['dropped'],
     });
     if (!result.ok) {
       const errorMessage = (result as { error?: string }).error;

--- a/src/process/services/import/memoryIndexer.ts
+++ b/src/process/services/import/memoryIndexer.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #256 / #412 - index freshly-ingested memories into the IJFW search index.
+ *
+ * Dropping a file (Drop folder or drag-drop) writes a .md into ~/.ijfw/memory,
+ * which makes it appear in the Memory UI - but free-text recall in the IJFW
+ * mcp-server is served from an FTS5 index that is only populated by
+ * `ijfw_memory_store`. Because the desktop drop path never called that tool, the
+ * agent could not recall what the Memory UI plainly showed ("Memory not found").
+ * After persisting the file we therefore also store its content through the MCP
+ * client so it lands in the FTS5 index and becomes recallable.
+ */
+import log from 'electron-log';
+import { ijfwMcpClient } from '@process/services/ijfw/ijfwMcpClient';
+
+// ijfw_memory_store caps: content <= 4096 chars, summary (frontmatter name) <= 80.
+const MAX_CONTENT = 4096;
+const MAX_SUMMARY = 80;
+
+type IndexDroppedMemoryOpts = {
+  /** Full text of the ingested memory; truncated to the store's content cap. */
+  content: string;
+  /** One-line summary used as the entry's frontmatter name. */
+  summary: string;
+  /** Original source filename, used as a summary fallback. */
+  sourceFile?: string;
+};
+
+/**
+ * Index a just-ingested memory into the IJFW FTS5 search index so the chat agent
+ * can recall it. Best-effort and fire-and-forget: a failure here (mcp-server
+ * unavailable, timeout, quota) must never break the drop/ingest itself - the
+ * .md file is already safely on disk and visible in the Memory UI.
+ */
+export async function indexDroppedMemory(opts: IndexDroppedMemoryOpts): Promise<void> {
+  const content = opts.content.trim();
+  if (!content) return;
+
+  const summary = (opts.summary?.trim() || opts.sourceFile?.trim() || 'Dropped memory')
+    .replace(/[\r\n]+/g, ' ')
+    .slice(0, MAX_SUMMARY);
+
+  try {
+    const result = await ijfwMcpClient.invoke('memory_store', {
+      content: content.slice(0, MAX_CONTENT),
+      type: 'observation',
+      summary,
+      tags: ['dropped'],
+    });
+    if (!result.ok) {
+      const errorMessage = (result as { error?: string }).error;
+      log.warn('[memoryIndexer] memory_store failed', { error: errorMessage, sourceFile: opts.sourceFile });
+    } else {
+      log.info('[memoryIndexer] indexed dropped memory into FTS5', { sourceFile: opts.sourceFile });
+    }
+  } catch (err) {
+    log.warn('[memoryIndexer] memory_store threw', { err, sourceFile: opts.sourceFile });
+  }
+}

--- a/tests/unit/dragDropMemoryFile.test.ts
+++ b/tests/unit/dragDropMemoryFile.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #256 B1 - the drag-drop ingest path (`memory.ingestFiles`) is what "drop a
+ * memory via the UI" actually hits, and it was the path the live Windows verify
+ * found broken: a BOM-prefixed file stored `title = <filename fallback>` and
+ * mangled metadata while the drop-folder path stayed clean. These drive the real
+ * assembly (buildDragDropMemoryFile) and assert the persisted frontmatter + the
+ * content handed to the FTS5 store are clean for Windows-authored input.
+ */
+import { describe, expect, it } from 'vitest';
+import { buildDragDropMemoryFile } from '@process/bridge/importBridge';
+
+const BOM = '﻿';
+const TS = 1_700_000_000_000;
+
+describe('drag-drop memory file assembly (#256 B1)', () => {
+  it('derives a clean title/description for a plain (LF, no BOM) file', () => {
+    const out = buildDragDropMemoryFile(
+      { name: 'hyperframes.md', content: '# HyperFrames Overview\n\nHyperFrames are a modular UI concept.' },
+      TS
+    );
+    expect(out.title).toBe('HyperFrames Overview');
+    expect(out.summary).toBe('HyperFrames are a modular UI concept.');
+    expect(out.fileContent).toMatch(/^title: HyperFrames Overview$/m);
+    expect(out.fileContent).toMatch(/^description: HyperFrames are a modular UI concept\.$/m);
+  });
+
+  it('REGRESSION: a Windows file (BOM + CRLF) keeps its heading title instead of the filename fallback', () => {
+    const out = buildDragDropMemoryFile(
+      {
+        name: 'nebula-note.md',
+        content: `${BOM}# Nebula Test Memory\r\n\r\nThe codename for the drop-recall test is NEBULA-2287.\r\n`,
+      },
+      TS
+    );
+
+    // The exact bug: before the fix the title fell back to "nebula-note".
+    expect(out.title).toBe('Nebula Test Memory');
+    expect(out.summary).toBe('The codename for the drop-recall test is NEBULA-2287.');
+    expect(out.fileContent).toMatch(/^title: Nebula Test Memory$/m);
+    expect(out.fileContent).toMatch(/^description: The codename for the drop-recall test is NEBULA-2287\.$/m);
+
+    // No BOM anywhere in the persisted file, and the content given to the FTS5
+    // store is BOM-free and starts at the heading.
+    expect(out.fileContent.charCodeAt(0)).not.toBe(0xfeff);
+    expect(out.fileContent).not.toContain(BOM);
+    expect(out.indexedContent).not.toContain(BOM);
+    expect(out.indexedContent.startsWith('# Nebula Test Memory')).toBe(true);
+  });
+
+  it('passes through a file that already has YAML frontmatter (BOM stripped)', () => {
+    const out = buildDragDropMemoryFile(
+      { name: 'preset.md', content: `${BOM}---\ntitle: Preset\n---\n# Body Heading\n\nbody` },
+      TS
+    );
+    // Existing frontmatter is preserved (not double-wrapped), just BOM-stripped.
+    expect(out.fileContent.startsWith('---\ntitle: Preset')).toBe(true);
+    expect(out.fileContent).not.toContain(BOM);
+  });
+
+  it('records the requested scope (defaults to global)', () => {
+    const proj = buildDragDropMemoryFile({ name: 'a.md', content: '# A\n\nbody', scope: 'project' }, TS);
+    const glob = buildDragDropMemoryFile({ name: 'b.md', content: '# B\n\nbody' }, TS);
+    expect(proj.fileContent).toMatch(/^scope: project$/m);
+    expect(glob.fileContent).toMatch(/^scope: global$/m);
+  });
+});

--- a/tests/unit/dropFolderIngest.test.ts
+++ b/tests/unit/dropFolderIngest.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #256 - integration coverage for the drop-folder ingest path. Drives the real
+ * runDropFolderProcess against temp directories and asserts the two behaviors a
+ * dropped memory needs to become recall-able: (1) it is written with canonical
+ * title/description frontmatter for the IJFW reader tier, and (2) its content is
+ * stored through ijfw_memory_store so it lands in the FTS5 index that free-text
+ * recall searches. Only the external MCP client is mocked - the file IO and
+ * frontmatter assembly run for real.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const invokeMock = vi.fn();
+vi.mock('@process/services/ijfw/ijfwMcpClient', () => ({
+  ijfwMcpClient: { invoke: (...args: unknown[]) => invokeMock(...args) },
+}));
+vi.mock('electron-log', () => ({ default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+
+import { runDropFolderProcess } from '@process/services/import/dropFolderWatcher';
+
+let baseDir: string;
+let dropFolder: string;
+let memDir: string;
+
+beforeEach(() => {
+  invokeMock.mockReset();
+  invokeMock.mockResolvedValue({ ok: true });
+  baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wl-drop-ingest-'));
+  dropFolder = path.join(baseDir, 'drop');
+  memDir = path.join(baseDir, 'mem');
+  fs.mkdirSync(dropFolder, { recursive: true });
+  fs.mkdirSync(memDir, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(baseDir, { recursive: true, force: true });
+});
+
+/** The void/fire-and-forget memory_store call resolves on the microtask queue; flush it. */
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe('drop-folder ingest makes a dropped memory recall-able (#256)', () => {
+  it('writes canonical frontmatter AND stores the content into the FTS5 index', async () => {
+    fs.writeFileSync(
+      path.join(dropFolder, 'hyperframes.md'),
+      '# HyperFrames Overview\n\nHyperFrames are a modular UI concept for Wayland.'
+    );
+
+    const result = await runDropFolderProcess({ dropFolder, ijfwMemoryDir: memDir });
+    await flush();
+
+    expect(result.count).toBe(1);
+
+    // (1) file persisted with title + description frontmatter for the reader tier
+    const written = fs.readdirSync(memDir).find((n) => n.startsWith('dropped-') && n.endsWith('.md'));
+    expect(written).toBeTruthy();
+    const fileContent = fs.readFileSync(path.join(memDir, written as string), 'utf8');
+    expect(fileContent).toMatch(/^title: HyperFrames Overview$/m);
+    expect(fileContent).toMatch(/^description: HyperFrames are a modular UI concept for Wayland\.$/m);
+
+    // (2) content indexed via ijfw_memory_store -> recall-able
+    expect(invokeMock).toHaveBeenCalledWith(
+      'memory_store',
+      expect.objectContaining({
+        content: expect.stringContaining('HyperFrames are a modular UI concept for Wayland.'),
+        type: 'observation',
+      })
+    );
+  });
+
+  it('still ingests the file even if the FTS5 store fails (best-effort, no regression)', async () => {
+    invokeMock.mockRejectedValue(new Error('mcp-server unavailable'));
+    fs.writeFileSync(path.join(dropFolder, 'resilient.md'), '# Resilient\n\nIngest must not depend on the index call.');
+
+    const result = await runDropFolderProcess({ dropFolder, ijfwMemoryDir: memDir });
+    await flush();
+
+    expect(result.count).toBe(1);
+    expect(result.errors).toHaveLength(0);
+    expect(fs.readdirSync(memDir).some((n) => n.startsWith('dropped-'))).toBe(true);
+  });
+});

--- a/tests/unit/dropFolderIngest.test.ts
+++ b/tests/unit/dropFolderIngest.test.ts
@@ -74,6 +74,37 @@ describe('drop-folder ingest makes a dropped memory recall-able (#256)', () => {
     );
   });
 
+  it('strips a leading UTF-8 BOM so the title, body, and stored content stay clean (#256 B1)', async () => {
+    // A Windows-saved drop file carries a UTF-8 BOM before the `#` heading. Left
+    // in place it defeated the heading match (title fell back to the filename),
+    // landed in the written body, and corrupted the store's own derivation.
+    fs.writeFileSync(
+      path.join(dropFolder, 'verify431-codename.md'),
+      '﻿# Verify431 Codename\n\nThe codename for the drop-recall test is NEBULA-2287.'
+    );
+
+    const result = await runDropFolderProcess({ dropFolder, ijfwMemoryDir: memDir });
+    await flush();
+    expect(result.count).toBe(1);
+
+    const written = fs.readdirSync(memDir).find((n) => n.startsWith('dropped-') && n.endsWith('.md'));
+    const fileContent = fs.readFileSync(path.join(memDir, written as string), 'utf8');
+
+    // Title comes from the heading, NOT the filename fallback "verify431-codename".
+    expect(fileContent).toMatch(/^title: Verify431 Codename$/m);
+    expect(fileContent).toMatch(/^description: The codename for the drop-recall test is NEBULA-2287\.$/m);
+    // No BOM anywhere in the persisted file (not at the start, not mid-body).
+    expect(fileContent.charCodeAt(0)).not.toBe(0xfeff);
+    expect(fileContent).not.toContain('﻿');
+
+    // The content handed to the FTS5 store is BOM-free and starts at the heading.
+    const storeCall = invokeMock.mock.calls.find((c) => c[0] === 'memory_store');
+    if (!storeCall) throw new Error('expected a memory_store call');
+    const storedContent = (storeCall[1] as { content: string }).content;
+    expect(storedContent).not.toContain('﻿');
+    expect(storedContent.startsWith('# Verify431 Codename')).toBe(true);
+  });
+
   it('still ingests the file even if the FTS5 store fails (best-effort, no regression)', async () => {
     invokeMock.mockRejectedValue(new Error('mcp-server unavailable'));
     fs.writeFileSync(path.join(dropFolder, 'resilient.md'), '# Resilient\n\nIngest must not depend on the index call.');

--- a/tests/unit/memoryBackfill.test.ts
+++ b/tests/unit/memoryBackfill.test.ts
@@ -1,0 +1,149 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #256 - memories that predate store-on-drop live on disk but never landed in the
+ * FTS5 index, so they can't be recalled and don't self-heal. The one-time
+ * backfill sweeps them into the index once per install, guarded by a marker.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const invokeMock = vi.fn();
+vi.mock('@process/services/ijfw/ijfwMcpClient', () => ({
+  ijfwMcpClient: { invoke: (...args: unknown[]) => invokeMock(...args) },
+}));
+vi.mock('electron-log', () => ({ default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+
+import { backfillMarkerPath, backfillMemoryIndex } from '@process/services/import/memoryBackfill';
+
+let tmpRoot: string;
+let memDir: string;
+
+beforeEach(async () => {
+  invokeMock.mockReset();
+  invokeMock.mockResolvedValue({ ok: true });
+  tmpRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'mem-backfill-'));
+  memDir = path.join(tmpRoot, 'memory');
+  await fs.promises.mkdir(memDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await fs.promises.rm(tmpRoot, { recursive: true, force: true });
+});
+
+async function writeMemory(name: string, body: string): Promise<void> {
+  await fs.promises.writeFile(path.join(memDir, name), body, 'utf8');
+}
+
+describe('backfillMemoryIndex (#256)', () => {
+  it('indexes each pre-existing .md memory once and writes the marker', async () => {
+    await writeMemory('a.md', '# Alpha\nfirst body line');
+    await writeMemory('b.md', '# Beta\nsecond body line');
+
+    const result = await backfillMemoryIndex({ ijfwMemoryDir: memDir });
+
+    expect(result.skipped).toBe(false);
+    expect(result.indexed).toBe(2);
+    expect(invokeMock).toHaveBeenCalledTimes(2);
+    // Marker exists after a completed sweep.
+    expect(fs.existsSync(backfillMarkerPath(memDir))).toBe(true);
+  });
+
+  it('tags backfilled entries so they are distinguishable from live drops', async () => {
+    await writeMemory('a.md', '# Alpha\nbody');
+    await backfillMemoryIndex({ ijfwMemoryDir: memDir });
+    expect(invokeMock).toHaveBeenCalledWith('memory_store', expect.objectContaining({ tags: ['dropped', 'backfill'] }));
+  });
+
+  it('indexes body only, stripping the synthetic frontmatter real files carry', async () => {
+    // Every real writer (drop/drag-drop/importers) persists frontmatter + body;
+    // the live paths store the pre-frontmatter body, so backfill must match.
+    const fileWithFrontmatter = [
+      '---',
+      'title: Nebula Codename',
+      'description: the reporter dropped this',
+      'type: observation',
+      'summary: Nebula Codename',
+      '---',
+      '# Nebula Codename',
+      'the secret marker is NEBULA-2287',
+    ].join('\n');
+    await writeMemory('dropped-123-nebula.md', fileWithFrontmatter);
+
+    await backfillMemoryIndex({ ijfwMemoryDir: memDir });
+
+    const stored = (invokeMock.mock.calls[0][1] as { content: string }).content;
+    expect(stored).toContain('NEBULA-2287');
+    expect(stored).not.toContain('type: observation');
+    expect(stored).not.toContain('description:');
+  });
+
+  it('does not write the marker on a transient readdir failure (retries next boot)', async () => {
+    await writeMemory('a.md', '# Alpha\nbody');
+    const err = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+    const spy = vi.spyOn(fs.promises, 'readdir').mockRejectedValueOnce(err as never);
+
+    const result = await backfillMemoryIndex({ ijfwMemoryDir: memDir });
+
+    expect(result.skipped).toBe(false);
+    expect(invokeMock).not.toHaveBeenCalled();
+    expect(fs.existsSync(backfillMarkerPath(memDir))).toBe(false);
+    spy.mockRestore();
+  });
+
+  it('is idempotent: a second run with the marker present indexes nothing', async () => {
+    await writeMemory('a.md', '# Alpha\nbody');
+    await backfillMemoryIndex({ ijfwMemoryDir: memDir });
+    invokeMock.mockClear();
+
+    const second = await backfillMemoryIndex({ ijfwMemoryDir: memDir });
+    expect(second.skipped).toBe(true);
+    expect(second.indexed).toBe(0);
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('skips non-.md files, subdirectories, and empty memories', async () => {
+    await writeMemory('keep.md', '# Keep\nbody');
+    await writeMemory('note.txt', 'plain text - not indexed');
+    await writeMemory('blank.md', '   \n  ');
+    await fs.promises.mkdir(path.join(memDir, 'global'), { recursive: true });
+    await fs.promises.writeFile(path.join(memDir, 'global', 'nested.md'), '# Nested\nbody', 'utf8');
+
+    const result = await backfillMemoryIndex({ ijfwMemoryDir: memDir });
+
+    expect(result.indexed).toBe(1);
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('is best-effort per file: one unreadable/failed file does not abort the rest', async () => {
+    await writeMemory('good1.md', '# Good1\nbody');
+    await writeMemory('bad.md', '# Bad\nbody');
+    await writeMemory('good2.md', '# Good2\nbody');
+    // Make the store reject only for bad.md's content.
+    invokeMock.mockImplementation((_verb: string, args: { content?: string }) => {
+      if (args?.content?.includes('Bad')) return Promise.reject(new Error('store failed'));
+      return Promise.resolve({ ok: true });
+    });
+
+    const result = await backfillMemoryIndex({ ijfwMemoryDir: memDir });
+
+    // indexDroppedMemory swallows the store failure, so all three are attempted
+    // and counted; the sweep completes and the marker is written.
+    expect(result.indexed).toBe(3);
+    expect(fs.existsSync(backfillMarkerPath(memDir))).toBe(true);
+  });
+
+  it('fresh install (no memory dir): lays the marker, indexes nothing', async () => {
+    const missing = path.join(tmpRoot, 'does-not-exist', 'memory');
+    const result = await backfillMemoryIndex({ ijfwMemoryDir: missing });
+
+    expect(result.indexed).toBe(0);
+    expect(result.skipped).toBe(false);
+    expect(invokeMock).not.toHaveBeenCalled();
+    expect(fs.existsSync(backfillMarkerPath(missing))).toBe(true);
+  });
+});

--- a/tests/unit/memoryFrontmatter.test.ts
+++ b/tests/unit/memoryFrontmatter.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #256 B1 - the shared title/description derivation used by BOTH memory ingest
+ * paths (drop folder + drag-drop). These assert the Windows failure modes the
+ * live verify hit: a leading UTF-8 BOM must not steal the title, and CRLF /
+ * lone-CR line endings must not mash the heading into the description.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  cleanText,
+  deriveSummary,
+  deriveTitle,
+  normalizeNewlines,
+  stripBom,
+  stripFrontmatter,
+} from '@process/services/import/memoryFrontmatter';
+
+const BOM = '﻿';
+
+describe('memoryFrontmatter shared helpers (#256 B1)', () => {
+  describe('stripBom / normalizeNewlines / cleanText', () => {
+    it('removes only a single leading BOM', () => {
+      expect(stripBom(`${BOM}# Title`)).toBe('# Title');
+      expect(stripBom('# Title')).toBe('# Title');
+      // A non-leading BOM is left untouched (we only strip the editor prefix).
+      expect(stripBom(`# Ti${BOM}tle`)).toBe(`# Ti${BOM}tle`);
+    });
+
+    it('normalizes CRLF and lone-CR to LF', () => {
+      expect(normalizeNewlines('a\r\nb\rc\nd')).toBe('a\nb\nc\nd');
+    });
+
+    it('cleanText strips BOM and normalizes newlines together (idempotent)', () => {
+      const once = cleanText(`${BOM}a\r\nb`);
+      expect(once).toBe('a\nb');
+      expect(cleanText(once)).toBe('a\nb');
+    });
+  });
+
+  describe('deriveTitle', () => {
+    it('uses the markdown heading when present', () => {
+      expect(deriveTitle('# Nebula Test Memory\n\nbody', 'note.md')).toBe('Nebula Test Memory');
+    });
+
+    it('falls back to the filename (sans extension) when there is no heading', () => {
+      expect(deriveTitle('just a plain note, no heading', 'nebula-note.md')).toBe('nebula-note');
+    });
+
+    it('REGRESSION: a leading BOM does not steal the title to the filename fallback', () => {
+      // This is the exact live-verify failure: BOM sat before `#`, the `^#`
+      // heading match failed, and the title silently became "nebula-note".
+      expect(deriveTitle(`${BOM}# Nebula Test Memory\n\nbody`, 'nebula-note.md')).toBe('Nebula Test Memory');
+    });
+
+    it('REGRESSION: CRLF and lone-CR endings still yield a clean heading title', () => {
+      expect(deriveTitle(`${BOM}# Nebula Test Memory\r\n\r\nbody`, 'nebula-note.md')).toBe('Nebula Test Memory');
+      expect(deriveTitle(`${BOM}# Nebula Test Memory\rbody`, 'nebula-note.md')).toBe('Nebula Test Memory');
+    });
+  });
+
+  describe('deriveSummary', () => {
+    it('prefers the first real body line over the heading (distinct from title)', () => {
+      const summary = deriveSummary('# Heading\n\nThe codename is NEBULA-2287.', 'note.md');
+      expect(summary).toBe('The codename is NEBULA-2287.');
+    });
+
+    it('REGRESSION: BOM + CRLF does not mash the heading into the description', () => {
+      const summary = deriveSummary(`${BOM}# Heading\r\n\r\nThe codename is NEBULA-2287.\r\n`, 'note.md');
+      expect(summary).toBe('The codename is NEBULA-2287.');
+      expect(summary).not.toContain('Heading');
+      expect(summary).not.toContain(BOM);
+      expect(summary).not.toContain('\r');
+    });
+
+    it('REGRESSION: lone-CR (old-Mac) endings split lines instead of mashing them', () => {
+      // With CR-only endings a naive split("\n") leaves "Heading\rBody" as one
+      // line and mashes them; normalization fixes it.
+      const summary = deriveSummary(`${BOM}# Heading\rThe codename is NEBULA-2287.`, 'note.md');
+      expect(summary).toBe('The codename is NEBULA-2287.');
+    });
+
+    it('falls back to the heading text, then the filename, when there is no body', () => {
+      expect(deriveSummary('# Only A Heading', 'note.md')).toBe('Only A Heading');
+      expect(deriveSummary('', 'fallback-name.md')).toBe('fallback-name.md');
+    });
+  });
+
+  describe('stripFrontmatter', () => {
+    it('removes a leading YAML block (even behind a BOM) so derivation reads the body', () => {
+      const raw = `${BOM}---\ntitle: x\n---\n# Real Heading\n\nbody`;
+      expect(stripFrontmatter(raw)).toBe('# Real Heading\n\nbody');
+      expect(deriveTitle(raw, 'note.md')).toBe('Real Heading');
+    });
+  });
+});

--- a/tests/unit/memoryIndexer.test.ts
+++ b/tests/unit/memoryIndexer.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #256 - dropped memories must land in the IJFW FTS5 index (via ijfw_memory_store)
+ * so the chat agent can recall them, not just see them in the Memory UI.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const invokeMock = vi.fn();
+vi.mock('@process/services/ijfw/ijfwMcpClient', () => ({
+  ijfwMcpClient: { invoke: (...args: unknown[]) => invokeMock(...args) },
+}));
+vi.mock('electron-log', () => ({ default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+
+import { indexDroppedMemory } from '@process/services/import/memoryIndexer';
+
+beforeEach(() => {
+  invokeMock.mockReset();
+  invokeMock.mockResolvedValue({ ok: true });
+});
+
+describe('indexDroppedMemory (#256)', () => {
+  it('stores ingested content through ijfw_memory_store so it is recallable', async () => {
+    await indexDroppedMemory({ content: 'Notes about HyperFrames', summary: 'HyperFrames', sourceFile: 'hf.md' });
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    expect(invokeMock).toHaveBeenCalledWith(
+      'memory_store',
+      expect.objectContaining({
+        content: 'Notes about HyperFrames',
+        type: 'observation',
+        summary: 'HyperFrames',
+        tags: ['dropped'],
+      })
+    );
+  });
+
+  it('caps content at 4096 and summary at 80 (ijfw_memory_store limits)', async () => {
+    await indexDroppedMemory({ content: 'x'.repeat(5000), summary: 'y'.repeat(200) });
+    const args = invokeMock.mock.calls[0][1] as { content: string; summary: string };
+    expect(args.content.length).toBe(4096);
+    expect(args.summary.length).toBe(80);
+  });
+
+  it('does not call the store for empty content', async () => {
+    await indexDroppedMemory({ content: '   \n  ', summary: 'irrelevant' });
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the source filename for the summary when none is given', async () => {
+    await indexDroppedMemory({ content: 'body text', summary: '', sourceFile: 'mydoc.md' });
+    expect((invokeMock.mock.calls[0][1] as { summary: string }).summary).toBe('mydoc.md');
+  });
+
+  it('never throws if the mcp client rejects (best-effort, must not break ingest)', async () => {
+    invokeMock.mockRejectedValue(new Error('mcp-server unavailable'));
+    await expect(indexDroppedMemory({ content: 'x', summary: 's' })).resolves.toBeUndefined();
+  });
+
+  it('swallows a structured failure result without throwing', async () => {
+    invokeMock.mockResolvedValue({ ok: false, error: 'storage failure' });
+    await expect(indexDroppedMemory({ content: 'x', summary: 's' })).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
Part 2 of the #412/#256 memory cluster (Overwatch ruling: fix the desktop integration gap here before implicating the external mcp-server).

## Root cause
Dropping a file (Drop folder watcher or drag-drop ingest) persists a .md into ~/.ijfw/memory, which is why it appears in the Memory UI. But free-text recall in the IJFW mcp-server is served from an FTS5 index that is only populated by the ijfw_memory_store tool. The desktop drop path never called it, so the agent could not recall a memory the UI plainly showed ("Memory not found", #256; "persistent memory non-existent", #412).

(The earlier 0.12.12 triage's "append a MEMORY.md index line" targeted wcore-native memory, a separate store + injection path — a no-op for the IJFW recall flow.)

## Fix (both desktop levers from the ruling)
- (a) After persisting a dropped/ingested file, call ijfw_memory_store with its content so it lands in the FTS5 index and becomes recallable. New helper src/process/services/import/memoryIndexer.ts; wired into both ingest paths (dropFolderWatcher.ingestFile and importBridge.ingestFiles). Best-effort and fire-and-forget — a store failure never breaks the ingest (the file is already on disk / in the Memory UI). Content is capped at the tool's 4096-char limit, summary at 80.
- (b) Write canonical title + description frontmatter on drop (previously only summary/type) so the IJFW reader tier surfaces a real label/description instead of the generated "dropped-<ts>-..." filename.

## Verification
- Unit: tests/unit/memoryIndexer.test.ts — 6 tests (stores via ijfw_memory_store with correct args; caps content/summary; skips empty; summary fallback to filename; best-effort swallows both thrown and structured failures). All green. Typecheck clean for the changed files.
- Local end-to-end could NOT be exercised: the drop-folder watcher and engine recall do not run under the local automation harness, and recall is engine-gated. Per the ruling, the authoritative drop -> ask-agent recall test runs on Windows (Overwatch). If recall still fails after this lands, the residual is the external ijfw mcp-server FTS5 logic and gets handed to its owner.

Scope: memoryIndexer.ts (new) + dropFolderWatcher.ts + importBridge.ts + test. Composer draft-persistence half is the separate PR #430.
