### PR TITLE
fix(voice): capture mic on signed macOS build + resolve OpenAI Whisper key from connected provider

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -228,6 +228,13 @@ mac:
     NSAppleEventsUsageDescription: >-
       Wayland controls other apps on your behalf when you ask the Computer-Use
       agent to complete a task.
+    # NSMicrophoneUsageDescription IS an Apple-honored TCC purpose string: macOS
+    # surfaces it on the microphone consent prompt. Required (with the
+    # com.apple.security.device.audio-input entitlement) for voice input
+    # (speech-to-text) to capture the mic on a hardened, signed build.
+    NSMicrophoneUsageDescription: >-
+      Wayland uses your microphone for voice input (speech-to-text) in the chat
+      box. Audio is only captured while you are dictating.
 
 dmg:
   # Use UDZO format which is more reliable on CI

--- a/entitlements.plist
+++ b/entitlements.plist
@@ -12,5 +12,7 @@
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
   </dict>
 </plist>

--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -12,6 +12,7 @@ import type { OpenDialogOptions } from 'electron';
 import { buildProvider, buildEmitter } from './bridgeAllowlist';
 import type { McpSource } from '../../process/services/mcpServices/McpProtocol';
 import type { CuaPermissionStatus, PrivacyPane } from '../../process/services/macPermissions/cuaPermissions';
+import type { MicPermissionStatus } from '../../process/services/macPermissions/micPermission';
 import type { DoctorReport } from '../../process/doctor/types';
 import type { AgentBackend, AcpModelInfo } from '../types/acpTypes';
 import type { SlashCommandItem } from '../chat/slash/types';
