### PR TITLE
feat(mcp): bundle + auto-enable Playwright MCP browser capability (#465)

### DIFF
--- a/src/process/resources/builtinMcp/constants.ts
+++ b/src/process/resources/builtinMcp/constants.ts
@@ -99,6 +99,20 @@ export const BUILTIN_CONCIERGE_DIAG_ID = 'concierge-diag';
 export const BUILTIN_CONCIERGE_DIAG_NAME = 'wayland-concierge-diag';
 export const BUILTIN_CONCIERGE_DIAG_TOOL_NAME = 'wayland_concierge_diag';
 
+// ── Bundled Playwright MCP (browser capability, #465) ────────────────────────
+// Unlike the @wayland builtins above (local node scripts), this is the upstream
+// npm package `@playwright/mcp` run through the bundled bun (npx->bun). It is
+// seeded default-ON so the agent has browser tools out of the box; chromium is
+// fetched on first use into a managed dir via PLAYWRIGHT_BROWSERS_PATH.
+// `name` mirrors the catalog entry's sanitized name so a manual install dedupes.
+export const BUILTIN_PLAYWRIGHT_ID = 'builtin-playwright-mcp';
+export const BUILTIN_PLAYWRIGHT_NAME = 'com.microsoft-playwright-mcp';
+/** Catalog entry id (src/renderer/mcp-catalog/entries/com.microsoft-playwright-mcp.json). */
+export const BUILTIN_PLAYWRIGHT_LIBRARY_ENTRY_ID = 'com.microsoft/playwright-mcp';
+/** Pinned to the catalog entry's version so the server and the install use the same package. */
+export const BUILTIN_PLAYWRIGHT_VERSION = '0.0.75';
+export const BUILTIN_PLAYWRIGHT_PACKAGE = `@playwright/mcp@${BUILTIN_PLAYWRIGHT_VERSION}`;
+
 export function isBuiltinConciergeDiagName(name?: string | null): boolean {
   if (!name) return false;
   return name === BUILTIN_CONCIERGE_DIAG_NAME;

--- a/src/process/resources/builtinMcp/constants.ts
+++ b/src/process/resources/builtinMcp/constants.ts
@@ -112,6 +112,26 @@ export const BUILTIN_PLAYWRIGHT_LIBRARY_ENTRY_ID = 'com.microsoft/playwright-mcp
 /** Pinned to the catalog entry's version so the server and the install use the same package. */
 export const BUILTIN_PLAYWRIGHT_VERSION = '0.0.75';
 export const BUILTIN_PLAYWRIGHT_PACKAGE = `@playwright/mcp@${BUILTIN_PLAYWRIGHT_VERSION}`;
+/**
+ * SSRF guardrail (#465, Sean ack): origins the bundled browser must never request
+ * — IPv4 link-local (169.254.0.0/16, via wildcard) plus the cloud instance-
+ * metadata endpoints that ride it (AWS/Azure/GCP/Oracle/DO `169.254.169.254`,
+ * GCP `metadata.google.internal`, Alibaba `100.100.100.200`). Passed to
+ * @playwright/mcp via `--blocked-origins` (semicolon-separated). Verified live:
+ * a nav to 169.254.169.254 returns net::ERR_BLOCKED_BY_CLIENT. NOTE: Playwright
+ * documents this as a guardrail, not a hard boundary (it does not affect
+ * redirects) — defense-in-depth, the network layer stays the real boundary.
+ */
+export const BUILTIN_PLAYWRIGHT_BLOCKED_ORIGINS = [
+  'http://169.254.169.254',
+  'https://169.254.169.254',
+  'http://169.254.*',
+  'https://169.254.*',
+  'http://metadata.google.internal',
+  'https://metadata.google.internal',
+  'http://100.100.100.200',
+  'https://100.100.100.200',
+].join(';');
 
 export function isBuiltinConciergeDiagName(name?: string | null): boolean {
   if (!name) return false;

--- a/src/process/services/mcpServices/McpService.ts
+++ b/src/process/services/mcpServices/McpService.ts
@@ -16,6 +16,8 @@ import { OpencodeMcpAgent } from './agents/OpencodeMcpAgent';
 import { WCoreMcpAgent } from './agents/WCoreMcpAgent';
 import type { IMcpProtocol, DetectedMcpServer, McpConnectionTestResult, McpSyncResult, McpSource } from './McpProtocol';
 import { validateMcpServer, sanitizeMcpServerName } from './validateMcpServer';
+import { ensurePlaywrightChromium } from './playwrightBrowsers';
+import { BUILTIN_PLAYWRIGHT_ID } from '@process/resources/builtinMcp/constants';
 
 /**
  * MCP service - coordinates the MCP operation protocol across agents
@@ -331,6 +333,14 @@ export class McpService {
 
       const results = await Promise.all(promises);
 
+      // #465 first-run browser provisioning: if the bundled Playwright MCP is
+      // enabled, make sure chromium is installed into its managed dir. Fire-and-
+      // forget + guarded (one download ever) so it never blocks sync; the agent's
+      // first browse then finds the browser instead of erroring.
+      if (enabledServers.some((s) => s.id === BUILTIN_PLAYWRIGHT_ID)) {
+        void ensurePlaywrightChromium();
+      }
+
       const allSuccess = results.every((r) => r.success);
 
       return { success: allSuccess, results };
@@ -362,11 +372,7 @@ export class McpService {
    */
   private async attachOAuthToken(server: IMcpServer): Promise<IMcpServer> {
     const transport = server.transport;
-    if (
-      transport.type !== 'http' &&
-      transport.type !== 'sse' &&
-      transport.type !== 'streamable_http'
-    ) {
+    if (transport.type !== 'http' && transport.type !== 'sse' && transport.type !== 'streamable_http') {
       return server;
     }
     const headers = transport.headers ?? {};

--- a/src/process/services/mcpServices/McpService.ts
+++ b/src/process/services/mcpServices/McpService.ts
@@ -16,8 +16,6 @@ import { OpencodeMcpAgent } from './agents/OpencodeMcpAgent';
 import { WCoreMcpAgent } from './agents/WCoreMcpAgent';
 import type { IMcpProtocol, DetectedMcpServer, McpConnectionTestResult, McpSyncResult, McpSource } from './McpProtocol';
 import { validateMcpServer, sanitizeMcpServerName } from './validateMcpServer';
-import { ensurePlaywrightChromium } from './playwrightBrowsers';
-import { BUILTIN_PLAYWRIGHT_ID } from '@process/resources/builtinMcp/constants';
 
 /**
  * MCP service - coordinates the MCP operation protocol across agents
@@ -333,14 +331,6 @@ export class McpService {
 
       const results = await Promise.all(promises);
 
-      // #465 first-run browser provisioning: if the bundled Playwright MCP is
-      // enabled, make sure chromium is installed into its managed dir. Fire-and-
-      // forget + guarded (one download ever) so it never blocks sync; the agent's
-      // first browse then finds the browser instead of erroring.
-      if (enabledServers.some((s) => s.id === BUILTIN_PLAYWRIGHT_ID)) {
-        void ensurePlaywrightChromium();
-      }
-
       const allSuccess = results.every((r) => r.success);
 
       return { success: allSuccess, results };
@@ -372,7 +362,11 @@ export class McpService {
    */
   private async attachOAuthToken(server: IMcpServer): Promise<IMcpServer> {
     const transport = server.transport;
-    if (transport.type !== 'http' && transport.type !== 'sse' && transport.type !== 'streamable_http') {
+    if (
+      transport.type !== 'http' &&
+      transport.type !== 'sse' &&
+      transport.type !== 'streamable_http'
+    ) {
       return server;
     }
     const headers = transport.headers ?? {};

--- a/src/process/services/mcpServices/agents/WCoreMcpAgent.ts
+++ b/src/process/services/mcpServices/agents/WCoreMcpAgent.ts
@@ -13,6 +13,8 @@ import { resolveWCoreBinary } from '@process/agent/wcore/binaryResolver';
 import type { McpOperationResult } from '../McpProtocol';
 import { AbstractMcpAgent } from '../McpProtocol';
 import type { IMcpServer, IMcpServerTransport } from '@/common/config/storage';
+import { ensurePlaywrightChromium } from '../playwrightBrowsers';
+import { BUILTIN_PLAYWRIGHT_ID } from '@process/resources/builtinMcp/constants';
 
 /**
  * wayland-core config.toml transport type (kebab-case)
@@ -244,6 +246,15 @@ export class WCoreMcpAgent extends AbstractMcpAgent {
         }
 
         await this.writeConfig(config);
+
+        // #465 first-run browser provisioning: once the bundled Playwright MCP
+        // is written to the engine config, make sure chromium is installed into
+        // its managed dir so the agent's first browse finds it. Fire-and-forget
+        // + guarded (one download ever), so it never blocks the sync.
+        if (mcpServers.some((s) => s.id === BUILTIN_PLAYWRIGHT_ID)) {
+          void ensurePlaywrightChromium();
+        }
+
         return { success: true };
       } catch (error) {
         return { success: false, error: error instanceof Error ? error.message : String(error) };

--- a/src/process/services/mcpServices/playwrightBrowsers.ts
+++ b/src/process/services/mcpServices/playwrightBrowsers.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * First-run chromium provisioning for the bundled Playwright MCP server (#465).
+ *
+ * `@playwright/mcp` does NOT ship or auto-download a browser; it errors on the
+ * first browse if chromium is missing. Its `cli.js` exposes an `install-browser`
+ * command (→ `playwright install`). We run it once, lazily, into an app-managed
+ * directory (PLAYWRIGHT_BROWSERS_PATH) so the download is cached and never
+ * repeats, and so it lands where the spawned server looks for it. The install
+ * runs through the SAME bundled bun the server uses, so no system Node is needed.
+ */
+import { spawn } from 'child_process';
+import { readdirSync } from 'fs';
+import path from 'path';
+import log from 'electron-log';
+import { BUILTIN_PLAYWRIGHT_PACKAGE } from '@process/resources/builtinMcp/constants';
+import { getDataPath } from '@process/utils/utils';
+import { getEnhancedEnv, resolveNpxPath } from '@process/utils/shellEnv';
+
+/** App-managed directory chromium is installed into and the MCP server reads from. */
+export function getPlaywrightBrowsersDir(): string {
+  return path.join(getDataPath(), 'playwright-browsers');
+}
+
+/** True if a chromium build is already present in the managed browsers dir. */
+export function isChromiumInstalled(browsersDir: string = getPlaywrightBrowsersDir()): boolean {
+  try {
+    return readdirSync(browsersDir).some((entry) => entry.startsWith('chromium-'));
+  } catch {
+    // Dir doesn't exist yet → not installed.
+    return false;
+  }
+}
+
+// One install at a time across the process; subsequent callers await the same run.
+let inflight: Promise<boolean> | null = null;
+
+/**
+ * Ensure chromium is installed for the Playwright MCP server. Idempotent and
+ * best-effort: returns true if chromium is present (already, or after a
+ * successful install), false on failure. Never throws — a failed install must
+ * not break MCP sync or chat; the agent simply gets a browse error it can retry.
+ */
+export function ensurePlaywrightChromium(browsersDir: string = getPlaywrightBrowsersDir()): Promise<boolean> {
+  if (isChromiumInstalled(browsersDir)) return Promise.resolve(true);
+  if (inflight) return inflight;
+
+  inflight = new Promise<boolean>((resolve) => {
+    const bun = resolveNpxPath(process.env);
+    const args = ['x', '--bun', BUILTIN_PLAYWRIGHT_PACKAGE, 'install-browser', 'chromium'];
+    const env = { ...getEnhancedEnv({ PLAYWRIGHT_BROWSERS_PATH: browsersDir }), TERM: 'dumb', NO_COLOR: '1' };
+    log.info('[playwright] installing chromium (first run)', { dir: browsersDir });
+
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(bun, args, { env, stdio: ['ignore', 'pipe', 'pipe'] });
+    } catch (err) {
+      log.warn('[playwright] failed to spawn chromium install', { err });
+      resolve(false);
+      return;
+    }
+
+    let stderr = '';
+    child.stderr?.on('data', (d) => {
+      if (stderr.length < 4096) stderr += String(d);
+    });
+    child.on('error', (err) => {
+      log.warn('[playwright] chromium install process error', { err });
+      resolve(false);
+    });
+    child.on('close', (code) => {
+      const ok = code === 0 && isChromiumInstalled(browsersDir);
+      if (ok) {
+        log.info('[playwright] chromium install complete', { dir: browsersDir });
+      } else {
+        log.warn('[playwright] chromium install failed', { code, stderr: stderr.slice(0, 1000) });
+      }
+      resolve(ok);
+    });
+  }).finally(() => {
+    inflight = null;
+  });
+
+  return inflight;
+}

--- a/src/process/utils/initStorage.ts
+++ b/src/process/utils/initStorage.ts
@@ -46,9 +46,15 @@ import {
   BUILTIN_IMAGE_GEN_ID,
   BUILTIN_IMAGE_GEN_LEGACY_NAMES,
   BUILTIN_IMAGE_GEN_NAME,
+  BUILTIN_PLAYWRIGHT_ID,
+  BUILTIN_PLAYWRIGHT_LIBRARY_ENTRY_ID,
+  BUILTIN_PLAYWRIGHT_NAME,
+  BUILTIN_PLAYWRIGHT_PACKAGE,
   BUILTIN_SEARCH_SKILLS_ID,
   BUILTIN_SEARCH_SKILLS_NAME,
 } from '../resources/builtinMcp/constants';
+import { resolveNpxPath } from './shellEnv';
+import { getPlaywrightBrowsersDir } from '../services/mcpServices/playwrightBrowsers';
 import { getMcpScriptPath, inspectMcpScripts } from './mcpScriptDir';
 import { getBuiltinCatalogAssistants } from './builtinCatalog';
 // Platform and architecture types (moved from deleted updateConfig)
@@ -966,6 +972,62 @@ const ensureBuiltinMcpServers = async (): Promise<void> => {
         createdAt: now,
         updatedAt: now,
         originalJson: buildConciergeDiagOriginalJson(conciergeDiagScriptPath, conciergeDiagEnv),
+      };
+      mcpServers.push(newServer);
+      changed = true;
+    }
+
+    // ── Built-in Playwright MCP server (browser capability, #465) ────────────
+    // The upstream @playwright/mcp server, run through the bundled bun (no system
+    // Node). Seeded ENABLED so the agent has browser tools out of the box. The
+    // `npx`->bun swap is app-side only (McpProtocol), but the wcore engine spawns
+    // MCP servers straight from its config.toml — so we pre-resolve the bundled
+    // bun HERE (command + `x --bun @playwright/mcp@<ver>`), so every spawn path
+    // (wcore engine, ACP CLIs, app SDK) runs it identically with no system Node.
+    // Chromium is fetched on first use into PLAYWRIGHT_BROWSERS_PATH; see
+    // playwrightBrowsers.ensurePlaywrightChromium (triggered from McpService).
+    const playwrightBun = resolveNpxPath(process.env);
+    const playwrightArgs = ['x', '--bun', BUILTIN_PLAYWRIGHT_PACKAGE];
+    const playwrightEnv: Record<string, string> = { PLAYWRIGHT_BROWSERS_PATH: getPlaywrightBrowsersDir() };
+    const buildPlaywrightOriginalJson = (command: string, args: string[], env: Record<string, string>) =>
+      JSON.stringify({ [BUILTIN_PLAYWRIGHT_NAME]: { command, args, env } }, null, 2);
+    const playwrightExistingIdx = mcpServers.findIndex((s) => s.builtin === true && s.id === BUILTIN_PLAYWRIGHT_ID);
+
+    if (playwrightExistingIdx >= 0) {
+      // Refresh command/args/env in case the bundled bun path or managed browsers
+      // dir changed across an app update. Never flip `enabled` — respect a user
+      // who turned browsing off.
+      const existing = mcpServers[playwrightExistingIdx];
+      const t = existing.transport;
+      if (t.type === 'stdio') {
+        const needsUpdate =
+          t.command !== playwrightBun ||
+          JSON.stringify(t.args ?? []) !== JSON.stringify(playwrightArgs) ||
+          JSON.stringify(t.env ?? {}) !== JSON.stringify(playwrightEnv);
+        if (needsUpdate) {
+          mcpServers[playwrightExistingIdx] = {
+            ...existing,
+            transport: { ...t, command: playwrightBun, args: playwrightArgs, env: playwrightEnv },
+            originalJson: buildPlaywrightOriginalJson(playwrightBun, playwrightArgs, playwrightEnv),
+            updatedAt: now,
+          };
+          changed = true;
+        }
+      }
+    } else {
+      const newServer: IMcpServer = {
+        id: BUILTIN_PLAYWRIGHT_ID,
+        name: BUILTIN_PLAYWRIGHT_NAME,
+        description:
+          'Headless browser automation (navigate, click, type, screenshot) powered by Playwright. Chromium is downloaded on first use.',
+        enabled: true,
+        builtin: true,
+        source: 'library',
+        libraryEntryId: BUILTIN_PLAYWRIGHT_LIBRARY_ENTRY_ID,
+        transport: { type: 'stdio', command: playwrightBun, args: playwrightArgs, env: playwrightEnv },
+        createdAt: now,
+        updatedAt: now,
+        originalJson: buildPlaywrightOriginalJson(playwrightBun, playwrightArgs, playwrightEnv),
       };
       mcpServers.push(newServer);
       changed = true;

--- a/src/process/utils/initStorage.ts
+++ b/src/process/utils/initStorage.ts
@@ -46,6 +46,7 @@ import {
   BUILTIN_IMAGE_GEN_ID,
   BUILTIN_IMAGE_GEN_LEGACY_NAMES,
   BUILTIN_IMAGE_GEN_NAME,
+  BUILTIN_PLAYWRIGHT_BLOCKED_ORIGINS,
   BUILTIN_PLAYWRIGHT_ID,
   BUILTIN_PLAYWRIGHT_LIBRARY_ENTRY_ID,
   BUILTIN_PLAYWRIGHT_NAME,
@@ -986,17 +987,42 @@ const ensureBuiltinMcpServers = async (): Promise<void> => {
     // (wcore engine, ACP CLIs, app SDK) runs it identically with no system Node.
     // Chromium is fetched on first use into PLAYWRIGHT_BROWSERS_PATH; see
     // playwrightBrowsers.ensurePlaywrightChromium (triggered from McpService).
+    // SSRF guardrail (#465): block link-local + cloud-metadata origins.
     const playwrightBun = resolveNpxPath(process.env);
-    const playwrightArgs = ['x', '--bun', BUILTIN_PLAYWRIGHT_PACKAGE];
+    const playwrightArgs = [
+      'x',
+      '--bun',
+      BUILTIN_PLAYWRIGHT_PACKAGE,
+      '--blocked-origins',
+      BUILTIN_PLAYWRIGHT_BLOCKED_ORIGINS,
+    ];
     const playwrightEnv: Record<string, string> = { PLAYWRIGHT_BROWSERS_PATH: getPlaywrightBrowsersDir() };
     const buildPlaywrightOriginalJson = (command: string, args: string[], env: Record<string, string>) =>
       JSON.stringify({ [BUILTIN_PLAYWRIGHT_NAME]: { command, args, env } }, null, 2);
-    const playwrightExistingIdx = mcpServers.findIndex((s) => s.builtin === true && s.id === BUILTIN_PLAYWRIGHT_ID);
+    // Match ANY existing Playwright server, not just our builtin id: a user may
+    // already have one (catalog/manual install) whose sanitized name collides
+    // with ours — two servers sharing the wcore config.toml [mcp.servers."<name>"]
+    // key is a TOML collision. Detect by id / libraryEntryId / name / @playwright/mcp arg.
+    const looksLikePlaywright = (s: IMcpServer): boolean => {
+      if (s.id === BUILTIN_PLAYWRIGHT_ID) return true;
+      if (s.libraryEntryId === BUILTIN_PLAYWRIGHT_LIBRARY_ENTRY_ID) return true;
+      if (s.name === BUILTIN_PLAYWRIGHT_NAME) return true;
+      return (
+        s.transport.type === 'stdio' &&
+        (s.transport.args ?? []).some((a) => typeof a === 'string' && a.includes('@playwright/mcp'))
+      );
+    };
+    const playwrightExistingIdx = mcpServers.findIndex(looksLikePlaywright);
 
-    if (playwrightExistingIdx >= 0) {
-      // Refresh command/args/env in case the bundled bun path or managed browsers
-      // dir changed across an app update. Never flip `enabled` — respect a user
-      // who turned browsing off.
+    if (playwrightExistingIdx >= 0 && mcpServers[playwrightExistingIdx].id !== BUILTIN_PLAYWRIGHT_ID) {
+      // ADOPT a pre-existing user/manual Playwright install: do NOT seed a second
+      // server (would collide on the wcore TOML key). The user owns that server's
+      // enabled state and args; we leave it untouched.
+      console.log('[Wayland] Adopting existing Playwright MCP server; skipping builtin seed');
+    } else if (playwrightExistingIdx >= 0) {
+      // Our builtin exists → refresh command/args/env in case the bundled bun
+      // path, managed browsers dir, or blocked-origins changed across an app
+      // update. Never flip `enabled` — respect a user who turned browsing off.
       const existing = mcpServers[playwrightExistingIdx];
       const t = existing.transport;
       if (t.type === 'stdio') {

--- a/tests/unit/playwrightBrowsers.test.ts
+++ b/tests/unit/playwrightBrowsers.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #465 - first-run chromium provisioning for the bundled Playwright MCP server.
+ * The install is guarded by a presence check so the ~150MB download happens at
+ * most once and never on a profile that already has chromium. These exercise
+ * that guard against a real temp dir (no network, no spawn when present).
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import os from 'os';
+import path from 'path';
+import fs from 'fs/promises';
+import { ensurePlaywrightChromium, isChromiumInstalled } from '@process/services/mcpServices/playwrightBrowsers';
+
+let tmp: string;
+
+beforeAll(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'wl-465-pw-'));
+});
+afterAll(async () => {
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+describe('isChromiumInstalled (#465)', () => {
+  it('is false for a missing dir', () => {
+    expect(isChromiumInstalled(path.join(tmp, 'nope'))).toBe(false);
+  });
+
+  it('is false for an empty browsers dir', async () => {
+    const dir = path.join(tmp, 'empty');
+    await fs.mkdir(dir, { recursive: true });
+    expect(isChromiumInstalled(dir)).toBe(false);
+  });
+
+  it('is false when only non-chromium browsers are present', async () => {
+    const dir = path.join(tmp, 'ffonly');
+    await fs.mkdir(path.join(dir, 'firefox-1234'), { recursive: true });
+    expect(isChromiumInstalled(dir)).toBe(false);
+  });
+
+  it('is true when a chromium build is present', async () => {
+    const dir = path.join(tmp, 'has-chromium');
+    await fs.mkdir(path.join(dir, 'chromium-1224'), { recursive: true });
+    await fs.mkdir(path.join(dir, 'ffmpeg-1011'), { recursive: true });
+    expect(isChromiumInstalled(dir)).toBe(true);
+  });
+});
+
+describe('ensurePlaywrightChromium (#465)', () => {
+  it('short-circuits to true (no spawn, no network) when chromium already exists', async () => {
+    const dir = path.join(tmp, 'cached');
+    await fs.mkdir(path.join(dir, 'chromium-1224'), { recursive: true });
+    // If this tried to spawn/download it would hang or fail offline; the presence
+    // guard must return immediately.
+    await expect(ensurePlaywrightChromium(dir)).resolves.toBe(true);
+  });
+});

--- a/tests/unit/playwrightBrowsersInstall.test.ts
+++ b/tests/unit/playwrightBrowsersInstall.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #465 - the first-run chromium install must be resilient: an offline machine
+ * (or any spawn/exit failure) must resolve to `false` WITHOUT throwing, so it
+ * never bricks MCP sync or chat. These mock the install subprocess to fail and
+ * assert ensurePlaywrightChromium degrades gracefully.
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'events';
+import os from 'os';
+import path from 'path';
+import fs from 'fs/promises';
+
+// A fake child process whose behavior each test sets via `mode`.
+let mode: 'exit-nonzero' | 'spawn-error' = 'exit-nonzero';
+vi.mock('child_process', () => ({
+  spawn: () => {
+    const child = new EventEmitter() as EventEmitter & { stderr: EventEmitter; stdout: EventEmitter };
+    child.stderr = new EventEmitter();
+    child.stdout = new EventEmitter();
+    queueMicrotask(() => {
+      if (mode === 'spawn-error') {
+        child.emit('error', new Error('ENOENT: bun not found'));
+      } else {
+        child.stderr.emit('data', 'offline: failed to download chromium');
+        child.emit('close', 1); // non-zero exit (e.g. network failure)
+      }
+    });
+    return child;
+  },
+}));
+
+// Keep electron out of the unit env (shellEnv pulls it transitively).
+vi.mock('electron', () => ({ app: { getPath: () => os.tmpdir() } }));
+
+import { ensurePlaywrightChromium } from '@process/services/mcpServices/playwrightBrowsers';
+
+let emptyDir: string;
+beforeAll(async () => {
+  emptyDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wl-465-off-'));
+});
+afterAll(async () => {
+  await fs.rm(emptyDir, { recursive: true, force: true });
+});
+
+describe('ensurePlaywrightChromium offline/failure resilience (#465)', () => {
+  it('resolves false (never throws) when the install exits non-zero (offline)', async () => {
+    mode = 'exit-nonzero';
+    await expect(ensurePlaywrightChromium(path.join(emptyDir, 'a'))).resolves.toBe(false);
+  });
+
+  it('resolves false (never throws) when the install process errors (no bun)', async () => {
+    mode = 'spawn-error';
+    await expect(ensurePlaywrightChromium(path.join(emptyDir, 'b'))).resolves.toBe(false);
+  });
+});

--- a/tests/unit/playwrightBrowsersInstall.test.ts
+++ b/tests/unit/playwrightBrowsersInstall.test.ts
@@ -14,10 +14,13 @@ import os from 'os';
 import path from 'path';
 import fs from 'fs/promises';
 
-// A fake child process whose behavior each test sets via `mode`.
+// A fake child process whose behavior each test sets via `mode`. `spawnCount`
+// lets the concurrency test assert the in-flight guard collapses callers.
 let mode: 'exit-nonzero' | 'spawn-error' = 'exit-nonzero';
+let spawnCount = 0;
 vi.mock('child_process', () => ({
   spawn: () => {
+    spawnCount++;
     const child = new EventEmitter() as EventEmitter & { stderr: EventEmitter; stdout: EventEmitter };
     child.stderr = new EventEmitter();
     child.stdout = new EventEmitter();
@@ -55,5 +58,19 @@ describe('ensurePlaywrightChromium offline/failure resilience (#465)', () => {
   it('resolves false (never throws) when the install process errors (no bun)', async () => {
     mode = 'spawn-error';
     await expect(ensurePlaywrightChromium(path.join(emptyDir, 'b'))).resolves.toBe(false);
+  });
+
+  it('collapses concurrent callers to a single install (in-flight guard)', async () => {
+    mode = 'exit-nonzero';
+    spawnCount = 0;
+    const dir = path.join(emptyDir, 'c');
+    const [a, b, c] = await Promise.all([
+      ensurePlaywrightChromium(dir),
+      ensurePlaywrightChromium(dir),
+      ensurePlaywrightChromium(dir),
+    ]);
+    // Three concurrent calls, one spawned install; all share the result.
+    expect(spawnCount).toBe(1);
+    expect([a, b, c]).toEqual([false, false, false]);
   });
 });


### PR DESCRIPTION
Closes #465 (do not auto-close — release/Sean action). Base: `main` (Overwatch ruling; `integration/0.11.4` doesn't exist, 0.11.7 is current).

## What
The agent now has a **browser out of the box** — navigate, click, type, screenshot — via the bundled, default-ON `@playwright/mcp`, with chromium fetched on first use. Faithful implementation of the Hermes browser basis (external server + first-run chromium), using the better-maintained Playwright MCP. Native engine Camoufox/Browser tool stays off (wayland-core#113).

## How
1. **Seed default-ON** — `ensureBuiltinMcpServers` (`initStorage.ts`) seeds the catalog server `enabled:true` (mirrors search-skills / concierge-diag). `PLAYWRIGHT_BROWSERS_PATH` → an app-managed dir (`getDataPath()/playwright-browsers`) so chromium is cached + reused.
2. **Bundled bun, no system Node** — the transport is **pre-resolved to bun** at seed time (`command=<bun>`, `args=['x','--bun','@playwright/mcp@0.0.75']`), NOT raw `npx`. *Why:* the `npx`→bun swap (`McpProtocol`) is **app-side only**, but the wcore engine spawns MCP servers straight from its `config.toml` (`WCoreMcpAgent.toWCoreConfig` writes `command` verbatim) — a raw `npx` there needs system Node, absent on most end-user Macs. Pre-resolving makes wcore / ACP / app all run it identically.
3. **First-run chromium** — `@playwright/mcp` ships no browser and doesn't auto-install; its `cli.js` exposes `install-browser` (→ `playwright install`). `ensurePlaywrightChromium` runs it once into the managed dir, **guarded by a presence check** (downloads at most once, never re-downloads), fired from `McpService` sync when the server is enabled. Best-effort — never blocks sync or chat.

## Tests
- Unit `playwrightBrowsers.test.ts`: presence guard (missing/empty/ff-only/chromium) + ensure short-circuits to true (no spawn) when cached.
- `prek` green: TypeScript / Oxlint / Oxfmt.

## LIVE-verified in the running app (mac arm64) — the hard gate
Built, launched, drove it end-to-end:
1. **Seeded enabled** — `mcp.config` shows `builtin-playwright-mcp` / `com.microsoft-playwright-mcp` **enabled=true**, transport `command=bun, args=[x,--bun,@playwright/mcp@0.0.75], env.PLAYWRIGHT_BROWSERS_PATH=…/.wayland-dev/playwright-browsers`.
2. **Wired to the default engine** — after MCP sync, wcore's `config.toml` has `[mcp.servers."com.microsoft-playwright-mcp"]` with `command="bun"` (NOT npx) + the `PLAYWRIGHT_BROWSERS_PATH` env.
3. **First-run install** — the app's `ensurePlaywrightChromium` hook fired on sync and installed `chromium-1224` into the managed dir (then re-runs are cached — no re-download).
4. **Real navigation + screenshot** — driving the seeded transport: connected, **23 tools** incl. `browser_navigate`/`browser_take_screenshot`; navigated to `https://example.com`; captured a real **16,667-byte PNG** that renders the "Example Domain" page. ✅

(The drive used the app's exact seeded transport + managed browser dir — the same `bun x @playwright/mcp` the engine spawns. A full LLM-driven turn is the agent picking the tool, orthogonal to the bundle/enable/first-run work here.)

## Gate
Independent adversarial cross-audit running; will fold fixes before requesting merge. Per the merge gate this still needs a **second independent (non-author) audit**. Not self-merging.
