### PR TITLE
feat(wcore): preserve resume replay trajectory

### DIFF
--- a/scripts/demo-wcore-resume-replay.ts
+++ b/scripts/demo-wcore-resume-replay.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IMessageText, IMessageToolGroup, TMessage } from '@/common/chat/chatLib';
+import { buildWCoreResumeReplayContext } from '../src/process/task/wcoreResumeReplay';
+
+const CONVERSATION_ID = 'demo-wcore-resume-replay';
+
+function textMessage(id: string, position: 'left' | 'right', content: string): IMessageText {
+  return {
+    id,
+    conversation_id: CONVERSATION_ID,
+    type: 'text',
+    position,
+    content: { content },
+  };
+}
+
+function editToolGroup(id: string): IMessageToolGroup {
+  return {
+    id,
+    conversation_id: CONVERSATION_ID,
+    type: 'tool_group',
+    position: 'left',
+    content: [
+      {
+        callId: 'call-edit-readme',
+        description: 'Updated the resume instructions in README.md',
+        name: 'Edit',
+        renderOutputAsMarkdown: true,
+        status: 'Success',
+        confirmationDetails: {
+          type: 'edit',
+          title: 'Edit README.md',
+          fileName: 'README.md',
+          fileDiff: '- old resume instructions\n+ structured resume replay instructions',
+        },
+      },
+    ],
+  };
+}
+
+const messages: TMessage[] = [
+  textMessage('m1', 'right', 'Please keep enough context when WCore resumes.'),
+  editToolGroup('m2'),
+  textMessage('m3', 'left', 'I updated README.md and kept the replay under the injection budget.'),
+];
+
+const replay = buildWCoreResumeReplayContext(messages, {
+  maxChars: 700,
+  perEntryCharLimit: 220,
+});
+
+if (!replay) {
+  throw new Error('Expected demo replay context to be generated');
+}
+
+console.log(replay.text);
+console.log('Replay stats:');
+console.log(JSON.stringify(replay.stats, null, 2));

--- a/src/process/task/WCoreManager.ts
+++ b/src/process/task/WCoreManager.ts
@@ -41,6 +41,7 @@ import { skillSuggestWatcher } from '@process/services/cron/SkillSuggestWatcher'
 import { getCostRecorder } from '@process/services/cost/CostRecorder';
 import { getBudgetController } from '@process/services/cost/BudgetController';
 import { RunawayMonitor } from '@process/services/runaway/RunawayMonitor';
+import { buildWCoreResumeReplayContext } from './wcoreResumeReplay';
 
 // ---------------------------------------------------------------------------
 // Truncation-heuristic constants (HC-4 - see audit at
@@ -335,12 +336,8 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
       try {
         const historyDb = await getDatabase();
         const history = historyDb.getConversationMessages(this.conversation_id, 0, 10000);
-        const lines = (history.data ?? [])
-          .filter((m): m is Extract<TMessage, { type: 'text' }> => m.type === 'text')
-          .slice(-20)
-          .map((m) => `${m.position === 'right' ? 'User' : 'Assistant'}: ${m.content.content || ''}`);
-        const text = lines.join('\n').slice(-4000);
-        if (text) await agent.injectConversationHistory(text);
+        const replay = buildWCoreResumeReplayContext(history.data ?? []);
+        if (replay?.text) await agent.injectConversationHistory(replay.text);
       } catch {
         // Best-effort: resume still proceeds without seeded history.
       }