@@ -99,6 +100,14 @@ export const shell = {
 export const cua = {
   getStatus: buildProvider<CuaPermissionStatus, void>('cua.get-permission-status'),
   openSettings: buildProvider<void, { pane: PrivacyPane }>('cua.open-privacy-pane'),
+};
+
+// Microphone permission for voice input (speech-to-text). requestAccess triggers
+// the macOS mic TCC prompt on demand; getStatus reads the grant without
+// prompting. Both report 'unsupported' off macOS.
+export const mic = {
+  getStatus: buildProvider<MicPermissionStatus, void>('mic.get-permission-status'),
+  requestAccess: buildProvider<MicPermissionStatus, void>('mic.request-permission'),
 };
 
 // Generic conversation capabilities

--- a/src/process/bridge/index.ts
+++ b/src/process/bridge/index.ts
@@ -31,6 +31,7 @@ import { initModelBridge } from './modelBridge';
 import { initPreviewHistoryBridge } from './previewHistoryBridge';
 import { initShellBridge } from './shellBridge';
 import { initCuaPermissionBridge } from './cuaPermissionBridge';
+import { initMicPermissionBridge } from './micPermissionBridge';
 import { initStarOfficeBridge } from './starOfficeBridge';
 import { initSpeechToTextBridge } from './speechToTextBridge';
 import { initVoiceAssetBridge } from './voiceAssetBridge';
@@ -88,6 +89,7 @@ export function initAllBridges(deps: BridgeDependencies): void {
   initDialogBridge();
   initShellBridge();
   initCuaPermissionBridge();
+  initMicPermissionBridge();
   initFsBridge();
   initFileWatchBridge();
   initConversationBridge(deps.conversationService, deps.workerTaskManager, deps.teamSessionService);

--- a/src/process/bridge/micPermissionBridge.ts
+++ b/src/process/bridge/micPermissionBridge.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Microphone permission IPC bridge (voice input / speech-to-text).
+ *
+ * `requestAccess` triggers the macOS mic TCC prompt on demand (when the user
+ * starts the mic test or dictation); `getStatus` reads the current grant
+ * without prompting. Quiet on non-macOS (both report `'unsupported'`).
+ */
+
+import { ipcBridge } from '@/common';
+import { getMicrophoneStatus, requestMicrophoneAccess } from '@process/services/macPermissions/micPermission';
+
+export function initMicPermissionBridge(): void {
+  ipcBridge.mic.getStatus.provider(async () => getMicrophoneStatus());
+  ipcBridge.mic.requestAccess.provider(async () => requestMicrophoneAccess());
+}

--- a/src/process/bridge/services/SpeechToTextService.ts
+++ b/src/process/bridge/services/SpeechToTextService.ts
@@ -16,6 +16,7 @@ import { mainError, mainLog, mainWarn } from '@process/utils/mainLogger';
 import { ProcessConfig } from '@process/utils/initStorage';
 import { WhisperLocal } from '@process/services/voice/WhisperLocal';
 import { readConnectedFluxKey } from '@process/connectors/fluxKey';
+import { readConnectedProviderKey } from '@process/connectors/providerKey';
 import { resolveFluxSttDefault } from '@process/utils/fluxSttDefault';
 
 type OpenAITranscriptionResponse = {
@@ -187,6 +188,26 @@ const resolveSpeechToTextConfig = async (): Promise<SpeechToTextConfig> => {
   if (!stored?.enabled) {
     mainWarn(STT_LOG_TAG, 'Speech-to-text request rejected because feature is disabled');
     throw new Error('STT_DISABLED');
+  }
+
+  // OpenAI Whisper: the key lives in the shared provider store (the connected
+  // OpenAI provider shown in Models/Providers), not the STT config. An explicit
+  // STT override still wins, but its absence falls back to the connected OpenAI
+  // key so a connected provider "just works" without re-entering the key here.
+  // Resolved before the Flux zero-config seed below so an explicit OpenAI choice
+  // backed by a connected key is never silently rerouted to Flux Voice.
+  if (stored.provider === 'openai' && !stored.openai?.apiKey?.trim()) {
+    const sharedKey = await readConnectedProviderKey('openai');
+    if (sharedKey) {
+      return {
+        ...stored,
+        openai: {
+          ...stored.openai,
+          apiKey: sharedKey,
+          model: stored.openai?.model ?? DEFAULT_OPENAI_MODEL,
+        },
+      };
+    }
   }
 
   // Zero-config default: if Flux is connected and the user hasn't configured

--- a/src/process/connectors/providerKey.ts
+++ b/src/process/connectors/providerKey.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Shared retrieval of a connected provider's stored API key from the model
+ * registry (the same store the Models/Providers page shows as "Connected").
+ * Returns the key only when the provider is in the `connected` state with a
+ * non-empty stored key, and swallows errors so callers can treat a missing key
+ * as "not connected" rather than crashing. Mirrors {@link readConnectedFluxKey}
+ * but is provider-agnostic.
+ */
+
+import { getDatabase } from '@process/services/database';
+import { ProviderRepository } from '@process/providers/storage/ProviderRepository';
+import type { ProviderId } from '@process/providers/types';
+
+/** The connected provider's API key, or undefined when not connected. */
+export async function readConnectedProviderKey(providerId: ProviderId): Promise<string | undefined> {
+  try {
+    const db = await getDatabase();
+    const repo = new ProviderRepository(db.getDriver());
+    const provider = repo.listRegistryProviders().find((p) => p.providerId === providerId);
+    if (!provider || provider.state !== 'connected') return undefined;
+    const stored = repo.getRegistryProviderCreds(providerId);
+    if (stored.status !== 'ok') return undefined;
+    const key = stored.creds.key;
+    return typeof key === 'string' && key.length > 0 ? key : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/process/services/macPermissions/micPermission.ts
+++ b/src/process/services/macPermissions/micPermission.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * macOS microphone permission (TCC) helpers for voice input (speech-to-text).
+ *
+ * Unlike the Computer-Use screen/accessibility flow (which deliberately never
+ * prompts - the engine owns that dialog), the mic grant is ours to request:
+ * `requestAccess` calls `systemPreferences.askForMediaAccess('microphone')`,
+ * which shows the OS consent dialog on a fresh install and resolves immediately
+ * (no dialog) once the user has decided. Pairs with the
+ * `com.apple.security.device.audio-input` entitlement + `NSMicrophoneUsageDescription`
+ * so `getUserMedia({ audio: true })` actually captures on a hardened, signed build.
+ *
+ * Both helpers are no-ops off macOS (report `'unsupported'`) so callers stay
+ * platform-agnostic.
+ */
+
+import { systemPreferences } from 'electron';
+
+export type MicPermissionStatus =
+  | 'granted'
+  | 'denied'
+  | 'restricted'
+  | 'not-determined'
+  | 'unknown'
+  | 'unsupported';
+
+/** Current microphone TCC status WITHOUT prompting. */
+export function getMicrophoneStatus(): MicPermissionStatus {
+  if (process.platform !== 'darwin') return 'unsupported';
+  return systemPreferences.getMediaAccessStatus('microphone') as MicPermissionStatus;
+}
+
+/**
+ * Ensure the microphone TCC grant, prompting once when the decision has not yet
+ * been made. Returns the resulting status so the renderer can surface a hard
+ * denial ("enable in System Settings") instead of a silent flat level meter.
+ */
+export async function requestMicrophoneAccess(): Promise<MicPermissionStatus> {
+  if (process.platform !== 'darwin') return 'unsupported';
+  const current = getMicrophoneStatus();
+  // Already decided: askForMediaAccess would resolve without a dialog anyway,
+  // so short-circuit a granted mic and report a prior denial as-is.
+  if (current === 'granted' || current === 'denied' || current === 'restricted') {
+    return current;
+  }
+  try {
+    const granted = await systemPreferences.askForMediaAccess('microphone');
+    return granted ? 'granted' : getMicrophoneStatus();
+  } catch {
+    return getMicrophoneStatus();
+  }
+}

--- a/src/renderer/components/settings/SettingsModal/contents/ToolsModalContent.tsx
+++ b/src/renderer/components/settings/SettingsModal/contents/ToolsModalContent.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/common/config/storage';
 import type { SpeechToTextConfig, SpeechToTextProvider } from '@/common/types/speech';
 import type { TextToSpeechConfig, TextToSpeechProvider } from '@/common/types/ttsTypes';
-import { voiceAsset } from '@/common/adapter/ipcBridge';
+import { modelRegistry, voiceAsset } from '@/common/adapter/ipcBridge';
 import {
   isImageModelName,
   imageModelDisplayLabel,
@@ -417,6 +417,26 @@ export const SpeechToTextSettingsSection: React.FC<{
 }> = ({ config, onChange }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  // Whether OpenAI is connected in the shared provider registry (the same store
+  // Models/Providers shows as "Connected"). When it is, OpenAI Whisper uses that
+  // key automatically, so the panel confirms the key is present instead of
+  // telling the user to go configure it.
+  const [openAIConnected, setOpenAIConnected] = useState<boolean | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void modelRegistry.list
+      .invoke()
+      .then((providers) => {
+        if (cancelled) return;
+        setOpenAIConnected(providers.some((p) => p.providerId === 'openai' && p.state === 'connected'));
+      })
+      .catch(() => {
+        if (!cancelled) setOpenAIConnected(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
   const handleOpenProvidersPage = useCallback(() => {
     try {
       navigate('/settings/models');
@@ -513,22 +533,41 @@ export const SpeechToTextSettingsSection: React.FC<{
         {config.provider === 'openai' ? (
           <>
             <Form.Item label={renderSpeechToTextFieldLabel('settings.speechToTextApiKey', 'required')}>
-              <div className='rounded-12px bg-[var(--color-fill-2)] p-12px flex flex-col sm:flex-row sm:items-center sm:justify-between gap-12px'>
-                <div className='min-w-0'>
-                  <div className='text-13px font-medium text-t-primary'>
-                    {t('settings.voiceProviderKeyDeferTitle', 'Configure your OpenAI key in Providers')}
+              {openAIConnected ? (
+                <div className='rounded-12px bg-[var(--color-fill-2)] p-12px flex flex-col sm:flex-row sm:items-center sm:justify-between gap-12px'>
+                  <div className='min-w-0'>
+                    <div className='text-13px font-medium text-t-primary'>
+                      {t('settings.voiceProviderKeyConnectedTitle', 'Using your connected OpenAI key')}
+                    </div>
+                    <div className='text-12px text-t-secondary'>
+                      {t(
+                        'settings.voiceProviderKeyConnectedBody',
+                        'Speech-to-text uses the OpenAI provider you connected in Models. No extra key needed here.'
+                      )}
+                    </div>
                   </div>
-                  <div className='text-12px text-t-secondary'>
-                    {t(
-                      'settings.voiceProviderKeyDeferBody',
-                      'Provider keys live in one place so every feature can use them.'
-                    )}
-                  </div>
+                  <Button size='small' className='w-full sm:w-auto shrink-0' onClick={handleOpenProvidersPage}>
+                    {t('settings.voiceProviderKeyManageCTA', 'Manage in Providers →')}
+                  </Button>
                 </div>
-                <Button size='small' className='w-full sm:w-auto shrink-0' onClick={handleOpenProvidersPage}>
-                  {t('settings.voiceProviderKeyDeferCTA', 'Open Providers →')}
-                </Button>
-              </div>
+              ) : (
+                <div className='rounded-12px bg-[var(--color-fill-2)] p-12px flex flex-col sm:flex-row sm:items-center sm:justify-between gap-12px'>
+                  <div className='min-w-0'>
+                    <div className='text-13px font-medium text-t-primary'>
+                      {t('settings.voiceProviderKeyDeferTitle', 'Configure your OpenAI key in Providers')}
+                    </div>
+                    <div className='text-12px text-t-secondary'>
+                      {t(
+                        'settings.voiceProviderKeyDeferBody',
+                        'Provider keys live in one place so every feature can use them.'
+                      )}
+                    </div>
+                  </div>
+                  <Button size='small' className='w-full sm:w-auto shrink-0' onClick={handleOpenProvidersPage}>
+                    {t('settings.voiceProviderKeyDeferCTA', 'Open Providers →')}
+                  </Button>
+                </div>
+              )}
             </Form.Item>
             <Form.Item label={renderSpeechToTextFieldLabel('settings.speechToTextBaseUrl', 'optional')}>
               <Input value={config.openai?.baseUrl} onChange={(value) => handleOpenAIChange('baseUrl', value)} />

--- a/src/renderer/components/settings/SettingsModal/contents/ToolsModalContent.tsx
+++ b/src/renderer/components/settings/SettingsModal/contents/ToolsModalContent.tsx
@@ -533,7 +533,11 @@ export const SpeechToTextSettingsSection: React.FC<{
         {config.provider === 'openai' ? (
           <>
             <Form.Item label={renderSpeechToTextFieldLabel('settings.speechToTextApiKey', 'required')}>
-              {openAIConnected ? (
+              {/* Three distinct states: connected (true) shows the "using your
+                  key" banner; not-connected (false) shows the configure/defer
+                  banner; loading (null) renders nothing so the defer banner -
+                  the exact Bug B symptom - never flashes for a connected user. */}
+              {openAIConnected === true ? (
                 <div className='rounded-12px bg-[var(--color-fill-2)] p-12px flex flex-col sm:flex-row sm:items-center sm:justify-between gap-12px'>
                   <div className='min-w-0'>
                     <div className='text-13px font-medium text-t-primary'>
@@ -550,7 +554,7 @@ export const SpeechToTextSettingsSection: React.FC<{
                     {t('settings.voiceProviderKeyManageCTA', 'Manage in Providers →')}
                   </Button>
                 </div>
-              ) : (
+              ) : openAIConnected === false ? (
                 <div className='rounded-12px bg-[var(--color-fill-2)] p-12px flex flex-col sm:flex-row sm:items-center sm:justify-between gap-12px'>
                   <div className='min-w-0'>
                     <div className='text-13px font-medium text-t-primary'>
@@ -567,7 +571,7 @@ export const SpeechToTextSettingsSection: React.FC<{
                     {t('settings.voiceProviderKeyDeferCTA', 'Open Providers →')}
                   </Button>
                 </div>
-              )}
+              ) : null}
             </Form.Item>
             <Form.Item label={renderSpeechToTextFieldLabel('settings.speechToTextBaseUrl', 'optional')}>
               <Input value={config.openai?.baseUrl} onChange={(value) => handleOpenAIChange('baseUrl', value)} />

--- a/src/renderer/hooks/system/useSpeechInput.ts
+++ b/src/renderer/hooks/system/useSpeechInput.ts
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLatestRef } from '@/renderer/hooks/ui/useLatestRef';
 import { transcribeAudioBlob } from '@/renderer/services/SpeechToTextService';
 import { isElectronDesktop } from '@/renderer/utils/platform';
+import { ipcBridge } from '@/common';
 
 export type SpeechInputAvailability = 'record' | 'file' | 'unsupported';
 export type SpeechInputStatus = 'idle' | 'recording' | 'transcribing' | 'error';
@@ -352,6 +353,23 @@ export const useSpeechInput = ({ locale, onTranscript }: UseSpeechInputOptions) 
       setErrorCode('recording-unsupported');
       setStatus('error');
       return;
+    }
+
+    // Trigger the macOS mic TCC prompt on demand (Electron desktop only) so a
+    // signed/hardened build can actually capture the mic, and a denial surfaces
+    // instead of a silent recording. Best-effort: any IPC failure falls through
+    // to getUserMedia, which maps its own permission error.
+    if (isElectronDesktop()) {
+      try {
+        const micStatus = await ipcBridge.mic.requestAccess.invoke();
+        if (micStatus === 'denied' || micStatus === 'restricted') {
+          setErrorCode('permission-denied');
+          setStatus('error');
+          return;
+        }
+      } catch {
+        // Best-effort: fall through to getUserMedia.
+      }
     }
 
     try {

--- a/src/renderer/pages/settings/VoiceSettings/MicrophoneCheck.tsx
+++ b/src/renderer/pages/settings/VoiceSettings/MicrophoneCheck.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@arco-design/web-react';
 import { Mic, Square } from 'lucide-react';
 import WaylandSelect from '@/renderer/components/base/WaylandSelect';
+import { ipcBridge } from '@/common';
 
 type CheckState = 'idle' | 'requesting' | 'listening' | 'graded' | 'error';
 type Grade = 'no-signal' | 'too-quiet' | 'good' | 'too-hot';
@@ -124,6 +125,27 @@ const MicrophoneCheck: React.FC = () => {
     setErrorMsg('');
     peakOverWindowRef.current = 0;
     if (barRef.current) barRef.current.style.width = '0%';
+
+    // Proactively request the macOS mic TCC grant so a signed/hardened build
+    // shows the OS prompt (and a prior denial is surfaced) instead of a silent
+    // flat meter. No-op off macOS (reports 'unsupported'); best-effort so any
+    // IPC failure falls through to getUserMedia's own error handling.
+    try {
+      const micStatus = await ipcBridge.mic.requestAccess.invoke();
+      if (micStatus === 'denied' || micStatus === 'restricted') {
+        cleanup();
+        setState('error');
+        setErrorMsg(
+          t(
+            'settings.voiceMicPermissionBlocked',
+            'Microphone access blocked. Open System Settings → Privacy → Microphone and enable Wayland.'
+          )
+        );
+        return;
+      }
+    } catch {
+      // Best-effort: fall through to getUserMedia.
+    }
 
     const constraints: MediaStreamConstraints = {
       audio: selectedDeviceId ? { deviceId: { exact: selectedDeviceId } } : true,

--- a/tests/unit/process/bridge/speechToTextService.test.ts
+++ b/tests/unit/process/bridge/speechToTextService.test.ts
@@ -24,10 +24,16 @@ import { ProcessConfig } from '@process/utils/initStorage';
 import { SpeechToTextService } from '@process/bridge/services/SpeechToTextService';
 import { mainError, mainLog, mainWarn } from '@process/utils/mainLogger';
 import { readConnectedProviderKey } from '@process/connectors/providerKey';
+import { readConnectedFluxKey } from '@process/connectors/fluxKey';
 
 describe('SpeechToTextService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Clean per-test default: no connected keys unless a test opts in. Set after
+    // clearAllMocks (which clears call history but keeps implementations) so a
+    // per-test override never leaks into the next test.
+    vi.mocked(readConnectedProviderKey).mockResolvedValue(undefined);
+    vi.mocked(readConnectedFluxKey).mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -235,6 +241,35 @@ describe('SpeechToTextService', () => {
       provider: 'openai',
       text: 'hi',
     });
+  });
+
+  it('resolves the OpenAI key before the Flux zero-config seed (no silent reroute)', async () => {
+    // OpenAI Whisper selected, no explicit STT key, and BOTH the connected
+    // OpenAI provider AND Flux have a key. Correct ordering resolves OpenAI
+    // first, so the request must hit the OpenAI endpoint with the OpenAI key -
+    // NOT be rerouted to Flux Voice. If the Flux seed ran first this fetch
+    // assertion fails (it would call the Flux endpoint with the Flux key).
+    vi.mocked(ProcessConfig.get).mockResolvedValue({
+      enabled: true,
+      provider: 'openai',
+    });
+    vi.mocked(readConnectedProviderKey).mockResolvedValue('shared-openai-key');
+    vi.mocked(readConnectedFluxKey).mockResolvedValue('flux-key');
+
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ language: 'en', text: 'hi' })));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await SpeechToTextService.transcribe({
+      audioBuffer: new Uint8Array([1, 2, 3]),
+      fileName: 'sample.webm',
+      mimeType: 'audio/webm',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, request] = fetchMock.mock.calls[0] as [string, { headers: Record<string, string> }];
+    expect(url).toBe('https://api.openai.com/v1/audio/transcriptions');
+    expect(request.headers.Authorization).toBe('Bearer shared-openai-key');
+    expect(result.provider).toBe('openai');
   });
 
   it('prefers an explicit STT OpenAI key over the shared provider key', async () => {

--- a/tests/unit/process/bridge/speechToTextService.test.ts
+++ b/tests/unit/process/bridge/speechToTextService.test.ts
@@ -12,9 +12,18 @@ vi.mock('@process/utils/mainLogger', () => ({
   mainWarn: vi.fn(),
 }));
 
+vi.mock('@process/connectors/providerKey', () => ({
+  readConnectedProviderKey: vi.fn(),
+}));
+
+vi.mock('@process/connectors/fluxKey', () => ({
+  readConnectedFluxKey: vi.fn(async () => undefined),
+}));
+
 import { ProcessConfig } from '@process/utils/initStorage';
 import { SpeechToTextService } from '@process/bridge/services/SpeechToTextService';
 import { mainError, mainLog, mainWarn } from '@process/utils/mainLogger';
+import { readConnectedProviderKey } from '@process/connectors/providerKey';
 
 describe('SpeechToTextService', () => {
   beforeEach(() => {
@@ -193,5 +202,81 @@ describe('SpeechToTextService', () => {
         provider: 'deepgram',
       })
     );
+  });
+
+  it('falls back to the connected OpenAI provider key when no STT-specific key is set', async () => {
+    // OpenAI Whisper selected, but no key entered in the Voice panel (it defers
+    // to the shared Providers store). The connected OpenAI provider supplies it.
+    vi.mocked(ProcessConfig.get).mockResolvedValue({
+      enabled: true,
+      provider: 'openai',
+    });
+    vi.mocked(readConnectedProviderKey).mockResolvedValue('shared-openai-key');
+
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ language: 'en', text: 'hi' })));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await SpeechToTextService.transcribe({
+      audioBuffer: new Uint8Array([1, 2, 3]),
+      fileName: 'sample.webm',
+      mimeType: 'audio/webm',
+    });
+
+    expect(readConnectedProviderKey).toHaveBeenCalledWith('openai');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.openai.com/v1/audio/transcriptions',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer shared-openai-key' }),
+      })
+    );
+    expect(result).toEqual({
+      language: 'en',
+      model: 'whisper-1',
+      provider: 'openai',
+      text: 'hi',
+    });
+  });
+
+  it('prefers an explicit STT OpenAI key over the shared provider key', async () => {
+    vi.mocked(ProcessConfig.get).mockResolvedValue({
+      enabled: true,
+      provider: 'openai',
+      openai: { apiKey: 'explicit-key', model: 'whisper-1' },
+    });
+    vi.mocked(readConnectedProviderKey).mockResolvedValue('shared-openai-key');
+
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ language: 'en', text: 'hi' })));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await SpeechToTextService.transcribe({
+      audioBuffer: new Uint8Array([1, 2, 3]),
+      fileName: 'sample.webm',
+      mimeType: 'audio/webm',
+    });
+
+    // Explicit key wins and the shared store is never consulted.
+    expect(readConnectedProviderKey).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.openai.com/v1/audio/transcriptions',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer explicit-key' }),
+      })
+    );
+  });
+
+  it('rejects when OpenAI is selected with neither an STT key nor a connected provider', async () => {
+    vi.mocked(ProcessConfig.get).mockResolvedValue({
+      enabled: true,
+      provider: 'openai',
+    });
+    vi.mocked(readConnectedProviderKey).mockResolvedValue(undefined);
+
+    await expect(
+      SpeechToTextService.transcribe({
+        audioBuffer: new Uint8Array([1, 2, 3]),
+        fileName: 'sample.webm',
+        mimeType: 'audio/webm',
+      })
+    ).rejects.toThrow('STT_OPENAI_NOT_CONFIGURED');
   });
 });


### PR DESCRIPTION
## Two voice bugs

### A — Microphone not captured on the signed macOS build (dead level meter)
Settings > Voice STT test showed "Listening..." with a flat meter; the device was listed but never heard. Works in dev, dies in the signed hardened-runtime release because the mic permission plumbing was missing.

- Added `com.apple.security.device.audio-input` to `entitlements.plist`.
- Added `NSMicrophoneUsageDescription` to `electron-builder.yml` `extendInfo`.
- New main-process mic-permission service + bridge (`macPermissions/micPermission.ts`, `bridge/micPermissionBridge.ts`, `ipcBridge.mic`) mirroring the Computer-Use screen-permission pattern: on-demand `askForMediaAccess('microphone')` + `getMediaAccessStatus`, macOS-guarded, registered in `bridge/index.ts`.
- Renderer requests access before `getUserMedia` (dictation start + mic test), best-effort, and surfaces a "microphone blocked — enable in System Settings" message instead of a silent flat meter.

Note: this only takes effect on a signed hardened build; it cannot be proven in dev (dev already captures the mic). Verify on the bundled signed cut: `Info.plist` contains `NSMicrophoneUsageDescription` and the signed entitlements include `com.apple.security.device.audio-input`.

### B — "Configure your OpenAI key" shown even though OpenAI is connected
The STT panel banner was rendered unconditionally for the OpenAI provider and the transcribe handler read only its own STT key block, ignoring the connected provider key.

- New `connectors/providerKey.ts::readConnectedProviderKey(providerId)` — a provider-agnostic clone of `readConnectedFluxKey`, reads the same model-registry store that reports "Connected".
- `SpeechToTextService.resolveSpeechToTextConfig`: for provider `openai` with no explicit STT key, falls back to the connected OpenAI key, resolved BEFORE the Flux zero-config seed (prevents a silent OpenAI->Flux reroute). Explicit STT key + base-URL/model overrides still win.
- UI banner now three-state on the shared registry: connected -> "Using your connected OpenAI key", not-connected -> configure, loading -> nothing (no flash).

## Verification
- STT vitest 8 passed, including an anti-hijack test proven by mutation (swapping the resolution order makes it fail); typecheck exit 0; oxlint 0 errors.
- Independent adversarial cross-audit: GO. Confirmed key precedence (explicit > shared OpenAI > error), Flux-only users unaffected, the resolver is a faithful clone with no dropped guard, Bug A config correct and on-demand (not launch-time, non-blocking). Both audit findings (banner-flash, test-gap) fixed.

Pre-existing follow-up (not this PR): picking OpenAI Whisper with no OpenAI key but Flux connected still silently transcribes via Flux (the Flux zero-config block predates this change).
