### PR TITLE
feat(updater): self-diagnose silent macOS ShipIt apply failures (#286)

### DIFF
--- a/src/process/services/autoUpdaterService.ts
+++ b/src/process/services/autoUpdaterService.ts
@@ -9,10 +9,93 @@ import type { ProgressInfo, UpdateInfo } from 'electron-updater';
 import { app } from 'electron';
 import log from 'electron-log';
 import { EventEmitter } from 'events';
+import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import { writeFileSyncAtomic } from '@process/utils/atomicWrite';
 import type { AutoUpdateInstallFailedReason } from '@/common/update/updateTypes';
+
+/**
+ * Redact the user's home-directory prefix from a path/string so diagnostic logs
+ * carry no PII (`/Users/<name>/...` → `~/...`). Pure + total. (#286)
+ */
+export function redactHome(value: string, home: string): string {
+  if (!value || !home) return value;
+  return value.split(home).join('~');
+}
+
+/** Decisive ShipItState.plist fields that disambiguate a silent apply failure (#286). */
+export type ShipItStateFields = {
+  launchAfterInstallation: unknown;
+  targetBundleURL: string;
+  updateBundleURL: string;
+};
+
+/**
+ * Injected IO surface for {@link buildShipItDiagnostics}. Every reader is total
+ * (returns `[]`/`null` instead of throwing) so the builder stays pure and the
+ * never-throws + redaction contract is unit-testable on any platform. (#286)
+ */
+export type ShipItDiagIO = {
+  homedir: string;
+  execPath: string;
+  isInApplicationsFolder: boolean | null;
+  /** List a directory's entries; returns `[]` when absent/unreadable. */
+  listDir: (dir: string) => string[];
+  /** Read a UTF-8 file; returns `null` when absent/unreadable. */
+  readText: (file: string) => string | null;
+  /** Parse decisive ShipItState fields; returns `null` when absent/unparseable. */
+  readPlistFields: (file: string) => ShipItStateFields | null;
+};
+
+/**
+ * Build PII-redacted ShipIt diagnostic log lines from injected IO. Pure and total:
+ * never throws, performs no real IO (all injected), so the redaction and
+ * graceful-absent guarantees are directly verifiable in unit tests on any OS. (#286)
+ *
+ * Emits, for each `*.ShipIt` dir under `~/Library/Caches`: the tail of
+ * `ShipIt_stderr.log` and the decisive `ShipItState.plist` fields — the artifacts
+ * that pick codesign/notarization rejection vs App Translocation vs a move error.
+ */
+export function buildShipItDiagnostics(io: ShipItDiagIO): string[] {
+  const lines: string[] = [];
+  const redact = (s: string): string => redactHome(s, io.homedir);
+  lines.push(`execPath=${redact(io.execPath)} isInApplicationsFolder=${io.isInApplicationsFolder}`);
+
+  const cachesDir = path.join(io.homedir, 'Library', 'Caches');
+  const entries = io.listDir(cachesDir).filter((n) => n.endsWith('.ShipIt'));
+  if (entries.length === 0) {
+    lines.push('no *.ShipIt directory under ~/Library/Caches (no apply artifacts)');
+    return lines;
+  }
+
+  for (const entry of entries) {
+    const dir = path.join(cachesDir, entry);
+    const logText = io.readText(path.join(dir, 'ShipIt_stderr.log'));
+    if (logText !== null) {
+      const tail = logText
+        .split(/\r?\n/)
+        .filter((l) => l.length > 0)
+        .slice(-40)
+        .join('\n');
+      lines.push(`${entry}/ShipIt_stderr.log (tail):\n${redact(tail)}`);
+    } else {
+      lines.push(`${entry}/ShipIt_stderr.log absent or unreadable`);
+    }
+
+    const fields = io.readPlistFields(path.join(dir, 'ShipItState.plist'));
+    if (fields) {
+      lines.push(
+        `${entry}/ShipItState: launchAfterInstallation=${String(fields.launchAfterInstallation)} ` +
+          `targetBundleURL=${redact(fields.targetBundleURL)} updateBundleURL=${redact(fields.updateBundleURL)}`
+      );
+    } else {
+      lines.push(`${entry}/ShipItState.plist absent or unparseable`);
+    }
+  }
+  return lines;
+}
 
 /**
  * Returns the appropriate update channel name based on the current platform and architecture.
@@ -461,9 +544,87 @@ class AutoUpdaterService extends EventEmitter {
       `[autoUpdater] Update to ${expected} was downloaded and install was attempted, but the app is ` +
         `still on ${current}. The post-quit Squirrel/ShipIt apply step silently failed (#286).`
     );
+    // Self-diagnose the silent apply failure: log the decisive ShipIt artifacts so
+    // every affected machine captures them locally — no manual per-user log fetch
+    // round-trip needed to tell signature-mismatch from translocation (#286).
+    this.logShipItDiagnostics();
     // Surface immediately if a renderer is already listening; the update-available
     // interception re-surfaces it once the 3s startup check runs, as a backstop.
     this.broadcastInstallFailed('silent-noop', expected);
+  }
+
+  /**
+   * Read whether the running app is inside /Applications, or null if the API is
+   * unavailable (non-darwin / test) or throws. Never throws. (#286)
+   */
+  private readIsInApplicationsFolder(): boolean | null {
+    try {
+      const fn = (app as { isInApplicationsFolder?: () => boolean }).isInApplicationsFolder;
+      return typeof fn === 'function' ? fn.call(app) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Parse the decisive ShipItState.plist fields via `plutil` (handles binary
+   * plists). Best-effort: returns null on any absence/parse/spawn failure. (#286)
+   */
+  private readShipItStateFields(plistPath: string): ShipItStateFields | null {
+    try {
+      if (!fs.existsSync(plistPath)) return null;
+      const json = execFileSync('plutil', ['-convert', 'json', '-o', '-', plistPath], {
+        encoding: 'utf8',
+        timeout: 2000,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
+      const parsed = JSON.parse(json) as Record<string, unknown>;
+      return {
+        launchAfterInstallation: parsed.launchAfterInstallation,
+        targetBundleURL: typeof parsed.targetBundleURL === 'string' ? parsed.targetBundleURL : '',
+        updateBundleURL: typeof parsed.updateBundleURL === 'string' ? parsed.updateBundleURL : '',
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * macOS-only, read-only, PII-safe diagnostics for a silent ShipIt apply
+   * failure. Wires real fs/plutil into the pure {@link buildShipItDiagnostics}
+   * and logs each redacted line. Best-effort — never breaks startup
+   * reconciliation, logs no secrets, redacts the home dir to `~`. (#286)
+   */
+  private logShipItDiagnostics(): void {
+    if (process.platform !== 'darwin') return;
+    try {
+      const io: ShipItDiagIO = {
+        homedir: os.homedir(),
+        execPath: process.execPath,
+        isInApplicationsFolder: this.readIsInApplicationsFolder(),
+        listDir: (dir) => {
+          try {
+            return fs.readdirSync(dir);
+          } catch {
+            return [];
+          }
+        },
+        readText: (file) => {
+          try {
+            return fs.readFileSync(file, 'utf8');
+          } catch {
+            return null;
+          }
+        },
+        readPlistFields: (file) => this.readShipItStateFields(file),
+      };
+      for (const line of buildShipItDiagnostics(io)) {
+        log.info(`[autoUpdater] ShipIt diag — ${line}`);
+      }
+    } catch (error) {
+      // Diagnostics are strictly best-effort; never let them break reconciliation.
+      log.warn('[autoUpdater] ShipIt diagnostics failed (ignored):', error);
+    }
   }
 
   /**

--- a/tests/unit/autoUpdaterShipItDiagnostics.test.ts
+++ b/tests/unit/autoUpdaterShipItDiagnostics.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// The diagnostics helpers are pure (all IO injected), so we exercise the
+// never-throws + zero-PII contract directly without electron. The module's
+// singleton still constructs at import, so mock the electron surface it touches.
+
+vi.mock('electron', () => ({
+  app: { getVersion: vi.fn(() => '1.0.0'), isPackaged: true, exit: vi.fn() },
+}));
+vi.mock('electron-updater', () => ({
+  autoUpdater: {
+    logger: null,
+    autoDownload: true,
+    autoInstallOnAppQuit: true,
+    channel: null,
+    on: vi.fn(),
+  },
+}));
+vi.mock('electron-log', () => ({
+  default: { transports: { file: { level: 'info' } }, info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
+import {
+  redactHome,
+  buildShipItDiagnostics,
+  type ShipItDiagIO,
+  type ShipItStateFields,
+} from '@/process/services/autoUpdaterService';
+
+const HOME = '/Users/alice';
+
+/** A baseline IO with present, populated artifacts. Tests override per case. */
+function makeIO(overrides: Partial<ShipItDiagIO> = {}): ShipItDiagIO {
+  return {
+    homedir: HOME,
+    execPath: `${HOME}/Applications/Wayland.app/Contents/MacOS/Wayland`,
+    isInApplicationsFolder: true,
+    listDir: () => ['com.ferroxlabs.wayland.ShipIt', 'unrelated-dir'],
+    readText: () =>
+      `Beginning installation\nMoving bundle ${HOME}/Library/Caches/x to /Applications\nInstallation completed successfully`,
+    readPlistFields: (): ShipItStateFields => ({
+      launchAfterInstallation: false,
+      targetBundleURL: `file://${HOME}/Applications/Wayland.app`,
+      updateBundleURL: `file://${HOME}/Library/Caches/com.ferroxlabs.wayland.ShipIt/update.app`,
+    }),
+    ...overrides,
+  };
+}
+
+describe('redactHome', () => {
+  it('replaces every home-dir occurrence with ~', () => {
+    expect(redactHome(`${HOME}/Library/Caches/log`, HOME)).toBe('~/Library/Caches/log');
+    expect(redactHome(`file://${HOME}/a and ${HOME}/b`, HOME)).toBe('file://~/a and ~/b');
+  });
+
+  it('is a no-op for empty value or empty home', () => {
+    expect(redactHome('', HOME)).toBe('');
+    expect(redactHome('/some/path', '')).toBe('/some/path');
+  });
+});
+
+describe('buildShipItDiagnostics — PII redaction', () => {
+  it('redacts the home dir from execPath, the log tail, and plist URLs', () => {
+    const lines = buildShipItDiagnostics(makeIO());
+    const joined = lines.join('\n');
+    // No raw home path may leak anywhere.
+    expect(joined).not.toContain(HOME);
+    // The redacted marker must be present (proves the strings were actually emitted).
+    expect(joined).toContain('execPath=~/Applications/Wayland.app');
+    expect(joined).toContain('targetBundleURL=file://~/Applications/Wayland.app');
+    expect(joined).toContain('launchAfterInstallation=false');
+  });
+});
+
+describe('buildShipItDiagnostics — graceful absence', () => {
+  it('never throws and reports "no *.ShipIt" when the Caches dir is empty/absent', () => {
+    const lines = buildShipItDiagnostics(makeIO({ listDir: () => [] }));
+    expect(lines.some((l) => l.includes('no *.ShipIt directory'))).toBe(true);
+  });
+
+  it('reports the log + plist as absent when both readers return null', () => {
+    const lines = buildShipItDiagnostics(makeIO({ readText: () => null, readPlistFields: () => null }));
+    const joined = lines.join('\n');
+    expect(joined).toContain('ShipIt_stderr.log absent or unreadable');
+    expect(joined).toContain('ShipItState.plist absent or unparseable');
+    // Even with everything absent, still no PII and still the execPath header line.
+    expect(joined).not.toContain(HOME);
+  });
+
+  it('only inspects *.ShipIt entries, ignoring unrelated cache dirs', () => {
+    const seen: string[] = [];
+    buildShipItDiagnostics(
+      makeIO({
+        listDir: () => ['unrelated', 'foo.ShipIt', 'bar'],
+        readText: (file) => {
+          seen.push(file);
+          return null;
+        },
+      })
+    );
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toContain('foo.ShipIt');
+  });
+
+  it('tails to the last 40 non-empty lines of a large log', () => {
+    const big = Array.from({ length: 100 }, (_, i) => `line-${i}`).join('\n');
+    const lines = buildShipItDiagnostics(makeIO({ readText: () => big }));
+    const tailLine = lines.find((l) => l.includes('ShipIt_stderr.log (tail)'));
+    expect(tailLine).toBeDefined();
+    expect(tailLine).toContain('line-99');
+    expect(tailLine).toContain('line-60');
+    expect(tailLine).not.toContain('line-59');
+  });
+});


### PR DESCRIPTION
## #286 part 1 of 3 — self-diagnosing ShipIt instrumentation (per Overwatch ruling 2026-06-29)

macOS auto-update (#286) silently no-ops the ShipIt apply on some machines: the app never restarts and re-offers the same version, with no surfaced failure. The root cause (signature-mismatch vs App Translocation vs a move/path error) can only be told apart from the ShipIt artifacts on the affected machine — today that needs a manual per-user log-fetch round-trip.

This PR makes every affected machine **self-capture** those artifacts. When `reconcilePendingInstall()` detects an install was attempted but the version never advanced, it logs (macOS only, read-only):

- the tail of each `*.ShipIt/ShipIt_stderr.log` under `~/Library/Caches`
- the decisive `ShipItState.plist` fields — `launchAfterInstallation`, `targetBundleURL`, `updateBundleURL` (parsed via `plutil`, handles binary plists)
- `process.execPath` and `isInApplicationsFolder` (the translocation signal)

### Safety contract (matches the audit requirements in the ruling)
- **Never throws** on missing files/dirs/unparseable plist — graceful-absent on every IO path; the whole thing is best-effort and cannot break startup reconciliation.
- **Zero PII** — the user's home dir is redacted to `~` in every logged path (ShipIt log tail + plist URLs + execPath). No secrets/tokens are read.
- **Read-only**, same safety class as the already-merged #307 marker/guard.

### Testability
The line-builder `buildShipItDiagnostics()` is **pure with all IO injected**, so the redaction + graceful-absence guarantees are verified directly in unit tests on every CI platform (not just macOS). The darwin-only method just wires real `fs`/`plutil` into it.

`tests/unit/autoUpdaterShipItDiagnostics.test.ts` — 7 tests: redaction (no raw home leaks anywhere), empty/absent Caches, both-absent log+plist, `*.ShipIt`-only filtering, and 40-line tail bounding.

### Verification
- `bun run test` (new suite 7/7; existing autoUpdaterService + InstallGuard 51/51) ✅
- `bun run typecheck` ✅
- `prek run --from-ref origin/main --to-ref HEAD` (full CI replica) ✅

### Scope / sequencing
This is **part 1 of the #286 ruling** (land now, gated by cross-audit). Part 2 (the restart fix — replacing the blunt `app.exit(0)` with `app.relaunch()` + clean quit) is a **separate PR** that holds for a real-mac live-verify. Part 3 (the targeted apply/signature fix) awaits Sean's diagnostic paste.

> **MERGE GATE:** per the hard gate, this needs an **independent adversarial cross-audit** (not self-review) before merge — green CI is not a merge ticket. Audit focus: confirm (a) never-throws on every missing artifact, and (b) no PII/secret can reach the log. Requesting audit via `wl`.