--- a/src/process/task/wcoreResumeReplay.ts
+++ b/src/process/task/wcoreResumeReplay.ts
@@ -1,0 +1,242 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { TMessage } from '@/common/chat/chatLib';
+
+const DEFAULT_MAX_MESSAGES = 20;
+const DEFAULT_MAX_CHARS = 4000;
+const DEFAULT_PER_ENTRY_CHAR_LIMIT = 500;
+
+export type WCoreResumeReplayOptions = {
+  maxMessages?: number;
+  maxChars?: number;
+  perEntryCharLimit?: number;
+};
+
+export type WCoreResumeReplayStats = {
+  inputMessages: number;
+  replayedMessages: number;
+  omittedMessages: number;
+  replayedToolEvents: number;
+  replayedFileEvents: number;
+  outputChars: number;
+  truncated: boolean;
+};
+
+export type WCoreResumeReplayResult = {
+  text: string;
+  stats: WCoreResumeReplayStats;
+};
+
+/**
+ * Build a budgeted, textual WCore resume replay block from persisted messages.
+ * The returned text is intended for `WCoreAgent.injectConversationHistory`.
+ */
+export function buildWCoreResumeReplayContext(
+  messages: TMessage[],
+  options?: WCoreResumeReplayOptions
+): WCoreResumeReplayResult | null {
+  const maxMessages = positiveInt(options?.maxMessages, DEFAULT_MAX_MESSAGES);
+  const maxChars = positiveInt(options?.maxChars, DEFAULT_MAX_CHARS);
+  const perEntryCharLimit = positiveInt(options?.perEntryCharLimit, DEFAULT_PER_ENTRY_CHAR_LIMIT);
+
+  const recent = messages.slice(-maxMessages);
+  const entries = recent.map((message) => formatMessage(message, perEntryCharLimit)).filter((entry) => entry !== null);
+
+  if (entries.length === 0) return null;
+
+  const fitted = fitToBudget(
+    entries.map((entry) => entry.line),
+    maxChars
+  );
+  const text = wrapReplayBlock(fitted.lines);
+  const replayedLines = new Set(fitted.lines);
+  const replayedEntries = entries.filter((entry) => replayedLines.has(entry.line));
+
+  return {
+    text,
+    stats: {
+      inputMessages: messages.length,
+      replayedMessages: replayedEntries.length,
+      omittedMessages: messages.length - replayedEntries.length,
+      replayedToolEvents: replayedEntries.reduce((total, entry) => total + entry.toolEvents, 0),
+      replayedFileEvents: replayedEntries.reduce((total, entry) => total + entry.fileEvents, 0),
+      outputChars: text.length,
+      truncated: fitted.truncated || recent.length < messages.length,
+    },
+  };
+}
+
+type ReplayEntry = {
+  line: string;
+  toolEvents: number;
+  fileEvents: number;
+};
+
+function formatMessage(message: TMessage, perEntryCharLimit: number): ReplayEntry | null {
+  switch (message.type) {
+    case 'text': {
+      const content = clip(message.content.content, perEntryCharLimit);
+      if (!content) return null;
+      const role = message.position === 'right' ? 'user' : 'assistant';
+      return { line: `[${role}]: ${content}`, toolEvents: 0, fileEvents: 0 };
+    }
+
+    case 'tool_group': {
+      const parts = message.content.map((tool) => {
+        const details = formatToolDetails(tool);
+        const suffix = details ? `; ${details}` : '';
+        return `[assistant tool: ${tool.name} (${tool.status})] ${tool.description}${suffix}`;
+      });
+      const line = clip(parts.filter(Boolean).join('\n'), perEntryCharLimit);
+      if (!line) return null;
+      return {
+        line,
+        toolEvents: message.content.length,
+        fileEvents: message.content.filter((tool) => isFileTool(tool)).length,
+      };
+    }
+
+    case 'tool_call': {
+      const args = message.content.args ?? {};
+      const argsText = clip(JSON.stringify(args), Math.min(200, perEntryCharLimit));
+      const fileRefs = collectFileRefs(args);
+      const details = [
+        message.content.status ?? 'completed',
+        argsText && argsText !== '{}' ? `args: ${argsText}` : '',
+        fileRefs.length > 0 ? `files: ${fileRefs.join(', ')}` : '',
+      ].filter(Boolean);
+      return {
+        line: `[assistant tool: ${message.content.name} (${details.join('; ')})]`,
+        toolEvents: 1,
+        fileEvents: fileRefs.length > 0 ? 1 : 0,
+      };
+    }
+
+    case 'codex_tool_call': {
+      const title = message.content.title ?? message.content.kind;
+      const fileRefs = collectFileRefs(message.content);
+      const details = [message.content.kind, fileRefs.length > 0 ? `files: ${fileRefs.join(', ')}` : ''].filter(
+        Boolean
+      );
+      const suffix = details.length > 0 ? ` ${details.join('; ')}` : '';
+      return {
+        line: `[assistant tool: ${title} (${message.content.status})]${suffix}`,
+        toolEvents: 1,
+        fileEvents: fileRefs.length > 0 ? 1 : 0,
+      };
+    }
+
+    default:
+      return null;
+  }
+}
+
+type ToolGroupItem = Extract<TMessage, { type: 'tool_group' }>['content'][number];
+
+function formatToolDetails(tool: ToolGroupItem): string {
+  const details: string[] = [];
+  const confirmation = tool.confirmationDetails;
+
+  if (confirmation?.type === 'edit') {
+    details.push(`file: ${confirmation.fileName}`);
+  } else if (confirmation?.type === 'exec') {
+    details.push(`command: ${confirmation.rootCommand}`);
+  } else if (confirmation?.type === 'mcp') {
+    details.push(`mcp: ${confirmation.serverName}/${confirmation.toolName}`);
+  }
+
+  if (tool.resultDisplay && typeof tool.resultDisplay === 'object') {
+    if ('fileName' in tool.resultDisplay) {
+      details.push(`result file: ${tool.resultDisplay.fileName}`);
+    } else if ('relative_path' in tool.resultDisplay) {
+      details.push(`result file: ${tool.resultDisplay.relative_path}`);
+    }
+  }
+
+  return details.join('; ');
+}
+
+function isFileTool(tool: ToolGroupItem): boolean {
+  if (tool.confirmationDetails?.type === 'edit') return true;
+  if (!tool.resultDisplay || typeof tool.resultDisplay !== 'object') return false;
+  return 'fileName' in tool.resultDisplay || 'relative_path' in tool.resultDisplay;
+}
+
+function collectFileRefs(value: unknown): string[] {
+  const refs = new Set<string>();
+  collectFileRefsInto(value, refs);
+  return [...refs];
+}
+
+function collectFileRefsInto(value: unknown, refs: Set<string>): void {
+  if (!value || typeof value !== 'object') return;
+
+  if (Array.isArray(value)) {
+    for (const item of value) collectFileRefsInto(item, refs);
+    return;
+  }
+
+  for (const [key, item] of Object.entries(value)) {
+    if (typeof item === 'string' && isFileRefKey(key)) {
+      refs.add(item);
+      continue;
+    }
+    collectFileRefsInto(item, refs);
+  }
+}
+
+function isFileRefKey(key: string): boolean {
+  return ['file', 'fileName', 'filename', 'filePath', 'path', 'relative_path'].includes(key);
+}
+
+function fitToBudget(lines: string[], maxChars: number): { lines: string[]; truncated: boolean } {
+  const wrapped = wrapReplayBlock(lines);
+  if (wrapped.length <= maxChars) return { lines, truncated: false };
+
+  const omittedMarker = '[... earlier replay entries omitted ...]';
+  const kept: string[] = [];
+  let includeMarker = false;
+
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const candidate = [lines[i], ...kept];
+    const candidateWithMarker = i > 0 ? [omittedMarker, ...candidate] : candidate;
+
+    if (wrapReplayBlock(candidateWithMarker).length <= maxChars) {
+      includeMarker = i > 0;
+      kept.unshift(lines[i]);
+      continue;
+    }
+
+    if (wrapReplayBlock(candidate).length > maxChars) break;
+    includeMarker = false;
+    kept.unshift(lines[i]);
+  }
+
+  return { lines: includeMarker ? [omittedMarker, ...kept] : kept, truncated: true };
+}
+
+function wrapReplayBlock(lines: string[]): string {
+  return [
+    '[BEGIN WCORE RESUME REPLAY - historical context only; do not repeat tool calls]',
+    ...lines,
+    '[END WCORE RESUME REPLAY]',
+    '',
+  ].join('\n');
+}
+
+function clip(value: string | undefined | null, maxChars: number): string {
+  if (!value) return '';
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxChars) return normalized;
+  return `${normalized.slice(0, Math.max(0, maxChars - 3)).trimEnd()}...`;
+}
+
+function positiveInt(value: number | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  if (!Number.isFinite(value) || value <= 0) return fallback;
+  return Math.floor(value);
+}

