### PR TITLE
fix(wcore): #456 stop name-guessing max_tokens; let engine size per-model

### DIFF
--- a/src/process/agent/wcore/envBuilder.ts
+++ b/src/process/agent/wcore/envBuilder.ts
@@ -254,53 +254,32 @@ const GEMINI_OPENAI_COMPAT_PATH = '/v1beta/openai';
 const LOCAL_KEYLESS_PLACEHOLDER = 'ollama';
 
 /**
- * Default `--max-tokens` budget for reasoning-tier models when the caller
- * does not specify one.
+ * `--max-tokens` policy (#456): the desktop does NOT name-guess a budget.
  *
- * Why this exists: wcore has no model-aware default for
- * `max_tokens`. Reasoning models (Gemini Pro/Preview, future
- * `*-thinking`/`*-reasoning` variants) burn ~50-60 hidden "thinking" tokens
- * before emitting any visible output. With wcore's low built-in default,
- * thinking consumes the entire budget, the API returns
- * `finish_reason: length`, and the user sees an empty response. Flash
- * variants are non-reasoning and work cleanly at low budgets, so we leave
- * them alone - bumping their budget would just waste tokens.
+ * The bundled engine (pin `v0.12.16`) sizes `max_tokens` per-model up front
+ * itself (`size_output_cap` in wcore-agent): when the desktop omits
+ * `--max-tokens` the engine substitutes a generous default (64000) and clamps
+ * it to the model's REAL output ceiling - a known model to its documented limit
+ * (`wcore-config::limits::model_output_ceiling`: e.g. sonnet-4 -> 64000,
+ * opus-4 -> 32000, gpt-4o -> 16384), and an unknown / router-aliased model
+ * (`flux-auto`, `flux-pinned-*`, OpenRouter ids, bare `o`-series) to a
+ * conservative 8192 floor that grows to 32768 on a reasoning turn
+ * (`UNKNOWN_REASONING_CAP`, engine #426 - this replaces the desktop's old
+ * `REASONING_MODEL_DEFAULT_MAX_TOKENS` floor, applied server-side only when the
+ * turn actually carries a thinking budget / `reasoning_effort`).
  *
- * Detection is intentionally name-pattern based:
- *   - Suffix match (`-pro` / `-preview` / `-thinking` / `-reasoning`) catches
- *     Gemini Pro, Preview, and any future explicit reasoning variant.
- *   - Anchored match (`^o\d+(-mini)?$`) catches OpenAI's bare o-series
- *     reasoning models (`o1`, `o3`, `o3-mini`, `o4`, `o4-mini`). Their names
- *     lack a reasoning-indicating suffix, so the suffix regex misses them.
- *     Listed in `src/renderer/utils/model/modelContextLimits.ts`, so they
- *     are reachable through any OpenAI-protocol provider in Wayland.
- *   - Anchored match (`^flux-(auto|reasoning)$`) catches Flux Router's
- *     reasoning-capable tier aliases. Their literal id reveals nothing about
- *     the model Flux routes to server-side, so they need an explicit floor
- *     (#422). `flux-fast`/`flux-standard` are non-reasoning tiers, left alone.
+ * So the desktop OMITS `--max-tokens` unless the caller passes an explicit
+ * value, and lets the engine apply the model-aware budget. A fixed desktop
+ * number could only LOWER a known model's real ceiling; omitting is always
+ * >= pushing. Truncation detection is unaffected: the engine emits
+ * `finish_reason:'length'` definitively (see `WCoreManager.detectTruncation`).
  *
- * `-flash` variants short-circuit first - they are non-reasoning and work
- * cleanly at low budgets; bumping them would just waste tokens. Callers that
- * pass an explicit `maxTokens` always win - this is only a fallback.
+ * NOTE: raising the budget for engine-UNKNOWN models above 8192/32768 (e.g.
+ * resolving `flux-pinned-*` / OpenRouter ids from models.dev) is engine-gated -
+ * `size_output_cap` hard-clamps unknown models, so a desktop-pushed value is
+ * clamped right back. That path needs an engine change (Core), not a desktop
+ * one.
  */
