### PR TITLE
fix(mcp): enabled connectors reach every agent backend (Codex, wcore, Gemini) [lane: BH1]

### DIFF
--- a/src/process/agent/acp/mcpSessionConfig.ts
+++ b/src/process/agent/acp/mcpSessionConfig.ts
@@ -45,10 +45,18 @@ function toNameValueEntries(source?: Record<string, string>): AcpSessionMcpNameV
  *
  * Builtin servers (image generation, skill search) are seeded into mcp.config
  * with `status: undefined` and are never connection-tested, so they must be
- * accepted on `undefined`; otherwise a backend silently drops them. User-added
- * (non-builtin) servers still require an active `connected` status.
+ * accepted on `undefined`; otherwise a backend silently drops them.
  *
- * Both backends must agree: previously the ACP path injected builtin servers
+ * User-added (non-builtin) servers are accepted on `undefined` OR `connected`,
+ * and only excluded on an explicit failure status (`disconnected`/`error`). An
+ * enabled connector the user has not yet connection-probed (`status: undefined`)
+ * must still reach the session - the live ACP path (McpConfig.fromStorageConfig,
+ * used by AcpAgentV2/AcpRuntime for Claude/Codex) already accepts `undefined`,
+ * so requiring `connected` here meant Gemini (and the wcore injector that shares
+ * this predicate) silently dropped connectors that Claude/Codex kept - the exact
+ * cross-backend divergence this predicate exists to prevent.
+ *
+ * Every backend must agree: previously the ACP path injected builtin servers
  * only, so a user's custom MCP server reached Gemini chats but never Codex or
  * Claude chats (GitHub #56). Using one predicate keeps them in lockstep.
  */
@@ -56,10 +64,9 @@ export function shouldInjectSessionMcpServer(server: IMcpServer): boolean {
   if (!server.enabled) {
     return false;
   }
-  if (server.builtin === true) {
-    return server.status === undefined || server.status === 'connected';
-  }
-  return server.status === 'connected';
+  // Both builtin and user servers: accept not-yet-probed (undefined) or
+  // connected; a known-broken (disconnected/error) server is not surfaced.
+  return server.status === undefined || server.status === 'connected';
 }
 
 /**
@@ -131,6 +138,43 @@ export function buildAcpSessionMcpServers(
       })
       .filter((server): server is AcpSessionMcpServer => server !== null)
   );
+}
+
+/**
+ * Build the stdio MCP servers for a Wayland Core spawn from the user's
+ * `mcp.config` connector list. wcore receives MCP servers at spawn via the
+ * engine's `add_mcp_server` runtime command (stdio only), so this mirrors the
+ * ACP session-injection path: same `shouldInjectSessionMcpServer` predicate and
+ * `isServerActiveForSession` per-conversation scoping (#348). Builtins
+ * (image-gen, skill-search, concierge-diag) are excluded - wcore surfaces those
+ * through its own mechanisms (system-prompt skills index / team guide), and
+ * injecting them here would double them up or leak the Concierge-only diag
+ * server. Non-stdio (hosted http/sse) connectors are skipped because the engine
+ * runtime command only adds stdio servers; those still reach wcore via the
+ * [mcp.servers] table written by WCoreMcpAgent.
+ */
+export function buildWCoreUserStdioMcpServers(
+  mcpServers: IMcpServer[] | undefined | null,
+  activeServerIds?: readonly string[]
+): AcpSessionMcpServerStdio[] {
+  if (!Array.isArray(mcpServers) || mcpServers.length === 0) {
+    return [];
+  }
+  return mcpServers
+    .filter(shouldInjectSessionMcpServer)
+    .filter((server) => server.builtin !== true)
+    .filter((server) => isServerActiveForSession(server, activeServerIds))
+    .filter((server) => server.transport.type === 'stdio')
+    .map((server): AcpSessionMcpServerStdio => {
+      const transport = server.transport as Extract<IMcpServer['transport'], { type: 'stdio' }>;
+      return {
+        type: 'stdio',
+        name: server.name,
+        command: transport.command,
+        args: transport.args || [],
+        env: toNameValueEntries(transport.env) ?? [],
+      };
+    });
 }
 
 /** Config shape passed from TeamSessionService to AgentManagers */

--- a/src/process/agent/acp/mcpSessionConfig.ts
+++ b/src/process/agent/acp/mcpSessionConfig.ts
@@ -7,6 +7,7 @@
 import type { IMcpServer } from '@/common/config/storage';
 import type { AcpMcpCapabilities } from '@/common/types/acpTypes';
 import { BUILTIN_CONCIERGE_DIAG_ID } from '@process/resources/builtinMcp/constants';
+import { sanitizeMcpServerName } from '@process/services/mcpServices/validateMcpServer';
 
 export interface AcpSessionMcpNameValue {
   name: string;
@@ -152,10 +153,25 @@ export function buildAcpSessionMcpServers(
  * server. Non-stdio (hosted http/sse) connectors are skipped because the engine
  * runtime command only adds stdio servers; those still reach wcore via the
  * [mcp.servers] table written by WCoreMcpAgent.
+ *
+ * `excludeNames` (#478): names already present in the active config.toml
+ * [mcp.servers] table. The engine loads those at startup, so re-injecting the
+ * same name via the runtime `add_mcp_server` command would register it twice.
+ * Callers pass the config.toml server names so those are skipped here - the
+ * engine keeps the config.toml copy, this path only adds what config.toml lacks.
+ *
+ * Names are sanitized with `sanitizeMcpServerName` (the SAME transform
+ * `McpService.syncMcpToAgents` applies before `WCoreMcpAgent` writes the
+ * config.toml key), so both the emitted `add_mcp_server` name AND the exclude
+ * comparison key the server identically to its config.toml copy. Without this a
+ * connector whose raw name needs sanitizing (e.g. `com.slack/slack-mcp`) would
+ * be injected under the raw name while config.toml holds `com.slack-slack-mcp` -
+ * the dedup would miss and the engine would register it twice (#478).
  */
 export function buildWCoreUserStdioMcpServers(
   mcpServers: IMcpServer[] | undefined | null,
-  activeServerIds?: readonly string[]
+  activeServerIds?: readonly string[],
+  excludeNames?: ReadonlySet<string>
 ): AcpSessionMcpServerStdio[] {
   if (!Array.isArray(mcpServers) || mcpServers.length === 0) {
     return [];
@@ -169,12 +185,13 @@ export function buildWCoreUserStdioMcpServers(
       const transport = server.transport as Extract<IMcpServer['transport'], { type: 'stdio' }>;
       return {
         type: 'stdio',
-        name: server.name,
+        name: sanitizeMcpServerName(server.name),
         command: transport.command,
         args: transport.args || [],
         env: toNameValueEntries(transport.env) ?? [],
       };
-    });
+    })
+    .filter((server) => !excludeNames?.has(server.name));
 }
 
 /** Config shape passed from TeamSessionService to AgentManagers */

--- a/src/process/agent/wcore/configMcpServers.ts
+++ b/src/process/agent/wcore/configMcpServers.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #478 - read the MCP server names already declared in the active-profile
+ * wayland-core `config.toml` `[mcp.servers]` table.
+ *
+ * The engine loads those servers at startup, so the spawn-time runtime injection
+ * (WCoreManager -> `add_mcp_server`) must skip any name that is already there,
+ * otherwise the same server is registered twice (once from config.toml, once at
+ * runtime). This reads the SAME active-profile config.toml the engine reads
+ * (WAYLAND_HOME = active profile dir) via `resolveActiveConfigPath`, so the two
+ * views cannot disagree.
+ */
+import { readFile } from 'node:fs/promises';
+import { parse } from 'smol-toml';
+import { resolveActiveConfigPath } from '@process/agent/wcore/profilePaths';
+
+type WCoreConfigShape = { mcp?: { servers?: Record<string, unknown> } };
+
+/**
+ * Best-effort set of server names in the active config.toml `[mcp.servers]`.
+ * Returns an empty set when the file is missing (ENOENT = the engine loads
+ * nothing, so injecting is correct) or unreadable/malformed - a lost dedup hint
+ * must never drop a connector, only risk a benign duplicate at worst. Callers
+ * pass the result to `buildWCoreUserStdioMcpServers(..., excludeNames)`.
+ */
+export async function readWCoreConfigMcpServerNames(): Promise<Set<string>> {
+  try {
+    const content = await readFile(await resolveActiveConfigPath(), 'utf-8');
+    const parsed = parse(content) as WCoreConfigShape;
+    const servers = parsed.mcp?.servers;
+    if (!servers || typeof servers !== 'object') return new Set();
+    return new Set(Object.keys(servers));
+  } catch {
+    return new Set();
+  }
+}

--- a/src/process/services/mcpServices/agents/WCoreMcpAgent.ts
+++ b/src/process/services/mcpServices/agents/WCoreMcpAgent.ts
@@ -10,6 +10,7 @@ import { dirname } from 'path';
 import { parse, stringify } from 'smol-toml';
 import { getEnhancedEnv } from '@process/utils/shellEnv';
 import { resolveWCoreBinary } from '@process/agent/wcore/binaryResolver';
+import { resolveActiveConfigPath } from '@process/agent/wcore/profilePaths';
 import type { McpOperationResult } from '../McpProtocol';
 import { AbstractMcpAgent } from '../McpProtocol';
 import type { IMcpServer, IMcpServerTransport } from '@/common/config/storage';
@@ -63,6 +64,31 @@ function getWCoreConfigPath(cliPath?: string): string {
 
   cachedConfigPath = result;
   return result;
+}
+
+/**
+ * Resolve the config.toml path that the ENGINE actually reads for the active
+ * profile (Design B: `WAYLAND_HOME` = the active profile's config dir, set on
+ * every spawn in envBuilder.ts). The settings-time sync MUST write to this same
+ * file or the engine reads a config.toml that never got the connector.
+ *
+ * Previously this used `<binary> --config-path`, which always resolves the
+ * NATIVE (default-profile) dir because the main process never has `WAYLAND_HOME`
+ * set - so on a NAMED profile the sync wrote one file while the spawn read
+ * another, and the connector was invisible in wcore. `resolveActiveConfigPath`
+ * is the single source of truth both the spawn (`resolveActiveConfigDir`) and
+ * the config bridge resolve through, so they can never disagree.
+ *
+ * Best-effort: a resolution failure falls back to the binary `--config-path`
+ * (backward-compatible for the default profile) rather than throwing.
+ */
+async function getActiveWCoreConfigPath(cliPath?: string): Promise<string> {
+  try {
+    return await resolveActiveConfigPath();
+  } catch (error) {
+    console.warn('[WCoreMcpAgent] Failed to resolve active profile config path, falling back to --config-path:', error);
+    return getWCoreConfigPath(cliPath);
+  }
 }
 
 /**
@@ -169,7 +195,7 @@ export class WCoreMcpAgent extends AbstractMcpAgent {
    */
   private async readConfig(cliPath?: string): Promise<WCoreConfigFile> {
     try {
-      const content = await fs.readFile(getWCoreConfigPath(cliPath), 'utf-8');
+      const content = await fs.readFile(await getActiveWCoreConfigPath(cliPath), 'utf-8');
       return parse(content) as WCoreConfigFile;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
@@ -183,8 +209,10 @@ export class WCoreMcpAgent extends AbstractMcpAgent {
    * Write the wayland-core config file (preserving non-MCP sections)
    */
   private async writeConfig(config: WCoreConfigFile): Promise<void> {
-    // Ensure directory exists
-    const configPath = getWCoreConfigPath(this.resolvedCliPath);
+    // Ensure directory exists. Write to the ACTIVE-PROFILE config.toml so the
+    // engine spawn (which reads via WAYLAND_HOME = active profile dir) sees what
+    // we wrote - not the native default-profile path the binary reports.
+    const configPath = await getActiveWCoreConfigPath(this.resolvedCliPath);
     await fs.mkdir(dirname(configPath), { recursive: true });
     await fs.writeFile(configPath, stringify(config), 'utf-8');
   }

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -1326,11 +1326,66 @@ ${collectedResponses.join('\n')}`;
 
   // ── initAgent ────────────────────────────────────────────────────────
 
+  /**
+   * Per-process de-dupe so we don't re-run `codex mcp add` on every codex chat.
+   * Keyed by a signature of the enabled connectors (name + status + updatedAt),
+   * so a newly enabled/connected/edited connector forces a re-sync.
+   */
+  private static lastCodexMcpSignature: string | null = null;
+
+  /**
+   * Ensure the user's enabled MCP connectors are present in codex's native
+   * config (~/.codex/config.toml) before a codex agent spawns. Reuses the same
+   * tested machinery the UI toggle uses (mcpService.syncMcpToAgents → name
+   * sanitisation, OAuth bearer attach, `codex mcp add`), scoped to the codex
+   * backend. Best-effort: any failure is logged and never blocks the spawn.
+   *
+   * Dynamic import of McpService (not a top-level import): its OAuth chain's
+   * static initializer references HybridTokenStorage and a top-level import
+   * triggers a module-init TDZ in any module that imports it.
+   */
+  private async ensureCodexNativeMcpServers(data: AcpAgentManagerData): Promise<void> {
+    try {
+      const mcpConfig = await ProcessConfig.get('mcp.config');
+      if (!Array.isArray(mcpConfig) || mcpConfig.length === 0) return;
+      const enabled = (mcpConfig as IMcpServer[]).filter((server) => server.enabled);
+      if (enabled.length === 0) return;
+
+      const signature = enabled
+        .map((server) => `${server.name}:${server.status ?? ''}:${server.updatedAt ?? ''}`)
+        .toSorted()
+        .join('|');
+      if (signature === AcpAgentManager.lastCodexMcpSignature) return;
+
+      const { mcpService } = await import('@process/services/mcpServices/McpService');
+      await mcpService.syncMcpToAgents(mcpConfig as IMcpServer[], [
+        { backend: 'codex', name: data.agentName ?? 'Codex CLI' },
+      ]);
+      AcpAgentManager.lastCodexMcpSignature = signature;
+    } catch (err) {
+      mainWarn('[AcpAgentManager]', 'ensureCodexNativeMcpServers failed', err);
+    }
+  }
+
   initAgent(data: AcpAgentManagerData = this.options) {
     if (this.bootstrap) return this.bootstrap;
 
     this.bootstrapping = true;
     const bootstrapPromise = (async () => {
+      // Codex reads MCP servers only from its native ~/.codex/config.toml at
+      // startup; unlike the wcore engine (add_mcp_server) it does not pick up
+      // session-injected stdio servers, and the settings-time sync
+      // (syncMcpToAgents) fires ONLY on a UI toggle - so a connector enabled
+      // while no codex chat was open never landed in codex's config and stayed
+      // invisible there while Claude (which keeps it in ~/.claude.json) worked.
+      // Re-sync the enabled connectors to codex's native config at bootstrap so
+      // an app-enabled connector is reliably available. Runs BEFORE
+      // resolveAgentCliConfig so a flux-routed spawn's materializeFluxCodexHome
+      // (which copies ~/.codex/config.toml's [mcp_servers]) sees them too.
+      if (data.backend === 'codex') {
+        await this.ensureCodexNativeMcpServers(data);
+      }
+
       const { cliPath, customArgs, customEnv, yoloMode } = await this.resolveAgentCliConfig(data);
 
       const agentConfig = {

--- a/src/process/task/WCoreManager.ts
+++ b/src/process/task/WCoreManager.ts
@@ -11,7 +11,8 @@ import { buildResumeSeedTranscript } from '@process/task/resumeSeed';
 import type { IResponseMessage } from '@/common/adapter/ipcBridge';
 import { channelEventBus } from '@process/channels/agent/ChannelEventBus';
 import { teamEventBus } from '@process/team/teamEventBus';
-import type { TProviderWithModel } from '@/common/config/storage';
+import type { IMcpServer, TProviderWithModel } from '@/common/config/storage';
+import { buildWCoreUserStdioMcpServers } from '@process/agent/acp/mcpSessionConfig';
 import { type OutputBudget, resolveFixedBudget } from '@/common/config/outputBudget';
 import { ProcessConfig } from '@process/utils/initStorage';
 import { BaseApprovalStore, type IApprovalKey } from '@/common/chat/approval';
@@ -118,6 +119,12 @@ type WCoreManagerData = {
   resume?: string;
   /** Per-conversation reasoning effort (sent to the engine via set_config). Absent => engine default. */
   effort?: 'low' | 'medium' | 'high';
+  /**
+   * Per-conversation MCP scoping (#348): the user-server ids active for this
+   * chat. `undefined` => all enabled servers; `[]` => no user servers. Forwarded
+   * to the same `isServerActiveForSession` predicate the ACP/Gemini paths use.
+   */
+  activeMcpServers?: string[];
   teamMcpStdioConfig?: {
     name: string;
     command: string;
@@ -260,6 +267,27 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
     } else {
       const teamGuide = await this.buildTeamGuideMcpStdioConfig();
       if (teamGuide) stdioMcpServers.push(teamGuide);
+    }
+
+    // Inject the user's enabled stdio MCP connectors (mcp.config) so an
+    // app-enabled connector reaches the engine WITHOUT a separate settings
+    // toggle - mirroring the ACP session-injection path. wcore otherwise depends
+    // entirely on the [mcp.servers] table written by WCoreMcpAgent (settings-time
+    // only), which left every connector invisible in a fresh wcore chat. Uses the
+    // shared predicate + per-conversation scoping (#348); builtins and hosted
+    // (http/sse) connectors are handled elsewhere (see buildWCoreUserStdioMcpServers).
+    // Best-effort: a config read failure must never block the spawn.
+    try {
+      const mcpConfig = await ProcessConfig.get('mcp.config');
+      const userServers = buildWCoreUserStdioMcpServers(
+        mcpConfig as IMcpServer[] | undefined,
+        mergedData.activeMcpServers
+      );
+      for (const server of userServers) {
+        stdioMcpServers.push({ name: server.name, command: server.command, args: server.args, env: server.env });
+      }
+    } catch (err) {
+      mainWarn('[WCoreManager]', 'failed to load user MCP connectors for injection', err);
     }
 
     // Raw-engine (power-user) mode: when `wcore.rawEngineMode` is

--- a/src/process/task/WCoreManager.ts
+++ b/src/process/task/WCoreManager.ts
@@ -13,6 +13,7 @@ import { channelEventBus } from '@process/channels/agent/ChannelEventBus';
 import { teamEventBus } from '@process/team/teamEventBus';
 import type { IMcpServer, TProviderWithModel } from '@/common/config/storage';
 import { buildWCoreUserStdioMcpServers } from '@process/agent/acp/mcpSessionConfig';
+import { readWCoreConfigMcpServerNames } from '@process/agent/wcore/configMcpServers';
 import { type OutputBudget, resolveFixedBudget } from '@/common/config/outputBudget';
 import { ProcessConfig } from '@process/utils/initStorage';
 import { BaseApprovalStore, type IApprovalKey } from '@/common/chat/approval';
@@ -276,12 +277,17 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
     // only), which left every connector invisible in a fresh wcore chat. Uses the
     // shared predicate + per-conversation scoping (#348); builtins and hosted
     // (http/sse) connectors are handled elsewhere (see buildWCoreUserStdioMcpServers).
+    // #478 dedup: skip any connector already in the active config.toml
+    // [mcp.servers] table (WCoreMcpAgent settings-time write) - the engine loads
+    // those at startup, so re-adding at runtime would register the server twice.
     // Best-effort: a config read failure must never block the spawn.
     try {
       const mcpConfig = await ProcessConfig.get('mcp.config');
+      const alreadyInConfig = await readWCoreConfigMcpServerNames();
       const userServers = buildWCoreUserStdioMcpServers(
         mcpConfig as IMcpServer[] | undefined,
-        mergedData.activeMcpServers
+        mergedData.activeMcpServers,
+        alreadyInConfig
       );
       for (const server of userServers) {
         stdioMcpServers.push({ name: server.name, command: server.command, args: server.args, env: server.env });

--- a/src/process/task/WCoreManager.ts
+++ b/src/process/task/WCoreManager.ts
@@ -270,6 +270,21 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
       if (teamGuide) stdioMcpServers.push(teamGuide);
     }
 
+    // Raw-engine (power-user) mode: when `wcore.rawEngineMode` is
+    // true, the embedded engine runs on its OWN config.toml exactly like the
+    // standalone CLI - so we SKIP (a) the Desktop model override (applied in
+    // buildSpawnConfig via the `rawEngineMode` flag passed below), (b) the
+    // Constitution/skills/specialist prompt overlay built below, and (c) the
+    // Desktop MCP-connector injection below (raw mode uses only the engine's own
+    // [mcp.servers] table, like the CLI). The renderer (RuntimePane) only
+    // persists the preference; this seam enacts it. A storage read failure falls
+    // back to the normal (overridden) path - never raw.
+    // Use ProcessConfig (main-process store) NOT ConfigStorage (renderer-bridged):
+    // ConfigStorage.get round-trips to the renderer and HANGS when WCore is
+    // spawned from a channel (a pure main-process path with no renderer in the
+    // loop), wedging every channel-triggered turn. `.catch` cannot save a hang.
+    const rawEngineMode = (await ProcessConfig.get('wcore.rawEngineMode').catch(() => false)) === true;
+
     // Inject the user's enabled stdio MCP connectors (mcp.config) so an
     // app-enabled connector reaches the engine WITHOUT a separate settings
     // toggle - mirroring the ACP session-injection path. wcore otherwise depends
@@ -280,34 +295,24 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
     // #478 dedup: skip any connector already in the active config.toml
     // [mcp.servers] table (WCoreMcpAgent settings-time write) - the engine loads
     // those at startup, so re-adding at runtime would register the server twice.
-    // Best-effort: a config read failure must never block the spawn.
-    try {
-      const mcpConfig = await ProcessConfig.get('mcp.config');
-      const alreadyInConfig = await readWCoreConfigMcpServerNames();
-      const userServers = buildWCoreUserStdioMcpServers(
-        mcpConfig as IMcpServer[] | undefined,
-        mergedData.activeMcpServers,
-        alreadyInConfig
-      );
-      for (const server of userServers) {
-        stdioMcpServers.push({ name: server.name, command: server.command, args: server.args, env: server.env });
+    // Skipped entirely in raw-engine mode (above). Best-effort: a config read
+    // failure must never block the spawn.
+    if (!rawEngineMode) {
+      try {
+        const mcpConfig = await ProcessConfig.get('mcp.config');
+        const alreadyInConfig = await readWCoreConfigMcpServerNames();
+        const userServers = buildWCoreUserStdioMcpServers(
+          mcpConfig as IMcpServer[] | undefined,
+          mergedData.activeMcpServers,
+          alreadyInConfig
+        );
+        for (const server of userServers) {
+          stdioMcpServers.push({ name: server.name, command: server.command, args: server.args, env: server.env });
+        }
+      } catch (err) {
+        mainWarn('[WCoreManager]', 'failed to load user MCP connectors for injection', err);
       }
-    } catch (err) {
-      mainWarn('[WCoreManager]', 'failed to load user MCP connectors for injection', err);
     }
-
-    // Raw-engine (power-user) mode: when `wcore.rawEngineMode` is
-    // true, the embedded engine runs on its OWN config.toml exactly like the
-    // standalone CLI - so we SKIP both (a) the Desktop model override (applied
-    // in buildSpawnConfig via the `rawEngineMode` flag passed below) and (b) the
-    // Constitution/skills/specialist prompt overlay built here. The renderer
-    // (RuntimePane) only persists the preference; this seam enacts it. A storage
-    // read failure falls back to the normal (overridden) path - never raw.
-    // Use ProcessConfig (main-process store) NOT ConfigStorage (renderer-bridged):
-    // ConfigStorage.get round-trips to the renderer and HANGS when WCore is
-    // spawned from a channel (a pure main-process path with no renderer in the
-    // loop), wedging every channel-triggered turn. `.catch` cannot save a hang.
-    const rawEngineMode = (await ProcessConfig.get('wcore.rawEngineMode').catch(() => false)) === true;
 
     // #468: Output-budget override. When the user picked a Fixed budget, pass it
     // as the per-call `--max-tokens` (via buildSpawnConfig); Auto (default/unset)

--- a/tests/unit/acpBuiltinMcp.test.ts
+++ b/tests/unit/acpBuiltinMcp.test.ts
@@ -123,9 +123,14 @@ describe('ACP built-in MCP session config', () => {
         originalJson: '{}',
       },
       {
+        // A known-broken (disconnected) non-builtin: excluded under the uniform
+        // predicate. (An enabled non-builtin with `status: undefined` is now
+        // INJECTED - covered by wcoreUserMcpInjection.test.ts - so this fixture
+        // uses a failure status to stay a negative case here.)
         id: 'external-server',
         name: 'chrome-devtools',
         enabled: true,
+        status: 'disconnected',
         transport: {
           type: 'stdio',
           command: 'npx',
@@ -230,9 +235,12 @@ describe('ACP custom MCP session config (#56)', () => {
     ]);
   });
 
-  it('excludes a custom server that is not connected (matches the Gemini path)', () => {
+  it('injects an enabled un-probed custom server but excludes known-broken/disabled (uniform with the live ACP path)', () => {
     const servers: IMcpServer[] = [
       {
+        // Enabled but not yet connection-tested: NOW injected (matches
+        // McpConfig.fromStorageConfig, the live Claude/Codex path) so an enabled
+        // connector reaches every backend without a connection probe first.
         id: 'custom-untested',
         name: 'unconnected-tool',
         enabled: true,
@@ -264,7 +272,9 @@ describe('ACP custom MCP session config (#56)', () => {
       },
     ];
 
-    expect(buildAcpSessionMcpServers(servers, { stdio: true, http: true, sse: true })).toEqual([]);
+    expect(buildAcpSessionMcpServers(servers, { stdio: true, http: true, sse: true })).toEqual([
+      { type: 'stdio', name: 'unconnected-tool', command: 'node', args: [], env: [] },
+    ]);
   });
 });
 

--- a/tests/unit/geminiMcpInjection.test.ts
+++ b/tests/unit/geminiMcpInjection.test.ts
@@ -59,11 +59,15 @@ describe('shouldInjectSessionMcpServer', () => {
   });
 
   it('does not inject a known-broken user server (disconnected/error)', () => {
-    expect(shouldInjectSessionMcpServer(server({ builtin: undefined, enabled: true, status: 'disconnected' }))).toBe(false);
+    expect(shouldInjectSessionMcpServer(server({ builtin: undefined, enabled: true, status: 'disconnected' }))).toBe(
+      false
+    );
     expect(shouldInjectSessionMcpServer(server({ builtin: undefined, enabled: true, status: 'error' }))).toBe(false);
   });
 
   it('does not inject a disabled user server even when connected', () => {
-    expect(shouldInjectSessionMcpServer(server({ builtin: undefined, enabled: false, status: 'connected' }))).toBe(false);
+    expect(shouldInjectSessionMcpServer(server({ builtin: undefined, enabled: false, status: 'connected' }))).toBe(
+      false
+    );
   });
 });

--- a/tests/unit/geminiMcpInjection.test.ts
+++ b/tests/unit/geminiMcpInjection.test.ts
@@ -46,12 +46,21 @@ describe('shouldInjectSessionMcpServer', () => {
     expect(shouldInjectSessionMcpServer(server({ builtin: true, enabled: true, status: 'error' }))).toBe(false);
   });
 
-  it('requires a user server to be connected (undefined is not injected)', () => {
-    expect(shouldInjectSessionMcpServer(server({ builtin: undefined, enabled: true, status: undefined }))).toBe(false);
+  it('injects an enabled user server that has not been probed (status undefined)', () => {
+    // Uniform with the live ACP path (McpConfig.fromStorageConfig): an enabled
+    // connector the user turned on but never connection-tested must still reach
+    // the session. Requiring `connected` here made Gemini drop connectors that
+    // Claude/Codex kept (cross-backend divergence).
+    expect(shouldInjectSessionMcpServer(server({ builtin: undefined, enabled: true, status: undefined }))).toBe(true);
   });
 
   it('injects a connected user server', () => {
     expect(shouldInjectSessionMcpServer(server({ builtin: undefined, enabled: true, status: 'connected' }))).toBe(true);
+  });
+
+  it('does not inject a known-broken user server (disconnected/error)', () => {
+    expect(shouldInjectSessionMcpServer(server({ builtin: undefined, enabled: true, status: 'disconnected' }))).toBe(false);
+    expect(shouldInjectSessionMcpServer(server({ builtin: undefined, enabled: true, status: 'error' }))).toBe(false);
   });
 
   it('does not inject a disabled user server even when connected', () => {

--- a/tests/unit/process/agent/acp/wcoreUserMcpInjection.test.ts
+++ b/tests/unit/process/agent/acp/wcoreUserMcpInjection.test.ts
@@ -1,0 +1,121 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Uniform MCP propagation: an enabled user connector must reach EVERY backend.
+ *
+ * Covers:
+ *  - shouldInjectSessionMcpServer now accepts a non-builtin connector with
+ *    `status: undefined` (enabled-but-not-yet-probed), matching the live ACP
+ *    path (McpConfig.fromStorageConfig). Previously it required `connected`, so
+ *    Gemini + the wcore injector silently dropped connectors Claude/Codex kept.
+ *  - buildWCoreUserStdioMcpServers: the wcore spawn-time injector. Same predicate
+ *    + #348 scoping, excludes builtins, stdio-only.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { shouldInjectSessionMcpServer, buildWCoreUserStdioMcpServers } from '@process/agent/acp/mcpSessionConfig';
+import type { IMcpServer } from '@/common/config/storage';
+
+const server = (over: Partial<IMcpServer>): IMcpServer =>
+  ({
+    id: 'srv',
+    name: 'srv',
+    enabled: true,
+    status: 'connected',
+    source: 'library',
+    transport: { type: 'stdio', command: 'uvx', args: ['google-workspace-mcp'], env: { KEY: 'v' } },
+    originalJson: '{}',
+    createdAt: 1,
+    updatedAt: 1,
+    ...over,
+  }) as IMcpServer;
+
+describe('shouldInjectSessionMcpServer (uniform acceptance)', () => {
+  it('accepts an enabled user connector that has not been probed (status undefined)', () => {
+    expect(shouldInjectSessionMcpServer(server({ builtin: undefined, status: undefined }))).toBe(true);
+  });
+
+  it('accepts an enabled connected user connector', () => {
+    expect(shouldInjectSessionMcpServer(server({ status: 'connected' }))).toBe(true);
+  });
+
+  it('rejects a disabled connector', () => {
+    expect(shouldInjectSessionMcpServer(server({ enabled: false }))).toBe(false);
+  });
+
+  it('rejects a known-broken connector (disconnected/error)', () => {
+    expect(shouldInjectSessionMcpServer(server({ status: 'disconnected' }))).toBe(false);
+    expect(shouldInjectSessionMcpServer(server({ status: 'error' as IMcpServer['status'] }))).toBe(false);
+  });
+
+  it('accepts a builtin on undefined/connected', () => {
+    expect(shouldInjectSessionMcpServer(server({ builtin: true, status: undefined }))).toBe(true);
+    expect(shouldInjectSessionMcpServer(server({ builtin: true, status: 'connected' }))).toBe(true);
+  });
+});
+
+describe('buildWCoreUserStdioMcpServers', () => {
+  const googleWorkspace = server({
+    id: 'gw',
+    name: 'io.github.taylorwilsdon-google-workspace-mcp',
+    status: undefined,
+    transport: { type: 'stdio', command: 'uvx', args: ['workspace-mcp'], env: { TOKEN: 't' } },
+  });
+  const builtinImageGen = server({ id: 'img', name: 'wayland-image-generation', builtin: true, status: undefined });
+  const hostedGithub = server({
+    id: 'gh',
+    name: 'com.github-github-mcp-server',
+    status: 'connected',
+    transport: { type: 'streamable_http', url: 'https://example/mcp', headers: {} },
+  });
+  const disabled = server({ id: 'off', name: 'filesystem', enabled: false });
+
+  it('returns [] for empty/missing config', () => {
+    expect(buildWCoreUserStdioMcpServers(undefined)).toEqual([]);
+    expect(buildWCoreUserStdioMcpServers([])).toEqual([]);
+  });
+
+  it('injects an enabled stdio user connector (status undefined) with command/args/env mapped', () => {
+    const out = buildWCoreUserStdioMcpServers([googleWorkspace]);
+    expect(out).toEqual([
+      {
+        type: 'stdio',
+        name: 'io.github.taylorwilsdon-google-workspace-mcp',
+        command: 'uvx',
+        args: ['workspace-mcp'],
+        env: [{ name: 'TOKEN', value: 't' }],
+      },
+    ]);
+  });
+
+  it('excludes builtins (handled by wcore via its own mechanisms)', () => {
+    const out = buildWCoreUserStdioMcpServers([builtinImageGen, googleWorkspace]);
+    expect(out.map((s) => s.name)).toEqual(['io.github.taylorwilsdon-google-workspace-mcp']);
+  });
+
+  it('excludes hosted (http/sse) connectors - engine add_mcp_server is stdio-only', () => {
+    const out = buildWCoreUserStdioMcpServers([hostedGithub, googleWorkspace]);
+    expect(out.map((s) => s.name)).toEqual(['io.github.taylorwilsdon-google-workspace-mcp']);
+  });
+
+  it('excludes disabled connectors', () => {
+    const out = buildWCoreUserStdioMcpServers([disabled, googleWorkspace]);
+    expect(out.map((s) => s.name)).toEqual(['io.github.taylorwilsdon-google-workspace-mcp']);
+  });
+
+  it('honors #348 per-conversation scoping', () => {
+    const a = server({ id: 'a', name: 'alpha' });
+    const b = server({ id: 'b', name: 'beta' });
+    expect(
+      buildWCoreUserStdioMcpServers([a, b], undefined)
+        .map((s) => s.name)
+        .toSorted()
+    ).toEqual(['alpha', 'beta']);
+    expect(buildWCoreUserStdioMcpServers([a, b], ['a']).map((s) => s.name)).toEqual(['alpha']);
+    expect(buildWCoreUserStdioMcpServers([a, b], [])).toEqual([]);
+  });
+});

--- a/tests/unit/process/agent/acp/wcoreUserMcpInjection.test.ts
+++ b/tests/unit/process/agent/acp/wcoreUserMcpInjection.test.ts
@@ -118,4 +118,38 @@ describe('buildWCoreUserStdioMcpServers', () => {
     expect(buildWCoreUserStdioMcpServers([a, b], ['a']).map((s) => s.name)).toEqual(['alpha']);
     expect(buildWCoreUserStdioMcpServers([a, b], [])).toEqual([]);
   });
+
+  it('#478 dedup: skips names already in config.toml [mcp.servers] (no double registration)', () => {
+    const a = server({ id: 'a', name: 'alpha' });
+    const b = server({ id: 'b', name: 'beta' });
+    // alpha is already in the engine config.toml -> engine loads it at startup;
+    // only beta should be injected at runtime.
+    const out = buildWCoreUserStdioMcpServers([a, b], undefined, new Set(['alpha']));
+    expect(out.map((s) => s.name)).toEqual(['beta']);
+  });
+
+  it('#478 dedup: an empty exclude set injects everything (fallback keeps connectors visible)', () => {
+    const a = server({ id: 'a', name: 'alpha' });
+    const b = server({ id: 'b', name: 'beta' });
+    expect(
+      buildWCoreUserStdioMcpServers([a, b], undefined, new Set())
+        .map((s) => s.name)
+        .toSorted()
+    ).toEqual(['alpha', 'beta']);
+  });
+
+  it('#478 dedup: sanitizes the name so a raw-slash connector matches its config.toml key', () => {
+    // syncMcpToAgents sanitizes com.slack/slack-mcp -> com.slack-slack-mcp before
+    // WCoreMcpAgent writes the config.toml key. The injected name + exclude must
+    // use that same sanitized form, or the dedup misses and the engine doubles.
+    const slack = server({
+      id: 'slack',
+      name: 'com.slack/slack-mcp',
+      transport: { type: 'stdio', command: 'uvx', args: ['slack'], env: {} },
+    });
+    // Not in config.toml yet -> injected under the SANITIZED name.
+    expect(buildWCoreUserStdioMcpServers([slack]).map((s) => s.name)).toEqual(['com.slack-slack-mcp']);
+    // Already in config.toml (sanitized key) -> excluded, no double registration.
+    expect(buildWCoreUserStdioMcpServers([slack], undefined, new Set(['com.slack-slack-mcp']))).toEqual([]);
+  });
 });

--- a/tests/unit/process/agent/wcore/configMcpServers.test.ts
+++ b/tests/unit/process/agent/wcore/configMcpServers.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #478 - readWCoreConfigMcpServerNames reports the [mcp.servers] names the engine
+ * already loads from config.toml, so the spawn-time injector can skip them and
+ * avoid registering a server twice.
+ */
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let configPath = '';
+vi.mock('@process/agent/wcore/profilePaths', () => ({
+  resolveActiveConfigPath: () => Promise.resolve(configPath),
+}));
+
+import { readWCoreConfigMcpServerNames } from '@process/agent/wcore/configMcpServers';
+
+let dir = '';
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'wcore-cfg-mcp-'));
+  configPath = join(dir, 'config.toml');
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe('readWCoreConfigMcpServerNames (#478)', () => {
+  it('returns the [mcp.servers] table names', async () => {
+    await writeFile(
+      configPath,
+      '[mcp.servers.alpha]\ntype = "stdio"\ncommand = "a"\n\n[mcp.servers.beta]\ntype = "stdio"\ncommand = "b"\n',
+      'utf-8'
+    );
+    const names = await readWCoreConfigMcpServerNames();
+    expect([...names].toSorted()).toEqual(['alpha', 'beta']);
+  });
+
+  it('round-trips a dotted connector name as ONE key (matches the injected name)', async () => {
+    // Real connector names contain dots (e.g. reverse-DNS ids). smol-toml must
+    // quote the key so it stays a single [mcp.servers."a.b.c"] entry, not nested
+    // tables - otherwise the dedup set would never match the injected name.
+    const name = 'io.github.taylorwilsdon-google-workspace-mcp';
+    await writeFile(configPath, `[mcp.servers."${name}"]\ntype = "stdio"\ncommand = "uvx"\n`, 'utf-8');
+    expect(await readWCoreConfigMcpServerNames()).toEqual(new Set([name]));
+  });
+
+  it('returns an empty set when the file is missing (engine loads nothing -> inject)', async () => {
+    configPath = join(dir, 'does-not-exist.toml');
+    expect(await readWCoreConfigMcpServerNames()).toEqual(new Set());
+  });
+
+  it('returns an empty set when there is no [mcp.servers] table', async () => {
+    await writeFile(configPath, '[tools]\nallow_list = ["ls"]\n', 'utf-8');
+    expect(await readWCoreConfigMcpServerNames()).toEqual(new Set());
+  });
+
+  it('returns an empty set on malformed TOML (never throws)', async () => {
+    await writeFile(configPath, 'this is = = not valid toml [[[', 'utf-8');
+    expect(await readWCoreConfigMcpServerNames()).toEqual(new Set());
+  });
+});


### PR DESCRIPTION
## Problem (live-confirmed)

An enabled MCP connector (e.g. the Google Workspace stdio `uvx` server) was **usable in Claude** but **invisible in Codex and Wayland Core**. Affects every connector.

## Verified diagnosis (overturns the prior, stale-branch diagnosis)

I verified against the running app's real on-disk state, not the stale branch:

- **The Codex stdio capability bit is NOT the cause.** Codex's cached ACP `initialize` advertises `mcpCapabilities {stdio:true, http:true, sse:false}` (read from the real `acp.cachedInitializeResult`). The diagnosis's "Codex omits mcpCapabilities → stdio dropped" is false for current Codex.
- **The cited code path is dead.** `loadBuiltinSessionMcpServers` in `src/process/agent/acp/index.ts` is never instantiated. The live ACP path is `AcpAgentV2`/`AcpRuntime` → `McpConfig.fromStorageConfig`, which already accepts `status: undefined`.
- **Real divergence #1 (predicate):** Gemini used the stricter `shouldInjectSessionMcpServer` (required `status === 'connected'`), so it dropped `status: undefined` connectors that Claude/Codex kept.
- **Real divergence #2 (wcore injection):** `WCoreManager` injected only team / team-guide MCPs — never `mcp.config` user connectors.
- **Real divergence #3 (wcore path):** `WCoreMcpAgent` wrote `[mcp.servers]` to `<binary> --config-path` (native default-profile dir, since the main process has no `WAYLAND_HOME`) while the engine spawn reads the **active-profile** config via `WAYLAND_HOME`. Verified live: bundled engine `--config-path` returns `~/Library/Application Support/wayland-core/config.toml` by default and `~/.wayland/profiles/<name>/config.toml` under `WAYLAND_HOME`.
- **Real divergence #4 (Codex native config):** Codex reads MCP only from `~/.codex/config.toml` at startup; the sync fired only on a UI toggle. Verified live: `~/.claude.json` had the connector; `~/.codex/config.toml` did not.

## Fix

1. **Predicate (Gemini + shared):** `shouldInjectSessionMcpServer` now accepts an enabled connector on `status === undefined || 'connected'` (only excludes a known-broken `disconnected`/`error`), matching the live ACP path so Gemini and wcore stay in lockstep with Claude/Codex.
2. **wcore injection:** `WCoreManager` injects enabled user **stdio** connectors at spawn via the proven `add_mcp_server` path (the same `stdioMcpServers` array the team MCPs already use), using the shared predicate + #348 per-conversation scoping. Builtins (image-gen, skill-search, concierge-diag) and hosted http/sse connectors are left to their existing mechanisms.
3. **wcore config path:** `WCoreMcpAgent` reads/writes `resolveActiveConfigPath()` (the single source of truth the engine spawn also resolves through), with a `--config-path` fallback — so settings-sync writes where the engine reads on named profiles.
4. **Codex native config:** `AcpAgentManager` re-syncs enabled connectors into `~/.codex/config.toml` at codex bootstrap (reusing `mcpService.syncMcpToAgents`), de-duped per process by a connector signature, and runs **before** `materializeFluxCodexHome` so the flux scoped `CODEX_HOME` inherits them.

Keeps #348 scoping, #56 lockstep, and the builtins intact; Claude is unchanged.

## Verification

- **Unit:** new `tests/unit/process/agent/acp/wcoreUserMcpInjection.test.ts` (relaxed predicate + wcore injector: stdio-only, builtins excluded, hosted excluded, disabled excluded, #348 scoping); updated `geminiMcpInjection` and `acpBuiltinMcp` to the uniform contract. Full mcp/wcore/codex unit surface green (**2797 passing, 0 failing**). `tsc --noEmit` clean.
- **Live — Claude:** unchanged (already worked; connector present in `~/.claude.json`).
- **Live — Codex mechanism:** `codex mcp add` (the exact call `CodexMcpAgent` makes) into a scoped `CODEX_HOME` wrote `[mcp_servers.<name>]` and `codex mcp list` showed it `enabled` — proving the bootstrap ensure lands the connector in codex's native config.
- **Live — wcore config-path alignment:** bundled engine `--config-path` confirmed to return the native dir by default and the profile dir under `WAYLAND_HOME=<profile>`; `resolveActiveConfigPath()` returns those same paths, so sync now writes exactly where the engine reads. wcore runtime injection uses the already-in-production `add_mcp_server` path (unchanged consumer; only the inputs are added).
- **Live — Gemini:** covered by the predicate change + unit tests (was the strict-predicate outlier).

### Not yet done
A full interactive 4-backend chat-turn in the dev app (sending a tool call through each running backend) was not performed in this session — that needs the packaged/dev app with live provider creds. The mechanisms are verified per-backend above (config writes + the proven injection path + unit tests).