--- a/tests/unit/process/task/WCoreManagerResumeReplay.test.ts
+++ b/tests/unit/process/task/WCoreManagerResumeReplay.test.ts
@@ -1,0 +1,206 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { IMessageText, IMessageToolGroup, TMessage } from '@/common/chat/chatLib';
+
+const { mockDb, agentStart, agentInstances } = vi.hoisted(() => ({
+  mockDb: {
+    getConversationMessages: vi.fn(),
+    getConversation: vi.fn(() => ({ success: false })),
+    updateConversation: vi.fn(),
+    createConversation: vi.fn(() => ({ success: true })),
+    insertMessage: vi.fn(),
+    updateMessage: vi.fn(),
+  },
+  agentStart: vi.fn().mockResolvedValue(undefined),
+  agentInstances: [] as Array<{ injectConversationHistory: ReturnType<typeof vi.fn> }>,
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    conversation: {
+      responseStream: { emit: vi.fn() },
+      confirmation: {
+        add: { emit: vi.fn() },
+        update: { emit: vi.fn() },
+        remove: { emit: vi.fn() },
+      },
+    },
+    cron: {
+      onJobCreated: { emit: vi.fn() },
+      onJobRemoved: { emit: vi.fn() },
+    },
+    cost: {
+      budgetGateBlocked: { emit: vi.fn() },
+    },
+  },
+}));
+
+vi.mock('@/common/platform', () => ({
+  getPlatformServices: () => ({
+    paths: { isPackaged: () => false, getAppPath: () => null },
+    worker: {
+      fork: vi.fn(() => ({
+        on: vi.fn().mockReturnThis(),
+        postMessage: vi.fn(),
+        kill: vi.fn(),
+      })),
+    },
+  }),
+}));
+
+vi.mock('@process/utils/shellEnv', () => ({
+  getEnhancedEnv: vi.fn(() => ({})),
+}));
+
+vi.mock('@process/services/database', () => ({
+  getDatabase: vi.fn(() => Promise.resolve(mockDb)),
+}));
+
+vi.mock('@process/services/database/export', () => ({
+  getDatabase: vi.fn(() => Promise.resolve(mockDb)),
+}));
+
+vi.mock('@process/utils/initStorage', () => ({
+  ProcessChat: { get: vi.fn(() => Promise.resolve([])) },
+  ProcessConfig: { get: vi.fn(() => Promise.resolve(false)) },
+}));
+
+vi.mock('@process/utils/message', () => ({
+  addMessage: vi.fn(),
+  addOrUpdateMessage: vi.fn(),
+}));
+
+vi.mock('@/common/utils', () => {
+  let counter = 0;
+  return { uuid: vi.fn(() => `uuid-${++counter}`) };
+});
+
+vi.mock('@/renderer/utils/common', () => {
+  let counter = 0;
+  return { uuid: vi.fn(() => `pipe-${++counter}`) };
+});
+
+vi.mock('@process/utils/mainLogger', () => ({
+  mainError: vi.fn(),
+  mainLog: vi.fn(),
+  mainWarn: vi.fn(),
+}));
+
+vi.mock('@process/services/cron/cronServiceSingleton', () => ({
+  cronService: {
+    addJob: vi.fn(async () => ({ id: 'cron-1', name: 'test', enabled: true })),
+    removeJob: vi.fn(async () => {}),
+    listJobsByConversation: vi.fn(async () => []),
+  },
+}));
+
+vi.mock('@process/agent/wcore', () => ({
+  WCoreAgent: function WCoreAgentMock(this: Record<string, unknown>) {
+    const injectConversationHistory = vi.fn().mockResolvedValue(undefined);
+    this.start = agentStart;
+    this.stop = vi.fn();
+    this.kill = vi.fn();
+    this.send = vi.fn().mockResolvedValue(undefined);
+    this.approveTool = vi.fn();
+    this.denyTool = vi.fn();
+    this.setConfig = vi.fn();
+    this.setMode = vi.fn();
+    this.sendCommand = vi.fn();
+    this.ping = vi.fn();
+    this.isAlive = true;
+    this.capabilities = null;
+    this.injectConversationHistory = injectConversationHistory;
+    agentInstances.push({ injectConversationHistory });
+  },
+}));
+
+vi.mock('@/process/task/agentUtils', () => ({
+  buildSystemInstructionsWithSkillsIndex: vi.fn(async () => undefined),
+  buildTurnSkillContext: vi.fn(async () => ({ advert: undefined, autoLoaded: [] })),
+  consumePendingSessionSkills: vi.fn(async () => undefined),
+  mergeLoadedSkillsExtra: vi.fn(async () => {}),
+  resolveCapabilitiesManifest: vi.fn(async () => undefined),
+}));
+
+import { WCoreManager } from '@/process/task/WCoreManager';
+
+const CONV_ID = 'conv-wcore-resume-replay';
+
+function textMessage(id: string, position: 'left' | 'right', content: string): IMessageText {
+  return {
+    id,
+    conversation_id: CONV_ID,
+    type: 'text',
+    position,
+    content: { content },
+  };
+}
+
+function editToolGroup(id: string): IMessageToolGroup {
+  return {
+    id,
+    conversation_id: CONV_ID,
+    type: 'tool_group',
+    position: 'left',
+    content: [
+      {
+        callId: 'call-edit-1',
+        description: 'Edited README quickstart',
+        name: 'Edit',
+        renderOutputAsMarkdown: true,
+        status: 'Success',
+        confirmationDetails: {
+          type: 'edit',
+          title: 'Edit README.md',
+          fileName: 'README.md',
+          fileDiff: '- old\n+ new',
+        },
+      },
+    ],
+  };
+}
+
+function createManager(): WCoreManager {
+  const data = {
+    workspace: '/test/workspace',
+    model: { name: 'test-provider', useModel: 'test-model', baseUrl: '', platform: 'test' },
+    conversation_id: CONV_ID,
+  };
+  return new WCoreManager(data as Record<string, unknown>, data.model as Record<string, unknown>);
+}
+
+describe('WCoreManager resume replay', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    agentInstances.length = 0;
+    agentStart.mockResolvedValue(undefined);
+  });
+
+  it('injects structured replay history with tool and file trajectory on resume', async () => {
+    const history: TMessage[] = [
+      textMessage('m1', 'right', 'Please fix the quickstart.'),
+      editToolGroup('m2'),
+      textMessage('m3', 'left', 'Updated README.md.'),
+    ];
+    mockDb.getConversationMessages.mockImplementation((_conversationId: string, _page: number, pageSize: number) => ({
+      data: pageSize === 1 ? [history[0]] : history,
+    }));
+
+    const manager = createManager();
+    await (manager as unknown as { agentReady: Promise<void> }).agentReady;
+
+    expect(agentInstances).toHaveLength(1);
+    expect(agentInstances[0].injectConversationHistory).toHaveBeenCalledTimes(1);
+    const injected = String(agentInstances[0].injectConversationHistory.mock.calls[0][0]);
+    expect(injected).toContain('[BEGIN WCORE RESUME REPLAY');
+    expect(injected).toContain('historical context only');
+    expect(injected).toContain('[assistant tool: Edit (Success)] Edited README quickstart');
+    expect(injected).toContain('file: README.md');
+    expect(injected).toContain('[assistant]: Updated README.md.');
+  });
+});