-const REASONING_MODEL_DEFAULT_MAX_TOKENS = 32768;
-
-export function defaultMaxTokensForModel(modelName: string): number | undefined {
-  if (!modelName) return undefined;
-  if (/-flash/i.test(modelName)) return undefined;
-  // Flux tier aliases are opaque to the desktop: `flux-auto` (and `flux-reasoning`)
-  // route server-side and can land on a reasoning model whose hidden thinking
-  // burns a low budget and emits zero visible answer (#422). The desktop can't
-  // see the routed model, so give the reasoning-capable Flux tiers the same
-  // generous output floor. `flux-fast`/`flux-standard` are non-reasoning tiers
-  // and fall through to `undefined`.
-  if (/^flux-(auto|reasoning)$/i.test(modelName)) return REASONING_MODEL_DEFAULT_MAX_TOKENS;
-  // TODO(reasoning-detector): only catches o-prefixed reasoning models (o1/o3/o4-mini etc.).
-  // When OpenAI ships a non-o-prefixed reasoning model (e.g. gpt-5-reasoning), revisit
-  // this matcher - see .blackboard/audits/hard-coded-values.md HC-5.
-  if (/^o\d+(-mini)?$/i.test(modelName)) return REASONING_MODEL_DEFAULT_MAX_TOKENS;
-  return /(-pro|-preview|-thinking|-reasoning)\b/i.test(modelName) ? REASONING_MODEL_DEFAULT_MAX_TOKENS : undefined;
-}
 
 /**
  * Resolve base URL for OpenAI-compatible providers.
@@ -351,11 +330,13 @@ export function buildSpawnConfig(
   env: Record<string, string>;
   projectConfig: string;
   /**
-   * The max_tokens value actually passed to wcore (or undefined if no `--max-tokens`
-   * arg was added). Callers persist this so WCoreManager's truncation heuristic
-   * can compare `output_tokens` against the real budget - including the silent
-   * reasoning-model default from `defaultMaxTokensForModel`, which would otherwise
-   * be invisible to anything above the wrapper.
+   * The max_tokens value actually passed to wcore via `--max-tokens`, or
+   * `undefined` when none was added (#456: that is now the common case - the
+   * desktop only passes a value when the caller set one explicitly, otherwise
+   * the engine sizes the budget per-model itself). Callers persist this so
+   * WCoreManager's legacy truncation heuristic can compare `output_tokens`
+   * against the budget on old engines; on the shipping engine the definitive
+   * signal is the emitted `finish_reason:'length'`, which is budget-independent.
    */
   resolvedMaxTokens: number | undefined;
 } {
@@ -377,7 +358,9 @@ export function buildSpawnConfig(
   const env: Record<string, string> = {};
   const args: string[] = ['--json-stream', '--provider', provider, '--model', model.useModel];
 
-  const resolvedMaxTokens = options.maxTokens ?? defaultMaxTokensForModel(model.useModel);
+  // #456: omit `--max-tokens` unless the caller explicitly set one; the engine
+  // sizes per-model itself (see the policy note above `buildSpawnConfig`).
+  const resolvedMaxTokens = options.maxTokens;
   if (resolvedMaxTokens) {
     args.push('--max-tokens', String(resolvedMaxTokens));
   }

--- a/src/process/agent/wcore/index.ts
+++ b/src/process/agent/wcore/index.ts
@@ -137,11 +137,15 @@ export class WCoreAgent {
   public sessionId?: string;
   public capabilities?: WCoreCapabilities;
   /**
-   * The `--max-tokens` value actually passed to wcore, after applying the
-   * reasoning-model default fallback in `buildSpawnConfig`. `undefined` when
-   * no `--max-tokens` arg was added. Set during `start()`; `WCoreManager`
-   * mirrors this into `data.data.maxTokens` so the truncation heuristic
-   * compares `output_tokens` against the real budget rather than `undefined`.
+   * The `--max-tokens` value actually passed to wcore. As of #456 this is
+   * explicit-only: it is set when the caller passed an explicit `maxTokens`,
+   * and otherwise `undefined` (no `--max-tokens` arg added) so the engine
+   * sizes the budget per-model itself (`size_output_cap`). Set during
+   * `start()`. `WCoreManager` still mirrors a defined value into
+   * `data.data.maxTokens`, but the legacy `output_tokens`-vs-budget truncation
+   * heuristic is retired in favour of the engine's definitive
+   * `finish_reason:'length'`, so an `undefined` value here no longer weakens
+   * truncation detection.
    */
   public resolvedMaxTokens?: number;
 

--- a/src/process/task/WCoreManager.ts
+++ b/src/process/task/WCoreManager.ts
@@ -726,11 +726,12 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
   // it requires kill + re-spawn, and a re-spawn uses `--resume` so the failed
   // empty `finish_reason: length` turn is already in engine session history
   // (re-sending appends a NEW turn rather than re-running the same one). The
-  // budget floor in `defaultMaxTokensForModel` already gives flux-auto/
-  // flux-reasoning the 32768 output budget at spawn, so an auto-retry at the
-  // same budget would just re-truncate — a real fix needs an engine-side
-  // per-turn budget control. Manual recovery ships now via the truncation
-  // banner's "Continue with more headroom" action (CHAT_RETRY_EVENT).
+  // engine already sizes the budget per-model at spawn (#456: it grants
+  // flux-auto/flux-reasoning the 32768 reasoning ceiling itself via
+  // `size_output_cap`/`UNKNOWN_REASONING_CAP`), so an auto-retry at the same
+  // budget would just re-truncate — a real fix needs an engine-side per-turn
+  // budget control. Manual recovery ships now via the truncation banner's
+  // "Continue with more headroom" action (CHAT_RETRY_EVENT).
 
   /**
    * Attach `truncatedDueToBudget: true` to the in-flight assistant message.

--- a/src/renderer/pages/conversation/Messages/components/MessageText.tsx
+++ b/src/renderer/pages/conversation/Messages/components/MessageText.tsx
@@ -181,9 +181,9 @@ const MessageText: React.FC<{ message: IMessageText; toolbarMode?: ActionsDispla
   const conversationId = conversationContext?.conversationId;
 
   // #422: one-click recovery on the truncation banner. Re-sends the turn's
-  // prompt through the existing retry plumbing (CHAT_RETRY_EVENT). Combined
-  // with the reasoning-tier budget floor in defaultMaxTokensForModel, the
-  // resend runs with the higher output budget instead of the low default.
+  // prompt through the existing retry plumbing (CHAT_RETRY_EVENT). The engine
+  // sizes the reasoning budget per-model itself (#456), so the resend runs with
+  // the model-aware output budget rather than a desktop-guessed floor.
   const handleContinueWithHeadroom = useCallback(() => {
     if (!retryText) return;
     window.dispatchEvent(

--- a/tests/unit/wcoreEnvBuilder.reasoningModels.test.ts
+++ b/tests/unit/wcoreEnvBuilder.reasoningModels.test.ts
@@ -5,8 +5,17 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { buildSpawnConfig, defaultMaxTokensForModel } from '../../src/process/agent/wcore/envBuilder';
+import { buildSpawnConfig } from '../../src/process/agent/wcore/envBuilder';
 import type { TProviderWithModel } from '../../src/common/config/storage';
+
+// #456 — The desktop no longer name-guesses a max_tokens floor. The bundled
+// engine (pin v0.12.16) sizes `max_tokens` per-model up front itself
+// (`size_output_cap`): a known model is clamped to its real output ceiling, and
+// an unknown / router-aliased model gets a conservative floor (8192) that grows
+// to 32768 on a reasoning turn (`UNKNOWN_REASONING_CAP`, engine #426). So the
+// desktop OMITS `--max-tokens` unless the caller passes an explicit value, and
+// lets the engine apply the model-aware budget. Pushing a fixed number could
+// only LOWER a known model's real ceiling; omitting is always >= pushing.
 
 function makeModel(platform: string, useModel: string): TProviderWithModel {
   return {
@@ -24,138 +33,61 @@ function maxTokensArg(args: string[]): string | undefined {
   return i === -1 ? undefined : args[i + 1];
 }
 
-describe('defaultMaxTokensForModel', () => {
-  it('returns 32768 for Gemini Pro Preview reasoning models', () => {
-    expect(defaultMaxTokensForModel('gemini-3.1-pro-preview')).toBe(32768);
-  });
-
-  it('returns 32768 for Gemini 2.5 Pro', () => {
-    expect(defaultMaxTokensForModel('gemini-2.5-pro')).toBe(32768);
-  });
-
-  it('returns undefined for Gemini Flash (non-reasoning)', () => {
-    expect(defaultMaxTokensForModel('gemini-2.5-flash')).toBeUndefined();
-  });
-
-  it('returns undefined for Anthropic Claude models (no thinking-token issue)', () => {
-    expect(defaultMaxTokensForModel('claude-sonnet-4-6')).toBeUndefined();
-  });
-
-  it('matches case-insensitively', () => {
-    expect(defaultMaxTokensForModel('Gemini-3.1-Pro-Preview')).toBe(32768);
-  });
-
-  it('returns 32768 for OpenAI o-series reasoning models (o1, o3, o3-mini, o4, o4-mini)', () => {
-    expect(defaultMaxTokensForModel('o1')).toBe(32768);
-    expect(defaultMaxTokensForModel('o3')).toBe(32768);
-    expect(defaultMaxTokensForModel('o3-mini')).toBe(32768);
-    expect(defaultMaxTokensForModel('o4')).toBe(32768);
-    expect(defaultMaxTokensForModel('o4-mini')).toBe(32768);
-  });
-
-  it('matches o-series case-insensitively (O1, O3-Mini)', () => {
-    expect(defaultMaxTokensForModel('O1')).toBe(32768);
-    expect(defaultMaxTokensForModel('O3-Mini')).toBe(32768);
-  });
-
-  it('returns undefined for non-reasoning models with similar prefixes (gpt-4o, gpt-4o-mini)', () => {
-    expect(defaultMaxTokensForModel('gpt-4o')).toBeUndefined();
-    expect(defaultMaxTokensForModel('gpt-4o-mini')).toBeUndefined();
-  });
-
-  it('still routes o1-preview through the suffix pattern (already-covered case)', () => {
-    expect(defaultMaxTokensForModel('o1-preview')).toBe(32768);
-  });
-
-  it('returns 32768 for the reasoning-capable Flux tiers (flux-auto, flux-reasoning) - #422', () => {
-    expect(defaultMaxTokensForModel('flux-auto')).toBe(32768);
-    expect(defaultMaxTokensForModel('flux-reasoning')).toBe(32768);
-  });
-
-  it('matches Flux tiers case-insensitively (Flux-Auto)', () => {
-    expect(defaultMaxTokensForModel('Flux-Auto')).toBe(32768);
-  });
-
-  it('returns undefined for the non-reasoning Flux tiers (flux-fast, flux-standard)', () => {
-    expect(defaultMaxTokensForModel('flux-fast')).toBeUndefined();
-    expect(defaultMaxTokensForModel('flux-standard')).toBeUndefined();
-  });
-});
-
-describe('buildSpawnConfig - reasoning model max_tokens fallback', () => {
+describe('buildSpawnConfig - max_tokens is omitted unless explicitly set (#456)', () => {
   const workspace = '/tmp/test-workspace';
 
-  it('injects default --max-tokens 32768 for gemini-3.1-pro-preview', () => {
-    const { args } = buildSpawnConfig(makeModel('gemini', 'gemini-3.1-pro-preview'), { workspace });
-    expect(maxTokensArg(args)).toBe('32768');
-  });
+  // Models that the OLD name-regex would have force-capped at 32768. The engine
+  // now sizes all of these itself, so the desktop must emit NO `--max-tokens`.
+  const omitCases: Array<[string, string]> = [
+    ['gemini', 'gemini-3.1-pro-preview'],
+    ['gemini', 'gemini-2.5-pro'],
+    ['gemini', 'gemini-2.5-flash'],
+    ['gemini', 'Gemini-3.1-Pro-Preview'],
+    ['anthropic', 'claude-sonnet-4-6'],
+    ['anthropic', 'claude-opus-4-8'],
+    ['openai', 'o1'],
+    ['openai', 'o3-mini'],
+    ['openai', 'gpt-4o'],
+    ['openai', 'gpt-5.1'],
+    ['flux-router', 'flux-auto'],
+    ['flux-router', 'flux-reasoning'],
+    ['flux-router', 'flux-fast'],
+    ['openai', 'some-openrouter/model-id'],
+  ];
 
-  it('injects default --max-tokens 32768 for gemini-2.5-pro', () => {
-    const { args } = buildSpawnConfig(makeModel('gemini', 'gemini-2.5-pro'), { workspace });
-    expect(maxTokensArg(args)).toBe('32768');
-  });
+  for (const [platform, model] of omitCases) {
+    it(`does NOT inject --max-tokens for ${model} (engine sizes it)`, () => {
+      const { args, resolvedMaxTokens } = buildSpawnConfig(makeModel(platform, model), { workspace });
+      expect(maxTokensArg(args)).toBeUndefined();
+      expect(resolvedMaxTokens).toBeUndefined();
+    });
+  }
 
-  it('does NOT inject --max-tokens for gemini-2.5-flash', () => {
-    const { args } = buildSpawnConfig(makeModel('gemini', 'gemini-2.5-flash'), { workspace });
-    expect(maxTokensArg(args)).toBeUndefined();
-  });
-
-  it('does NOT inject --max-tokens for Anthropic claude-sonnet-4-6', () => {
-    const { args } = buildSpawnConfig(makeModel('anthropic', 'claude-sonnet-4-6'), { workspace });
-    expect(maxTokensArg(args)).toBeUndefined();
-  });
-
-  it('explicit options.maxTokens=8000 overrides the default for reasoning models', () => {
-    const { args } = buildSpawnConfig(makeModel('gemini', 'gemini-3.1-pro-preview'), {
+  it('passes an explicit caller maxTokens through for a reasoning model', () => {
+    const { args, resolvedMaxTokens } = buildSpawnConfig(makeModel('gemini', 'gemini-3.1-pro-preview'), {
       workspace,
       maxTokens: 8000,
     });
     expect(maxTokensArg(args)).toBe('8000');
+    expect(resolvedMaxTokens).toBe(8000);
   });
 
-  it('explicit options.maxTokens=8000 is preserved for non-reasoning models', () => {
-    const { args } = buildSpawnConfig(makeModel('gemini', 'gemini-2.5-flash'), {
-      workspace,
-      maxTokens: 8000,
-    });
-    expect(maxTokensArg(args)).toBe('8000');
-  });
-
-  it('matches reasoning-model pattern case-insensitively (Gemini-3.1-Pro-Preview)', () => {
-    const { args } = buildSpawnConfig(makeModel('gemini', 'Gemini-3.1-Pro-Preview'), { workspace });
-    expect(maxTokensArg(args)).toBe('32768');
-  });
-
-  it('injects default --max-tokens 32768 for flux-auto (#422)', () => {
-    const { args } = buildSpawnConfig(makeModel('flux-router', 'flux-auto'), { workspace });
-    expect(maxTokensArg(args)).toBe('32768');
-  });
-
-  it('does NOT inject --max-tokens for flux-fast', () => {
-    const { args } = buildSpawnConfig(makeModel('flux-router', 'flux-fast'), { workspace });
-    expect(maxTokensArg(args)).toBeUndefined();
-  });
-});
-
-describe('buildSpawnConfig - resolvedMaxTokens return value', () => {
-  const workspace = '/tmp/test-workspace';
-
-  it('returns resolvedMaxTokens=32768 for a reasoning model when caller omits maxTokens', () => {
-    const { resolvedMaxTokens } = buildSpawnConfig(makeModel('gemini', 'gemini-2.5-pro'), { workspace });
-    expect(resolvedMaxTokens).toBe(32768);
-  });
-
-  it('returns resolvedMaxTokens matching the caller value when explicitly set', () => {
-    const { resolvedMaxTokens } = buildSpawnConfig(makeModel('gemini', 'gemini-2.5-pro'), {
+  it('passes an explicit caller maxTokens through for a non-reasoning model', () => {
+    const { args, resolvedMaxTokens } = buildSpawnConfig(makeModel('gemini', 'gemini-2.5-flash'), {
       workspace,
       maxTokens: 12345,
     });
+    expect(maxTokensArg(args)).toBe('12345');
     expect(resolvedMaxTokens).toBe(12345);
   });
 
-  it('returns resolvedMaxTokens=undefined for a non-reasoning model with no explicit maxTokens', () => {
-    const { resolvedMaxTokens } = buildSpawnConfig(makeModel('gemini', 'gemini-2.5-flash'), { workspace });
-    expect(resolvedMaxTokens).toBeUndefined();
+  it('passes an explicit caller maxTokens through for flux-auto', () => {
+    const { args, resolvedMaxTokens } = buildSpawnConfig(makeModel('flux-router', 'flux-auto'), {
+      workspace,
+      maxTokens: 16384,
+    });
+    expect(maxTokensArg(args)).toBe('16384');
+    expect(resolvedMaxTokens).toBe(16384);
   });
 });
 


### PR DESCRIPTION
## #456 — stop name-guessing `max_tokens`; let the engine size per-model

Closes part of #456 (desktop portion). The remaining "big budget for engine-UNKNOWN models" is engine-gated — see **Scope** below.

### Root finding (gating verification, vs shipping engine pin `v0.12.16`)
The desktop's `defaultMaxTokensForModel` force-pushed a flat **32768** for name-matched reasoning models (`flux-auto`, `o`-series, `-pro`/`-preview`/`-thinking`/`-reasoning`) and nothing for everything else — a brittle name-regex that never consulted the model's real limits.

But the bundled engine **already** sizes `max_tokens` per-model up front (`size_output_cap`, `wcore-agent/src/engine.rs`). When the desktop omits `--max-tokens`, the engine substitutes a generous `default_max_tokens() = 64000` and clamps it:
- **Engine-KNOWN model** (`wcore-config::limits::model_output_ceiling`): clamped to the model's **real output ceiling** — `sonnet-4 → 64000`, `opus-4 → 32000`, `gpt-4.1 → 32768`, `gpt-4o → 16384`, `grok-3 → 64000`.
- **Engine-UNKNOWN / router model** (`flux-auto`, `flux-pinned-*`, OpenRouter ids, bare `o`-series): `min(config_max, 8192)` normally, growing to `min(config_max, 32768)` (`UNKNOWN_REASONING_CAP`, engine #426) on a reasoning turn (thinking budget or `reasoning_effort`).

So the desktop's flat 32768 was **redundant and slightly harmful**: it duplicated the engine's reasoning cap less correctly, and could only ever *lower* a known model's real ceiling. **Omitting is always ≥ pushing a fixed value.**

### Change (desktop)
- Remove `defaultMaxTokensForModel` + `REASONING_MODEL_DEFAULT_MAX_TOKENS`.
- `resolvedMaxTokens = options.maxTokens` — **omit `--max-tokens` unless the caller set one explicitly**; let the engine apply the model-aware budget.
- Keep the explicit-override path (engine respects an explicit low `config_max`) and the `rawEngine` path (untouched).
- Refresh now-stale comments in `WCoreManager` / `MessageText`.

Truncation detection is unaffected: the v0.12.16 engine emits `finish_reason:'length'` definitively (`WCoreManager.detectTruncation`); the `maxTokens`-ratio path is ≤0.1.21 backward-compat only, so a now-`undefined` `resolvedMaxTokens` is fine.

### Scope (what this PR does NOT do)
Raising the budget for **engine-UNKNOWN** models above 8192/32768 (resolving `flux-pinned-*` / OpenRouter / 1M-context ids from models.dev to their real ceiling) is **engine-gated**: `size_output_cap`'s unknown branch hard-clamps `min(config_max, cap)`, so a desktop-pushed registry value is clamped right back. That part of #456's acceptance needs a wayland-core change (expand `limits.rs` / consult cached models.dev engine-side, or accept an authoritative desktop-supplied ceiling) — flagged to Overwatch for a Core handoff, coordinated with engine #426/#422 and the boost lever in #457.

### Tests
- Rewrote `tests/unit/wcoreEnvBuilder.reasoningModels.test.ts` to the omit contract: 14 models the old regex would have capped now emit **no** `--max-tokens` (and `resolvedMaxTokens === undefined`); explicit caller `maxTokens` still passes through; `rawEngine` unchanged. **21/21 pass.**
- Related suites green: `WCoreManager*`, `finishReasonLength`, `wcore-*` (103 tests).
- `prek run --from-ref ferrox/main --to-ref HEAD`: TypeScript / Oxlint / Oxfmt all **Passed**.

> Cross-audit required before merge (not self-review) — not self-merging.

---

### Behavior change / release note (audit nit b)
Previously the desktop force-pushed **32768** for name-matched models (`flux-auto`/`flux-reasoning`, `o`-series, `-pro`/`-preview`/`-thinking`/`-reasoning`). After this change the desktop omits `--max-tokens` and the engine sizes per-model. On the bundled engine (v0.12.16), models the engine does **not** recognize (these same router/unknown ids) therefore sit at the engine's conservative output ceiling — **8192** on a normal turn, **32768** on a reasoning turn (`UNKNOWN_REASONING_CAP`) — rather than a desktop-forced 32768, **until the engine learns their real ceilings** via **wayland-core#112**.

Note this is equal-or-better than the prior *effective* behavior on v0.12.16 (the engine already clamped the desktop's 32768 to 8192 for unknown non-reasoning turns), but it's the binding ceiling to document. Engine-**known** models are unaffected/improved (they get their real ceiling, e.g. sonnet-4 → 64000).

### Follow-up (Core, filed)
- **wayland-core#112** — engine-side per-model output sizing for the models the engine doesn't yet recognize (`flux-pinned-*`, OpenRouter ids, 1M-context), via expanded `limits.rs` / cached models.dev, or an authoritative desktop-supplied ceiling. This is what unlocks #456's "big budget for unknown models" acceptance.
- The **#457** continuation output-cap boost is **deferred to Core** (same work as wayland-core#112) — after this PR the desktop holds no token budget to multiply, so no desktop multiplier will be reintroduced (Overwatch-ruled).
