### PR TITLE
fix(installer): bump headless wayland-core pin to v0.12.16 + lockstep guard (#451)

### DIFF
--- a/installer/scripts/postinstall.mjs
+++ b/installer/scripts/postinstall.mjs
@@ -15,7 +15,9 @@ import { get } from 'node:https';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const WCORE_VERSION = 'v0.10.0';
+// Kept in lockstep with scripts/prepareWaylandCore.js DEFAULT_WCORE_VERSION by
+// scripts/stage-wcore-bump.mjs. Do not hand-edit; run that tool so both move.
+const WCORE_VERSION = 'v0.12.16';
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PAYLOAD = resolve(HERE, '..', 'payload');
 

--- a/scripts/stage-wcore-bump.mjs
+++ b/scripts/stage-wcore-bump.mjs
@@ -8,10 +8,13 @@
 /**
  * Stage a bundled wayland-core engine version bump.
  *
- * Bumping the bundled engine is two coupled edits that MUST move in lockstep:
- *   1. DEFAULT_WCORE_VERSION in scripts/prepareWaylandCore.js
+ * Bumping the bundled engine is three coupled edits that MUST move in lockstep:
+ *   1. DEFAULT_WCORE_VERSION in scripts/prepareWaylandCore.js (Electron bundle)
  *   2. a per-tag SHA-256 block in scripts/bundled-wcore-shasums.json (the
  *      manifest every download is verified against before it is trusted).
+ *   3. WCORE_VERSION in installer/scripts/postinstall.mjs (the getwayland
+ *      headless self-host installer's OWN engine pin). Missing this is why it
+ *      silently drifted to a 2-minor-stale v0.10.0 engine (#451).
  *
  * Hand-transcribing six checksums is the error surface. This helper pulls the
  * authoritative `wayland-core-checksums.txt` asset published alongside the
@@ -36,6 +39,7 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SHASUMS_FILE = path.join(__dirname, 'bundled-wcore-shasums.json');
 const PREPARE_FILE = path.join(__dirname, 'prepareWaylandCore.js');
+const POSTINSTALL_FILE = path.join(__dirname, '..', 'installer', 'scripts', 'postinstall.mjs');
 const REPO = 'FerroxLabs/wayland-core';
 
 // The six platform archives a release must publish. The bump fails loudly if
@@ -103,7 +107,15 @@ const versionMatch = prepareSrc.match(/const DEFAULT_WCORE_VERSION = '([^']+)';/
 if (!versionMatch) fail('could not find DEFAULT_WCORE_VERSION in prepareWaylandCore.js');
 const currentVersion = versionMatch[1];
 
+const postinstallSrc = fs.readFileSync(POSTINSTALL_FILE, 'utf-8');
+const postinstallMatch = postinstallSrc.match(/const WCORE_VERSION = '([^']+)';/);
+if (!postinstallMatch) fail('could not find WCORE_VERSION in installer/scripts/postinstall.mjs');
+const postinstallVersion = postinstallMatch[1];
+
 console.log(`\nStage bundled wayland-core bump: ${currentVersion} -> ${tag}\n`);
+if (postinstallVersion !== currentVersion) {
+  console.log(`  (headless installer pin was out of lockstep at ${postinstallVersion} - it will be realigned to ${tag})\n`);
+}
 console.log('Resolved checksums (from the published wayland-core-checksums.txt):');
 for (const [file, sha] of Object.entries(orderedBlock)) console.log(`  ${file}\n    ${sha}`);
 if (alreadyPinned) console.log(`\nNote: ${tag} already has a block in bundled-wcore-shasums.json - it will be overwritten.`);
@@ -129,9 +141,18 @@ fs.writeFileSync(
   ),
   'utf-8'
 );
+fs.writeFileSync(
+  POSTINSTALL_FILE,
+  postinstallSrc.replace(
+    /const WCORE_VERSION = '[^']+';/,
+    `const WCORE_VERSION = '${tag}';`
+  ),
+  'utf-8'
+);
 
 console.log('\nApplied:');
 console.log(`  scripts/prepareWaylandCore.js   DEFAULT_WCORE_VERSION -> '${tag}'`);
 console.log(`  scripts/bundled-wcore-shasums.json   added ${tag} block (6 archives)`);
+console.log(`  installer/scripts/postinstall.mjs   WCORE_VERSION -> '${tag}'`);
 console.log('\nNow verify end-to-end (downloads + checks all six archives):');
 console.log('  WCORE_REQUIRE_VERIFIED=1 WCORE_FORCE_DOWNLOAD=1 node scripts/prepareWaylandCore.js\n');

--- a/tests/unit/scripts/wcorePinLockstep.test.ts
+++ b/tests/unit/scripts/wcorePinLockstep.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Guards #451: the getwayland headless installer carries its OWN engine pin
+ * (installer/scripts/postinstall.mjs WCORE_VERSION), separate from the Electron
+ * bundle pin (scripts/prepareWaylandCore.js DEFAULT_WCORE_VERSION). The headless
+ * pin silently drifted to a 2-minor-stale v0.10.0 because the bump tooling only
+ * moved the Electron pin. These static-source assertions fail the build the
+ * moment the two pins fall out of lockstep again - no network required.
+ */
+
+const ROOT = join(__dirname, '..', '..', '..');
+const PREPARE = readFileSync(join(ROOT, 'scripts', 'prepareWaylandCore.js'), 'utf-8');
+const POSTINSTALL = readFileSync(join(ROOT, 'installer', 'scripts', 'postinstall.mjs'), 'utf-8');
+
+function bundlePin(): string {
+  const m = PREPARE.match(/const DEFAULT_WCORE_VERSION = '([^']+)';/);
+  expect(m, 'DEFAULT_WCORE_VERSION not found in prepareWaylandCore.js').toBeTruthy();
+  return m![1];
+}
+
+function headlessPin(): string {
+  const m = POSTINSTALL.match(/const WCORE_VERSION = '([^']+)';/);
+  expect(m, 'WCORE_VERSION not found in postinstall.mjs').toBeTruthy();
+  return m![1];
+}
+
+describe('wayland-core engine pin lockstep (#451)', () => {
+  it('headless installer pin matches the Electron bundle pin', () => {
+    expect(headlessPin()).toBe(bundlePin());
+  });
+
+  it('both pins are real vX.Y.Z release tags', () => {
+    expect(headlessPin()).toMatch(/^v\d+\.\d+\.\d+$/);
+    expect(bundlePin()).toMatch(/^v\d+\.\d+\.\d+$/);
+  });
+
+  it('headless installer builds the canonical release asset URL from the pin', () => {
+    // Asset/URL must interpolate WCORE_VERSION so a pin bump actually changes
+    // what gets fetched (regression guard against a stray hardcoded version).
+    expect(POSTINSTALL).toContain('wayland-core-${WCORE_VERSION}-${triple}.tar.gz');
+    expect(POSTINSTALL).toContain('github.com/FerroxLabs/wayland-core/releases/download/${WCORE_VERSION}/${asset}');
+  });
+});


