### PR TITLE
fix(updater): restart after a macOS update instead of dying silently (#286)

### DIFF
--- a/src/process/services/autoUpdaterService.ts
+++ b/src/process/services/autoUpdaterService.ts
@@ -410,7 +410,14 @@ class AutoUpdaterService extends EventEmitter {
     // NOTE: behavioral change to the quit/relaunch path — must be live-verified
     // through a real macOS update cycle before merge (see PR description).
     setTimeout(() => {
-      app.relaunch();
+      // Only macOS needs Electron's own relaunch: Squirrel.Mac's launchAfterInstallation
+      // is the leg that's broken here, whereas the NSIS (Windows) and AppImage (Linux)
+      // updaters already relaunch themselves — so gate relaunch to darwin to avoid a
+      // redundant second spawn off-mac (#286 audit nit). app.quit() runs everywhere so
+      // the process still tears down cleanly for the install handoff.
+      if (process.platform === 'darwin') {
+        app.relaunch();
+      }
       app.quit();
     }, 1000);
   }

--- a/src/process/services/autoUpdaterService.ts
+++ b/src/process/services/autoUpdaterService.ts
@@ -12,6 +12,7 @@ import { EventEmitter } from 'events';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { writeFileSyncAtomic } from '@process/utils/atomicWrite';
+import { setIsQuitting } from '@process/utils/quitState';
 import type { AutoUpdateInstallFailedReason } from '@/common/update/updateTypes';
 
 /**
@@ -386,14 +387,31 @@ class AutoUpdaterService extends EventEmitter {
     // the next launch can detect a silent apply failure (downloaded + attempted
     // but the version never advanced) and surface it instead of looping (#286).
     this.writePendingInstallMarker();
-    // On macOS, autoUpdater.quitAndInstall() closes all windows but the
-    // 'window-all-closed' handler does NOT call app.quit() (standard macOS
-    // behavior + close-to-tray). This leaves the process alive and Squirrel
-    // cannot finish replacing the app bundle. Force-exit after a short delay
-    // to let Squirrel receive the install signal.
+
+    // The main window's 'close' handler hides-to-tray (and 'window-all-closed'
+    // never quits on macOS) unless we're explicitly quitting. Without this flag a
+    // clean app.quit() would just hide the window and the process would stay
+    // alive, so Squirrel/ShipIt can never swap the bundle. Mark the quit as
+    // intentional so windows actually close during the install handoff (#286).
+    setIsQuitting(true);
+
     autoUpdater.quitAndInstall(true, true);
+
+    // #286: the previous code force-killed the process with app.exit(0) one second
+    // later. That abrupt exit pre-empts the Squirrel relaunch handoff — on the
+    // affected macs ShipIt applied the update but the app never restarted
+    // (ShipItState launchAfterInstallation=false, no relaunch). Instead, arm
+    // Electron's own relaunch and quit cleanly: app.relaunch() schedules a fresh
+    // instance to start once this process exits (the same idiom as the tray
+    // "Restart" action), and app.quit() runs the normal before-quit teardown so
+    // ShipIt can finish replacing the bundle. The short delay gives
+    // quitAndInstall() time to stage the install before we tear down.
+    //
+    // NOTE: behavioral change to the quit/relaunch path — must be live-verified
+    // through a real macOS update cycle before merge (see PR description).
     setTimeout(() => {
-      app.exit(0);
+      app.relaunch();
+      app.quit();
     }, 1000);
   }
 

--- a/src/process/utils/quitState.ts
+++ b/src/process/utils/quitState.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Whether the app is intentionally quitting (vs. hiding to tray).
+ *
+ * Kept in a tiny standalone module — deliberately separate from the heavy tray
+ * UI module (`tray.ts`, which pulls i18n + the worker task manager) — so any
+ * quit-path code can read/flip the flag without dragging those dependencies in.
+ * The auto-updater needs exactly this during the macOS install handoff (#286).
+ *
+ * `tray.ts` re-exports {@link getIsQuitting} / {@link setIsQuitting} so existing
+ * import sites keep working unchanged.
+ */
+let isQuitting = false;
+
+export const getIsQuitting = (): boolean => isQuitting;
+
+export const setIsQuitting = (quitting: boolean): void => {
+  isQuitting = quitting;
+};

--- a/src/process/utils/tray.ts
+++ b/src/process/utils/tray.ts
@@ -14,10 +14,10 @@ import {
 import * as path from 'path';
 import i18n from '@process/services/i18n';
 import { workerTaskManager } from '../task/workerTaskManagerSingleton';
+import { getIsQuitting, setIsQuitting } from './quitState';
 
 let tray: TrayInstance | null = null;
 let closeToTrayEnabled = false;
-let isQuitting = false;
 let mainWindowRef: BrowserWindow | null = null;
 
 export const setTrayMainWindow = (win: BrowserWindow): void => {
@@ -30,11 +30,10 @@ export const setCloseToTrayEnabled = (enabled: boolean): void => {
   closeToTrayEnabled = enabled;
 };
 
-export const getIsQuitting = (): boolean => isQuitting;
-
-export const setIsQuitting = (quitting: boolean): void => {
-  isQuitting = quitting;
-};
+// Re-exported from the standalone quit-state module so existing import sites
+// (e.g. src/index.ts) keep working; the flag itself lives in quitState.ts so
+// non-UI quit-path code can use it without tray's heavy deps (#286).
+export { getIsQuitting, setIsQuitting };
 
 /**
  * Get tray icon.
@@ -171,7 +170,7 @@ const buildTrayContextMenu = async (): Promise<Electron.Menu> => {
   template.push({
     label: i18n.t('common.tray.restart'),
     click: () => {
-      isQuitting = true;
+      setIsQuitting(true);
       app.relaunch();
       app.exit(0);
     },
@@ -180,7 +179,7 @@ const buildTrayContextMenu = async (): Promise<Electron.Menu> => {
   template.push({
     label: i18n.t('common.tray.quit'),
     click: () => {
-      isQuitting = true;
+      setIsQuitting(true);
       app.quit();
     },
   });

--- a/tests/unit/autoUpdaterService.test.ts
+++ b/tests/unit/autoUpdaterService.test.ts
@@ -59,6 +59,13 @@ vi.mock('electron-log', () => ({
   },
 }));
 
+/** Temporarily override process.platform for a test; returns a restore fn. */
+function setPlatform(value: NodeJS.Platform): () => void {
+  const original = process.platform;
+  Object.defineProperty(process, 'platform', { value, configurable: true });
+  return () => Object.defineProperty(process, 'platform', { value: original, configurable: true });
+}
+
 describe('AutoUpdaterService', () => {
   let autoUpdaterService: any;
   let mockStatusBroadcast: ReturnType<typeof vi.fn>;
@@ -244,7 +251,8 @@ describe('AutoUpdaterService', () => {
   });
 
   describe('quitAndInstall', () => {
-    it('marks the quit intentional, stages the install, then relaunches + quits cleanly (#286)', async () => {
+    it('on macOS: marks the quit intentional, stages the install, then relaunches + quits cleanly (#286)', async () => {
+      const restore = setPlatform('darwin');
       vi.useFakeTimers();
       const { app } = vi.mocked(await import('electron'));
       const { setIsQuitting } = vi.mocked(await import('@process/utils/quitState'));
@@ -268,6 +276,26 @@ describe('AutoUpdaterService', () => {
       expect(app.quit).toHaveBeenCalledTimes(1);
       expect(app.exit).not.toHaveBeenCalled();
       vi.useRealTimers();
+      restore();
+    });
+
+    it('off macOS: quits cleanly but does NOT self-relaunch (NSIS/AppImage relaunch themselves) (#286)', async () => {
+      const restore = setPlatform('linux');
+      vi.useFakeTimers();
+      const { app } = vi.mocked(await import('electron'));
+
+      autoUpdaterService.quitAndInstall();
+      expect(autoUpdater.quitAndInstall).toHaveBeenCalledWith(true, true);
+
+      vi.advanceTimersByTime(1000);
+
+      // Audit nit: gate the backstop relaunch to darwin so Win/Linux get no
+      // redundant double-spawn — quit still fires so the process tears down.
+      expect(app.relaunch).not.toHaveBeenCalled();
+      expect(app.quit).toHaveBeenCalledTimes(1);
+      expect(app.exit).not.toHaveBeenCalled();
+      vi.useRealTimers();
+      restore();
     });
   });
 

--- a/tests/unit/autoUpdaterService.test.ts
+++ b/tests/unit/autoUpdaterService.test.ts
@@ -14,7 +14,16 @@ vi.mock('electron', () => ({
     getVersion: vi.fn(() => '1.0.0'),
     isPackaged: true,
     exit: vi.fn(),
+    relaunch: vi.fn(),
+    quit: vi.fn(),
   },
+}));
+
+// quitAndInstall() flips the "is quitting" flag so the window close handler stops
+// hiding-to-tray during the install handoff (#286). It lives in the lightweight
+// quitState module; mock it to a spy.
+vi.mock('@process/utils/quitState', () => ({
+  setIsQuitting: vi.fn(),
 }));
 
 // Mock electron-updater
@@ -235,16 +244,29 @@ describe('AutoUpdaterService', () => {
   });
 
   describe('quitAndInstall', () => {
-    it('should call quitAndInstall on autoUpdater and force exit after delay', async () => {
+    it('marks the quit intentional, stages the install, then relaunches + quits cleanly (#286)', async () => {
       vi.useFakeTimers();
       const { app } = vi.mocked(await import('electron'));
+      const { setIsQuitting } = vi.mocked(await import('@process/utils/quitState'));
 
       autoUpdaterService.quitAndInstall();
+
+      // Bypass close-to-tray so windows actually close during the handoff, then
+      // stage the Squirrel/ShipIt install — both synchronously, before the delay.
+      expect(setIsQuitting).toHaveBeenCalledWith(true);
       expect(autoUpdater.quitAndInstall).toHaveBeenCalledWith(true, true);
 
-      // app.exit is called after a 1s delay
+      // Nothing tears the process down until the stage-install delay elapses.
+      expect(app.relaunch).not.toHaveBeenCalled();
+      expect(app.quit).not.toHaveBeenCalled();
+
       vi.advanceTimersByTime(1000);
-      expect(app.exit).toHaveBeenCalledWith(0);
+
+      // #286 fix: arm Electron's own relaunch and quit cleanly — NOT a blunt
+      // app.exit(0), which pre-empted the relaunch handoff and left the app dead.
+      expect(app.relaunch).toHaveBeenCalledTimes(1);
+      expect(app.quit).toHaveBeenCalledTimes(1);
+      expect(app.exit).not.toHaveBeenCalled();
       vi.useRealTimers();
     });
   });


### PR DESCRIPTION
## #286 part 2 of 3 — restart-after-update fix (⚠️ HOLDS for real-mac live-verify)

> **DO NOT MERGE on green CI alone.** Per the Overwatch ruling this is a behavioral change to the quit/relaunch path and its merge **gates on a real macOS update-cycle live-verify** (old build → update → confirm it relaunches into the new version). Unit tests cannot prove the Squirrel/ShipIt handoff.

### Root cause (found on a working mac, #286)
`quitAndInstall()` force-killed the process with `app.exit(0)` one second after `autoUpdater.quitAndInstall(true, true)`. That abrupt exit **pre-empts Squirrel's relaunch handoff** — on the affected macs ShipIt applied the update but the app never restarted (`ShipItState launchAfterInstallation=false`, no relaunch fired), so it reopened on the old version and re-offered the same update.

Why `app.exit(0)` was there in the first place: the main window's `close` handler hides-to-tray and `window-all-closed` never quits on macOS, so a plain `app.quit()` would just hide the window and leave the process alive — Squirrel could then never swap the bundle.

### The fix
- `setIsQuitting(true)` **before** the handoff so the close-to-tray guard lets windows actually close during install (the "temporarily allow window-all-closed → quit during install" the ruling called for).
- Replace `app.exit(0)` with **`app.relaunch()` + clean `app.quit()`** — arm Electron's own relaunch (the same idiom the tray "Restart" action already uses) and quit cleanly so `before-quit` teardown runs and ShipIt can finish swapping the bundle.

### Refactor (keeps it test-safe)
The quit-state flag moves into a tiny standalone `quitState.ts` so quit-path code (the updater) can flip it **without** dragging in `tray.ts`'s heavy UI deps (i18n, worker task manager). `tray.ts` re-exports `getIsQuitting`/`setIsQuitting`, so every existing call site (e.g. `src/index.ts`, the tray menu) is unchanged.

### Verification (necessary, not sufficient)
- `bun run test` — autoUpdaterService + InstallGuard + integration (60/60) and tray suites (20/20) ✅
- `bun run typecheck` ✅
- `prek` full CI replica ✅
- ⬜ **Real-mac update cycle — REQUIRED before merge.** Routing to Overwatch/Sean: install an old signed build in /Applications, trigger the update, confirm the app **relaunches into the new version** (and the part-1 ShipIt diagnostics stay silent on success).

### Sequencing
Independent of **part 1** (PR #435, the self-diagnosing instrumentation — lands now, fast gate). Part 3 (the targeted apply/signature fix) awaits Sean's diagnostic paste.

> **MERGE GATE:** independent adversarial cross-audit + the real-mac live-verify above. Green CI is not a merge ticket.