### PR TITLE
test(tools): stub modelRegistry in ToolsModalContent mock (fixes main red shard)

### DIFF
--- a/tests/unit/common/toolsModalContent.dom.test.tsx
+++ b/tests/unit/common/toolsModalContent.dom.test.tsx
@@ -233,6 +233,14 @@ vi.mock('@/common/adapter/ipcBridge', () => ({
       invoke: vi.fn(() => Promise.resolve({ success: true, data: [] })),
     },
   },
+  // ToolsModalContent's STT panel reads the shared provider registry on mount to
+  // decide whether OpenAI Whisper can reuse a connected key (#496). Stub it so
+  // the mount effect resolves instead of throwing "No modelRegistry export".
+  modelRegistry: {
+    list: {
+      invoke: vi.fn(() => Promise.resolve([])),
+    },
+  },
 }));
 
 vi.mock('@/renderer/hooks/mcp', () => ({


### PR DESCRIPTION
#496 (94fca5780) added a `modelRegistry.list.invoke()` mount effect to ToolsModalContent (OpenAI Whisper key reuse) but did not update the DOM test's `ipcBridge` mock, which stubbed only `acpConversation`. The effect throws "No modelRegistry export is defined on the ipcBridge mock", failing all 3 tests in `tests/unit/common/toolsModalContent.dom.test.tsx` on Unit Tests Shard 1/4 (macos + ubuntu) — a false-green merge that turned main red and blocks every downstream PR (incl. the 0.11.9 cut).

Fix: stub `modelRegistry.list.invoke` to resolve `[]` so the mount effect settles. Test-only; component code is correct (`modelRegistry` is a real export at ipcBridge.ts:2028).

Verified: `vitest run tests/unit/common/toolsModalContent.dom.test.tsx` → 3/3 pass.