### PR TITLE
fix: harden composer draft persistence (debounce/quota-signal + clear-on-delete)

### DIFF
--- a/src/renderer/components/layout/Sider/CronJobSiderSection/CronJobSiderItem.tsx
+++ b/src/renderer/components/layout/Sider/CronJobSiderSection/CronJobSiderItem.tsx
@@ -15,6 +15,7 @@ import { Input, Message, Modal } from '@arco-design/web-react';
 import type { ICronJob } from '@/common/adapter/ipcBridge';
 import type { TChatConversation } from '@/common/config/storage';
 import { ipcBridge } from '@/common';
+import { clearPersistedDraftsForConversation } from '@/renderer/hooks/chat/useSendBoxDraft';
 import { emitter } from '@/renderer/utils/emitter';
 import { isConversationPinned } from '@renderer/pages/conversation/GroupedHistory/utils/groupingHelpers';
 import { refreshConversationCache } from '@/renderer/pages/conversation/utils/conversationCache';
@@ -105,6 +106,7 @@ const CronJobSiderItem: React.FC<CronJobSiderItemProps> = ({
           try {
             const success = await ipcBridge.conversation.remove.invoke({ id: convId });
             if (success) {
+              clearPersistedDraftsForConversation(convId);
               emitter.emit('conversation.deleted', convId);
               emitter.emit('chat.history.refresh');
               Message.success(t('conversation.history.deleteSuccess'));

--- a/src/renderer/hooks/chat/useSendBoxDraft.ts
+++ b/src/renderer/hooks/chat/useSendBoxDraft.ts
@@ -88,6 +88,12 @@ export function __clearInMemoryDraftsForTests(): void {
 // in-memory store keeps working if storage is unavailable or over quota.
 const DRAFT_STORAGE_PREFIX = 'wayland:sendbox-draft:';
 
+// Coalesce rapid keystrokes into a single durable write. The in-memory store is
+// still updated synchronously (so reads stay correct), but the localStorage
+// mirror is deferred by this trailing debounce - a large draft no longer pays a
+// JSON.stringify + setItem on every keystroke, which is what added input lag.
+const DRAFT_WRITE_DEBOUNCE_MS = 300;
+
 function draftStorageKey(type: string, conversation_id: string): string {
   return `${DRAFT_STORAGE_PREFIX}${type}:${conversation_id}`;
 }
@@ -122,19 +128,156 @@ function readPersistedDraft<K extends TChatConversation['type']>(
   }
 }
 
-/** Write-through a draft to localStorage, or clear it once the draft is empty (e.g. after send). */
-function writePersistedDraft(type: string, conversation_id: string, draft: Draft | undefined): void {
+/** A storage error that means the draft was not persisted (over quota), across browsers/Electron. */
+function isQuotaExceededError(error: unknown): boolean {
+  if (!(error instanceof DOMException)) return false;
+  return (
+    error.name === 'QuotaExceededError' ||
+    error.name === 'NS_ERROR_DOM_QUOTA_REACHED' ||
+    error.code === 22 ||
+    error.code === 1014
+  );
+}
+
+/**
+ * Synchronously write-through a draft to localStorage, or clear it once the
+ * draft is empty (e.g. after send). Storage failures are surfaced, not swallowed:
+ * a quota/serialization error means the draft was NOT persisted and will be lost
+ * on reload, so warn loudly. The in-memory store keeps working either way, so
+ * typing is never blocked.
+ */
+function persistDraftNow(type: string, conversation_id: string, draft: Draft | undefined): void {
   if (typeof localStorage === 'undefined') return;
+  const key = draftStorageKey(type, conversation_id);
   try {
-    const key = draftStorageKey(type, conversation_id);
     if (isDraftPersistable(draft)) {
       localStorage.setItem(key, JSON.stringify(draft));
     } else {
       localStorage.removeItem(key);
     }
-  } catch {
-    // Quota exceeded / serialization failure: in-memory draft still works.
+  } catch (error) {
+    if (isQuotaExceededError(error)) {
+      console.warn(
+        `[sendbox-draft] localStorage quota exceeded; draft "${key}" was not saved and may be lost on reload.`,
+        error
+      );
+    } else {
+      console.warn(`[sendbox-draft] failed to persist draft "${key}"; it may be lost on reload.`, error);
+    }
   }
+}
+
+type PendingDraftWrite = {
+  timer: ReturnType<typeof setTimeout>;
+  type: string;
+  conversation_id: string;
+  draft: Draft | undefined;
+};
+
+// One pending trailing write per draft key; a newer keystroke replaces the older.
+const pendingDraftWrites = new Map<string, PendingDraftWrite>();
+
+/** Cancel any scheduled trailing write for a key (its value is now stale or being flushed). */
+function cancelPendingDraftWrite(key: string): void {
+  const pending = pendingDraftWrites.get(key);
+  if (pending) {
+    clearTimeout(pending.timer);
+    pendingDraftWrites.delete(key);
+  }
+}
+
+/**
+ * Mirror a draft to durable storage. An empty draft (after send/clear) flushes
+ * immediately so the key never lingers on disk; a non-empty draft is coalesced
+ * through a short trailing debounce so rapid typing writes once after input
+ * settles instead of on every keystroke.
+ */
+function writePersistedDraft(type: string, conversation_id: string, draft: Draft | undefined): void {
+  if (typeof localStorage === 'undefined') return;
+  const key = draftStorageKey(type, conversation_id);
+  // Removal must not be debounced: a deferred clear would leave just-sent text on
+  // disk between send and the timer firing.
+  if (!isDraftPersistable(draft)) {
+    cancelPendingDraftWrite(key);
+    persistDraftNow(type, conversation_id, draft);
+    return;
+  }
+  cancelPendingDraftWrite(key);
+  const timer = setTimeout(() => {
+    pendingDraftWrites.delete(key);
+    persistDraftNow(type, conversation_id, draft);
+  }, DRAFT_WRITE_DEBOUNCE_MS);
+  pendingDraftWrites.set(key, { timer, type, conversation_id, draft });
+}
+
+/**
+ * Remove every persisted send-box draft for a conversation across all draft
+ * types, and drop the matching in-memory entries. Called when a conversation is
+ * deleted: the delete sites don't know the conversation's draft type, so this
+ * matches on the `wayland:sendbox-draft:<type>:<conversation_id>` key suffix.
+ * Without this, an unsent draft for a deleted conversation lingers on disk
+ * (unbounded growth + deleted text remains stored).
+ */
+export function clearPersistedDraftsForConversation(conversation_id: string): void {
+  // Drop in-memory drafts (the type is unknown here, so clear every map).
+  for (const map of Object.values(store)) map.delete(conversation_id);
+  // Cancel any debounced write still pending for this conversation. A draft
+  // deleted inside the debounce window may not be on disk yet, so the storage
+  // scan below would miss it and the trailing timer would re-persist the deleted
+  // draft after we clear. Match on conversation_id, not the (unknown) draft type.
+  for (const [key, pending] of pendingDraftWrites) {
+    if (pending.conversation_id === conversation_id) {
+      clearTimeout(pending.timer);
+      pendingDraftWrites.delete(key);
+    }
+  }
+  if (typeof localStorage === 'undefined') return;
+  // Best-effort: enumerating or mutating localStorage can throw outright when
+  // storage is blocked/disabled. This runs after the conversation is already
+  // deleted, so a throw here must never bubble up - the delete sites call this
+  // inside their own try/catch and would otherwise report a successful delete as
+  // failed (and skip refresh/navigation).
+  try {
+    const suffix = `:${conversation_id}`;
+    const keysToRemove: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key && key.startsWith(DRAFT_STORAGE_PREFIX) && key.endsWith(suffix)) {
+        keysToRemove.push(key);
+      }
+    }
+    for (const key of keysToRemove) {
+      cancelPendingDraftWrite(key);
+      localStorage.removeItem(key);
+    }
+  } catch (error) {
+    console.warn(`[sendbox-draft] failed to clear drafts for a deleted conversation "${conversation_id}".`, error);
+  }
+}
+
+/** Synchronously write out every pending debounced draft (e.g. just before the renderer unloads). */
+function flushPendingDraftWrites(): void {
+  for (const pending of pendingDraftWrites.values()) {
+    clearTimeout(pending.timer);
+    persistDraftNow(pending.type, pending.conversation_id, pending.draft);
+  }
+  pendingDraftWrites.clear();
+}
+
+// A reload/close can land inside the 300ms debounce window, leaving the latest
+// edit only in memory. Flush pending writes on unload so the durable copy still
+// survives the reload/restart - the exact guarantee #412 added. `pagehide` fires
+// reliably on both reload and navigation (more so than `beforeunload`).
+if (typeof window !== 'undefined') {
+  window.addEventListener('pagehide', flushPendingDraftWrites);
+}
+
+/**
+ * Test-only: synchronously flush any pending debounced durable writes so a test
+ * can assert on localStorage without waiting for the trailing timer to fire.
+ */
+export function __flushPersistedDraftWritesForTests(): void {
+  flushPendingDraftWrites();
 }
 
 const setDraft = <K extends TChatConversation['type']>(

--- a/src/renderer/pages/conversation/GroupedHistory/hooks/useConversationActions.ts
+++ b/src/renderer/pages/conversation/GroupedHistory/hooks/useConversationActions.ts
@@ -6,6 +6,7 @@
 
 import { ipcBridge } from '@/common';
 import type { TChatConversation } from '@/common/config/storage';
+import { clearPersistedDraftsForConversation } from '@/renderer/hooks/chat/useSendBoxDraft';
 import { refreshConversationCache } from '@/renderer/pages/conversation/utils/conversationCache';
 import { emitter } from '@/renderer/utils/emitter';
 import { blockMobileInputFocus, blurActiveElement } from '@/renderer/utils/ui/focus';
@@ -97,6 +98,10 @@ export const useConversationActions = ({
       if (!success) {
         return false;
       }
+
+      // The conversation is gone; drop its unsent send-box draft so deleted text
+      // doesn't linger in localStorage.
+      clearPersistedDraftsForConversation(conversationId);
 
       emitter.emit('conversation.deleted', conversationId);
       if (id === conversationId) {

--- a/src/renderer/pages/conversation/components/ChatHistory.tsx
+++ b/src/renderer/pages/conversation/components/ChatHistory.tsx
@@ -8,6 +8,7 @@ import { MessageSquare, Pencil, Trash2 } from 'lucide-react';
 import { ipcBridge } from '@/common';
 import type { TChatConversation } from '@/common/config/storage';
 import FlexFullContainer from '@/renderer/components/layout/FlexFullContainer';
+import { clearPersistedDraftsForConversation } from '@/renderer/hooks/chat/useSendBoxDraft';
 import { CronJobIndicator, useCronJobsMap } from '@/renderer/pages/cron';
 import { refreshConversationCache } from '@/renderer/pages/conversation/utils/conversationCache';
 import { addEventListener, emitter } from '@/renderer/utils/emitter';
@@ -129,6 +130,8 @@ const ChatHistory: React.FC<{ onSessionClick?: () => void; collapsed?: boolean }
       .invoke({ id })
       .then((success) => {
         if (success) {
+          // Drop the deleted conversation's unsent send-box draft from localStorage.
+          clearPersistedDraftsForConversation(id);
           // Trigger refresh to reload from database
           emitter.emit('chat.history.refresh');
           void Promise.resolve(navigate('/')).catch((error) => {

--- a/src/renderer/pages/conversations/ConversationsListPage.tsx
+++ b/src/renderer/pages/conversations/ConversationsListPage.tsx
@@ -7,6 +7,7 @@
 import { ipcBridge } from '@/common';
 import type { TChatConversation } from '@/common/config/storage';
 import type { IProject } from '@/common/types/project';
+import { clearPersistedDraftsForConversation } from '@/renderer/hooks/chat/useSendBoxDraft';
 import AssignToProjectModal from '@/renderer/pages/projects/components/AssignToProjectModal';
 import { useProjects } from '@/renderer/pages/projects/hooks/useProjects';
 import {
@@ -183,6 +184,7 @@ const ConversationsListPage: React.FC = () => {
           try {
             const ok = await ipcBridge.conversation.remove.invoke({ id: conv.id });
             if (ok) {
+              clearPersistedDraftsForConversation(conv.id);
               Message.success(t('conversation.history.deleteSuccess', { defaultValue: 'Deleted' }));
               void fetchAll();
             } else {

--- a/src/renderer/pages/conversations/ConversationsListPage.tsx
+++ b/src/renderer/pages/conversations/ConversationsListPage.tsx
@@ -60,10 +60,7 @@ const ConversationsListPage: React.FC = () => {
 
   const [assignProjectCtrl, assignProjectNode] = AssignToProjectModal.useModal({ conversationId: undefined });
 
-  const projectById = useMemo<Map<string, IProject>>(
-    () => new Map(projects.map((p) => [p.id, p])),
-    [projects]
-  );
+  const projectById = useMemo<Map<string, IProject>>(() => new Map(projects.map((p) => [p.id, p])), [projects]);
 
   const fetchAll = useCallback(async () => {
     try {
@@ -145,9 +142,17 @@ const ConversationsListPage: React.FC = () => {
     return (
       [
         { key: 'today', label: t('conversations.group.today', { defaultValue: 'Today' }), items: buckets.today },
-        { key: 'yesterday', label: t('conversations.group.yesterday', { defaultValue: 'Yesterday' }), items: buckets.yesterday },
+        {
+          key: 'yesterday',
+          label: t('conversations.group.yesterday', { defaultValue: 'Yesterday' }),
+          items: buckets.yesterday,
+        },
         { key: 'week', label: t('conversations.group.week', { defaultValue: 'Previous 7 days' }), items: buckets.week },
-        { key: 'month', label: t('conversations.group.month', { defaultValue: 'Previous 30 days' }), items: buckets.month },
+        {
+          key: 'month',
+          label: t('conversations.group.month', { defaultValue: 'Previous 30 days' }),
+          items: buckets.month,
+        },
         { key: 'older', label: t('conversations.group.older', { defaultValue: 'Older' }), items: buckets.older },
       ] as const
     ).filter((s) => s.items.length > 0);

--- a/tests/unit/sendBoxDraftPersistence.dom.test.tsx
+++ b/tests/unit/sendBoxDraftPersistence.dom.test.tsx
@@ -9,19 +9,31 @@
  * These tests pin the durable-storage behavior: drafts are mirrored to
  * localStorage, rehydrated on a cold read, and cleared once emptied.
  *
+ * #432 follow-up hardening also covered here: the durable write is debounced
+ * (coalesced) rather than fired on every keystroke, storage failures (quota) are
+ * surfaced instead of swallowed, and a deleted conversation's draft is purged.
+ *
  * Each test uses a unique conversation id so the in-memory Map has no entry for
  * it - that forces getDraft down the persisted (localStorage) path, which is
  * what a post-restart session exercises.
  */
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it } from 'vitest';
-import { __clearInMemoryDraftsForTests, getSendBoxDraftHook } from '@/renderer/hooks/chat/useSendBoxDraft';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  __clearInMemoryDraftsForTests,
+  __flushPersistedDraftWritesForTests,
+  clearPersistedDraftsForConversation,
+  getSendBoxDraftHook,
+} from '@/renderer/hooks/chat/useSendBoxDraft';
 
 const STORAGE_PREFIX = 'wayland:sendbox-draft:';
 const emptyWcoreDraft = { _type: 'wcore' as const, content: '', atPath: [], uploadFile: [] };
 const useWcoreDraft = getSendBoxDraftHook('wcore', emptyWcoreDraft);
 
 beforeEach(() => {
+  // Drop any debounced writes still pending from a prior test before wiping state,
+  // so a stray trailing timer can't write into the next test's storage.
+  __flushPersistedDraftWritesForTests();
   localStorage.clear();
   __clearInMemoryDraftsForTests();
 });
@@ -34,6 +46,8 @@ describe('send-box draft persistence (#412)', () => {
     act(() => {
       result.current.mutate((prev) => ({ ...prev, content: 'half-written message' }));
     });
+    // The durable write is debounced; flush it so we can assert synchronously.
+    act(() => __flushPersistedDraftWritesForTests());
 
     const raw = localStorage.getItem(`${STORAGE_PREFIX}wcore:${id}`);
     expect(raw).toBeTruthy();
@@ -61,8 +75,11 @@ describe('send-box draft persistence (#412)', () => {
     act(() => {
       result.current.mutate((prev) => ({ ...prev, content: 'about to send' }));
     });
+    act(() => __flushPersistedDraftWritesForTests());
     expect(localStorage.getItem(`${STORAGE_PREFIX}wcore:${id}`)).toBeTruthy();
 
+    // Emptying the draft must clear the key immediately, with no debounce window
+    // in which just-sent text lingers on disk.
     act(() => {
       result.current.mutate((prev) => ({ ...prev, content: '' }));
     });
@@ -77,6 +94,7 @@ describe('send-box draft persistence (#412)', () => {
     act(() => {
       session1.result.current.mutate((prev) => ({ ...prev, content: 'a half-finished thought' }));
     });
+    act(() => __flushPersistedDraftWritesForTests());
     session1.unmount();
 
     // Simulate a renderer reload: the in-memory store is gone, localStorage remains.
@@ -105,6 +123,7 @@ describe('send-box draft persistence (#412)', () => {
     act(() => {
       result.current.mutate((prev) => ({ ...prev, atPath: ['/some/file'] }));
     });
+    act(() => __flushPersistedDraftWritesForTests());
     expect(JSON.parse(localStorage.getItem(`${STORAGE_PREFIX}wcore:${id}`) as string).content).toBe(
       'precious unsent text'
     );
@@ -117,5 +136,89 @@ describe('send-box draft persistence (#412)', () => {
     const { result } = renderHook(() => useWcoreDraft(id));
     // Give SWR a tick; the mismatched entry must NOT surface as wcore data.
     await waitFor(() => expect(result.current.data).toBeUndefined());
+  });
+});
+
+describe('send-box draft hardening (#432)', () => {
+  it('debounces the durable write: rapid keystrokes coalesce into a single setItem', () => {
+    const id = 'conv-debounce';
+    const setItemSpy = vi.spyOn(localStorage, 'setItem');
+    const { result } = renderHook(() => useWcoreDraft(id));
+
+    // Three quick keystrokes in a row.
+    act(() => result.current.mutate((prev) => ({ ...prev, content: 'a' })));
+    act(() => result.current.mutate((prev) => ({ ...prev, content: 'ab' })));
+    act(() => result.current.mutate((prev) => ({ ...prev, content: 'abc' })));
+
+    // Nothing has been written to storage yet - the write is deferred until input settles.
+    expect(setItemSpy).not.toHaveBeenCalled();
+
+    act(() => __flushPersistedDraftWritesForTests());
+    // The three keystrokes coalesced into a single durable write of the final value.
+    expect(setItemSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(localStorage.getItem(`${STORAGE_PREFIX}wcore:${id}`) as string).content).toBe('abc');
+
+    setItemSpy.mockRestore();
+  });
+
+  it('surfaces a localStorage quota failure instead of swallowing it (draft still usable)', () => {
+    const id = 'conv-quota';
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const setItemSpy = vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
+      throw new DOMException('exceeded the quota', 'QuotaExceededError');
+    });
+
+    const { result } = renderHook(() => useWcoreDraft(id));
+    // Typing never throws even though the durable write will fail - the in-memory
+    // store is updated independently of localStorage.
+    act(() => result.current.mutate((prev) => ({ ...prev, content: 'a very large draft' })));
+
+    act(() => __flushPersistedDraftWritesForTests());
+    // The quota failure is reported, not silently dropped.
+    expect(warnSpy).toHaveBeenCalled();
+
+    setItemSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it('clearPersistedDraftsForConversation purges every draft type for the id and leaves others', () => {
+    const target = 'conv-deleted';
+    const other = 'conv-kept';
+    localStorage.setItem(
+      `${STORAGE_PREFIX}wcore:${target}`,
+      JSON.stringify({ _type: 'wcore', content: 'gone soon', atPath: [], uploadFile: [] })
+    );
+    localStorage.setItem(
+      `${STORAGE_PREFIX}codex:${target}`,
+      JSON.stringify({ _type: 'codex', content: 'also gone', atPath: [], uploadFile: [] })
+    );
+    localStorage.setItem(
+      `${STORAGE_PREFIX}wcore:${other}`,
+      JSON.stringify({ _type: 'wcore', content: 'untouched', atPath: [], uploadFile: [] })
+    );
+
+    clearPersistedDraftsForConversation(target);
+
+    expect(localStorage.getItem(`${STORAGE_PREFIX}wcore:${target}`)).toBeNull();
+    expect(localStorage.getItem(`${STORAGE_PREFIX}codex:${target}`)).toBeNull();
+    // An unrelated conversation's draft must survive.
+    expect(localStorage.getItem(`${STORAGE_PREFIX}wcore:${other}`)).toBeTruthy();
+  });
+
+  it('deleting a conversation within the debounce window does not re-persist its draft', () => {
+    const id = 'conv-delete-in-window';
+    const { result } = renderHook(() => useWcoreDraft(id));
+
+    // Type a draft - the durable write is scheduled but not yet flushed, so the
+    // key is not on disk for clearPersistedDraftsForConversation's scan to find.
+    act(() => result.current.mutate((prev) => ({ ...prev, content: 'typed then deleted' })));
+    expect(localStorage.getItem(`${STORAGE_PREFIX}wcore:${id}`)).toBeNull();
+
+    // Delete the conversation while the write is still pending, then let any
+    // trailing timer flush. The pending write must have been cancelled.
+    clearPersistedDraftsForConversation(id);
+    act(() => __flushPersistedDraftWritesForTests());
+
+    expect(localStorage.getItem(`${STORAGE_PREFIX}wcore:${id}`)).toBeNull();
   });
 });


### PR DESCRIPTION
# Pull Request

## Description

Follow-up hardening to the merged composer draft persistence work (#430, #412). Two issues remained in how send-box drafts are stored.

1. `useSendBoxDraft.ts` mirrored every keystroke into `localStorage` synchronously through `writePersistedDraft`, and its `catch` block swallowed quota and serialization failures with no signal. On a large draft this adds input lag, and a failed write left the draft lost on restart with nothing logged. The durable write is now coalesced through a short trailing debounce (300ms) while the in-memory `setDraft` stays synchronous so reads are always correct. An empty draft (after send or clear) still flushes immediately so a sent draft never lingers, pending writes flush on `pagehide` so a reload inside the debounce window does not drop the last edit, and a failed write now calls `console.warn` (detecting `QuotaExceededError`) instead of returning silently.

2. `conversation.remove` deleted the conversation but never removed its `wayland:sendbox-draft:<type>:<conversation_id>` entry, so unsent text for deleted conversations stayed on disk and grew without bound. A new exported `clearPersistedDraftsForConversation(conversation_id)` scans for the prefix and the `:<conversation_id>` suffix (type-agnostic, since the delete sites do not know the conversation type), removes the matching keys and in-memory store entries, and cancels any debounced write still pending for that id. It runs after a successful `ipcBridge.conversation.remove.invoke` at all four renderer delete sites: `useConversationActions.ts`, `ConversationsListPage.tsx`, `ChatHistory.tsx`, and `CronJobSiderItem.tsx`. The storage scan is best-effort so it can never turn a successful delete into a reported failure.

## Related Issues

- Closes #432

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

Extended `tests/unit/sendBoxDraftPersistence.dom.test.tsx` and ran it with `bun run test` (10 passing) on macOS, plus `oxlint` and `oxfmt` on the changed files. New cases cover: rapid keystrokes coalescing into a single durable write, a quota failure being surfaced rather than swallowed while the in-memory draft keeps working, `clearPersistedDraftsForConversation` purging every draft type for an id while leaving unrelated conversations untouched, and deleting a conversation inside the debounce window not re-persisting its draft. The change is renderer TypeScript with no OS-specific code, and the jsdom unit tests run identically across platforms in CI.

## Screenshots

Not applicable. This change has no UI or visual impact.

## Additional Context

The debounce keeps `getInMemoryDraft` / `getDraft` synchronous, so the SWR read path and the #412 rehydrate-on-restart behavior are unchanged; only the durable mirror write is deferred.

---

**Thank you for contributing to Wayland! 🎉**
