### PR TITLE
fix(security): adopt wire-Force gate + close remote cron escalation surface (#495)

### DIFF
--- a/src/common/adapter/bridgeAllowlist.ts
+++ b/src/common/adapter/bridgeAllowlist.ts
@@ -215,14 +215,22 @@ const REMOTE_DENIED_KEYS: ReadonlySet<string> = new Set([
   //     is no per-call remote/local signal inside a buildProvider handler (remote
   //     enforcement is name-based here), so mode cannot be clamped in-handler;
   //     deny the write/exec surface outright, mirroring `wcoreConfig.setSection`.
-  //     add-job/update-job set the mode; run-now fires the agent (exec). The
-  //     read-only views (cron.list-jobs / list-jobs-by-conversation / get-job)
-  //     and cron.remove-job stay allowed for the paired UI. Tradeoff: remote
-  //     devices can no longer create/update or manually trigger cron jobs;
-  //     scheduled jobs still fire and local creation is unaffected. ---
+  //     add-job/update-job set the mode; run-now fires the agent (exec);
+  //     save-skill writes the job's SKILL.md verbatim (validated only for YAML
+  //     frontmatter shape, NOT instruction content), so a remote caller could
+  //     plant arbitrary agent instructions that the next scheduled fire runs
+  //     with exec capability — deny it too; confirm-proposal accepts a pending
+  //     cron proposal (creates a real job) and leaks its edit payload. The
+  //     read-only views (cron.list-jobs / list-jobs-by-conversation / get-job /
+  //     has-skill) and cron.remove-job stay allowed for the paired UI. Tradeoff:
+  //     remote devices can no longer create/update, plant skills for, accept
+  //     proposals for, or manually trigger cron jobs; scheduled jobs still fire
+  //     and local creation is unaffected. ---
   'cron.add-job',
   'cron.update-job',
   'cron.run-now',
+  'cron.save-skill',
+  'cron.confirm-proposal',
   // --- In-app engine updater. `install` downloads + stages a native binary the
   //     next engine spawn executes; a remote caller reaching it is an RCE chain.
   //     `check` hits the network + discloses the engine version. HUMAN-only. ---

--- a/src/common/adapter/bridgeAllowlist.ts
+++ b/src/common/adapter/bridgeAllowlist.ts
@@ -207,6 +207,22 @@ const REMOTE_DENIED_KEYS: ReadonlySet<string> = new Set([
   // Also deny the read: it discloses the engine's security/tools posture to a
   // paired WebUI client (no secret values, but defence-in-depth — SEC review F2).
   'wcoreConfig.getSection',
+  // --- Cron write/exec surface. A cron job carries `agentConfig.mode`, which the
+  //     executor applies via `task.setMode()` at run time. With the bundled
+  //     engine now honoring a wire `set_mode` (WAYLAND_ALLOW_WIRE_FORCE, #495), a
+  //     remote-authored job with mode `yolo`/`force`/`auto_edit`/`bypassPermissions`
+  //     would spawn a Force/AutoEdit-mode agent with NO local user action. There
+  //     is no per-call remote/local signal inside a buildProvider handler (remote
+  //     enforcement is name-based here), so mode cannot be clamped in-handler;
+  //     deny the write/exec surface outright, mirroring `wcoreConfig.setSection`.
+  //     add-job/update-job set the mode; run-now fires the agent (exec). The
+  //     read-only views (cron.list-jobs / list-jobs-by-conversation / get-job)
+  //     and cron.remove-job stay allowed for the paired UI. Tradeoff: remote
+  //     devices can no longer create/update or manually trigger cron jobs;
+  //     scheduled jobs still fire and local creation is unaffected. ---
+  'cron.add-job',
+  'cron.update-job',
+  'cron.run-now',
   // --- In-app engine updater. `install` downloads + stages a native binary the
   //     next engine spawn executes; a remote caller reaching it is an RCE chain.
   //     `check` hits the network + discloses the engine version. HUMAN-only. ---

--- a/src/process/agent/wcore/envBuilder.ts
+++ b/src/process/agent/wcore/envBuilder.ts
@@ -676,9 +676,10 @@ export function buildEngineSpawnEnv(opts: {
   //     explicit local user action (the composer selector) or a cron job whose
   //     mode was set by the local user - NEVER from model output (inbound engine
   //     events never call setMode). The model cannot induce a `set_mode`. A
-  //     paired REMOTE device cannot author a looser cron mode either: the cron
-  //     write/exec surface (cron.add-job/update-job/run-now) is remote-denied in
-  //     bridgeAllowlist, so a remote caller cannot plant a Force/AutoEdit job.
+  //     paired REMOTE device cannot author a looser cron mode either: the full
+  //     cron write/exec/skill surface (cron.add-job/update-job/run-now/save-skill/
+  //     confirm-proposal) is remote-denied in bridgeAllowlist, so a remote caller
+  //     cannot plant a Force/AutoEdit job nor a skill file it would run.
   //  3. Remote/WebUI callers reach `acp.set-mode` only through the paired-device
   //     WebSocket, which is already gated by the WebUI's own token/pairing auth
   //     (see bridgeAllowlist). Opening the gate restores exactly the pre-0.12.19

--- a/src/process/agent/wcore/envBuilder.ts
+++ b/src/process/agent/wcore/envBuilder.ts
@@ -658,5 +658,31 @@ export function buildEngineSpawnEnv(opts: {
     out.WAYLAND_HOME = opts.waylandHome;
   }
 
+  // Opt the bundled engine into honoring a wire `set_mode` that loosens
+  // permission (AutoEdit / Force). Engine >=0.12.19 (GHSA-8r7g-7556-hj3j)
+  // IGNORES a permission-loosening `set_mode` sent over the json-stream wire
+  // unless it was launched with `--force` or this env is set. The desktop's
+  // composer "Permission/Autopilot" selector drives `set_mode` over that wire
+  // (AgentModeSelector -> acp.set-mode -> WCoreManager.setMode -> WCoreAgent),
+  // so without opting in, selecting Autopilot/Force would silently no-op after
+  // the 0.12.19 bundle bump (#495).
+  //
+  // Blanket-enabling is safe here (not scoped per-mode / no respawn) because:
+  //  1. The gate is BOOT-ONLY (set once at launch, immutable mid-session), so a
+  //     per-mode approach would force a kill+respawn on every switch into a
+  //     looser mode.
+  //  2. This engine is the desktop's OWN trusted child, spawned over a private
+  //     stdin the desktop exclusively writes. `set_mode` is only ever emitted
+  //     from an explicit local user action (the composer selector) or a
+  //     user-configured cron job - NEVER from model output (inbound engine
+  //     events never call setMode). The model cannot induce a `set_mode`.
+  //  3. Remote/WebUI callers reach `acp.set-mode` only through the paired-device
+  //     WebSocket, which is already gated by the WebUI's own token/pairing auth
+  //     (see bridgeAllowlist). Opening the gate restores exactly the pre-0.12.19
+  //     behavior for that already-authenticated surface; it grants no new
+  //     capability. The engine's default (gate closed) still protects any OTHER
+  //     spawner (standalone CLI, third-party) from an untrusted wire peer.
+  out.WAYLAND_ALLOW_WIRE_FORCE = '1';
+
   return out;
 }

--- a/src/process/agent/wcore/envBuilder.ts
+++ b/src/process/agent/wcore/envBuilder.ts
@@ -672,10 +672,13 @@ export function buildEngineSpawnEnv(opts: {
   //     per-mode approach would force a kill+respawn on every switch into a
   //     looser mode.
   //  2. This engine is the desktop's OWN trusted child, spawned over a private
-  //     stdin the desktop exclusively writes. `set_mode` is only ever emitted
-  //     from an explicit local user action (the composer selector) or a
-  //     user-configured cron job - NEVER from model output (inbound engine
-  //     events never call setMode). The model cannot induce a `set_mode`.
+  //     stdin the desktop exclusively writes. `set_mode` is emitted only from an
+  //     explicit local user action (the composer selector) or a cron job whose
+  //     mode was set by the local user - NEVER from model output (inbound engine
+  //     events never call setMode). The model cannot induce a `set_mode`. A
+  //     paired REMOTE device cannot author a looser cron mode either: the cron
+  //     write/exec surface (cron.add-job/update-job/run-now) is remote-denied in
+  //     bridgeAllowlist, so a remote caller cannot plant a Force/AutoEdit job.
   //  3. Remote/WebUI callers reach `acp.set-mode` only through the paired-device
   //     WebSocket, which is already gated by the WebUI's own token/pairing auth
   //     (see bridgeAllowlist). Opening the gate restores exactly the pre-0.12.19

--- a/tests/unit/bridgeAllowlist.redteam.test.ts
+++ b/tests/unit/bridgeAllowlist.redteam.test.ts
@@ -115,7 +115,11 @@ describe('isAllowedForRemote - onboarding credential writes denied', () => {
  * remote/local signal inside a buildProvider handler, so the mode cannot be
  * clamped in-handler; the write/exec surface is denied outright, mirroring
  * `wcoreConfig.setSection`. add-job/update-job set the mode; run-now fires the
- * agent. The read-only views + remove-job stay allowed for the paired UI.
+ * agent; save-skill writes the job's SKILL.md verbatim (a remote caller could
+ * otherwise plant arbitrary agent instructions the next fire runs with exec);
+ * confirm-proposal accepts a pending proposal (creates a job) and leaks its edit
+ * payload. The read-only views (+ has-skill) and remove-job stay allowed for the
+ * paired UI.
  *
  * Note: this is the REMOTE gate only. A LOCALLY-configured cron job (local
  * Electron IPC renderer) never passes through `isAllowedForRemote` - the adapter
@@ -123,14 +127,14 @@ describe('isAllowedForRemote - onboarding credential writes denied', () => {
  * is unaffected.
  */
 describe('isAllowedForRemote - cron write/exec surface denied (#495)', () => {
-  it.each(['cron.add-job', 'cron.update-job', 'cron.run-now'])(
-    'denies subscribe-%s for remote callers (blocks remote mode escalation)',
+  it.each(['cron.add-job', 'cron.update-job', 'cron.run-now', 'cron.save-skill', 'cron.confirm-proposal'])(
+    'denies subscribe-%s for remote callers (blocks remote mode escalation / skill planting)',
     (key) => {
       expect(isAllowedForRemote(`subscribe-${key}`)).toBe(false);
     }
   );
 
-  it.each(['cron.list-jobs', 'cron.list-jobs-by-conversation', 'cron.get-job', 'cron.remove-job'])(
+  it.each(['cron.list-jobs', 'cron.list-jobs-by-conversation', 'cron.get-job', 'cron.has-skill', 'cron.remove-job'])(
     'still allows the read/remove provider subscribe-%s for remote callers',
     (key) => {
       expect(isAllowedForRemote(`subscribe-${key}`)).toBe(true);

--- a/tests/unit/bridgeAllowlist.redteam.test.ts
+++ b/tests/unit/bridgeAllowlist.redteam.test.ts
@@ -104,3 +104,36 @@ describe('isAllowedForRemote - onboarding credential writes denied', () => {
     expect(isAllowedForRemote('subscribe-onboarding.infer-focus')).toBe(true);
   });
 });
+
+/**
+ * Cron write/exec surface must NOT be reachable by a remote (paired-device
+ * WebSocket) caller (#495 follow-up). A cron job carries `agentConfig.mode`,
+ * which the executor applies via `task.setMode()` at run time; with the bundled
+ * engine now honoring a wire `set_mode` (WAYLAND_ALLOW_WIRE_FORCE), a
+ * remote-authored `yolo`/`force`/`auto_edit`/`bypassPermissions` job would spawn
+ * a Force/AutoEdit-mode agent with no local user action. There is no per-call
+ * remote/local signal inside a buildProvider handler, so the mode cannot be
+ * clamped in-handler; the write/exec surface is denied outright, mirroring
+ * `wcoreConfig.setSection`. add-job/update-job set the mode; run-now fires the
+ * agent. The read-only views + remove-job stay allowed for the paired UI.
+ *
+ * Note: this is the REMOTE gate only. A LOCALLY-configured cron job (local
+ * Electron IPC renderer) never passes through `isAllowedForRemote` - the adapter
+ * applies it exclusively to the WebSocket path - so local creation with any mode
+ * is unaffected.
+ */
+describe('isAllowedForRemote - cron write/exec surface denied (#495)', () => {
+  it.each(['cron.add-job', 'cron.update-job', 'cron.run-now'])(
+    'denies subscribe-%s for remote callers (blocks remote mode escalation)',
+    (key) => {
+      expect(isAllowedForRemote(`subscribe-${key}`)).toBe(false);
+    }
+  );
+
+  it.each(['cron.list-jobs', 'cron.list-jobs-by-conversation', 'cron.get-job', 'cron.remove-job'])(
+    'still allows the read/remove provider subscribe-%s for remote callers',
+    (key) => {
+      expect(isAllowedForRemote(`subscribe-${key}`)).toBe(true);
+    }
+  );
+});

--- a/tests/unit/wcore-toolKeyEnv.test.ts
+++ b/tests/unit/wcore-toolKeyEnv.test.ts
@@ -156,6 +156,15 @@ describe('buildEngineSpawnEnv - SEC-1 allowlist', () => {
     expect(env.BRAVE_SEARCH_API_KEY).toBeUndefined();
     expect(env.TAVILY_API_KEY).toBeUndefined();
   });
+
+  it('opts the bundled engine into honoring a wire set_mode (WAYLAND_ALLOW_WIRE_FORCE, #495/GHSA-8r7g)', () => {
+    // Engine >=0.12.19 ignores a permission-loosening wire `set_mode` unless
+    // launched with this env. The desktop is the engine's trusted local
+    // operator, so the bundled spawn always opts in - otherwise the composer's
+    // Autopilot/Force selector would silently no-op after the bundle bump.
+    const env = buildEngineSpawnEnv({ providerEnv: {} });
+    expect(env.WAYLAND_ALLOW_WIRE_FORCE).toBe('1');
+  });
 });
 
 describeNativeSqlite('ToolKeyStore - encrypted at rest (real DB round-trip)', () => {


### PR DESCRIPTION
## What
Desktop adoption of engine 0.12.19's boot-only wire-Force gate, plus closing the pre-existing remote cron privilege-escalation surface it amplifies.

Closes #495.

## Changes
1. **Wire-Force adoption** (`ee9945a6e`): the desktop sets `WAYLAND_ALLOW_WIRE_FORCE=1` when spawning the bundled engine, so Autopilot/Force keeps working against 0.12.19's new boot-only gate. Safe because the model cannot induce `set_mode` (inbound engine events never call setMode) and the wire is the desktop-owned stdin.

2. **Close the remote cron escalation-to-exec class** (`0f0799ae3` + `b6139f8c5`): a cron job carries `agentConfig.mode`, applied by the executor via `task.setMode()`; with the engine now honoring wire `set_mode`, a remote paired device could author/trigger a Force/AutoEdit job with no local action. There is no per-call remote/local signal inside a bridge handler, so the mode can't be clamped in-handler — the full inbound cron write/exec/skill command surface is denied at the WebSocket allowlist (mirroring `wcoreConfig.setSection`):
   - `cron.add-job`, `cron.update-job` (set mode)
   - `cron.run-now` (fires the agent)
   - `cron.save-skill` (writes a job's `SKILL.md` verbatim — a remote caller could otherwise plant arbitrary agent instructions the next fire runs with exec)
   - `cron.confirm-proposal` (accepts a pending proposal → creates a job; edit branch leaks payload)

   Read-only views (`list-jobs`, `list-jobs-by-conversation`, `get-job`, `has-skill`) and `remove-job` stay remote-allowed. Local Electron IPC never passes through the remote gate, so local cron creation with any mode is unaffected.

## Verification
- Two independent adversarial security audits. The first found the initial deny list incomplete (`save-skill`, `confirm-proposal` reachable = remote-to-RCE); both were added. The second confirmed the full write/exec/skill class is closed with no sibling gap, correct key spelling, and no regression.
- Full inbound cron command surface enumerated (10 `.provider` handlers): every write/exec/skill handler denied; only reads + `remove-job` allowed.
- Red-team test (`tests/unit/bridgeAllowlist.redteam.test.ts`): 39/39 pass, covering the full deny set and the read+remove allow set.
- oxfmt clean; oxlint 4 warnings, all pre-existing (none in changed lines).