### PR DESCRIPTION
Fixes #451.

## Problem (verified)
The getwayland headless self-host installer carries its OWN engine pin at `installer/scripts/postinstall.mjs:18` — `const WCORE_VERSION = 'v0.10.0'` — separate from the Electron bundle pin (`DEFAULT_WCORE_VERSION`, #441). The release tool `stage-wcore-bump.mjs` only ever bumped the Electron pin, so this one silently drifted: getwayland shipped through 0.11.7 while every headless self-host user kept downloading a **v0.10.0** engine — two minors stale, missing all of 0.12.x (Windows sandbox, WebFetch, reasoning-budget, Crucible).

This is NOT a `wayland-core --version` bug. The binary reports its real version correctly; the customer's "0.10.0" is the genuine version getwayland pinned.

## Fix
1. **Bump** `postinstall.mjs` `WCORE_VERSION` -> `v0.12.16`. Verified all four release triples exist (`x86_64`/`aarch64` x `apple-darwin`/`unknown-linux-gnu` `.tar.gz`), so the asset-name pattern matches exactly.
2. **Anti-drift:** teach `stage-wcore-bump.mjs` to rewrite this pin too — all three coupled edits (Electron pin, SHASUMS, headless pin) now move in lockstep on every engine bump. The tool also prints a warning when it finds the headless pin out of sync.
3. **Guard:** `tests/unit/scripts/wcorePinLockstep.test.ts` — static-source test that fails the build if the headless and Electron pins ever fall out of sync, and asserts the installer still builds its asset URL from the pin. Proven to catch the exact regression (reverting the pin to v0.10.0 turns the test red).

## Verification
- `vitest run wcorePinLockstep.test.ts` -> 3/3 pass; negative test (pin reverted) -> 1 fail as expected.
- `stage-wcore-bump.mjs v0.12.16` dry-run -> parses, reads the headless pin, prints the lockstep warning when drifted.
- oxlint/oxfmt clean on the test file. `.mjs` files intentionally left at their existing formatting (not in the prek oxfmt/oxlint trigger scope; build pipeline dropped repo-wide oxfmt) to keep the diff surgical.

## Notes / out of scope
- Takes effect for new installs/upgrades after the next getwayland npm publish. Immediate customer workaround: `npm i -g @ferroxlabs/wayland-core@latest` (standalone CLI reports v0.12.16).
- The headless installer does not checksum-verify the downloaded tarball (the Electron bundle does, via SHASUMS). Pre-existing; a reasonable follow-up to mirror the bundle's verification, tracked separately rather than scope-creeping this fix.
