### PR TITLE
fix: route project chats to the project workspace (stop writing to Temporary Space)

### DIFF
--- a/src/process/services/ProjectServiceImpl.ts
+++ b/src/process/services/ProjectServiceImpl.ts
@@ -7,6 +7,7 @@
 import type { IProjectService } from './IProjectService';
 import type { IProjectRepository } from '@process/services/database/IProjectRepository';
 import type { IConversationService } from './IConversationService';
+import type { AgentStatus } from '@process/task/agentTypes';
 import type { IProject, ICreateProjectParams, IUpdateProjectParams } from '@/common/types/project';
 import type { TChatConversation } from '@/common/config/storage';
 import { uuid } from '@/common/utils';
@@ -28,12 +29,17 @@ export class ProjectServiceImpl implements IProjectService {
     private readonly repo: IProjectRepository,
     private readonly conversations: IConversationService,
     /**
-     * Evicts a conversation's cached worker task so its next turn rebuilds with a
-     * corrected workspace (used after assign re-homes a chat). Injected, not
-     * imported, so the service carries no hard dependency on the task layer.
+     * Port over the cached worker tasks, used after assign re-homes a chat so its
+     * next turn rebuilds in the corrected workspace. Injected, not imported, so
+     * the service carries no hard dependency on the task layer. `getStatus`
+     * returns the cached task's status (undefined when none is cached) so we can
+     * skip evicting a task that is actively streaming; `evict` drops (kills) it.
      * Optional: omitted in unit tests and callers with no live task cache.
      */
-    private readonly evictTask?: (conversationId: string) => void
+    private readonly taskCache?: {
+      getStatus(conversationId: string): AgentStatus | undefined;
+      evict(conversationId: string): void;
+    }
   ) {}
 
   async createProject(params: ICreateProjectParams): Promise<IProject> {
@@ -124,10 +130,15 @@ export class ProjectServiceImpl implements IProjectService {
       true
     );
     // A chat that's already open keeps writing to its old temp cwd until its
-    // cached worker task is rebuilt. Drop the cached task so the next turn
-    // re-spawns in the re-homed workspace - no app restart needed. Only when the
-    // workspace actually moved.
-    if (rehomed) this.evictTask?.(conversationId);
+    // cached worker task is rebuilt. When the workspace actually moved, drop the
+    // cached task so the next turn re-spawns in the re-homed workspace - no app
+    // restart needed. But NEVER evict a task that is actively streaming
+    // ('running'): killing it would abort the in-flight turn and lose the
+    // response. That rare case re-homes on its next spawn instead;
+    // extra.workspace is already persisted above, so correctness holds either way.
+    if (rehomed && this.taskCache && this.taskCache.getStatus(conversationId) !== 'running') {
+      this.taskCache.evict(conversationId);
+    }
   }
 
   async removeConversationFromProject(conversationId: string): Promise<void> {

--- a/src/process/services/ProjectServiceImpl.ts
+++ b/src/process/services/ProjectServiceImpl.ts
@@ -11,7 +11,11 @@ import type { IProject, ICreateProjectParams, IUpdateProjectParams } from '@/com
 import type { TChatConversation } from '@/common/config/storage';
 import { uuid } from '@/common/utils';
 import { bootstrapProjectKnowledge } from '@process/services/projectKnowledge/bootstrap';
-import { allocateProjectWorkspace } from '@process/services/projectWorkspace';
+import {
+  allocateProjectWorkspace,
+  ensureProjectWorkspace,
+  enforceProjectWorkspace,
+} from '@process/services/projectWorkspace';
 
 /**
  * Concrete IProjectService. Owns id/timestamp generation and the `.wayland/`
@@ -22,7 +26,14 @@ import { allocateProjectWorkspace } from '@process/services/projectWorkspace';
 export class ProjectServiceImpl implements IProjectService {
   constructor(
     private readonly repo: IProjectRepository,
-    private readonly conversations: IConversationService
+    private readonly conversations: IConversationService,
+    /**
+     * Evicts a conversation's cached worker task so its next turn rebuilds with a
+     * corrected workspace (used after assign re-homes a chat). Injected, not
+     * imported, so the service carries no hard dependency on the task layer.
+     * Optional: omitted in unit tests and callers with no live task cache.
+     */
+    private readonly evictTask?: (conversationId: string) => void
   ) {}
 
   async createProject(params: ICreateProjectParams): Promise<IProject> {
@@ -96,11 +107,27 @@ export class ProjectServiceImpl implements IProjectService {
   }
 
   async assignConversation(conversationId: string, projectId: string): Promise<void> {
+    // Stamp the project, then re-home the chat's workspace onto the project's
+    // managed folder exactly like the create path (ConversationServiceImpl
+    // .reconcileProjectWorkspace): ensure the project has a persistent workspace,
+    // then copy it onto this chat's extra so agent files land in the project
+    // folder instead of the throwaway temp dir the chat was created with. A
+    // user-chosen custom workspace (extra.customWorkspace) is left untouched by
+    // enforceProjectWorkspace.
+    const conversation = await this.conversations.getConversation(conversationId);
+    const extra = { ...conversation?.extra, projectId } as Record<string, unknown>;
+    await ensureProjectWorkspace(projectId);
+    const rehomed = await enforceProjectWorkspace(extra);
     await this.conversations.updateConversation(
       conversationId,
-      { extra: { projectId } } as Partial<TChatConversation>,
+      { extra } as unknown as Partial<TChatConversation>,
       true
     );
+    // A chat that's already open keeps writing to its old temp cwd until its
+    // cached worker task is rebuilt. Drop the cached task so the next turn
+    // re-spawns in the re-homed workspace - no app restart needed. Only when the
+    // workspace actually moved.
+    if (rehomed) this.evictTask?.(conversationId);
   }
 
   async removeConversationFromProject(conversationId: string): Promise<void> {

--- a/src/process/services/projectServiceSingleton.ts
+++ b/src/process/services/projectServiceSingleton.ts
@@ -17,10 +17,18 @@ import { conversationServiceSingleton } from './conversationServiceSingleton';
 import { workerTaskManager } from '@process/task/workerTaskManagerSingleton';
 import type { IProjectService } from './IProjectService';
 
+// Note: workerTaskManager is already booted transitively whenever this module is
+// imported (conversationServiceSingleton -> ConversationServiceImpl ->
+// cronServiceSingleton imports it at module top level), so this direct import
+// adds no new eager construction.
 export const projectServiceSingleton: IProjectService = new ProjectServiceImpl(
   new SqliteProjectRepository(),
   conversationServiceSingleton,
-  // Evict the cached worker task when a chat is re-homed into a project, so its
+  // When a chat is re-homed into a project, drop its cached worker task so the
   // next turn rebuilds in the project workspace instead of the stale temp cwd.
-  (conversationId) => workerTaskManager.kill(conversationId)
+  // ProjectServiceImpl skips this for an actively-streaming task (status check).
+  {
+    getStatus: (conversationId) => workerTaskManager.getTask(conversationId)?.status,
+    evict: (conversationId) => workerTaskManager.kill(conversationId, 'workspace_rehome'),
+  }
 );

--- a/src/process/services/projectServiceSingleton.ts
+++ b/src/process/services/projectServiceSingleton.ts
@@ -14,9 +14,13 @@
 import { SqliteProjectRepository } from '@process/services/database/SqliteProjectRepository';
 import { ProjectServiceImpl } from './ProjectServiceImpl';
 import { conversationServiceSingleton } from './conversationServiceSingleton';
+import { workerTaskManager } from '@process/task/workerTaskManagerSingleton';
 import type { IProjectService } from './IProjectService';
 
 export const projectServiceSingleton: IProjectService = new ProjectServiceImpl(
   new SqliteProjectRepository(),
-  conversationServiceSingleton
+  conversationServiceSingleton,
+  // Evict the cached worker task when a chat is re-homed into a project, so its
+  // next turn rebuilds in the project workspace instead of the stale temp cwd.
+  (conversationId) => workerTaskManager.kill(conversationId)
 );

--- a/src/process/task/IAgentManager.ts
+++ b/src/process/task/IAgentManager.ts
@@ -9,7 +9,7 @@
 import type { IConfirmation } from '@/common/chat/chatLib';
 import type { AgentType, AgentStatus } from './agentTypes';
 
-export type AgentKillReason = 'idle_timeout' | 'team_deleted';
+export type AgentKillReason = 'idle_timeout' | 'team_deleted' | 'workspace_rehome';
 
 export interface IAgentManager {
   readonly type: AgentType;

--- a/src/renderer/pages/conversation/Workspace/components/WorkspaceContextMenu.tsx
+++ b/src/renderer/pages/conversation/Workspace/components/WorkspaceContextMenu.tsx
@@ -102,18 +102,18 @@ const WorkspaceContextMenu: React.FC<WorkspaceContextMenuProps> = ({
         >
           {t('conversation.workspace.contextMenu.open')}
         </button>
-        {isFile && (
-          <button
-            type='button'
-            className={MENU_BUTTON_BASE}
-            onClick={() => {
-              void handleRevealNode(node);
-              closeContextMenu();
-            }}
-          >
-            {t('conversation.workspace.contextMenu.openLocation')}
-          </button>
-        )}
+        {/* Reveal in the OS file explorer. Works for folders too: showItemInFolder
+            on a folder path selects it in its parent, exactly like the file case. */}
+        <button
+          type='button'
+          className={MENU_BUTTON_BASE}
+          onClick={() => {
+            void handleRevealNode(node);
+            closeContextMenu();
+          }}
+        >
+          {t('conversation.workspace.contextMenu.openLocation')}
+        </button>
         {isFile && isPreviewSupported && (
           <button
             type='button'

--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -103,11 +103,16 @@ const GuidPage: React.FC = () => {
     projectId?: string;
     /** Project name, shown as a "New chat in {project}" indicator above the composer. */
     projectName?: string;
+    /** The project's managed workspace folder, auto-filled as the chat's dir. */
+    projectWorkspace?: string;
   } | null;
   // Project scoping: when present, useGuidSend stamps extra.projectId on the new
   // conversation. Backend / model / assistant pickers stay fully free.
   const projectId = workflowRouteState?.projectId;
   const projectName = workflowRouteState?.projectName;
+  // The project's own folder, when the composer opened from a project. Threaded
+  // into useGuidSend so an auto-filled project dir is NOT flagged customWorkspace.
+  const projectWorkspace = workflowRouteState?.projectWorkspace;
   const workflowSession = useWorkflowSession(
     workflowRouteState?.workflowSessionId,
     workflowRouteState?.initialWorkflowSession
@@ -263,6 +268,7 @@ const GuidPage: React.FC = () => {
 
     // Project scoping (undefined on the normal new-chat surface)
     projectId,
+    projectWorkspace,
   });
 
   const recordTelemetry = useUsageTelemetry();

--- a/src/renderer/pages/guid/hooks/useGuidSend.ts
+++ b/src/renderer/pages/guid/hooks/useGuidSend.ts
@@ -80,6 +80,14 @@ export type GuidSendDeps = {
    * model / assistant pickers stay fully free - the project does not constrain them.
    */
   projectId?: string;
+  /**
+   * The project's managed workspace folder, when the composer opened inside a
+   * project. Used to distinguish "user deliberately picked a custom folder" from
+   * "we auto-filled the project's own folder": only the former is a custom
+   * workspace. Marking an auto-filled project dir as custom would wrongly disable
+   * the project-workspace self-heal guards. Undefined outside a project.
+   */
+  projectWorkspace?: string;
 };
 
 export type GuidSendResult = {
@@ -151,11 +159,15 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
     openTab,
     t,
     projectId,
+    projectWorkspace,
   } = deps;
   const sendingRef = useRef(false);
 
   const handleSend = useCallback(async (): Promise<boolean> => {
-    const isCustomWorkspace = !!dir;
+    // customWorkspace means ONLY that the user chose a folder that is NOT the
+    // project's managed folder. An auto-filled project dir (dir === project
+    // workspace) is not custom, so it never disables the project self-heal guards.
+    const isCustomWorkspace = !!dir && dir !== projectWorkspace;
     const finalWorkspace = dir || '';
     // Stamped into every create path's extra when the composer runs inside a
     // project. Omitted from extra when undefined so it never pollutes a normal chat.
@@ -550,6 +562,7 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
     openTab,
     t,
     projectId,
+    projectWorkspace,
   ]);
 
   const sendMessageHandler = useCallback((opts?: { onSent?: () => void }) => {

--- a/src/renderer/pages/projects/components/ProjectFilesPanel.tsx
+++ b/src/renderer/pages/projects/components/ProjectFilesPanel.tsx
@@ -8,6 +8,7 @@ import { Message } from '@arco-design/web-react';
 import React from 'react';
 import ChatWorkspace from '@/renderer/pages/conversation/Workspace';
 import { PreviewPanel, PreviewProvider, usePreviewContext } from '@/renderer/pages/conversation/Preview';
+import WorkspaceOpenButton from '@/renderer/pages/conversation/components/ChatLayout/WorkspaceOpenButton';
 
 /**
  * Project Files = the same file tree the chat workspace uses, PLUS the same
@@ -19,18 +20,26 @@ import { PreviewPanel, PreviewProvider, usePreviewContext } from '@/renderer/pag
 const FilesInner: React.FC<{ workspace: string; projectId: string }> = ({ workspace, projectId }) => {
   const { isOpen } = usePreviewContext();
   return (
-    <div className='flex h-full w-full overflow-hidden'>
-      <div
-        className={isOpen ? 'w-340px flex-shrink-0 h-full overflow-hidden' : 'flex-1 h-full overflow-hidden'}
-        style={isOpen ? { borderRight: '1px solid var(--color-border-2)' } : undefined}
-      >
-        <ChatWorkspace workspace={workspace} conversation_id={`project:${projectId}`} messageApi={Message} />
+    <div className='flex h-full w-full flex-col overflow-hidden'>
+      {/* Open-folder affordance: project files live in a real, Finder-visible
+          folder (~/Documents/Wayland/<name>), so give the Files tab a way to open
+          it. WorkspaceOpenButton hides itself for temp/non-desktop workspaces. */}
+      <div className='flex items-center justify-end px-12px py-4px border-b border-[var(--color-border-2)] flex-shrink-0'>
+        <WorkspaceOpenButton workspacePath={workspace} />
       </div>
-      {isOpen && (
-        <div className='flex-1 min-w-0 h-full overflow-hidden'>
-          <PreviewPanel />
+      <div className='flex flex-1 w-full min-h-0 overflow-hidden'>
+        <div
+          className={isOpen ? 'w-340px flex-shrink-0 h-full overflow-hidden' : 'flex-1 h-full overflow-hidden'}
+          style={isOpen ? { borderRight: '1px solid var(--color-border-2)' } : undefined}
+        >
+          <ChatWorkspace workspace={workspace} conversation_id={`project:${projectId}`} messageApi={Message} />
         </div>
-      )}
+        {isOpen && (
+          <div className='flex-1 min-w-0 h-full overflow-hidden'>
+            <PreviewPanel />
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/tests/unit/projectServiceWorkspace.test.ts
+++ b/tests/unit/projectServiceWorkspace.test.ts
@@ -10,8 +10,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockAllocate = vi.hoisted(() => vi.fn(async (name: string) => `/Docs/Wayland/${name}`));
+const mockEnsure = vi.hoisted(() => vi.fn(async () => '/Docs/Wayland/Proj'));
+const mockEnforce = vi.hoisted(() =>
+  // Mirror the real enforcer: repoint a non-custom project chat's workspace onto
+  // the project folder (returns true), but never touch a user-picked custom one.
+  vi.fn(async (extra: Record<string, unknown>) => {
+    if (extra.customWorkspace) return false;
+    extra.workspace = '/Docs/Wayland/Proj';
+    return true;
+  })
+);
 vi.mock('@process/services/projectWorkspace', () => ({
   allocateProjectWorkspace: mockAllocate,
+  ensureProjectWorkspace: mockEnsure,
+  enforceProjectWorkspace: mockEnforce,
 }));
 
 const mockBootstrap = vi.hoisted(() => vi.fn(async () => {}));
@@ -74,5 +86,60 @@ describe('ProjectServiceImpl.createProject persistent workspace (#455)', () => {
     expect(repo.createProject).toHaveBeenCalled();
     // No workspace -> no bootstrap.
     expect(mockBootstrap).not.toHaveBeenCalled();
+  });
+});
+
+describe('ProjectServiceImpl.assignConversation re-homes workspace (#30)', () => {
+  beforeEach(() => {
+    mockEnsure.mockClear();
+    mockEnforce.mockClear();
+  });
+
+  it('ensures + enforces the project workspace, persists it, and evicts the cached task', async () => {
+    const repo = makeRepo();
+    const convs = {
+      getConversation: vi.fn(async () => ({ id: 'c1', extra: { workspace: '/tmp/wcore-temp-1' } })),
+      updateConversation: vi.fn(async () => {}),
+    };
+    const evict = vi.fn();
+    const svc = new ProjectServiceImpl(repo as never, convs as never, evict);
+
+    await svc.assignConversation('c1', 'p1');
+
+    // Lazy-migrate the project workspace, then pin this chat onto it.
+    expect(mockEnsure).toHaveBeenCalledWith('p1');
+    expect(mockEnforce).toHaveBeenCalled();
+    // The exact re-homed extra is what gets persisted (not a stale copy).
+    const [id, updates, mergeExtra] = convs.updateConversation.mock.calls[0];
+    expect(id).toBe('c1');
+    expect(mergeExtra).toBe(true);
+    expect(updates).toEqual({
+      extra: expect.objectContaining({ projectId: 'p1', workspace: '/Docs/Wayland/Proj' }),
+    });
+    // Re-homed -> cached task evicted so the next turn rebuilds in the project dir.
+    expect(evict).toHaveBeenCalledWith('c1');
+  });
+
+  it('preserves a user-picked custom workspace and does not evict', async () => {
+    const repo = makeRepo();
+    const convs = {
+      getConversation: vi.fn(async () => ({
+        id: 'c2',
+        extra: { workspace: '/picked/dir', customWorkspace: true },
+      })),
+      updateConversation: vi.fn(async () => {}),
+    };
+    const evict = vi.fn();
+    const svc = new ProjectServiceImpl(repo as never, convs as never, evict);
+
+    await svc.assignConversation('c2', 'p1');
+
+    // projectId is still stamped + persisted, but the custom folder is untouched.
+    const persisted = convs.updateConversation.mock.calls[0][1] as {
+      extra: { projectId: string; workspace: string };
+    };
+    expect(persisted.extra.projectId).toBe('p1');
+    expect(persisted.extra.workspace).toBe('/picked/dir');
+    expect(evict).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/projectServiceWorkspace.test.ts
+++ b/tests/unit/projectServiceWorkspace.test.ts
@@ -95,14 +95,16 @@ describe('ProjectServiceImpl.assignConversation re-homes workspace (#30)', () =>
     mockEnforce.mockClear();
   });
 
-  it('ensures + enforces the project workspace, persists it, and evicts the cached task', async () => {
+  it('ensures + enforces the project workspace, persists it, and evicts the idle cached task', async () => {
     const repo = makeRepo();
     const convs = {
       getConversation: vi.fn(async () => ({ id: 'c1', extra: { workspace: '/tmp/wcore-temp-1' } })),
       updateConversation: vi.fn(async () => {}),
     };
-    const evict = vi.fn();
-    const svc = new ProjectServiceImpl(repo as never, convs as never, evict);
+    // An open-but-idle chat: the cached task exists and is finished, so evicting
+    // it is safe and forces the next turn to respawn in the project folder.
+    const taskCache = { getStatus: vi.fn(() => 'finished' as const), evict: vi.fn() };
+    const svc = new ProjectServiceImpl(repo as never, convs as never, taskCache);
 
     await svc.assignConversation('c1', 'p1');
 
@@ -116,8 +118,27 @@ describe('ProjectServiceImpl.assignConversation re-homes workspace (#30)', () =>
     expect(updates).toEqual({
       extra: expect.objectContaining({ projectId: 'p1', workspace: '/Docs/Wayland/Proj' }),
     });
-    // Re-homed -> cached task evicted so the next turn rebuilds in the project dir.
-    expect(evict).toHaveBeenCalledWith('c1');
+    // Re-homed + idle -> cached task evicted so the next turn rebuilds in the project dir.
+    expect(taskCache.evict).toHaveBeenCalledWith('c1');
+  });
+
+  it('does NOT evict an actively-streaming (running) task, but still persists the re-home', async () => {
+    const repo = makeRepo();
+    const convs = {
+      getConversation: vi.fn(async () => ({ id: 'c3', extra: { workspace: '/tmp/wcore-temp-9' } })),
+      updateConversation: vi.fn(async () => {}),
+    };
+    // Chat assigned mid-turn: evicting would kill the in-flight stream, so skip it.
+    const taskCache = { getStatus: vi.fn(() => 'running' as const), evict: vi.fn() };
+    const svc = new ProjectServiceImpl(repo as never, convs as never, taskCache);
+
+    await svc.assignConversation('c3', 'p1');
+
+    // Workspace is still re-homed + persisted (correctness holds either way)...
+    const persisted = convs.updateConversation.mock.calls[0][1] as { extra: { workspace: string } };
+    expect(persisted.extra.workspace).toBe('/Docs/Wayland/Proj');
+    // ...but the in-flight turn is NOT aborted; it re-homes on its next spawn.
+    expect(taskCache.evict).not.toHaveBeenCalled();
   });
 
   it('preserves a user-picked custom workspace and does not evict', async () => {
@@ -129,8 +150,8 @@ describe('ProjectServiceImpl.assignConversation re-homes workspace (#30)', () =>
       })),
       updateConversation: vi.fn(async () => {}),
     };
-    const evict = vi.fn();
-    const svc = new ProjectServiceImpl(repo as never, convs as never, evict);
+    const taskCache = { getStatus: vi.fn(() => 'finished' as const), evict: vi.fn() };
+    const svc = new ProjectServiceImpl(repo as never, convs as never, taskCache);
 
     await svc.assignConversation('c2', 'p1');
 
@@ -140,6 +161,7 @@ describe('ProjectServiceImpl.assignConversation re-homes workspace (#30)', () =>
     };
     expect(persisted.extra.projectId).toBe('p1');
     expect(persisted.extra.workspace).toBe('/picked/dir');
-    expect(evict).not.toHaveBeenCalled();
+    // Not re-homed -> no eviction (guard short-circuits before getStatus).
+    expect(taskCache.evict).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/useGuidSend.dom.test.ts
+++ b/tests/unit/useGuidSend.dom.test.ts
@@ -342,4 +342,65 @@ describe('useGuidSend', () => {
       );
     });
   });
+
+  describe('customWorkspace flag (project vs user-picked folder)', () => {
+    // wcore create call carries extra.customWorkspace directly, so assert on it.
+    const MODEL = { useModel: 'test-model', name: 'Test', platform: 'wcore' } as unknown as TProviderWithModel;
+
+    it('does NOT flag customWorkspace when the dir is the auto-filled project workspace', async () => {
+      const deps = makeDeps({
+        selectedAgent: 'wcore',
+        currentModel: MODEL,
+        dir: '/Docs/Wayland/Proj',
+        projectId: 'p1',
+        projectWorkspace: '/Docs/Wayland/Proj',
+      });
+      const { result } = renderHook(() => useGuidSend(deps));
+      await act(async () => {
+        await result.current.handleSend();
+      });
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'wcore',
+          extra: expect.objectContaining({ customWorkspace: false, projectId: 'p1' }),
+        })
+      );
+    });
+
+    it('flags customWorkspace when the user picked a folder different from the project workspace', async () => {
+      const deps = makeDeps({
+        selectedAgent: 'wcore',
+        currentModel: MODEL,
+        dir: '/some/other/folder',
+        projectId: 'p1',
+        projectWorkspace: '/Docs/Wayland/Proj',
+      });
+      const { result } = renderHook(() => useGuidSend(deps));
+      await act(async () => {
+        await result.current.handleSend();
+      });
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          extra: expect.objectContaining({ customWorkspace: true }),
+        })
+      );
+    });
+
+    it('flags customWorkspace for a non-project chat with a chosen dir', async () => {
+      const deps = makeDeps({
+        selectedAgent: 'wcore',
+        currentModel: MODEL,
+        dir: '/some/folder',
+      });
+      const { result } = renderHook(() => useGuidSend(deps));
+      await act(async () => {
+        await result.current.handleSend();
+      });
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          extra: expect.objectContaining({ customWorkspace: true }),
+        })
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Problem

Chats that belong to a Project wrote the agent's files to a hidden, ephemeral "Temporary Space" (`<userData>/wayland/<backend>-temp-<timestamp>`) instead of the project's real folder (`~/Documents/Wayland/<name>/`). Files never appeared in the project's Files tab and users could not find them on disk.

## Root causes (three)

1. **Assigning an existing chat to a project never re-homed its workspace.** `ProjectServiceImpl.assignConversation` only stamped `projectId` into `extra`; it never allocated or repointed the workspace, so the chat kept its temp dir.
2. **A running/cached chat kept writing to temp after assignment until app restart**, because the spawn-time enforcement is skipped for cached tasks.
3. **Project chats were wrongly flagged `customWorkspace: true`.** The composer pre-fills `dir` with the project's own folder, which set `isCustomWorkspace = !!dir`, permanently disabling the self-heal guards — so a project whose workspace was unresolved at compose time could never recover to the project folder.

Separately, there was no "open folder" affordance on the Projects UI, and the file-tree "open location" item was gated to files only (folders could not be revealed).

## Changes

- `assignConversation` now re-homes: `ensureProjectWorkspace(projectId)` -> `enforceProjectWorkspace(extra)` -> persist, reusing the exact helpers the create path uses. It evicts the cached task so a live chat picks up the new folder without a restart, but only when the task is not actively streaming (gated on `AgentStatus !== 'running'`) so an in-flight turn is never aborted; the corrected workspace still persists and takes effect on the next spawn.
- `isCustomWorkspace` now means only a deliberately user-chosen folder: `!!dir && dir !== projectWorkspace`. Auto-filling with the project's own folder no longer sets the flag.
- Projects Files tab renders the existing `WorkspaceOpenButton` ("Open workspace folder"); the file-tree "open location" item now works for folder nodes too.
- New `AgentKillReason` variant `workspace_rehome` for the eviction path.

## Verification

- `npm run typecheck`, `oxlint` (0/0), and vitest all green; new unit tests cover the re-home + eviction (idle -> evict, running -> not evicted but still persisted) and the customWorkspace flag logic (auto-fill -> false, user pick -> true).
- Independent adversarial cross-audit: no blockers (verdict GO-WITH-NITS; nits addressed).
- Live-verified on a running build with a real Flux profile: a project chat created `wayland-verify.md` in `~/Documents/Wayland/WSVerify1/` (engine cwd = the project folder, panel header showed the project path, `find` confirmed it was in zero temp dirs); assigning a standalone chat switched its engine cwd from the temp dir to the project folder live with no restart; the Open-folder affordance renders on the Files tab.

Fixes the "chat files land in a Temporary Space you cannot open" report.
