### PR TITLE
fix(mcp): bump Google Workspace MCP 1.4.2 -> 1.22.0 (server crashed on import via pydantic incompat)

### DIFF
--- a/src/renderer/mcp-catalog/entries/io.github.taylorwilsdon-google-workspace-mcp.json
+++ b/src/renderer/mcp-catalog/entries/io.github.taylorwilsdon-google-workspace-mcp.json
@@ -14,9 +14,24 @@
       "runtimeHint": "uvx",
       "transport": { "type": "stdio" },
       "environmentVariables": [
-        { "name": "GOOGLE_OAUTH_CLIENT_ID", "description": "OAuth client ID from your Google Cloud Console.", "isRequired": true, "isSecret": false },
-        { "name": "GOOGLE_OAUTH_CLIENT_SECRET", "description": "OAuth client secret.", "isRequired": true, "isSecret": true },
-        { "name": "GOOGLE_OAUTH_REDIRECT_URI", "description": "Local redirect URI Wayland listens on.", "isRequired": false, "default": "http://localhost:8765" }
+        {
+          "name": "GOOGLE_OAUTH_CLIENT_ID",
+          "description": "OAuth client ID from your Google Cloud Console.",
+          "isRequired": true,
+          "isSecret": false
+        },
+        {
+          "name": "GOOGLE_OAUTH_CLIENT_SECRET",
+          "description": "OAuth client secret.",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "GOOGLE_OAUTH_REDIRECT_URI",
+          "description": "Local redirect URI Wayland listens on.",
+          "isRequired": false,
+          "default": "http://localhost:8765"
+        }
       ]
     }
   ],
@@ -53,7 +68,11 @@
       { "label": "Slides", "count": 5 },
       { "label": "Tasks & Forms", "count": 5 }
     ],
-    "setupGuide": { "path": "guides/io.github.taylorwilsdon-google-workspace-mcp.md", "estimatedMinutes": 7, "stepCount": 4 },
+    "setupGuide": {
+      "path": "guides/io.github.taylorwilsdon-google-workspace-mcp.md",
+      "estimatedMinutes": 7,
+      "stepCount": 4
+    },
     "platforms": ["macos", "windows", "linux"],
     "minWaylandVersion": "0.8.0"
   }

--- a/src/renderer/mcp-catalog/entries/io.github.taylorwilsdon-google-workspace-mcp.json
+++ b/src/renderer/mcp-catalog/entries/io.github.taylorwilsdon-google-workspace-mcp.json
@@ -3,14 +3,14 @@
   "name": "io.github.taylorwilsdon/google-workspace-mcp",
   "title": "Google Workspace",
   "description": "Gmail, Calendar, Drive, Docs, Sheets, Slides, Chat, Forms, Tasks - every Google service in one MCP.",
-  "version": "1.4.2",
+  "version": "1.22.0",
   "websiteUrl": "https://github.com/taylorwilsdon/google_workspace_mcp",
   "repository": { "url": "https://github.com/taylorwilsdon/google_workspace_mcp", "source": "github" },
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "workspace-mcp",
-      "version": "1.4.2",
+      "version": "1.22.0",
       "runtimeHint": "uvx",
       "transport": { "type": "stdio" },
       "environmentVariables": [


### PR DESCRIPTION
Live-test finding while verifying the student's Google Workspace report.

**Student's reported error (OAuth requires HTTP-family transport, got stdio): already fixed** in 0.11.4 (PR #341); they're on a stale build. Confirmed on main: Sign-in no longer throws that error, routes correctly to the env-credential/install flow.

**The NEXT blocker, found live:** the spawned server crashes on import. `uvx workspace-mcp==1.4.2` resolves a fastmcp whose settings.py is incompatible with current pydantic (>=2.11 rejects both default and default_factory) -> TypeError on import -> MCP -32000 Connection closed. The connector can never start.

**Fix:** bump the catalog pin 1.4.2 -> 1.22.0. Verified live: 1.4.2 crashes on import, 1.22.0 imports + starts (Transport: stdio) clean with the same GOOGLE_OAUTH_CLIENT_ID/SECRET env contract.

Remaining: the full OAuth consent round-trip (Google login + a tool call) needs a human consent click; the server-starts blocker is what this fixes.