### PR TITLE
feat(workspace): persistent per-project workspace, kill temp-dir default (#455)

### DIFF
--- a/src/process/services/ConversationServiceImpl.ts
+++ b/src/process/services/ConversationServiceImpl.ts
@@ -11,7 +11,7 @@ import { uuid } from '@/common/utils';
 import { cronService } from './cron/cronServiceSingleton';
 import { SqliteProjectRepository } from '@process/services/database/SqliteProjectRepository';
 import { loadProjectKnowledgeBlock, loadGlobalMemoryBlock } from '@process/services/projectKnowledge/knowledge';
-import { enforceProjectWorkspace } from '@process/services/projectWorkspace';
+import { enforceProjectWorkspace, ensureProjectWorkspace } from '@process/services/projectWorkspace';
 import {
   createGeminiAgent,
   createAcpAgent,
@@ -180,7 +180,16 @@ export class ConversationServiceImpl implements IConversationService {
    * overwritten; if the project has no workspace the temp fallback still applies.
    */
   private async reconcileProjectWorkspace(params: CreateConversationParams): Promise<void> {
-    await enforceProjectWorkspace(params.extra as Record<string, unknown> | undefined);
+    const extra = params.extra as Record<string, unknown> | undefined;
+    // #455: lazy-migrate a project that has no persistent workspace yet (created
+    // before #455, or allocation deferred) BEFORE enforcement pins the chat to
+    // it. A user-chosen custom workspace is left alone. Then enforce copies the
+    // (now guaranteed) project workspace onto this conversation's extra, so the
+    // chat lands in the persistent dir instead of a throwaway temp dir.
+    if (extra?.projectId && !extra.customWorkspace) {
+      await ensureProjectWorkspace(extra.projectId as string);
+    }
+    await enforceProjectWorkspace(extra);
   }
 
   async createConversation(params: CreateConversationParams): Promise<TChatConversation> {
@@ -213,7 +222,8 @@ export class ConversationServiceImpl implements IConversationService {
           params.extra.sessionMode,
           params.extra.isHealthCheck,
           params.extra.extraSkillPaths as string[] | undefined,
-          params.extra.excludeBuiltinSkills as string[] | undefined
+          params.extra.excludeBuiltinSkills as string[] | undefined,
+          params.extra.projectId as string | undefined
         );
         break;
       }

--- a/src/process/services/ProjectServiceImpl.ts
+++ b/src/process/services/ProjectServiceImpl.ts
@@ -11,6 +11,7 @@ import type { IProject, ICreateProjectParams, IUpdateProjectParams } from '@/com
 import type { TChatConversation } from '@/common/config/storage';
 import { uuid } from '@/common/utils';
 import { bootstrapProjectKnowledge } from '@process/services/projectKnowledge/bootstrap';
+import { allocateProjectWorkspace } from '@process/services/projectWorkspace';
 
 /**
  * Concrete IProjectService. Owns id/timestamp generation and the `.wayland/`
@@ -26,11 +27,25 @@ export class ProjectServiceImpl implements IProjectService {
 
   async createProject(params: ICreateProjectParams): Promise<IProject> {
     const now = Date.now();
+    const name = params.name.trim() || 'Untitled project';
+    // #455: every project gets a PERSISTENT, user-visible workspace. When the
+    // user didn't pick a folder, allocate the default (~/Documents/Wayland/<name>)
+    // so chats never silently fall back to a throwaway temp dir. Best-effort: if
+    // allocation fails we still create the project (lazy migration will retry on
+    // first chat), so a filesystem hiccup never blocks project creation.
+    let workspace = params.workspace;
+    if (!workspace) {
+      try {
+        workspace = await allocateProjectWorkspace(name);
+      } catch (err) {
+        console.error('[ProjectService] Failed to allocate persistent workspace:', err);
+      }
+    }
     const project: IProject = {
       id: uuid(),
-      name: params.name.trim() || 'Untitled project',
+      name,
       description: params.description,
-      workspace: params.workspace,
+      workspace,
       icon: params.icon,
       iconColor: params.iconColor,
       pinned: false,

--- a/src/process/services/projectWorkspace.ts
+++ b/src/process/services/projectWorkspace.ts
@@ -87,6 +87,29 @@ export async function ensureProjectWorkspace(
   allocate: (projectName: string) => Promise<string> = allocateProjectWorkspace
 ): Promise<string | null> {
   if (!projectId) return null;
+  // Serialize concurrent first-chat allocations for the SAME project. Without
+  // this, two conversations created back-to-back in a project that has no
+  // workspace yet each read an empty workspace, allocate distinct dirs, and race
+  // the DB write - leaking one directory. All conversation creation happens in
+  // the main process, so an in-process lock fully closes the window.
+  const inflight = ensureLocks.get(projectId);
+  if (inflight) return inflight;
+  const run = ensureProjectWorkspaceUnlocked(projectId, allocate);
+  ensureLocks.set(projectId, run);
+  try {
+    return await run;
+  } finally {
+    ensureLocks.delete(projectId);
+  }
+}
+
+/** In-flight allocation per projectId (see ensureProjectWorkspace). */
+const ensureLocks = new Map<string, Promise<string | null>>();
+
+async function ensureProjectWorkspaceUnlocked(
+  projectId: string,
+  allocate: (projectName: string) => Promise<string>
+): Promise<string | null> {
   try {
     const repo = new SqliteProjectRepository();
     const project = await repo.getProject(projectId);

--- a/src/process/services/projectWorkspace.ts
+++ b/src/process/services/projectWorkspace.ts
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { existsSync } from 'fs';
+import fs from 'fs/promises';
+import path from 'path';
 import { SqliteProjectRepository } from '@process/services/database/SqliteProjectRepository';
+import { bootstrapProjectKnowledge } from '@process/services/projectKnowledge/bootstrap';
+import { resolveProjectWorkspacePath } from '@process/utils/workspaceLocation';
 
 /**
  * #30 NO-DRIFT: a chat created inside a project (extra.projectId) must always
@@ -38,5 +43,69 @@ export async function enforceProjectWorkspace(extra: Record<string, unknown> | u
   } catch (err) {
     console.error('[projectWorkspace] #30 workspace enforcement failed:', err);
     return false;
+  }
+}
+
+/**
+ * Resolve the default base dir for managed project workspaces:
+ * `~/Documents/Wayland`. Discoverable (visible in Finder/Explorer) per #455, so
+ * files an agent writes "to the local workspace" are not lost in a hidden temp
+ * dir. Electron is imported lazily so this module stays loadable in unit tests
+ * that don't exercise allocation.
+ */
+async function defaultWorkspaceBaseDir(): Promise<string> {
+  const { app } = await import('electron');
+  return path.join(app.getPath('documents'), 'Wayland');
+}
+
+/**
+ * Allocate a fresh, collision-free persistent workspace dir for a project and
+ * create it on disk. Default location is `~/Documents/Wayland/<project-name>`;
+ * the path logic (sanitize + de-dupe) lives in workspaceLocation.ts.
+ */
+export async function allocateProjectWorkspace(projectName: string): Promise<string> {
+  const base = await defaultWorkspaceBaseDir();
+  await fs.mkdir(base, { recursive: true });
+  const dir = resolveProjectWorkspacePath(base, projectName, existsSync);
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+}
+
+/**
+ * #455 lazy migration: make sure a project has a persistent workspace. If it
+ * already has one, return it untouched. Otherwise allocate one, persist it to
+ * `projects.workspace`, and bootstrap the `.wayland/` knowledge folder. Existing
+ * projects created before #455 (empty `workspace` column) self-heal the next
+ * time this runs - typically when a chat is created inside them - with no data
+ * loss. `allocate` is injectable for testing.
+ *
+ * Returns the workspace path, or null when there is nothing to do / on failure
+ * (allocation must never block chat creation - the temp fallback still applies).
+ */
+export async function ensureProjectWorkspace(
+  projectId: string | undefined,
+  allocate: (projectName: string) => Promise<string> = allocateProjectWorkspace
+): Promise<string | null> {
+  if (!projectId) return null;
+  try {
+    const repo = new SqliteProjectRepository();
+    const project = await repo.getProject(projectId);
+    if (!project) return null;
+    const existing = typeof project.workspace === 'string' ? project.workspace.trim() : '';
+    if (existing) return existing;
+
+    const workspace = await allocate(project.name);
+    await repo.updateProject(projectId, { workspace });
+    // Best-effort: a filesystem hiccup bootstrapping knowledge must not undo the
+    // allocation (the workspace is already persisted and usable).
+    try {
+      await bootstrapProjectKnowledge(workspace, project.name, project.description);
+    } catch (err) {
+      console.error('[projectWorkspace] knowledge bootstrap failed:', err);
+    }
+    return workspace;
+  } catch (err) {
+    console.error('[projectWorkspace] ensureProjectWorkspace failed:', err);
+    return null;
   }
 }

--- a/src/process/services/projectWorkspace.ts
+++ b/src/process/services/projectWorkspace.ts
@@ -53,9 +53,14 @@ export async function enforceProjectWorkspace(extra: Record<string, unknown> | u
  * dir. Electron is imported lazily so this module stays loadable in unit tests
  * that don't exercise allocation.
  */
+let _baseDirPromise: Promise<string> | null = null;
 async function defaultWorkspaceBaseDir(): Promise<string> {
-  const { app } = await import('electron');
-  return path.join(app.getPath('documents'), 'Wayland');
+  // Memoized: the documents dir doesn't change at runtime, and sharing a single
+  // import keeps concurrent allocations from each re-importing electron.
+  if (!_baseDirPromise) {
+    _baseDirPromise = import('electron').then(({ app }) => path.join(app.getPath('documents'), 'Wayland'));
+  }
+  return _baseDirPromise;
 }
 
 /**
@@ -63,12 +68,26 @@ async function defaultWorkspaceBaseDir(): Promise<string> {
  * create it on disk. Default location is `~/Documents/Wayland/<project-name>`;
  * the path logic (sanitize + de-dupe) lives in workspaceLocation.ts.
  */
+/** Paths chosen by an in-flight allocateProjectWorkspace but not yet created on disk. */
+const allocatingPaths = new Set<string>();
+
 export async function allocateProjectWorkspace(projectName: string): Promise<string> {
   const base = await defaultWorkspaceBaseDir();
   await fs.mkdir(base, { recursive: true });
-  const dir = resolveProjectWorkspacePath(base, projectName, existsSync);
-  await fs.mkdir(dir, { recursive: true });
-  return dir;
+  // Resolve + reserve in ONE synchronous step so two concurrent allocations whose
+  // names sanitize to the SAME folder (different projects -> the per-projectId
+  // lock doesn't help) can't both pick the same dir before either is created on
+  // disk. A path counts as taken if it exists OR another in-flight allocation
+  // already claimed it, so the second caller falls through to the (2)/(3) suffix.
+  const dir = resolveProjectWorkspacePath(base, projectName, (p) => existsSync(p) || allocatingPaths.has(p));
+  allocatingPaths.add(dir);
+  try {
+    await fs.mkdir(dir, { recursive: true });
+    return dir;
+  } finally {
+    // Once created, existsSync(dir) keeps it "taken"; safe to drop the reservation.
+    allocatingPaths.delete(dir);
+  }
 }
 
 /**

--- a/src/process/utils/initAgent.ts
+++ b/src/process/utils/initAgent.ts
@@ -17,6 +17,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { getSkillsDir, getBuiltinSkillsCopyDir, getAutoSkillsDir, getSystemDir, ProcessConfig } from './initStorage';
 import { computeOpenClawIdentityHash } from './openclawUtils';
+import { writeWorkspaceGitignore } from './workspaceGitignore';
 
 /**
  * Minimal skills.preferences shape used by setupAssistantWorkspace.
@@ -202,6 +203,28 @@ export async function setupAssistantWorkspace(
 }
 
 /**
+ * Decide whether to lay down native skill symlinks for a workspace, and keep the
+ * user's folder tidy when we do (#455 scope 4).
+ *
+ * - Temp workspaces (the app-created `*-temp-*` dirs): always set up skills.
+ * - Project workspaces (managed or user-picked, identified by `projectId`): set
+ *   up skills too — a project chat needs them to resolve — and write a managed
+ *   `.gitignore` so the skill dot-dirs stay out of the user's git.
+ * - A non-project custom workspace the user picked for a one-off chat is left
+ *   untouched (never pollute a dir the app didn't create for a project).
+ */
+async function setupWorkspaceSkills(
+  workspace: string,
+  customWorkspace: boolean,
+  isProjectWorkspace: boolean,
+  options: Parameters<typeof setupAssistantWorkspace>[1]
+): Promise<void> {
+  if (customWorkspace && !isProjectWorkspace) return;
+  await setupAssistantWorkspace(workspace, options);
+  if (isProjectWorkspace) await writeWorkspaceGitignore(workspace);
+}
+
+/**
  * Create workspace directory (without copying files)
  *
  * Note: File copying is handled by copyFilesToDirectory in sendMessage
@@ -241,7 +264,8 @@ export const createGeminiAgent = async (
   sessionMode?: string,
   isHealthCheck?: boolean,
   extraSkillPaths?: string[],
-  excludeBuiltinSkills?: string[]
+  excludeBuiltinSkills?: string[],
+  projectId?: string
 ): Promise<TChatConversation> => {
   const { workspace: newWorkspace, customWorkspace: finalCustomWorkspace } = await buildWorkspaceWidthFiles(
     `gemini-temp-${Date.now()}`,
@@ -250,15 +274,13 @@ export const createGeminiAgent = async (
     customWorkspace
   );
 
-  // Set up skill symlinks for native SkillManager discovery
-  if (!finalCustomWorkspace) {
-    await setupAssistantWorkspace(newWorkspace, {
-      agentType: 'gemini',
-      enabledSkills,
-      extraSkillPaths,
-      excludeBuiltinSkills,
-    });
-  }
+  // Set up skill symlinks for native SkillManager discovery (temp + project ws).
+  await setupWorkspaceSkills(newWorkspace, finalCustomWorkspace, !!projectId, {
+    agentType: 'gemini',
+    enabledSkills,
+    extraSkillPaths,
+    excludeBuiltinSkills,
+  });
 
   return {
     type: 'gemini',
@@ -298,15 +320,13 @@ export const createAcpAgent = async (options: ICreateConversationParams): Promis
     extra.customWorkspace
   );
 
-  // Set up skill symlinks for temp workspace (native discovery)
-  if (!customWorkspace) {
-    await setupAssistantWorkspace(workspace, {
-      backend: extra.backend,
-      enabledSkills: extra.enabledSkills,
-      extraSkillPaths: extra.extraSkillPaths,
-      excludeBuiltinSkills: extra.excludeBuiltinSkills,
-    });
-  }
+  // Set up skill symlinks for temp + project workspaces (native discovery).
+  await setupWorkspaceSkills(workspace, customWorkspace, !!extra.projectId, {
+    backend: extra.backend,
+    enabledSkills: extra.enabledSkills,
+    extraSkillPaths: extra.extraSkillPaths,
+    excludeBuiltinSkills: extra.excludeBuiltinSkills,
+  });
 
   return {
     type: 'acp',
@@ -349,15 +369,13 @@ export const createNanobotAgent = async (options: ICreateConversationParams): Pr
     extra.customWorkspace
   );
 
-  // Set up skill symlinks for temp workspace
-  if (!customWorkspace) {
-    await setupAssistantWorkspace(workspace, {
-      agentType: 'nanobot',
-      enabledSkills: extra.enabledSkills,
-      extraSkillPaths: extra.extraSkillPaths,
-      excludeBuiltinSkills: extra.excludeBuiltinSkills,
-    });
-  }
+  // Set up skill symlinks for temp + project workspaces
+  await setupWorkspaceSkills(workspace, customWorkspace, !!extra.projectId, {
+    agentType: 'nanobot',
+    enabledSkills: extra.enabledSkills,
+    extraSkillPaths: extra.extraSkillPaths,
+    excludeBuiltinSkills: extra.excludeBuiltinSkills,
+  });
 
   return {
     type: 'nanobot',
@@ -383,13 +401,11 @@ export const createRemoteAgent = async (options: ICreateConversationParams): Pro
     extra.customWorkspace
   );
 
-  if (!customWorkspace) {
-    await setupAssistantWorkspace(workspace, {
-      enabledSkills: extra.enabledSkills,
-      extraSkillPaths: extra.extraSkillPaths,
-      excludeBuiltinSkills: extra.excludeBuiltinSkills,
-    });
-  }
+  await setupWorkspaceSkills(workspace, customWorkspace, !!extra.projectId, {
+    enabledSkills: extra.enabledSkills,
+    extraSkillPaths: extra.extraSkillPaths,
+    excludeBuiltinSkills: extra.excludeBuiltinSkills,
+  });
 
   return {
     type: 'remote',
@@ -419,15 +435,14 @@ export const createWCoreAgent = async (options: ICreateConversationParams): Prom
   // Set up skill symlinks for native discovery by wayland-core.
   // The engine looks in `.wayland-core/skills/` (engine paths.rs:46);
   // the 'wcore' agentType key is mapped to that directory in NON_ACP_SKILLS_DIRS
-  // so the symlinks land where the engine reads.
-  if (!customWorkspace) {
-    await setupAssistantWorkspace(workspace, {
-      agentType: 'wcore',
-      enabledSkills: extra.enabledSkills,
-      extraSkillPaths: extra.extraSkillPaths,
-      excludeBuiltinSkills: extra.excludeBuiltinSkills,
-    });
-  }
+  // so the symlinks land where the engine reads. Project workspaces (#455) get
+  // them too — with a managed .gitignore — so project chats can resolve skills.
+  await setupWorkspaceSkills(workspace, customWorkspace, !!extra.projectId, {
+    agentType: 'wcore',
+    enabledSkills: extra.enabledSkills,
+    extraSkillPaths: extra.extraSkillPaths,
+    excludeBuiltinSkills: extra.excludeBuiltinSkills,
+  });
 
   return {
     // 'wcore' is the canonical conversation type.
@@ -458,14 +473,12 @@ export const createOpenClawAgent = async (options: ICreateConversationParams): P
     extra.customWorkspace
   );
 
-  // Set up skill symlinks for temp workspace
-  if (!customWorkspace) {
-    await setupAssistantWorkspace(workspace, {
-      enabledSkills: extra.enabledSkills,
-      extraSkillPaths: extra.extraSkillPaths,
-      excludeBuiltinSkills: extra.excludeBuiltinSkills,
-    });
-  }
+  // Set up skill symlinks for temp + project workspaces
+  await setupWorkspaceSkills(workspace, customWorkspace, !!extra.projectId, {
+    enabledSkills: extra.enabledSkills,
+    extraSkillPaths: extra.extraSkillPaths,
+    excludeBuiltinSkills: extra.excludeBuiltinSkills,
+  });
 
   const expectedIdentityHash = await computeOpenClawIdentityHash(workspace);
   return {

--- a/src/process/utils/initAgent.ts
+++ b/src/process/utils/initAgent.ts
@@ -52,7 +52,10 @@ export type WorkspaceSkillEntry = {
  * symlinked regardless of any other setting (B8 quarantines them physically;
  * this is the second filter).
  *
- * Only runs for temp workspaces (not user-specified) to avoid polluting user project dirs.
+ * Invoked (via setupWorkspaceSkills) for temp workspaces and for project
+ * workspaces (#455); a non-project user-picked custom workspace is left alone.
+ * For project workspaces a managed `.gitignore` keeps these dot-dirs out of the
+ * user's git, so skills resolve without polluting the folder.
  *
  * Note: Rules/personality are injected via system prompt, NOT written to context files
  */

--- a/src/process/utils/workspaceGitignore.ts
+++ b/src/process/utils/workspaceGitignore.ts
@@ -64,5 +64,11 @@ export async function writeWorkspaceGitignore(workspace: string): Promise<void> 
     // No .gitignore yet - treat as empty.
   }
   const next = buildManagedGitignore(existing);
-  if (next !== null) await fs.writeFile(file, next, 'utf8');
+  if (next === null) return;
+  try {
+    await fs.writeFile(file, next, 'utf8');
+  } catch (err) {
+    // Best-effort: a read-only / full workspace must not block chat creation.
+    console.error('[workspaceGitignore] Failed to write .gitignore:', err);
+  }
 }

--- a/src/process/utils/workspaceGitignore.ts
+++ b/src/process/utils/workspaceGitignore.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #455 scope 4 - managed `.gitignore` for persistent project workspaces.
+ *
+ * Native skill discovery requires the engine/CLIs to find their skill dirs at
+ * the workspace ROOT (the wayland-core engine scans `<cwd>/.wayland-core/skills`,
+ * each ACP CLI scans its own `.<tool>/skills`; this is hard-coded relative to the
+ * spawn cwd, with no env/arg override). For a persistent, user-visible project
+ * workspace those managed dot-dirs (plus the `.wayland/` knowledge folder) would
+ * otherwise clutter the user's folder and git status, so we add them to a managed
+ * `.gitignore` block. The block is marked and idempotent so it never duplicates,
+ * and it is appended (never overwrites) so a user's own .gitignore is preserved.
+ */
+import fs from 'fs/promises';
+import path from 'path';
+import { ACP_BACKENDS_ALL } from '@/common/types/acpTypes';
+
+export const MANAGED_GITIGNORE_START = '# --- Wayland (managed): skill symlinks & knowledge, safe to keep ---';
+const MANAGED_GITIGNORE_END = '# --- end Wayland ---';
+
+/**
+ * The top-level dot-dirs Wayland creates inside a project workspace: every ACP
+ * backend's skill dir, the wcore + gemini engine skill dirs, and the `.wayland/`
+ * knowledge folder. Derived from ACP_BACKENDS_ALL so new backends stay covered.
+ */
+function managedEntries(): string[] {
+  const dirs = new Set<string>(['.wayland/', '.wayland-core/', '.gemini/']);
+  for (const cfg of Object.values(ACP_BACKENDS_ALL)) {
+    for (const dir of cfg.skillsDirs ?? []) {
+      const top = dir.split('/')[0];
+      if (top) dirs.add(top.endsWith('/') ? top : `${top}/`);
+    }
+  }
+  return [...dirs].toSorted();
+}
+
+/**
+ * Given the current `.gitignore` contents (empty string when absent), return the
+ * contents to write so the managed block is present, or `null` when no change is
+ * needed (the block is already there - idempotent). User content is preserved.
+ */
+export function buildManagedGitignore(existing: string): string | null {
+  if (existing.includes(MANAGED_GITIGNORE_START)) return null;
+  const block = [MANAGED_GITIGNORE_START, ...managedEntries(), MANAGED_GITIGNORE_END].join('\n');
+  if (!existing.trim()) return `${block}\n`;
+  return `${existing.replace(/\s*$/, '')}\n\n${block}\n`;
+}
+
+/**
+ * Ensure the managed block is present in `<workspace>/.gitignore`. Best-effort
+ * and idempotent: reads the current file (treating absent as empty), and writes
+ * only when the block is missing. Never throws - failing to write a .gitignore
+ * must not block chat creation.
+ */
+export async function writeWorkspaceGitignore(workspace: string): Promise<void> {
+  const file = path.join(workspace, '.gitignore');
+  let existing = '';
+  try {
+    existing = await fs.readFile(file, 'utf8');
+  } catch {
+    // No .gitignore yet - treat as empty.
+  }
+  const next = buildManagedGitignore(existing);
+  if (next !== null) await fs.writeFile(file, next, 'utf8');
+}

--- a/src/process/utils/workspaceLocation.ts
+++ b/src/process/utils/workspaceLocation.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Pure path logic for per-project persistent workspaces (#455). A project's
+ * workspace is a real, user-visible directory (default: ~/Documents/Wayland/<name>);
+ * the rules here turn a free-form project name into a filesystem-safe,
+ * collision-free folder. Kept free of electron/fs so the effectful allocator
+ * (see projectWorkspace.ts) can inject `exists`.
+ */
+import path from 'path';
+
+/** Filesystem-safe cap for a project folder name. */
+const MAX_NAME_LEN = 80;
+
+/**
+ * Turn a project name into a safe folder name:
+ * - path separators become spaces (a name can never escape the base dir),
+ * - control chars and Windows-reserved chars (`<>:"|?*`) are dropped,
+ * - whitespace is collapsed and trimmed,
+ * - leading/trailing dots and spaces are stripped (Windows rejects them),
+ * - length is capped,
+ * - falls back to `Project` when nothing usable remains.
+ */
+export function sanitizeProjectFolderName(name: string): string {
+  const cleaned = (name ?? '')
+    .normalize('NFC')
+    .replace(/[/\\]+/g, ' ') // path separators -> space
+    .replace(/\p{Cc}/gu, '') // control characters
+    .replace(/[<>:"|?*]+/g, '') // Windows-reserved characters
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^[.\s]+|[.\s]+$/g, '') // no leading/trailing dot or space
+    .slice(0, MAX_NAME_LEN)
+    .trim();
+  return cleaned || 'Project';
+}
+
+/**
+ * Resolve a collision-free absolute workspace path under `baseDir` for a project.
+ * `exists` is injected (production passes `fs.existsSync`) so this stays pure and
+ * unit-testable. Returns `baseDir/<name>`, or `baseDir/<name> (2)`, `(3)`... when
+ * the preferred path is already taken (two same-named projects stay distinct).
+ */
+export function resolveProjectWorkspacePath(
+  baseDir: string,
+  projectName: string,
+  exists: (p: string) => boolean
+): string {
+  const safe = sanitizeProjectFolderName(projectName);
+  let candidate = path.join(baseDir, safe);
+  let n = 2;
+  while (exists(candidate)) {
+    candidate = path.join(baseDir, `${safe} (${n})`);
+    n++;
+  }
+  return candidate;
+}

--- a/src/process/utils/workspaceLocation.ts
+++ b/src/process/utils/workspaceLocation.ts
@@ -33,7 +33,7 @@ export function sanitizeProjectFolderName(name: string): string {
     .trim()
     .replace(/^[.\s]+|[.\s]+$/g, '') // no leading/trailing dot or space
     .slice(0, MAX_NAME_LEN)
-    .trim();
+    .replace(/[.\s]+$/, ''); // re-strip a trailing dot/space the cap may expose (Windows-invalid)
   return cleaned || 'Project';
 }
 

--- a/tests/e2e/specs/project-persistent-workspace.e2e.ts
+++ b/tests/e2e/specs/project-persistent-workspace.e2e.ts
@@ -1,0 +1,84 @@
+/**
+ * #455 - every project has a PERSISTENT workspace (no temp-dir default).
+ *
+ * Exercises the real running app through the IPC bridge (no agent turn needed):
+ *   1. project.create -> the project gets a real, user-visible workspace dir on
+ *      disk (default ~/Documents/Wayland/<name>), NOT a throwaway `*-temp-*` dir.
+ *   2. create-conversation in that project -> the conversation resolves to the
+ *      project's persistent workspace (scope 3: no drift to a temp dir).
+ *
+ * The agent-writes-a-file acceptance (file lands in the dir + renders in Files)
+ * needs a live wcore turn and is covered by the in-app manual verify; this spec
+ * pins the deterministic, turn-free guarantees so a regression can't slip past CI.
+ */
+import { existsSync, rmSync } from 'fs';
+import path from 'path';
+import { test, expect } from '../fixtures';
+import { invokeBridge } from '../helpers';
+
+type Project = { id: string; name: string; workspace?: string };
+type Conversation = { id: string; extra?: { workspace?: string; projectId?: string } };
+
+const TEMP_WS = /-temp-\d+$/i;
+
+test.describe('Project: persistent workspace (#455)', () => {
+  test('project.create allocates a real, non-temp workspace dir on disk', async ({ page }) => {
+    const name = `E2E Persistent WS ${Date.now()}`;
+    const project = await invokeBridge<Project>(page, 'project.create', { name }, 20_000);
+
+    expect(project?.id, 'project was created').toBeTruthy();
+    expect(project.workspace, 'project has a workspace path').toBeTruthy();
+    const ws = project.workspace!;
+
+    // Real + discoverable: under a Wayland folder, not a throwaway temp dir.
+    expect(TEMP_WS.test(ws), `workspace must not be a temp dir: ${ws}`).toBe(false);
+    expect(ws.includes(`${path.sep}Wayland${path.sep}`), `workspace under Wayland/: ${ws}`).toBe(true);
+    // The dir exists on disk (this is the bug the issue fixes - it used to be a
+    // hidden temp dir the user never saw).
+    expect(existsSync(ws), `workspace dir exists on disk: ${ws}`).toBe(true);
+
+    // Cleanup: remove the project and its dir so the run is repeatable.
+    await invokeBridge(page, 'project.remove', { id: project.id }, 10_000).catch(() => {});
+    try {
+      rmSync(ws, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  test('a project chat resolves to the project workspace, not a temp dir', async ({ page }) => {
+    const name = `E2E Project Chat WS ${Date.now()}`;
+    const project = await invokeBridge<Project>(page, 'project.create', { name }, 20_000);
+    expect(project.workspace).toBeTruthy();
+    const ws = project.workspace!;
+
+    const conv = await invokeBridge<Conversation>(
+      page,
+      'create-conversation',
+      {
+        type: 'wcore',
+        model: {
+          id: 'e2e-455',
+          platform: 'openai',
+          name: 'E2E 455',
+          baseUrl: 'https://api.example.com',
+          apiKey: 'sk-e2e',
+          useModel: 'gpt-4o-mini',
+        },
+        extra: { projectId: project.id },
+      },
+      20_000
+    );
+
+    // Scope 3: the chat is pinned to the project's persistent workspace.
+    expect(conv?.extra?.workspace, 'chat workspace').toBe(ws);
+    expect(TEMP_WS.test(conv?.extra?.workspace ?? ''), 'chat workspace is not a temp dir').toBe(false);
+
+    await invokeBridge(page, 'project.remove', { id: project.id }, 10_000).catch(() => {});
+    try {
+      rmSync(ws, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+});

--- a/tests/unit/ConversationServiceImpl.test.ts
+++ b/tests/unit/ConversationServiceImpl.test.ts
@@ -452,7 +452,9 @@ describe('ConversationServiceImpl.createConversation', () => {
 
   it('fills an empty workspace from the project for a project chat (#30)', async () => {
     const { createGeminiAgent } = await import('../../src/process/utils/initAgent');
-    mockGetProject.mockResolvedValueOnce({ workspace: '/projects/alpha' });
+    // #455 lazy migration reads the project (ensure) before #30 pinning re-reads
+    // it (enforce); a real repository answers both reads, so use a persistent mock.
+    mockGetProject.mockResolvedValue({ workspace: '/projects/alpha' });
     const repo = makeRepo();
     const svc = new ConversationServiceImpl(repo);
 
@@ -484,7 +486,8 @@ describe('ConversationServiceImpl.createConversation', () => {
 
   it('corrects a project chat that arrives pointed at a non-project workspace (#30)', async () => {
     const { createGeminiAgent } = await import('../../src/process/utils/initAgent');
-    mockGetProject.mockResolvedValueOnce({ workspace: '/projects/alpha' });
+    // #455: ensure + enforce both read the project; persistent mock models a real repo.
+    mockGetProject.mockResolvedValue({ workspace: '/projects/alpha' });
     const repo = makeRepo();
     const svc = new ConversationServiceImpl(repo);
 

--- a/tests/unit/ensureProjectWorkspace.test.ts
+++ b/tests/unit/ensureProjectWorkspace.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #455 - lazy migration. A project that has no workspace yet must get one
+ * allocated, persisted, and knowledge-bootstrapped on demand (e.g. the next time
+ * a chat is created in it), so existing empty-workspace projects self-heal with
+ * no data loss. `ensureProjectWorkspace` is the shared seam createProject and the
+ * conversation-create reconcile both lean on.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetProject = vi.hoisted(() =>
+  vi.fn(async (_id: string) => null as { id: string; name: string; description?: string; workspace?: string } | null)
+);
+const mockUpdateProject = vi.hoisted(() => vi.fn(async (_id: string, _u: Record<string, unknown>) => {}));
+vi.mock('../../src/process/services/database/SqliteProjectRepository', () => ({
+  SqliteProjectRepository: class {
+    getProject = mockGetProject;
+    updateProject = mockUpdateProject;
+  },
+}));
+
+const mockBootstrap = vi.hoisted(() => vi.fn(async () => {}));
+vi.mock('@process/services/projectKnowledge/bootstrap', () => ({
+  WAYLAND_KNOWLEDGE_DIR: '.wayland',
+  bootstrapProjectKnowledge: mockBootstrap,
+}));
+
+import { ensureProjectWorkspace } from '../../src/process/services/projectWorkspace';
+
+describe('ensureProjectWorkspace (#455 lazy migration)', () => {
+  beforeEach(() => {
+    mockGetProject.mockReset();
+    mockUpdateProject.mockReset();
+    mockBootstrap.mockReset();
+  });
+
+  it('returns null for a missing projectId', async () => {
+    expect(await ensureProjectWorkspace(undefined)).toBe(null);
+    expect(mockGetProject).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the project does not exist', async () => {
+    mockGetProject.mockResolvedValueOnce(null);
+    expect(await ensureProjectWorkspace('p1', async () => '/should/not/run')).toBe(null);
+    expect(mockUpdateProject).not.toHaveBeenCalled();
+  });
+
+  it('returns the existing workspace untouched (no allocation, no write)', async () => {
+    mockGetProject.mockResolvedValueOnce({ id: 'p1', name: 'Alpha', workspace: '/projects/alpha' });
+    const allocate = vi.fn(async () => '/never');
+    expect(await ensureProjectWorkspace('p1', allocate)).toBe('/projects/alpha');
+    expect(allocate).not.toHaveBeenCalled();
+    expect(mockUpdateProject).not.toHaveBeenCalled();
+  });
+
+  it('allocates, persists, and bootstraps when the project has no workspace', async () => {
+    mockGetProject.mockResolvedValueOnce({ id: 'p1', name: 'My Notes', description: 'd', workspace: '' });
+    const allocate = vi.fn(async (name: string) => `/Docs/Wayland/${name}`);
+    const result = await ensureProjectWorkspace('p1', allocate);
+    expect(result).toBe('/Docs/Wayland/My Notes');
+    expect(allocate).toHaveBeenCalledWith('My Notes');
+    expect(mockUpdateProject).toHaveBeenCalledWith('p1', { workspace: '/Docs/Wayland/My Notes' });
+    expect(mockBootstrap).toHaveBeenCalledWith('/Docs/Wayland/My Notes', 'My Notes', 'd');
+  });
+
+  it('still returns the workspace when knowledge bootstrap fails (best-effort)', async () => {
+    mockGetProject.mockResolvedValueOnce({ id: 'p1', name: 'Alpha', workspace: undefined });
+    mockBootstrap.mockRejectedValueOnce(new Error('disk full'));
+    const result = await ensureProjectWorkspace('p1', async () => '/Docs/Wayland/Alpha');
+    expect(result).toBe('/Docs/Wayland/Alpha');
+    expect(mockUpdateProject).toHaveBeenCalledWith('p1', { workspace: '/Docs/Wayland/Alpha' });
+  });
+
+  it('swallows repository failure and returns null', async () => {
+    mockGetProject.mockRejectedValueOnce(new Error('db down'));
+    expect(await ensureProjectWorkspace('p1', async () => '/x')).toBe(null);
+  });
+});

--- a/tests/unit/ensureProjectWorkspace.test.ts
+++ b/tests/unit/ensureProjectWorkspace.test.ts
@@ -78,4 +78,20 @@ describe('ensureProjectWorkspace (#455 lazy migration)', () => {
     mockGetProject.mockRejectedValueOnce(new Error('db down'));
     expect(await ensureProjectWorkspace('p1', async () => '/x')).toBe(null);
   });
+
+  it('serializes concurrent first-chats for the same project (allocates once)', async () => {
+    mockGetProject.mockResolvedValue({ id: 'p1', name: 'Alpha', workspace: '' });
+    let calls = 0;
+    const allocate = vi.fn(async () => {
+      calls++;
+      await new Promise((r) => setTimeout(r, 5));
+      return '/Docs/Wayland/Alpha';
+    });
+    const [a, b] = await Promise.all([ensureProjectWorkspace('p1', allocate), ensureProjectWorkspace('p1', allocate)]);
+    expect(a).toBe('/Docs/Wayland/Alpha');
+    expect(b).toBe('/Docs/Wayland/Alpha');
+    // The lock collapses the two concurrent calls to a single allocation + write.
+    expect(calls).toBe(1);
+    expect(mockUpdateProject).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/unit/projectServiceWorkspace.test.ts
+++ b/tests/unit/projectServiceWorkspace.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #455 scope 1 - on project create, a project with no user-picked folder gets a
+ * PERSISTENT workspace allocated (default ~/Documents/Wayland/<name>) and stored
+ * on projects.workspace, so its chats never fall back to a throwaway temp dir.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockAllocate = vi.hoisted(() => vi.fn(async (name: string) => `/Docs/Wayland/${name}`));
+vi.mock('@process/services/projectWorkspace', () => ({
+  allocateProjectWorkspace: mockAllocate,
+}));
+
+const mockBootstrap = vi.hoisted(() => vi.fn(async () => {}));
+vi.mock('@process/services/projectKnowledge/bootstrap', () => ({
+  WAYLAND_KNOWLEDGE_DIR: '.wayland',
+  bootstrapProjectKnowledge: mockBootstrap,
+}));
+
+import { ProjectServiceImpl } from '@process/services/ProjectServiceImpl';
+import type { IProject } from '@/common/types/project';
+
+function makeRepo() {
+  return {
+    createProject: vi.fn(async (p: IProject) => p),
+    getProject: vi.fn(async () => null),
+    listProjects: vi.fn(async () => []),
+    updateProject: vi.fn(async () => {}),
+    removeProject: vi.fn(async () => {}),
+    getProjectConversations: vi.fn(async () => []),
+  };
+}
+
+describe('ProjectServiceImpl.createProject persistent workspace (#455)', () => {
+  beforeEach(() => {
+    mockAllocate.mockClear();
+    mockBootstrap.mockClear();
+  });
+
+  it('allocates a persistent workspace when the user picked none', async () => {
+    const repo = makeRepo();
+    const svc = new ProjectServiceImpl(repo as never, {} as never);
+
+    const project = await svc.createProject({ name: 'My Notes' });
+
+    expect(mockAllocate).toHaveBeenCalledWith('My Notes');
+    expect(project.workspace).toBe('/Docs/Wayland/My Notes');
+    expect(repo.createProject).toHaveBeenCalledWith(expect.objectContaining({ workspace: '/Docs/Wayland/My Notes' }));
+    // Knowledge folder bootstrapped at the new workspace.
+    expect(mockBootstrap).toHaveBeenCalledWith('/Docs/Wayland/My Notes', 'My Notes', undefined);
+  });
+
+  it('respects a user-picked workspace and does not allocate', async () => {
+    const repo = makeRepo();
+    const svc = new ProjectServiceImpl(repo as never, {} as never);
+
+    const project = await svc.createProject({ name: 'Alpha', workspace: '/picked/dir' });
+
+    expect(mockAllocate).not.toHaveBeenCalled();
+    expect(project.workspace).toBe('/picked/dir');
+  });
+
+  it('still creates the project when allocation fails (lazy migration retries later)', async () => {
+    mockAllocate.mockRejectedValueOnce(new Error('disk full'));
+    const repo = makeRepo();
+    const svc = new ProjectServiceImpl(repo as never, {} as never);
+
+    const project = await svc.createProject({ name: 'Alpha' });
+
+    expect(project.workspace).toBeUndefined();
+    expect(repo.createProject).toHaveBeenCalled();
+    // No workspace -> no bootstrap.
+    expect(mockBootstrap).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/projectWorkspaceFs.integration.test.ts
+++ b/tests/unit/projectWorkspaceFs.integration.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #455 acceptance, filesystem level: allocating and ensuring a project workspace
+ * must create a REAL directory on disk (not a temp `*-temp-*` dir) under the
+ * default base, and persist + bootstrap it. Exercises the real fs (only electron
+ * `app.getPath` is stubbed to a tmpdir) so we prove "create a project -> it has a
+ * real workspace dir on disk" without an agent turn.
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import os from 'os';
+import path from 'path';
+import { existsSync } from 'fs';
+import fs from 'fs/promises';
+
+let tmpBase: string;
+
+vi.mock('electron', () => ({
+  app: { getPath: (k: string) => (k === 'documents' ? tmpBase : tmpBase) },
+}));
+
+import { allocateProjectWorkspace } from '@process/services/projectWorkspace';
+import { WAYLAND_KNOWLEDGE_DIR } from '@process/services/projectKnowledge/bootstrap';
+
+beforeAll(async () => {
+  tmpBase = await fs.mkdtemp(path.join(os.tmpdir(), 'wl-455-'));
+});
+afterAll(async () => {
+  await fs.rm(tmpBase, { recursive: true, force: true });
+});
+
+describe('#455 allocateProjectWorkspace (real fs)', () => {
+  it('creates a real, discoverable dir under <documents>/Wayland', async () => {
+    const ws = await allocateProjectWorkspace('My Notes');
+    expect(ws).toBe(path.join(tmpBase, 'Wayland', 'My Notes'));
+    expect(existsSync(ws)).toBe(true);
+    // It is NOT a throwaway temp workspace.
+    expect(/-temp-\d+$/.test(ws)).toBe(false);
+  });
+
+  it('two same-named projects get distinct real dirs on disk', async () => {
+    const a = await allocateProjectWorkspace('Same Name');
+    const b = await allocateProjectWorkspace('Same Name');
+    expect(a).not.toBe(b);
+    expect(existsSync(a)).toBe(true);
+    expect(existsSync(b)).toBe(true);
+    expect(b.endsWith('Same Name (2)')).toBe(true);
+  });
+
+  it('the workspace is writable and survives a re-read (relaunch-stable)', async () => {
+    const ws = await allocateProjectWorkspace('Persist Me');
+    const file = path.join(ws, 'note.md');
+    await fs.writeFile(file, '# hello', 'utf8');
+    // Simulate "relaunch": the dir + file are still there (no cleanup).
+    expect(existsSync(ws)).toBe(true);
+    expect(await fs.readFile(file, 'utf8')).toBe('# hello');
+    // And the knowledge folder can be bootstrapped into the same real dir.
+    await fs.mkdir(path.join(ws, WAYLAND_KNOWLEDGE_DIR), { recursive: true });
+    expect(existsSync(path.join(ws, WAYLAND_KNOWLEDGE_DIR))).toBe(true);
+  });
+});

--- a/tests/unit/projectWorkspaceFs.integration.test.ts
+++ b/tests/unit/projectWorkspaceFs.integration.test.ts
@@ -49,6 +49,18 @@ describe('#455 allocateProjectWorkspace (real fs)', () => {
     expect(b.endsWith('Same Name (2)')).toBe(true);
   });
 
+  it('CONCURRENT allocations that sanitize to the same name get distinct dirs (cross-project collision guard)', async () => {
+    // Different project names that all sanitize to "Clash" (`?`/`:` are stripped).
+    // The per-projectId lock can't help here - this is the path-level guard.
+    const [a, b, c] = await Promise.all([
+      allocateProjectWorkspace('Clash'),
+      allocateProjectWorkspace('Clash?'),
+      allocateProjectWorkspace('Clash:'),
+    ]);
+    expect(new Set([a, b, c]).size, `must be 3 distinct dirs, got ${[a, b, c].join(', ')}`).toBe(3);
+    for (const p of [a, b, c]) expect(existsSync(p)).toBe(true);
+  });
+
   it('the workspace is writable and survives a re-read (relaunch-stable)', async () => {
     const ws = await allocateProjectWorkspace('Persist Me');
     const file = path.join(ws, 'note.md');

--- a/tests/unit/workspaceGitignore.test.ts
+++ b/tests/unit/workspaceGitignore.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #455 scope 4 - persistent project workspaces still need native skill symlinks
+ * (the engine/CLIs scan `.wayland-core/skills`, `.claude/skills`, ... at the
+ * workspace root). To keep the user's folder clean those managed dot-dirs are
+ * gitignored. buildManagedGitignore must be idempotent and must never clobber a
+ * user's existing .gitignore.
+ */
+import { describe, expect, it } from 'vitest';
+import { MANAGED_GITIGNORE_START, buildManagedGitignore } from '@process/utils/workspaceGitignore';
+
+describe('buildManagedGitignore (#455)', () => {
+  it('creates a managed block for an empty/absent .gitignore', () => {
+    const out = buildManagedGitignore('');
+    expect(out).not.toBeNull();
+    expect(out).toContain(MANAGED_GITIGNORE_START);
+    expect(out).toContain('.wayland-core/');
+    expect(out).toContain('.wayland/');
+    expect(out).toContain('.claude/');
+    expect(out!.endsWith('\n')).toBe(true);
+  });
+
+  it('appends the managed block to an existing user .gitignore without losing content', () => {
+    const existing = 'node_modules/\ndist/\n';
+    const out = buildManagedGitignore(existing);
+    expect(out).not.toBeNull();
+    expect(out!.startsWith('node_modules/\ndist/')).toBe(true);
+    expect(out).toContain(MANAGED_GITIGNORE_START);
+    expect(out).toContain('.wayland-core/');
+  });
+
+  it('is idempotent - returns null when the managed block is already present', () => {
+    const first = buildManagedGitignore('node_modules/\n');
+    expect(first).not.toBeNull();
+    expect(buildManagedGitignore(first!)).toBeNull();
+  });
+});

--- a/tests/unit/workspaceLocation.test.ts
+++ b/tests/unit/workspaceLocation.test.ts
@@ -7,6 +7,7 @@
  * turns a project name into a filesystem-safe, collision-free workspace dir.
  * Kept free of electron/fs so the rules are exercised directly.
  */
+import path from 'path';
 import { describe, expect, it } from 'vitest';
 import { resolveProjectWorkspacePath, sanitizeProjectFolderName } from '@process/utils/workspaceLocation';
 
@@ -52,19 +53,21 @@ describe('sanitizeProjectFolderName (#455)', () => {
 });
 
 describe('resolveProjectWorkspacePath (#455)', () => {
-  const base = '/Users/me/Documents/Wayland';
+  // resolveProjectWorkspacePath builds paths with path.join, so expectations use
+  // path.join too (native separators) — otherwise these assertions fail on Windows.
+  const base = path.join('/Users/me', 'Documents', 'Wayland');
 
   it('uses base/<name> when the path is free', () => {
-    expect(resolveProjectWorkspacePath(base, 'Alpha', () => false)).toBe(`${base}/Alpha`);
+    expect(resolveProjectWorkspacePath(base, 'Alpha', () => false)).toBe(path.join(base, 'Alpha'));
   });
 
   it('sanitizes the name into the path', () => {
-    expect(resolveProjectWorkspacePath(base, 'a/b', () => false)).toBe(`${base}/a b`);
+    expect(resolveProjectWorkspacePath(base, 'a/b', () => false)).toBe(path.join(base, 'a b'));
   });
 
   it('appends a numeric suffix on collision', () => {
-    const taken = new Set([`${base}/Alpha`, `${base}/Alpha (2)`]);
-    expect(resolveProjectWorkspacePath(base, 'Alpha', (p) => taken.has(p))).toBe(`${base}/Alpha (3)`);
+    const taken = new Set([path.join(base, 'Alpha'), path.join(base, 'Alpha (2)')]);
+    expect(resolveProjectWorkspacePath(base, 'Alpha', (p) => taken.has(p))).toBe(path.join(base, 'Alpha (3)'));
   });
 
   it('two projects with the same name resolve to distinct dirs', () => {
@@ -72,8 +75,8 @@ describe('resolveProjectWorkspacePath (#455)', () => {
     const first = resolveProjectWorkspacePath(base, 'Notes', (p) => taken.has(p));
     taken.add(first);
     const second = resolveProjectWorkspacePath(base, 'Notes', (p) => taken.has(p));
-    expect(first).toBe(`${base}/Notes`);
-    expect(second).toBe(`${base}/Notes (2)`);
+    expect(first).toBe(path.join(base, 'Notes'));
+    expect(second).toBe(path.join(base, 'Notes (2)'));
     expect(first).not.toBe(second);
   });
 });

--- a/tests/unit/workspaceLocation.test.ts
+++ b/tests/unit/workspaceLocation.test.ts
@@ -43,6 +43,12 @@ describe('sanitizeProjectFolderName (#455)', () => {
     const out = sanitizeProjectFolderName('x'.repeat(500));
     expect(out.length).toBeLessThanOrEqual(80);
   });
+
+  it('never ends in a dot when the length cap slices mid-dot (Windows-invalid)', () => {
+    const out = sanitizeProjectFolderName('a'.repeat(79) + '.tail extra');
+    expect(out.length).toBeLessThanOrEqual(80);
+    expect(out.endsWith('.')).toBe(false);
+  });
 });
 
 describe('resolveProjectWorkspacePath (#455)', () => {

--- a/tests/unit/workspaceLocation.test.ts
+++ b/tests/unit/workspaceLocation.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #455 - persistent project workspaces. These cover the pure path logic that
+ * turns a project name into a filesystem-safe, collision-free workspace dir.
+ * Kept free of electron/fs so the rules are exercised directly.
+ */
+import { describe, expect, it } from 'vitest';
+import { resolveProjectWorkspacePath, sanitizeProjectFolderName } from '@process/utils/workspaceLocation';
+
+describe('sanitizeProjectFolderName (#455)', () => {
+  it('keeps an ordinary name intact', () => {
+    expect(sanitizeProjectFolderName('My Notes')).toBe('My Notes');
+  });
+
+  it('strips path separators so a name can never escape the base dir', () => {
+    expect(sanitizeProjectFolderName('a/b\\c')).toBe('a b c');
+    expect(sanitizeProjectFolderName('../../etc/passwd')).toBe('etc passwd');
+  });
+
+  it('removes control and reserved filesystem characters', () => {
+    expect(sanitizeProjectFolderName('re<po>:"|?*name')).toBe('reponame');
+  });
+
+  it('collapses whitespace and trims', () => {
+    expect(sanitizeProjectFolderName('  spaced   out  ')).toBe('spaced out');
+  });
+
+  it('strips leading/trailing dots and spaces (Windows-unsafe)', () => {
+    expect(sanitizeProjectFolderName('...hidden...')).toBe('hidden');
+    expect(sanitizeProjectFolderName('.')).toBe('Project');
+  });
+
+  it('falls back to "Project" when nothing usable remains', () => {
+    expect(sanitizeProjectFolderName('')).toBe('Project');
+    expect(sanitizeProjectFolderName('///')).toBe('Project');
+    expect(sanitizeProjectFolderName('   ')).toBe('Project');
+  });
+
+  it('caps very long names', () => {
+    const out = sanitizeProjectFolderName('x'.repeat(500));
+    expect(out.length).toBeLessThanOrEqual(80);
+  });
+});
+
+describe('resolveProjectWorkspacePath (#455)', () => {
+  const base = '/Users/me/Documents/Wayland';
+
+  it('uses base/<name> when the path is free', () => {
+    expect(resolveProjectWorkspacePath(base, 'Alpha', () => false)).toBe(`${base}/Alpha`);
+  });
+
+  it('sanitizes the name into the path', () => {
+    expect(resolveProjectWorkspacePath(base, 'a/b', () => false)).toBe(`${base}/a b`);
+  });
+
+  it('appends a numeric suffix on collision', () => {
+    const taken = new Set([`${base}/Alpha`, `${base}/Alpha (2)`]);
+    expect(resolveProjectWorkspacePath(base, 'Alpha', (p) => taken.has(p))).toBe(`${base}/Alpha (3)`);
+  });
+
+  it('two projects with the same name resolve to distinct dirs', () => {
+    const taken = new Set<string>();
+    const first = resolveProjectWorkspacePath(base, 'Notes', (p) => taken.has(p));
+    taken.add(first);
+    const second = resolveProjectWorkspacePath(base, 'Notes', (p) => taken.has(p));
+    expect(first).toBe(`${base}/Notes`);
+    expect(second).toBe(`${base}/Notes (2)`);
+    expect(first).not.toBe(second);
+  });
+});


### PR DESCRIPTION
Closes #455 (do not auto-close — release/Sean action).

## What
Every **project** now gets a **persistent, user-visible workspace** instead of silently falling back to a hidden `*-temp-*` dir whose files the user never sees (the exact bug in the issue: a write to "the local workspace" landed in `~/.wayland/wcore-temp-…` and was lost).

## Root cause
`buildWorkspaceWidthFiles` (`initAgent.ts:219`) defaults to a temp dir under `getSystemDir().workDir` whenever no workspace is passed, and that happens because a project can have an **empty** `workspace` column. Most of the plumbing already existed (`enforceProjectWorkspace` pins a project chat to the project workspace; the create/settings folder picker; the temp-vs-real panel detection) — they just never fired because projects had no workspace to begin with.

## Changes (by scope item)
1. **Allocate on create** — `ProjectServiceImpl.createProject` allocates a default `~/Documents/Wayland/<name>` (collision-safe) when the user picks no folder, and persists it. *(scope 1)*
2. **Folder picker** — already present in `CreateProjectModal`/`ProjectSettingsDrawer`; lights up automatically. *(scope 2 — no change needed)*
3. **Resolution** — project chats resolve to the project's persistent workspace via the existing `enforceProjectWorkspace`, now that one always exists. *(scope 3)*
4. **Skills without pollution** — project workspaces now get native skill symlinks (previously skipped as "custom") via a shared `setupWorkspaceSkills` gate, plus a **managed, idempotent `.gitignore`** so the skill dot-dirs stay out of the user's git. *(scope 4 — see engine note below)*
5. **Lazy migration** — `ensureProjectWorkspace` allocates+persists+bootstraps for existing empty-workspace projects on the next chat, no data loss. *(scope 5)*
6. **Real-path panel** — already keyed off the `-temp-` regex; shows the real path now that workspaces are real. *(scope 6 — no change needed)*

### ⚠️ Engine note on scope 4
The issue asked for skill symlinks in a `.wayland/` **subdir**. Verified the wcore engine spawns with `cwd: workspace` and scans `<cwd>/.wayland-core/skills/` **hard-coded relative to cwd** (no env/arg override; Rust source not vendored), and every ACP CLI likewise scans its own dot-dir at cwd. A `.wayland/` subdir is therefore **infeasible without a Core engine change** (a `WCORE_SKILLS_DIR` redirect). This PR keeps symlinks at the engine-required dot-dirs and uses a managed `.gitignore` to honor the intent ("folder stays clean and skills resolve"). **A Core follow-up for true `.wayland/` consolidation is the right home for the subdir design.**

## Tests
- Unit: `workspaceLocation` (sanitize + collision-safe path, incl. path-escape + Windows trailing-dot), `workspaceGitignore`, `ensureProjectWorkspace` (incl. concurrency lock), `ProjectServiceImpl` allocation.
- Real-fs integration: `projectWorkspaceFs.integration.test.ts` proves a real dir on disk, collision-safe, relaunch-stable.
- E2E (turn-free): `project-persistent-workspace.e2e.ts` drives the running app — `project.create` → real `~/Documents/Wayland/<name>`, project chat pinned to it.
- `prek` (full CI) green: TypeScript / Oxlint / Oxfmt / EOF / whitespace.

## Live-verified in the running app (mac, electromcp)
- `project.create` → `workspace: /Users/…/Documents/Wayland/<name>` (real, not temp).
- Dir exists on disk; `.wayland/` knowledge bootstrapped (CONTEXT/rules/decisions).
- wcore project chat `extra.workspace` === the project workspace (no temp drift).
- `.wayland-core/skills/` symlinks present + managed `.gitignore` written.
- **Still owed (routes to Windows box):** the full agent-turn write — "ask the agent to write a file to the local workspace → appears in the dir + Files panel" — needs a live wcore turn the mac harness can't run.

## Gate
Independent adversarial cross-audit run pre-PR; it found 3 real issues (gitignore unguarded write = blocker, alloc TOCTOU race = major, name-cap trailing dot = minor) — **all fixed** in `bc0ea97e5` with added tests. Per the merge gate this still needs a **second independent audit (non-author)** + the **Windows agent-turn verify** before merge. Not self-merging.
