### PR TITLE
feat(concierge): workspace + config-path diagnostics in the diag tool (#458)

### DIFF
--- a/src/process/resources/assistant/concierge/concierge.md
+++ b/src/process/resources/assistant/concierge/concierge.md
@@ -58,6 +58,33 @@ grounded in the live summary — real counts, the providers they actually have c
 of concrete examples of jobs they could hand off. **Never dump the whole list of skills.** It's
 overwhelming and useless. Pick the few things most likely to help this person and offer to go deeper.
 
+## When something isn't working (run a diagnosis — don't guess)
+
+When a user says something is broken — "it's not working", "I can't find my files / my config",
+"the file I asked for went nowhere", "my model/provider keeps failing", "my scheduled task didn't
+run", "my connected tool has no tools" — **run the `wayland_concierge_diag` tool before answering.**
+It reads the real, on-disk state of this install (read-only, never changes anything, and every
+secret is masked), so you diagnose from facts instead of guessing.
+
+Pass `section` to focus, or omit it for the full `overview`:
+
+- **workspace** — flags any project or chat using a throwaway **temporary** workspace instead of a
+  real folder. This is the usual reason a file the user asked you to "save to the local workspace"
+  seems to vanish: it landed in a temp directory. Each item has a plain-English `whyProblem`. If you
+  see `isTemporary: true`, tell them their project has no persistent workspace folder yet and offer to
+  point them at setting one.
+- **configPaths** — reports the two real locations Wayland uses: the app config directory and the
+  separate engine config directory. Use this when someone asks "where is my config?" or mentions
+  "two config paths", or when a stale config seems to have survived a reinstall.
+- **providers** — each provider's connection state and error (never credentials). For "my model
+  keeps failing".
+- **mcp** — connected-tool health; flags a server that's enabled but exposes zero tools.
+- **scheduledTasks** — why a timed task didn't run.
+- **recentErrors** — recent redacted error lines from the logs.
+
+Read the result, then explain the actual finding in plain English and offer the one concrete fix.
+Never paste the raw JSON at the user.
+
 ## How to answer a "how do I…" question
 
 1. Give a **short numbered list** of the real steps — usually three to five, in plain words.

--- a/src/process/resources/builtinMcp/conciergeDiagServer.ts
+++ b/src/process/resources/builtinMcp/conciergeDiagServer.ts
@@ -593,12 +593,14 @@ export const createConciergeDiagServer = (deps: ConciergeDiagDeps = {}) => {
         items: [],
       };
     }
-    // Default/temp workspaces are named `<kind>-temp-<timestamp>` (see initAgent),
+    // Default/temp workspaces are named `<kind>-temp-<Date.now()>` (see initAgent),
     // or sit under the OS temp dir. A null path means no workspace at all, which
