### PR TITLE
fix(mcp): keep local stdio MCP servers alive on macOS (#438)

### DIFF
--- a/scripts/prepareBundledBun.js
+++ b/scripts/prepareBundledBun.js
@@ -80,16 +80,15 @@ function loadExpectedShaForAsset(version, assetName) {
 
   const raw = versionEntry[assetName];
   if (!raw || typeof raw !== 'string') {
-    throw new Error(
-      `No SHA-256 entry for asset "${assetName}" under version "${versionKey}" in ${SHASUMS_FILE}.`
-    );
+    throw new Error(`No SHA-256 entry for asset "${assetName}" under version "${versionKey}" in ${SHASUMS_FILE}.`);
   }
 
-  const hex = raw.replace(/^sha256:/i, '').trim().toLowerCase();
+  const hex = raw
+    .replace(/^sha256:/i, '')
+    .trim()
+    .toLowerCase();
   if (!/^[0-9a-f]{64}$/.test(hex)) {
-    throw new Error(
-      `Malformed SHA-256 entry for "${assetName}" (version "${versionKey}") in ${SHASUMS_FILE}: ${raw}`
-    );
+    throw new Error(`Malformed SHA-256 entry for "${assetName}" (version "${versionKey}") in ${SHASUMS_FILE}: ${raw}`);
   }
   return hex;
 }
@@ -151,7 +150,12 @@ function getPlatformAsset(platform, arch, variant = 'default') {
 }
 
 function needsBaselineVariant(platform, arch) {
-  return platform === 'linux' && arch === 'x64';
+  // x64 builds need an AVX2-free "baseline" bun for older CPUs (the standard
+  // build SIGILLs without AVX2). This applies to macOS Intel too: the runtime
+  // (shellEnv.getBundledBunDir) requests `darwin-x64-baseline` on a non-AVX2
+  // Intel chip, but only linux-x64 was ever staged — so those Macs got no
+  // usable bun and every npx-based local MCP server died with -32000 (#438).
+  return arch === 'x64' && (platform === 'linux' || platform === 'darwin');
 }
 
 function getDownloadUrl(assetName, version) {
@@ -451,3 +455,6 @@ function prepareBundledBun() {
 }
 
 module.exports = prepareBundledBun;
+// Named helpers exposed for unit tests (the default export stays the function).
+module.exports.needsBaselineVariant = needsBaselineVariant;
+module.exports.getPlatformAsset = getPlatformAsset;

--- a/src/process/services/mcpServices/McpProtocol.ts
+++ b/src/process/services/mcpServices/McpProtocol.ts
@@ -200,9 +200,25 @@ export abstract class AbstractMcpAgent implements IMcpProtocol {
     retryCount: number = 0
   ): Promise<McpConnectionTestResult> {
     let mcpClient: Client | null = null;
+    // Hoisted so the catch block can report the resolved spawn argv and the
+    // child's stderr even when connect() throws.
+    let command = '';
+    let args: string[] = [];
+    let childStderr = '';
 
     try {
       // app imported statically
+
+      const rawArgs = transport.args ?? [];
+      // Bundled @wayland MCPs are stored as { command: 'node', args: ['builtin-mcp-<name>.mjs'] }.
+      // End-user Macs frequently have no system `node` on PATH, so spawning the
+      // bare command dies on launch and surfaces only as -32000 "Connection
+      // closed". Run our own builtins through the app's Electron binary as Node
+      // (ELECTRON_RUN_AS_NODE=1) — always present, correct arch, no system Node
+      // required — mirroring the IJFW stdio client. The bare filename is also
+      // rewritten to an absolute path under out/main (dev) or
+      // app.asar.unpacked/out/main (packaged).
+      const isBuiltinWaylandMcp = transport.command === 'node' && isBuiltinWaylandMcpArg(rawArgs[0]);
 
       // Use enhanced env (includes shell PATH) instead of bare process.env
       // so CLI tools installed via nvm/fnm/volta are discoverable in packaged mode
@@ -210,20 +226,20 @@ export abstract class AbstractMcpAgent implements IMcpProtocol {
         ...getEnhancedEnv(transport.env),
         TERM: 'dumb',
         NO_COLOR: '1',
+        ...(isBuiltinWaylandMcp ? { ELECTRON_RUN_AS_NODE: '1' } : {}),
       };
-      const command = transport.command === 'npx' ? resolveNpxPath(enhancedEnv) : transport.command;
-      // Bundled @wayland MCPs are stored as { command: 'node', args: ['builtin-mcp-<name>.mjs'] }.
-      // Rewrite the bare filename to an absolute path under out/main (dev) or
-      // app.asar.unpacked/out/main (packaged) so `node` can execute it.
-      const rawArgs = transport.args ?? [];
-      const resolvedBuiltinArgs =
-        transport.command === 'node' && isBuiltinWaylandMcpArg(rawArgs[0])
-          ? [getMcpScriptPath(rawArgs[0]), ...rawArgs.slice(1)]
-          : null;
-      const args =
-        transport.command === 'npx'
+
+      command = isBuiltinWaylandMcp
+        ? process.execPath
+        : transport.command === 'npx'
+          ? resolveNpxPath(enhancedEnv)
+          : transport.command;
+
+      args = isBuiltinWaylandMcp
+        ? [getMcpScriptPath(rawArgs[0]), ...rawArgs.slice(1)]
+        : transport.command === 'npx'
           ? ['x', '--bun', ...normalizeNpxArgsForBundledBun(rawArgs)]
-          : (resolvedBuiltinArgs ?? rawArgs);
+          : rawArgs;
 
       const stdioTransport = new StdioClientTransport({
         command,
@@ -234,6 +250,18 @@ export abstract class AbstractMcpAgent implements IMcpProtocol {
         // spawned MCP server (e.g. npx) writes to stderr while Electron
         // runs under terminal job control.
         stderr: 'pipe',
+      });
+
+      // Capture the child's stderr. When a local stdio MCP server dies on
+      // launch (bad arch, missing `node`/`bun` binary, dyld/dependency error)
+      // the SDK only surfaces a generic -32000 "Connection closed" — the real
+      // OS-level reason is on the child's stderr. With stderr:'pipe' the SDK
+      // exposes a PassThrough immediately (before start), so attaching here
+      // loses no early output. Bounded so a chatty server can't grow unbounded.
+      stdioTransport.stderr?.on('data', (chunk: Buffer) => {
+        if (childStderr.length < 4096) {
+          childStderr += chunk.toString('utf8');
+        }
       });
 
       // Create MCP client
@@ -262,6 +290,17 @@ export abstract class AbstractMcpAgent implements IMcpProtocol {
       const errorMessage = error instanceof Error ? error.message : String(error);
       const errorCode = (error as NodeJS.ErrnoException)?.code;
 
+      // Surface the real launch failure. A bare -32000 "Connection closed"
+      // means the child exited before the handshake; the captured stderr (and
+      // the exact spawn argv) is the only place the real reason lives.
+      const stderrTail = childStderr.trim().split('\n').slice(-6).join('\n').trim();
+      console.error(
+        `[McpStdio] connect failed: spawn=${JSON.stringify([command, ...args])} code=${errorCode ?? 'n/a'} message=${errorMessage}` +
+          (stderrTail ? `\n[McpStdio] server stderr:\n${stderrTail}` : '\n[McpStdio] server stderr: <empty>')
+      );
+      // Compact suffix appended to user-facing errors so the cause isn't lost.
+      const stderrSuffix = stderrTail ? ` Server output: ${stderrTail.replace(/\s+/g, ' ').slice(0, 300)}` : '';
+
       // Detect missing command (npx/node not installed)
       if (
         errorCode === 'ENOENT' ||
@@ -274,13 +313,12 @@ export abstract class AbstractMcpAgent implements IMcpProtocol {
         if (isNpx) {
           return {
             success: false,
-            error:
-              'Bundled bun runtime is unavailable. Please reinstall Wayland or use a direct stdio command instead of npx.',
+            error: `Bundled bun runtime is unavailable. Please reinstall Wayland or use a direct stdio command instead of npx.${stderrSuffix}`,
           };
         }
         return {
           success: false,
-          error: `Command "${cmd}" not found. Please ensure it is installed and available in your PATH.`,
+          error: `Command "${cmd}" not found. Please ensure it is installed and available in your PATH.${stderrSuffix}`,
         };
       }
 
@@ -302,7 +340,7 @@ export abstract class AbstractMcpAgent implements IMcpProtocol {
 
       return {
         success: false,
-        error: errorMessage,
+        error: `${errorMessage}${stderrSuffix}`,
       };
     } finally {
       // Clean up connection

--- a/src/process/utils/shellEnv.ts
+++ b/src/process/utils/shellEnv.ts
@@ -136,15 +136,24 @@ export function getBundledBunDir(): string | null {
   const platform = process.platform === 'win32' ? 'win32' : process.platform;
   const arch = process.arch;
   const needsBaseline = arch === 'x64' && !detectAvx2();
+  const binName = platform === 'win32' ? 'bun.exe' : 'bun';
+
+  // The directory existing is not enough: prepareBundledBun's failure path
+  // creates an EMPTY `<platform>-<arch>/` dir (and a partial copy can leave it
+  // without the binary). Returning such a dir hands resolveNpxPath a path to a
+  // `bun` that doesn't exist → the child spawns as ENOENT and surfaces only as
+  // -32000 "Connection closed". Validate the actual binary so we fall back to a
+  // clean error instead.
+  const hasBun = (dir: string): boolean => existsSync(path.join(dir, binName));
 
   if (needsBaseline) {
     const baselineDir = path.join(resourcesPath, 'bundled-bun', `${platform}-${arch}-baseline`);
     // No baseline → return null. Falling through to the standard build would SIGILL.
-    return existsSync(baselineDir) ? baselineDir : null;
+    return hasBun(baselineDir) ? baselineDir : null;
   }
 
   const bunDir = path.join(resourcesPath, 'bundled-bun', `${platform}-${arch}`);
-  return existsSync(bunDir) ? bunDir : null;
+  return hasBun(bunDir) ? bunDir : null;
 }
 
 /**

--- a/src/renderer/pages/settings/McpLibrary/DetailPage.tsx
+++ b/src/renderer/pages/settings/McpLibrary/DetailPage.tsx
@@ -307,6 +307,17 @@ export function DetailPage() {
       await saveAndConnect();
       return;
     }
+    // Apple Ecosystem "Done - verify access" step. Full Disk Access is not
+    // queryable via API (macOS TCC) — the canonical verification is to spawn
+    // the server and actually use it. Install + connect (same as the stdio
+    // path); the connect result reports whether access works, instead of the
+    // previous silent no-op. (After granting FDA for the first time the app
+    // must be relaunched — macOS only re-reads FDA at launch — so a clear
+    // failure here is the expected nudge to quit & reopen.)
+    if (action === 'verify-fda') {
+      await saveAndConnect();
+      return;
+    }
     // Install first (or reuse the existing server if already installed), then
     // trigger OAuth for entries whose setup guide emits an 'oauth-flow' action.
     if (action !== 'oauth-flow') return;

--- a/tests/unit/getBundledBunDir.test.ts
+++ b/tests/unit/getBundledBunDir.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * #438: getBundledBunDir must validate the actual `bun` binary, not just the
+ * arch directory. prepareBundledBun's error path creates an EMPTY
+ * `bundled-bun/<platform>-<arch>/` dir; returning it handed resolveNpxPath a
+ * path to a `bun` that doesn't exist, so every npx-based local stdio MCP server
+ * spawned ENOENT and surfaced only as -32000 "Connection closed".
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  isPackaged: vi.fn(() => false),
+  existsSync: vi.fn(),
+}));
+
+vi.mock('@/common/platform', () => ({
+  getPlatformServices: () => ({ paths: { isPackaged: () => mocks.isPackaged() } }),
+}));
+
+// Override existsSync only; keep the rest of fs real so detectAvx2's
+// readFileSync('/proc/cpuinfo') on x64 Linux runners still works.
+vi.mock('fs', async (orig) => {
+  const actual = await orig<typeof import('fs')>();
+  return { ...actual, existsSync: mocks.existsSync };
+});
+
+const isBunBinary = (p: string): boolean => p.endsWith('bun') || p.endsWith('bun.exe');
+
+describe('getBundledBunDir (#438 — validate the bun binary, not just the dir)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.existsSync.mockReset();
+    mocks.isPackaged.mockReturnValue(false);
+  });
+
+  it('returns null when the arch dir exists but the bun binary is missing (empty-dir failure path)', async () => {
+    // The directory "exists", but the bun binary inside does not — exactly the
+    // state prepareBundledBun leaves on a failed download.
+    mocks.existsSync.mockImplementation((p: unknown) => !isBunBinary(String(p)));
+    const { getBundledBunDir } = await import('@process/utils/shellEnv');
+    expect(getBundledBunDir()).toBeNull();
+  });
+
+  it('returns the arch dir when the bun binary is present', async () => {
+    mocks.existsSync.mockReturnValue(true);
+    const { getBundledBunDir } = await import('@process/utils/shellEnv');
+    const dir = getBundledBunDir();
+    expect(dir).not.toBeNull();
+    expect(dir).toContain('bundled-bun');
+  });
+});

--- a/tests/unit/prepareBundledBun.test.ts
+++ b/tests/unit/prepareBundledBun.test.ts
@@ -161,3 +161,31 @@ describe('prepareBundledBun', () => {
     expect(manifest.files).toContain(runtimeFileName);
   });
 });
+
+// #438: the AVX2-free baseline bun must be staged for macOS Intel, not only
+// linux-x64 — otherwise non-AVX2 Intel Macs get no usable bun and every
+// npx-based local MCP server dies with -32000. Pure-logic, no download.
+describe('needsBaselineVariant (#438 — darwin-x64 baseline staging)', () => {
+  const needsBaselineVariant = (
+    prepareBundledBun as unknown as {
+      needsBaselineVariant: (platform: string, arch: string) => boolean;
+    }
+  ).needsBaselineVariant;
+  const getPlatformAsset = (
+    prepareBundledBun as unknown as {
+      getPlatformAsset: (platform: string, arch: string, variant?: string) => string | null;
+    }
+  ).getPlatformAsset;
+
+  it('stages a baseline variant for x64 on both linux and macOS (darwin), but never for arm64', () => {
+    expect(needsBaselineVariant('linux', 'x64')).toBe(true);
+    expect(needsBaselineVariant('darwin', 'x64')).toBe(true);
+    expect(needsBaselineVariant('darwin', 'arm64')).toBe(false);
+    expect(needsBaselineVariant('linux', 'arm64')).toBe(false);
+  });
+
+  it('resolves the darwin-x64 baseline to a real published asset name', () => {
+    expect(getPlatformAsset('darwin', 'x64', 'baseline')).toBe('bun-darwin-x64-baseline.zip');
+    expect(getPlatformAsset('darwin', 'x64')).toBe('bun-darwin-x64.zip');
+  });
+});

--- a/tests/unit/process/services/mcpProtocol.test.ts
+++ b/tests/unit/process/services/mcpProtocol.test.ts
@@ -263,7 +263,9 @@ describe('AbstractMcpAgent', () => {
         } as any;
       } as any);
       vi.mocked(StdioClientTransport).mockImplementation(function MockTransport(config: unknown) {
-        return config as any;
+        // Mirror the real SDK: `.stderr` is a stream (or null) for stderr:'pipe',
+        // never the literal 'pipe' string the input config carries.
+        return Object.assign({}, config, { stderr: undefined }) as any;
       } as any);
 
       const result = await testAgent.testMcpConnection({
@@ -279,6 +281,101 @@ describe('AbstractMcpAgent', () => {
           args: ['x', '--bun', '@modelcontextprotocol/server-filesystem', '/tmp/workspace'],
         })
       );
+    });
+  });
+
+  // #438: local stdio MCP servers (Apple Ecosystem, Filesystem, ...) failed
+  // with -32000 "Connection closed" on macOS Intel. Two launch defects:
+  // bundled @wayland builtins spawned bare `node` (absent on most end-user
+  // Macs), and child stderr was piped but never read so the real reason was
+  // masked. These tests lock the fixes.
+  describe('testMcpConnection - stdio launch (#438)', () => {
+    // Returns a fresh StdioClientTransport mock (calls cleared) whose returned
+    // transport exposes a real EventEmitter as `.stderr` (the production SDK
+    // returns a PassThrough for stderr:'pipe'), optionally emitting `stderrLine`
+    // during connect to simulate a child dying with a real OS error.
+    const setupTransport = async (stderrLine?: string) => {
+      const { EventEmitter } = await import('node:events');
+      const stderrStream = new EventEmitter();
+      const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js');
+      vi.mocked(StdioClientTransport).mockReset();
+      vi.mocked(StdioClientTransport).mockImplementation(function MockTransport(config: unknown) {
+        return Object.assign({}, config, { stderr: stderrStream }) as any;
+      } as any);
+      return { StdioClientTransport, stderrStream };
+    };
+    const setupClientOk = async () => {
+      const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+      vi.mocked(Client).mockImplementation(function MockClient() {
+        return {
+          connect: vi.fn().mockResolvedValue(undefined),
+          listTools: vi.fn().mockResolvedValue({ tools: [] }),
+          close: vi.fn().mockResolvedValue(undefined),
+        } as any;
+      } as any);
+    };
+
+    it('launches a bundled @wayland builtin via Electron-as-Node (process.execPath + ELECTRON_RUN_AS_NODE=1), not bare node', async () => {
+      await setupClientOk();
+      const { StdioClientTransport } = await setupTransport();
+
+      const result = await testAgent.testMcpConnection({
+        type: 'stdio',
+        command: 'node',
+        args: ['builtin-mcp-apple.mjs'],
+      });
+
+      expect(result.success).toBe(true);
+      const cfg = vi.mocked(StdioClientTransport).mock.calls[0]![0] as any;
+      expect(cfg.command).toBe(process.execPath);
+      // bare filename rewritten to an ABSOLUTE path that still ends in the
+      // builtin name (accept either path separator — Windows uses '\').
+      expect(cfg.args[0]).toMatch(/[/\\]builtin-mcp-apple\.mjs$/);
+      expect(cfg.env.ELECTRON_RUN_AS_NODE).toBe('1');
+    });
+
+    it('does NOT rewrite a user-defined node stdio server (only our bundled builtins)', async () => {
+      await setupClientOk();
+      const { StdioClientTransport } = await setupTransport();
+
+      await testAgent.testMcpConnection({
+        type: 'stdio',
+        command: 'node',
+        args: ['/Users/me/custom-server.js'],
+      });
+
+      const cfg = vi.mocked(StdioClientTransport).mock.calls[0]![0] as any;
+      expect(cfg.command).toBe('node');
+      expect(cfg.args).toEqual(['/Users/me/custom-server.js']);
+      expect(cfg.env.ELECTRON_RUN_AS_NODE).toBeUndefined();
+    });
+
+    it('surfaces the child process stderr in the error when the server dies on launch (-32000)', async () => {
+      const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+      const { stderrStream } = await setupTransport();
+
+      vi.mocked(Client).mockImplementation(function MockClient() {
+        return {
+          connect: vi.fn().mockImplementation(async () => {
+            // The child writes the real reason to stderr just before the pipe
+            // closes; the listener was attached synchronously before connect().
+            stderrStream.emit('data', Buffer.from('dyld: bad CPU type in executable\n'));
+            throw new Error('MCP error -32000: Connection closed');
+          }),
+          listTools: vi.fn(),
+          close: vi.fn().mockResolvedValue(undefined),
+        } as any;
+      } as any);
+
+      const result = await testAgent.testMcpConnection({
+        type: 'stdio',
+        command: 'node',
+        args: ['builtin-mcp-apple.mjs'],
+      });
+
+      expect(result.success).toBe(false);
+      expect((result as { error?: string }).error).toContain('-32000');
+      expect((result as { error?: string }).error).toContain('dyld: bad CPU type');
     });
   });
 });

--- a/tests/unit/renderer/mcp-library/DetailPage.stdioOauth.dom.test.tsx
+++ b/tests/unit/renderer/mcp-library/DetailPage.stdioOauth.dom.test.tsx
@@ -260,3 +260,38 @@ test('HTTP-family oauth2-byo: "Sign in" still runs the loopback OAuth via login(
   await waitFor(() => expect(login).toHaveBeenCalledTimes(1));
   expect(testMcpConnection).not.toHaveBeenCalled();
 });
+
+// #438 - the Apple Ecosystem FDA step's "Done - verify access" button dispatched
+// onPrimary('verify-fda'), which fell through onPrimary unhandled (silent no-op).
+// It must now install + connection-test the server (the canonical macOS Full Disk
+// Access check, since TCC is not queryable), never the loopback OAuth path.
+const APPLE_ID = 'com.wayland/apple-mcp';
+
+test('#438 apple FDA: "Done - verify access" installs + connection-tests (no longer a no-op)', async () => {
+  const fakeServer: IMcpServer = {
+    id: 'mcp_apple',
+    name: APPLE_ID.replace(/[^A-Za-z0-9_.-]/g, '-'),
+    enabled: false,
+    transport: { type: 'stdio', command: 'node', args: ['builtin-mcp-apple.mjs'], env: {} },
+    originalJson: '{}',
+    createdAt: 1,
+    updatedAt: 1,
+    source: 'library',
+    libraryEntryId: APPLE_ID,
+  };
+  handleAddMcpServer.mockResolvedValue(fakeServer);
+
+  renderDetail(APPLE_ID);
+  await screen.findByText('Apple Ecosystem');
+  fireEvent.click(screen.getByRole('button', { name: /^Setup$/i }));
+
+  await act(async () => {
+    fireEvent.click(await screen.findByRole('button', { name: /Done.*verify access/i }));
+  });
+
+  await waitFor(() => expect(handleAddMcpServer).toHaveBeenCalledTimes(1));
+  expect(login).not.toHaveBeenCalled();
+  expect(testMcpConnection).toHaveBeenCalledTimes(1);
+  expect(handleToggleMcpServer).toHaveBeenCalledWith('mcp_apple', true);
+  expect(messageSuccess).toHaveBeenCalled();
+});


### PR DESCRIPTION
## What & why

Fixes #438. Local **stdio** MCP connectors (Apple Ecosystem, Filesystem, *any*) died with `-32000 "Connection closed"` while **remote** ones (GitHub, Microsoft 365) kept working. The cause is OS/environment, **not CPU arch** — an arm64 Mac without system Node fails identically.

Two defects produced the failure, two more made it undiagnosable / left a dead button:

| # | Defect | Fix |
|---|--------|-----|
| **A** | `McpProtocol` set child `stderr:'pipe'` but **never read it**, so every launch failure collapsed to a bare `-32000`. | Capture the child's stderr + the exact spawn argv; surface them in the error and `console.error`. |
| **B** | Bundled `@wayland` builtins (Apple) spawned **bare `node`**, which most end-user Macs don't have on PATH → ENOENT. | Launch our builtins via the app's own **Electron-as-Node** (`process.execPath` + `ELECTRON_RUN_AS_NODE=1`) — present on any macOS, any arch. User-defined `node` servers are left untouched. |
| **C** | `getBundledBunDir` returned a dir whenever it merely *existed* (`prepareBundledBun`'s error path leaves an **empty** dir), and `darwin-x64-baseline` bun was never staged though the runtime requests it on non-AVX2 Intel. | Validate the actual `bun` **binary**; stage the AVX2-free **baseline** bun for `darwin-x64`, not only `linux-x64`. |
| **D** | Apple FDA **"Done – verify access"** dispatched `verify-fda`, which fell through `onPrimary` unhandled → **silent no-op**. | Wire it to install + connection-test (the canonical macOS FDA check — TCC isn't queryable). |

## Tests (real, behavior-exercising)

- `mcpProtocol.test.ts`: builtins resolve to `execPath` + `ELECTRON_RUN_AS_NODE=1` (not bare `node`); a user's own `node` server is **not** rewritten; a child dying mid-connect **surfaces its stderr** in the error.
- `getBundledBunDir.test.ts`: returns `null` when the arch dir exists but the `bun` binary is missing; returns the dir when present.
- `prepareBundledBun.test.ts`: `needsBaselineVariant` covers `darwin-x64` (and never arm64); the asset resolves to the real `bun-darwin-x64-baseline.zip`.
- `DetailPage.stdioOauth.dom.test.tsx`: "Done – verify access" installs + connection-tests, never the OAuth path.

48/48 green in the touched suites; full typecheck + oxlint + oxfmt + prek clean.

## Verification

**Live-verified on arm64** (Overwatch's clean-PATH method — no Intel rig needed): with `node` off PATH, a bare-`node` spawn ENOENTs (`exit 127` = the reporter's `-32000`), while an absolute `execPath` spawn runs. The fix uses the absolute `process.execPath`, so it is PATH-independent.

**Verified by reasoning** (single genuinely Intel-only slice, no Intel hardware available): the `darwin-x64-baseline` staging for non-AVX2 Intel chips — covered by the `prepareBundledBun` unit test above and the matching runtime request in `shellEnv.getBundledBunDir`.

## Gate

Per the hard gate: requesting an **independent cross-audit** before merge (not self-merge). The audit's make-or-break for B is that builtins no longer depend on a system `node`; for A that the stderr is actually surfaced (assertions exercise it). Once the reporter / community-ops retries on a real Intel Mac, the surfaced stderr line confirms B/C end-to-end.

Closes none — release/Overwatch closes #438.
