### PR TITLE
test(ijfw): de-flake the Windows bootstrap-upgrade flake — vi.waitFor not fixed-tick (#292)

### DIFF
--- a/tests/unit/process/services/ijfwSystemService.bootstrap.test.ts
+++ b/tests/unit/process/services/ijfwSystemService.bootstrap.test.ts
@@ -105,11 +105,21 @@ function flush(): Promise<void> {
   return new Promise((resolve) => setImmediate(resolve));
 }
 
-// Flush the event loop until `pred()` is true or `max` flushes elapse. Replaces
-// fixed-count flush loops that race the async install-exit handler - those are
-// flaky on fast hosts and worse on the ~2.7x-slower windows runners.
-async function flushUntil(pred: () => boolean, max = 200): Promise<void> {
-  for (let i = 0; i < max && !pred(); i++) await flush();
+// Wait until `pred()` holds, on a REAL-TIME budget rather than a fixed flush
+// count. The async install-exit handler chain (move-pending → emit →
+// release-lock) can exceed any fixed tick count on the ~2.7x-slower windows
+// runners, so the old 200-flush loop returned with the condition still false and
+// the following assertion saw 0 calls — the #292 windows flake. vi.waitFor
+// re-evaluates pred against a 5s deadline (polling every 5ms, which yields to
+// the event loop so the setImmediate callbacks fire), deterministic on every
+// platform with no arbitrary sleeps.
+async function flushUntil(pred: () => boolean): Promise<void> {
+  await vi.waitFor(
+    () => {
+      if (!pred()) throw new Error('flushUntil: condition not met yet');
+    },
+    { timeout: 5000, interval: 5 }
+  );
 }
 
 // eslint-disable-next-line import/first


### PR DESCRIPTION
## #292 — flaky Windows unit test (the live remaining one)

#292's two originally-named flakes were already fixed (PR #336: team-TeammateManager + webuiStaticRoutes), and a 4th family member (officeWatchBridge) was de-flaked in #428. This fixes the 3rd sibling reported on the issue (05:11) — the only one still reddening the Windows matrix.

### The flake
`tests/unit/process/services/ijfwSystemService.bootstrap.test.ts` → `upgrades - emits upgrading then installed_pending_activation` fails intermittently on Windows shard 3/4:
`AssertionError: expected vi.fn() to be called with arguments [...] Number of calls: 0`.

### Root cause
The test helper `flushUntil(pred, max=200)` polled a fixed 200 `setImmediate` ticks for the async install-exit handler chain (move-pending → emit → release-lock). On the ~2.7x-slower Windows runners that chain can exceed 200 ticks, so `flushUntil` returned with the condition still false and the following assertion saw 0 emit calls. Same bug class as officeWatchBridge's fixed-tick `waitForSpawn` (fixed in #428): a fixed tick count is not a real wait.

### Fix
Replace the fixed-tick loop with `vi.waitFor` against a real 5s deadline (polls every 5ms, yielding to the event loop so the setImmediate callbacks fire). Deterministic on every platform, **no arbitrary sleeps**. All 7 specs in the file pass; the full #292 family (4 files, 96 tests) is green locally.

This is the deterministic-wait pattern, not a timeout bump or a sleep.

Tracks #292. Not closing (release/Sean). Goes through the independent cross-audit before merge.