--- a/tests/unit/process/task/wcoreResumeReplay.test.ts
+++ b/tests/unit/process/task/wcoreResumeReplay.test.ts
@@ -1,0 +1,141 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import type {
+  IMessageCodexToolCall,
+  IMessageText,
+  IMessageToolCall,
+  IMessageToolGroup,
+  TMessage,
+} from '@/common/chat/chatLib';
+import { buildWCoreResumeReplayContext } from '@process/task/wcoreResumeReplay';
+
+function textMessage(id: string, position: 'left' | 'right', content: string): IMessageText {
+  return {
+    id,
+    conversation_id: 'conv-wcore-replay',
+    type: 'text',
+    position,
+    content: { content },
+  };
+}
+
+function editToolGroup(id: string): IMessageToolGroup {
+  return {
+    id,
+    conversation_id: 'conv-wcore-replay',
+    type: 'tool_group',
+    position: 'left',
+    content: [
+      {
+        callId: 'call-edit-1',
+        description: 'Edited README quickstart',
+        name: 'Edit',
+        renderOutputAsMarkdown: true,
+        status: 'Success',
+        confirmationDetails: {
+          type: 'edit',
+          title: 'Edit README.md',
+          fileName: 'README.md',
+          fileDiff: '- old\n+ new',
+          isModifying: true,
+        },
+      },
+    ],
+  };
+}
+
+function toolCall(id: string): IMessageToolCall {
+  return {
+    id,
+    conversation_id: 'conv-wcore-replay',
+    type: 'tool_call',
+    position: 'left',
+    content: {
+      callId: 'call-read-1',
+      name: 'read_file',
+      args: { path: 'src/process/task/WCoreManager.ts' },
+      status: 'success',
+    },
+  };
+}
+
+function codexPatch(id: string): IMessageCodexToolCall {
+  return {
+    id,
+    conversation_id: 'conv-wcore-replay',
+    type: 'codex_tool_call',
+    position: 'left',
+    content: {
+      toolCallId: 'codex-patch-1',
+      status: 'success',
+      title: 'Patch applied',
+      kind: 'patch',
+      subtype: 'generic',
+      content: [
+        {
+          type: 'diff',
+          filePath: 'src/process/task/wcoreResumeReplay.ts',
+          oldText: 'throw new Error',
+          newText: 'return replay',
+        },
+      ],
+    },
+  };
+}
+
+describe('buildWCoreResumeReplayContext', () => {
+  it('preserves text, tool calls, and file edit trajectory for WCore resume', () => {
+    const messages: TMessage[] = [
+      textMessage('m1', 'right', 'Please fix the quickstart.'),
+      editToolGroup('m2'),
+      textMessage('m3', 'left', 'Updated README.md and kept the commands unchanged.'),
+    ];
+
+    const result = buildWCoreResumeReplayContext(messages);
+
+    expect(result).not.toBeNull();
+    expect(result?.text).toContain('[BEGIN WCORE RESUME REPLAY');
+    expect(result?.text).toContain('historical context only');
+    expect(result?.text).toContain('[user]: Please fix the quickstart.');
+    expect(result?.text).toContain('[assistant tool: Edit (Success)] Edited README quickstart');
+    expect(result?.text).toContain('file: README.md');
+    expect(result?.text).toContain('[assistant]: Updated README.md and kept the commands unchanged.');
+    expect(result?.stats.replayedToolEvents).toBe(1);
+    expect(result?.stats.replayedFileEvents).toBe(1);
+  });
+
+  it('preserves standalone tool calls and Codex file patches', () => {
+    const messages: TMessage[] = [toolCall('m1'), codexPatch('m2')];
+
+    const result = buildWCoreResumeReplayContext(messages);
+
+    expect(result).not.toBeNull();
+    expect(result?.text).toContain('[assistant tool: read_file');
+    expect(result?.text).toContain('src/process/task/WCoreManager.ts');
+    expect(result?.text).toContain('[assistant tool: Patch applied (success)]');
+    expect(result?.text).toContain('src/process/task/wcoreResumeReplay.ts');
+    expect(result?.stats.replayedToolEvents).toBe(2);
+    expect(result?.stats.replayedFileEvents).toBe(2);
+  });
+
+  it('keeps the replay text within the configured character budget', () => {
+    const messages: TMessage[] = [
+      textMessage('m1', 'right', 'first turn establishes the task framing and should be dropped when budget is tiny'),
+      textMessage('m2', 'left', 'middle assistant response that is less important than the latest state'),
+      textMessage('m3', 'right', 'latest user request with the important resume intent'),
+    ];
+
+    const result = buildWCoreResumeReplayContext(messages, { maxChars: 180, perEntryCharLimit: 60 });
+
+    expect(result).not.toBeNull();
+    expect(result?.text.length).toBeLessThanOrEqual(180);
+    expect(result?.text).toContain('latest user request');
+    expect(result?.stats.truncated).toBe(true);
+    expect(result?.stats.omittedMessages).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Problem

WCore resume currently seeds restored sessions with a plain-text replay of only the last text messages. Tool calls, file edits, and other execution trajectory details are dropped, so a resumed engine can lose important context about what actions were already performed and which files were touched.

## Solution

Add a dedicated WCore resume replay builder that converts persisted conversation messages into a structured, budget-controlled text block for the existing `init_history` channel. This keeps the WCore protocol unchanged while preserving tool and file trajectory in a form the engine can consume safely on resume.

The replay block explicitly marks the content as historical context and instructs the engine not to repeat tool calls, reducing the risk that restored tool history is interpreted as new work to execute.

## Changes

- Added `buildWCoreResumeReplayContext` for WCore resume history generation.
- Preserved text messages, `tool_group` entries, standalone `tool_call` entries, and `codex_tool_call` file patches in replay output.
- Added character-budget controls for total replay size and per-entry snippets.
- Replaced the inline text-only resume history logic in `WCoreManager` with the new replay builder.
- Added unit tests for replay formatting, file/tool trajectory preservation, budget truncation, and WCoreManager resume integration.
- Added a minimal demo script: `bun scripts/demo-wcore-resume-replay.ts`.

## Testing

- `bun scripts/demo-wcore-resume-replay.ts`
- `ELECTRON_OVERRIDE_DIST_PATH=".../Electron.app/Contents/MacOS" bun run test tests/unit/process/task/wcoreResumeReplay.test.ts tests/unit/process/task/WCoreManagerResumeReplay.test.ts tests/unit/WCoreManagerTurnCompletion.test.ts`
- `bun run typecheck`
- `bun run format:check src/process/task/WCoreManager.ts src/process/task/wcoreResumeReplay.ts tests/unit/process/task/wcoreResumeReplay.test.ts tests/unit/process/task/WCoreManagerResumeReplay.test.ts scripts/demo-wcore-resume-replay.ts`
- `bun run lint src/process/task/WCoreManager.ts src/process/task/wcoreResumeReplay.ts tests/unit/process/task/wcoreResumeReplay.test.ts tests/unit/process/task/WCoreManagerResumeReplay.test.ts scripts/demo-wcore-resume-replay.ts`

Test coverage includes:
- Text plus tool-group file edit replay.
- Standalone tool calls and Codex patch file paths.
- Replay truncation within a configured character budget.
- WCoreManager resume integration through `injectConversationHistory`.

## Notes for Reviewer

- This intentionally keeps `WCoreAgent.injectConversationHistory(text)` unchanged to avoid changing the Rust/WCore protocol surface.
- The replay format is textual by design because the current WCore init-history channel accepts only a string.
- The replay block includes “historical context only; do not repeat tool calls” to reduce ambiguity around restored tool history.
- The local Electron install is missing `path.txt`, so WCore-related tests require `ELECTRON_OVERRIDE_DIST_PATH` in this environment.