-    // also falls back to a temp dir.
+    // also falls back to a temp dir. The timestamp run must be >=10 digits (a
+    // Unix-ms timestamp is 13) so user folders like `client-temp-2024` (a year
+    // or small counter suffix) are NOT mistaken for engine temp dirs.
     const isTempPath = (p: string | null): boolean => {
       if (!p) return true;
-      return /(^|[/\\])[a-z]+-temp-\d+([/\\]|$)/i.test(p) || p.includes(os.tmpdir());
+      return /(^|[/\\])[a-z]+-temp-\d{10,}([/\\]|$)/i.test(p) || p.includes(os.tmpdir());
     };
     try {
       const items: WorkspaceHealth[] = [];

--- a/src/process/resources/builtinMcp/conciergeDiagServer.ts
+++ b/src/process/resources/builtinMcp/conciergeDiagServer.ts
@@ -56,8 +56,18 @@ export type ConciergeDiagDeps = {
   cronDbPath?: string;
   /** Path to the SQLite DB holding `model_registry_providers`. */
   providerDbPath?: string;
+  /**
+   * Path to the SQLite DB holding `projects` + `conversations` (workspace
+   * health). The app uses one shared `wayland.db`, so this defaults to the
+   * provider DB path when unset.
+   */
+  workspaceDbPath?: string;
   /** Directory containing app log files (tailed for recent errors). */
   logDir?: string;
+  /** Resolved app config directory (`.../Wayland/config`), for the paths report. */
+  appConfigDir?: string;
+  /** Resolved engine config directory (`nativeConfigDir()`), for the paths report. */
+  engineConfigDir?: string;
 };
 
 export type ScheduledTaskHealth = {
@@ -101,10 +111,39 @@ export type RecentErrorsSection = {
   lines: string[];
 };
 
+export type WorkspaceHealth = {
+  /** "project" or "conversation". */
+  kind: string;
+  name: string;
+  /** Resolved workspace path (home-scrubbed to `~/…`), or null when unset. */
+  workspace: string | null;
+  /** True when this is a throwaway temp/default workspace, not a real folder. */
+  isTemporary: boolean;
+  /** Plain-English problem when files would land somewhere the user can't find, else null. */
+  whyProblem: string | null;
+};
+
+export type ConfigPathsInfo = {
+  /** App settings/config directory (channels, providers, OAuth tokens live here). */
+  appConfigDir: string | null;
+  /** Engine (wayland-core) config directory — a SEPARATE location from the app config. */
+  engineConfigDir: string | null;
+  /** Plain-English note explaining the two distinct locations. */
+  note: string;
+};
+
+export type ConfigPathsSection = {
+  available: boolean;
+  source: string;
+  info: ConfigPathsInfo;
+};
+
 export type ConciergeDiagOverview = {
   scheduledTasks: DiagSection<ScheduledTaskHealth>;
   mcp: DiagSection<McpServerHealth>;
   providers: DiagSection<ProviderHealth>;
+  workspace: DiagSection<WorkspaceHealth>;
+  configPaths: ConfigPathsSection;
   recentErrors: RecentErrorsSection;
 };
 
@@ -359,7 +398,11 @@ export const createConciergeDiagServer = (deps: ConciergeDiagDeps = {}) => {
   const configPath = deps.configPath ?? process.env.WAYLAND_CONFIG_PATH;
   const cronDbPath = deps.cronDbPath ?? process.env.WAYLAND_CRON_DB;
   const providerDbPath = deps.providerDbPath ?? process.env.WAYLAND_PROVIDER_DB;
+  // projects + conversations live in the same shared wayland.db as providers.
+  const workspaceDbPath = deps.workspaceDbPath ?? process.env.WAYLAND_WORKSPACE_DB ?? providerDbPath;
   const logDir = deps.logDir ?? process.env.WAYLAND_LOG_DIR;
+  const appConfigDir = deps.appConfigDir ?? process.env.WAYLAND_APP_CONFIG_DIR;
+  const engineConfigDir = deps.engineConfigDir ?? process.env.WAYLAND_ENGINE_CONFIG_DIR;
 
   /** Scheduled-task health from the cron store (`cron_jobs`). */
   const readScheduledTasks = (): DiagSection<ScheduledTaskHealth> => {
@@ -534,15 +577,120 @@ export const createConciergeDiagServer = (deps: ConciergeDiagDeps = {}) => {
     return { available: true, source: scrubHome(logDir), lines };
   };
 
+  /**
+   * Workspace health: flag projects/conversations writing to throwaway temp
+   * dirs instead of a real, findable folder. This is the root cause behind
+   * "Concierge looked in a temporary workspace" / "my file went nowhere".
+   */
+  const readWorkspaceHealth = (): DiagSection<WorkspaceHealth> => {
+    const db = openReadonlyDb(workspaceDbPath);
+    if (!db) {
+      return {
+        available: false,
+        source: workspaceDbPath
+          ? `workspace db unavailable: ${scrubHome(workspaceDbPath)}`
+          : 'workspace db path not set',
+        items: [],
+      };
+    }
+    // Default/temp workspaces are named `<kind>-temp-<timestamp>` (see initAgent),
+    // or sit under the OS temp dir. A null path means no workspace at all, which
+    // also falls back to a temp dir.
+    const isTempPath = (p: string | null): boolean => {
+      if (!p) return true;
+      return /(^|[/\\])[a-z]+-temp-\d+([/\\]|$)/i.test(p) || p.includes(os.tmpdir());
+    };
+    try {
+      const items: WorkspaceHealth[] = [];
+      try {
+        const projects = db.prepare('SELECT name, workspace FROM projects ORDER BY name ASC').all() as Array<
+          Record<string, unknown>
+        >;
+        for (const r of projects) {
+          const workspace = asNullableString(r.workspace);
+          const temp = isTempPath(workspace);
+          items.push({
+            kind: 'project',
+            name: typeof r.name === 'string' ? r.name : '(unnamed)',
+            workspace,
+            isTemporary: temp,
+            whyProblem: temp
+              ? 'This project has no persistent workspace folder, so files it creates go to a temporary directory and are easily lost. Set a workspace folder for the project.'
+              : null,
+          });
+        }
+      } catch {
+        /* projects table may be absent on older DBs - skip */
+      }
+      try {
+        const convs = db
+          .prepare('SELECT name, extra FROM conversations ORDER BY updated_at DESC LIMIT 50')
+          .all() as Array<Record<string, unknown>>;
+        for (const r of convs) {
+          let workspace: string | null = null;
+          let customWorkspace: boolean | null = null;
+          const extraRaw = asNullableString(r.extra);
+          if (extraRaw) {
+            try {
+              const extra = JSON.parse(extraRaw) as Record<string, unknown>;
+              workspace = asNullableString(extra.workspace);
+              customWorkspace = typeof extra.customWorkspace === 'boolean' ? extra.customWorkspace : null;
+            } catch {
+              /* unparseable extra - leave nulls */
+            }
+          }
+          if (workspace == null && customWorkspace == null) continue;
+          // `customWorkspace === false` is the app's own authoritative "this is a
+          // temp/default workspace" flag.
+          const temp = customWorkspace === false || isTempPath(workspace);
+          if (!temp) continue;
+          items.push({
+            kind: 'conversation',
+            name: typeof r.name === 'string' ? r.name : '(unnamed)',
+            workspace,
+            isTemporary: true,
+            whyProblem:
+              'This chat is using a temporary workspace, so files it writes (e.g. "save to the local workspace") land in a throwaway directory you may not be able to find. Open it inside a project that has a workspace folder, or set one.',
+          });
+        }
+      } catch {
+        /* conversations table may be absent - skip */
+      }
+      return { available: true, source: 'projects + conversations', items };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return { available: false, source: `workspace read failed: ${scrubHome(message)}`, items: [] };
+    } finally {
+      try {
+        db.close();
+      } catch {
+        /* ignore close errors */
+      }
+    }
+  };
+
+  /** Config-path report: the app config dir vs the engine config dir (the "two paths"). */
+  const readConfigPaths = (): ConfigPathsSection => {
+    const appDir = appConfigDir ?? (configPath ? path.dirname(configPath) : null);
+    const info: ConfigPathsInfo = {
+      appConfigDir: appDir ? scrubHome(appDir) : null,
+      engineConfigDir: engineConfigDir ? scrubHome(engineConfigDir) : null,
+      note: 'Wayland keeps two separate config locations: the desktop app settings (providers, channels, OAuth) live in the app config directory; the wayland-core engine reads its own config from the engine config directory. Uninstalling the app does NOT delete these, so a stale config can survive a reinstall.',
+    };
+    return { available: appDir != null || engineConfigDir != null, source: 'resolved paths', info };
+  };
+
   return {
     name: 'wayland_concierge_diag',
 
-    /** One-shot health snapshot across all four sources. */
+    /** One-shot health snapshot across all sources. */
     overview(): ConciergeDiagOverview {
       return sanitize({
         scheduledTasks: readScheduledTasks(),
         mcp: readMcpHealth(),
         providers: readProviders(),
+        workspace: readWorkspaceHealth(),
+        configPaths: readConfigPaths(),
         recentErrors: readRecentErrors(),
       });
     },
@@ -560,6 +708,16 @@ export const createConciergeDiagServer = (deps: ConciergeDiagDeps = {}) => {
     /** Provider/model connection health only (state, never creds). */
     providers(): DiagSection<ProviderHealth> {
       return sanitize(readProviders());
+    },
+
+    /** Workspace health only ("my file went nowhere" / temp-workspace fallback). */
+    workspace(): DiagSection<WorkspaceHealth> {
+      return sanitize(readWorkspaceHealth());
+    },
+
+    /** Config-path report only (app config dir vs engine config dir). */
+    configPaths(): ConfigPathsSection {
+      return sanitize(readConfigPaths());
     },
 
     /** Recent redacted error lines from the log directory. */

--- a/src/process/resources/builtinMcp/conciergeDiagServerEntry.ts
+++ b/src/process/resources/builtinMcp/conciergeDiagServerEntry.ts
@@ -31,10 +31,12 @@ const CONCIERGE_DIAG_SERVER_NAME = BUILTIN_CONCIERGE_DIAG_NAME;
 const DIAG_TOOL_DESCRIPTION = `Read-only diagnostics for this Wayland install. Use it to honestly answer "why isn't X working?" — it inspects on-disk state and NEVER mutates anything. All secrets/keys are masked to their last 4 characters.
 
 Sections (pass \`section\`, default "overview"):
-- "overview": one snapshot of all four below.
+- "overview": one snapshot of all sections below.
 - "scheduledTasks": each scheduled task's name, enabled flag, next/last run, last error, and a plain-English \`whyNotRunning\` when an enabled task is stuck. Answers "why didn't my scheduled task run?".
 - "mcp": each MCP server's name, enabled flag, status, tool count, last error, and a flag when it is enabled but exposes 0 tools. Answers "my MCP is on but has no tools".
 - "providers": each connected provider's id, connection state, and error (credentials are never read or returned). Answers "why is my model provider failing?".
+- "workspace": each project/conversation using a throwaway TEMPORARY workspace instead of a real folder, with a plain-English \`whyProblem\`. Answers "where did my file go?" / "Concierge can't find my files" / "it's writing to a temporary workspace".
+- "configPaths": the resolved app config directory AND the separate engine config directory. Answers "where is my config?" / "there seem to be two config paths" / "a stale config survived my reinstall".
 - "recentErrors": recent redacted error/warning lines tailed from the log directory.
 
 Output is bounded JSON. This tool cannot change settings — it only reports.`;
@@ -52,7 +54,7 @@ async function main(): Promise<void> {
     DIAG_TOOL_DESCRIPTION,
     {
       section: z
-        .enum(['overview', 'scheduledTasks', 'mcp', 'providers', 'recentErrors'])
+        .enum(['overview', 'scheduledTasks', 'mcp', 'providers', 'workspace', 'configPaths', 'recentErrors'])
         .optional()
         .describe('Which diagnostics section to return. Defaults to "overview" (all sections).'),
     },
@@ -65,9 +67,13 @@ async function main(): Promise<void> {
               ? handler.mcpHealth()
               : section === 'providers'
                 ? handler.providers()
-                : section === 'recentErrors'
-                  ? handler.recentErrors()
-                  : handler.overview();
+                : section === 'workspace'
+                  ? handler.workspace()
+                  : section === 'configPaths'
+                    ? handler.configPaths()
+                    : section === 'recentErrors'
+                      ? handler.recentErrors()
+                      : handler.overview();
         return {
           content: [
             {

--- a/src/process/resources/builtinMcp/conciergeDiagServerEntry.ts
+++ b/src/process/resources/builtinMcp/conciergeDiagServerEntry.ts
@@ -11,9 +11,10 @@
  * factory in a `@modelcontextprotocol/sdk` `McpServer` over stdio. Intended to
  * be bundled by `scripts/build-mcp-servers.js` into
  * `out/main/builtin-mcp-concierge-diag.js`, packaged as `app.asar.unpacked`,
- * and spawned via `mcp.config` with the four on-disk source paths injected as
- * env vars (WAYLAND_CONFIG_PATH / WAYLAND_CRON_DB / WAYLAND_PROVIDER_DB /
- * WAYLAND_LOG_DIR) by `ensureBuiltinMcpServers()`.
+ * and spawned via `mcp.config` with the on-disk source paths injected as env
+ * vars (WAYLAND_CONFIG_PATH / WAYLAND_CRON_DB / WAYLAND_PROVIDER_DB /
+ * WAYLAND_WORKSPACE_DB / WAYLAND_LOG_DIR / WAYLAND_APP_CONFIG_DIR /
+ * WAYLAND_ENGINE_CONFIG_DIR) by `ensureBuiltinMcpServers()`.
  *
  * Strictly READ-ONLY: every tool only reads on-disk state, masks secrets to
  * last-4, and never mutates anything.

--- a/src/process/utils/initStorage.ts
+++ b/src/process/utils/initStorage.ts
@@ -881,16 +881,18 @@ const ensureBuiltinMcpServers = async (): Promise<void> => {
     // ── Built-in concierge-diag MCP server (Phase 2a) ────────────────────────
     // Read-only diagnostics tool (`wayland_concierge_diag`) that inspects
     // on-disk state to answer "why isn't X working?". The standalone stdio
-    // subprocess has no Electron APIs, so the four on-disk sources it reads are
+    // subprocess has no Electron APIs, so the on-disk sources it reads are
     // injected as env vars — using the EXACT same path expressions the app uses
     // to write them:
     //   - WAYLAND_CONFIG_PATH → the config file `configFile` writes (mcp.config).
-    //   - WAYLAND_CRON_DB / WAYLAND_PROVIDER_DB → the main `wayland.db`
-    //     (resolveDbPath() = path.join(getDataPath(), 'wayland.db')); CronStore
-    //     and ProviderRepository both run against this single shared DB.
+    //   - WAYLAND_CRON_DB / WAYLAND_PROVIDER_DB / WAYLAND_WORKSPACE_DB → the main
+    //     `wayland.db` (resolveDbPath() = path.join(getDataPath(), 'wayland.db'));
+    //     CronStore, ProviderRepository, and projects/conversations all share it.
     //   - WAYLAND_LOG_DIR → the electron-log directory (same one getSystemDir()
-    //     reports). Enabled by default — the tool is silent unless invoked and
-    //     never mutates anything.
+    //     reports).
+    //   - WAYLAND_APP_CONFIG_DIR / WAYLAND_ENGINE_CONFIG_DIR → the two distinct
+    //     config locations, for the configPaths report.
+    // Enabled by default — the tool is silent unless invoked and never mutates.
     const conciergeDiagScriptPath = getBuiltinMcpScriptPath('builtin-mcp-concierge-diag');
     const conciergeDiagDbPath = path.join(getDataPath(), 'wayland.db');
     const conciergeDiagEnv: Record<string, string> = {

--- a/src/process/utils/initStorage.ts
+++ b/src/process/utils/initStorage.ts
@@ -11,6 +11,7 @@ import { getPlatformServices } from '@/common/platform';
 import { application } from '@/common/adapter/ipcBridge';
 import type { TMessage } from '@/common/chat/chatLib';
 import { ASSISTANT_PRESETS } from '@/common/config/presets/assistantPresets';
+import { nativeConfigDir } from '@process/agent/wcore/profilePaths';
 import type {
   IChannelAssistantConfigRefer,
   IChatConversationRefer,
@@ -896,7 +897,13 @@ const ensureBuiltinMcpServers = async (): Promise<void> => {
       WAYLAND_CONFIG_PATH: path.join(cacheDir, STORAGE_PATH.config),
       WAYLAND_CRON_DB: conciergeDiagDbPath,
       WAYLAND_PROVIDER_DB: conciergeDiagDbPath,
+      // projects + conversations live in the same shared wayland.db (workspace health).
+      WAYLAND_WORKSPACE_DB: conciergeDiagDbPath,
       WAYLAND_LOG_DIR: getPlatformServices().paths.getLogsDir(),
+      // The two distinct config locations, for the configPaths report: the app
+      // settings dir, and the wayland-core engine config dir.
+      WAYLAND_APP_CONFIG_DIR: cacheDir,
+      WAYLAND_ENGINE_CONFIG_DIR: nativeConfigDir(),
     };
     const conciergeDiagExistingIdx = mcpServers.findIndex(
       (s) => s.builtin === true && s.id === BUILTIN_CONCIERGE_DIAG_ID

--- a/tests/unit/process/resources/builtinMcp/conciergeDiagServer.test.ts
+++ b/tests/unit/process/resources/builtinMcp/conciergeDiagServer.test.ts
@@ -636,6 +636,9 @@ function makeWorkspaceDb(dbPath: string): void {
   const proj = db.prepare('INSERT INTO projects (id, name, workspace) VALUES (?, ?, ?)');
   proj.run('p1', 'no-workspace-project', ''); // empty -> temp fallback
   proj.run('p2', 'real-project', '/Users/someone/Documents/real-project'); // persistent
+  // A real user folder whose name happens to contain "-temp-" + a short year/
+  // counter suffix must NOT be mistaken for an engine temp dir (needs >=10 digits).
+  proj.run('p3', 'year-suffixed-project', '/Users/someone/Documents/client-temp-2024');
   const conv = db.prepare('INSERT INTO conversations (id, name, extra, updated_at) VALUES (?, ?, ?, ?)');
   conv.run(
     'c1',
@@ -669,6 +672,12 @@ describeNativeSqlite('createConciergeDiagServer — workspace health', () => {
     const realProj = result.items.find((i) => i.name === 'real-project');
     expect(realProj?.isTemporary).toBe(false);
     expect(realProj?.whyProblem).toBeNull();
+
+    // Regression: a "-temp-<year>" folder name is a real user dir, not an engine
+    // temp dir (which uses a >=10-digit Date.now() timestamp).
+    const yearProj = result.items.find((i) => i.name === 'year-suffixed-project');
+    expect(yearProj?.isTemporary).toBe(false);
+    expect(yearProj?.whyProblem).toBeNull();
 
     const tempChat = result.items.find((i) => i.name === 'temp-chat');
     expect(tempChat?.isTemporary).toBe(true);

--- a/tests/unit/process/resources/builtinMcp/conciergeDiagServer.test.ts
+++ b/tests/unit/process/resources/builtinMcp/conciergeDiagServer.test.ts
@@ -285,7 +285,16 @@ describe('createConciergeDiagServer — MCP health (config JSON)', () => {
     }
     // The exact read-only surface.
     expect(Object.keys(server).sort()).toEqual(
-      ['mcpHealth', 'name', 'overview', 'providers', 'recentErrors', 'scheduledTasks'].sort()
+      [
+        'configPaths',
+        'mcpHealth',
+        'name',
+        'overview',
+        'providers',
+        'recentErrors',
+        'scheduledTasks',
+        'workspace',
+      ].sort()
     );
   });
 
@@ -611,5 +620,93 @@ describeNativeSqlite('createConciergeDiagServer — overview (all sources wired)
     expect(result.mcp.available).toBe(true);
     expect(result.mcp.items[0].flag).toContain('0 tools');
     expect(JSON.stringify(result)).not.toContain(FAKE_SECRET);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Workspace health — flags projects/conversations on throwaway temp dirs
+// ---------------------------------------------------------------------------
+
+function makeWorkspaceDb(dbPath: string): void {
+  const db = new BetterSqlite3(dbPath);
+  db.exec(
+    `CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT NOT NULL, workspace TEXT);
+     CREATE TABLE conversations (id TEXT PRIMARY KEY, name TEXT NOT NULL, extra TEXT, updated_at INTEGER);`
+  );
+  const proj = db.prepare('INSERT INTO projects (id, name, workspace) VALUES (?, ?, ?)');
+  proj.run('p1', 'no-workspace-project', ''); // empty -> temp fallback
+  proj.run('p2', 'real-project', '/Users/someone/Documents/real-project'); // persistent
+  const conv = db.prepare('INSERT INTO conversations (id, name, extra, updated_at) VALUES (?, ?, ?, ?)');
+  conv.run(
+    'c1',
+    'temp-chat',
+    JSON.stringify({ workspace: '/Users/someone/.wayland/wcore-temp-1782747314076', customWorkspace: false }),
+    2000
+  );
+  conv.run(
+    'c2',
+    'real-chat',
+    JSON.stringify({ workspace: '/Users/someone/Documents/real-project', customWorkspace: true }),
+    1000
+  );
+  db.close();
+}
+
+describeNativeSqlite('createConciergeDiagServer — workspace health', () => {
+  it('flags empty-workspace projects and temp-workspace conversations, not real ones', () => {
+    const workspaceDbPath = tmp('wayland.db');
+    makeWorkspaceDb(workspaceDbPath);
+
+    const server = createConciergeDiagServer({ workspaceDbPath });
+    const result = server.workspace();
+
+    expect(result.available).toBe(true);
+
+    const noWs = result.items.find((i) => i.name === 'no-workspace-project');
+    expect(noWs?.isTemporary).toBe(true);
+    expect(noWs?.whyProblem).toContain('no persistent workspace');
+
+    const realProj = result.items.find((i) => i.name === 'real-project');
+    expect(realProj?.isTemporary).toBe(false);
+    expect(realProj?.whyProblem).toBeNull();
+
+    const tempChat = result.items.find((i) => i.name === 'temp-chat');
+    expect(tempChat?.isTemporary).toBe(true);
+    expect(tempChat?.whyProblem).toContain('temporary workspace');
+
+    // A conversation with customWorkspace:true and a real path is NOT reported.
+    expect(result.items.find((i) => i.name === 'real-chat')).toBeUndefined();
+  });
+
+  it('degrades gracefully when the workspace db is missing', () => {
+    const server = createConciergeDiagServer({ workspaceDbPath: tmp('missing.db') });
+    const result = server.workspace();
+    expect(result.available).toBe(false);
+    expect(result.items).toEqual([]);
+  });
+});
+
+describe('createConciergeDiagServer — config paths', () => {
+  it('reports app + engine config dirs (home-scrubbed) with the two-paths note', () => {
+    const server = createConciergeDiagServer({
+      appConfigDir: '/Users/someone/Library/Application Support/Wayland/config',
+      engineConfigDir: '/Users/someone/.config/wayland-core',
+    });
+    const result = server.configPaths();
+
+    expect(result.available).toBe(true);
+    expect(result.info.appConfigDir).toContain('Wayland/config');
+    expect(result.info.engineConfigDir).toContain('wayland-core');
+    expect(result.info.note).toContain('two separate config locations');
+    // Username must be scrubbed from both paths.
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain('/Users/someone');
+  });
+
+  it('falls back to the config-file directory when appConfigDir is unset', () => {
+    const server = createConciergeDiagServer({ configPath: '/Users/someone/cfg/wayland-config.txt' });
+    const result = server.configPaths();
+    expect(result.available).toBe(true);
+    expect(result.info.appConfigDir).toContain('/cfg');
   });
 });


### PR DESCRIPTION
Part of #458 (Phase 1: the on-disk increment, wired into Concierge today).

## What
The Concierge diagnostics tool (`wayland_concierge_diag`) gains two read-only sections that catch the failures users actually hit:

- **workspace** — flags any project or conversation running in a throwaway TEMPORARY workspace instead of a persistent folder (the reason a file "saved to the local workspace" seems to vanish). Uses the app's own `customWorkspace=false` flag as the authoritative signal, plus a temp-path name heuristic; each item carries a plain-English `whyProblem`.
- **configPaths** — reports the app config dir AND the separate engine config dir, with a note that uninstalling does not remove them (so a stale config survives a reinstall — the "two config paths" confusion).

Both fit the existing read-only/sanitized subprocess pattern (no new infra, no main-process singletons). `concierge.md` now tells Concierge to run the tool before answering "it's not working / where's my config / my file vanished" instead of guessing.

## Why
These are the exact root causes behind a customer's "Concierge looks in a temporary workspace / can't find my config" report and a live-demo jam where a file write went to `~/.wayland/wcore-temp-*`.

## Verification
- Unit: new tests for workspace (temp project + temp conversation flagged; real ones not) and configPaths (home-scrubbed, two-paths note, configPath fallback). The exact-surface contract test updated for the two new methods. Full diag suite: 42 passed (9 native-sqlite skipped locally, run in CI).
- tsc --noEmit: clean. oxfmt/oxlint: clean.
- MCP bundle (`build-mcp-servers.js`) rebuilds and contains the new sections.
- LIVE-verified against the real wayland.db: the workspace check flagged exactly the failing items — the empty-workspace project "What the hell am I going to build", and the temp-workspace chats "PHASE 4 …" and "Elite Income-Asset Strategy" (the ones that jammed) — 4/4, zero false positives.

## Scope note
This is the Concierge-facing, on-disk increment. The full live-probe Settings Doctor (`src/process/doctor/`, 9 checks) stays a separate surface; bridging it to Concierge via an in-main MCP is a follow-up tracked on #458. Pairs with the persistent-workspace fix (#455) — once projects always have a real workspace, this check goes quiet for the healthy case and only flags genuine strays.
