### PR TITLE
chore(release): 0.11.9 — bundle wayland-core v0.12.19 (GHSA-8r7g batch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to the Wayland Electron app are documented in this file. For
 
 ## [Unreleased]
 
+## [0.11.9] - 2026-07-01
+
+### Highlights
+
+- **Bundled engine → wayland-core v0.12.19.** Carries the GHSA-8r7g-7556-hj3j security batch: approval-token binding, project-config posture clamp, a boot-only opt-in gate for wire-driven Force/AutoEdit (`--force` / `WAYLAND_ALLOW_WIRE_FORCE=1`), default-deny project-config hooks, and shared MCP tool-name sanitization across all providers.
+
+### Security
+
+- **Adopt the engine's boot-only wire-Force gate (#495).** The desktop now opts the bundled engine into wire-driven mode changes (`WAYLAND_ALLOW_WIRE_FORCE=1`) so Autopilot/Force keeps working against v0.12.19, and closes the remote cron privilege-escalation surface it would otherwise expose: the full remote cron write/exec/skill command set (`add-job`, `update-job`, `run-now`, `save-skill`, `confirm-proposal`) is denied to paired-device WebSocket callers. Read-only cron views and local cron creation are unaffected.
+
+### Fixes
+
+- **Project chats write to the project workspace (#494).** Conversations created inside a project now share the project's workspace folder instead of a per-chat Temporary Space, and the folder opens correctly.
+- **Voice dictation on the signed macOS build (#496).** The microphone permission is requested on demand with the correct entitlement and usage string, and OpenAI Whisper reuses the key from your connected provider.
+
 ## [0.11.8] - 2026-06-30
 
 ### Highlights
@@ -25,7 +40,7 @@ All notable changes to the Wayland Electron app are documented in this file. For
 
 ### Highlights
 
-- **Meet Concierge — the first built-in helper inside Wayland.** Concierge knows your actual setup (the models you've connected, your skills, your scheduled tasks) and answers from it in plain English. Ask it what Wayland can do, how to do anything, or why something didn't run. Better yet, it sets things up *for* you: it proposes a change, you see a confirmation card, you click Apply — connect an AI provider, set your default model, add a connected tool, or edit an assistant. You stay in control; it does the legwork.
+- **Meet Concierge — the first built-in helper inside Wayland.** Concierge knows your actual setup (the models you've connected, your skills, your scheduled tasks) and answers from it in plain English. Ask it what Wayland can do, how to do anything, or why something didn't run. Better yet, it sets things up _for_ you: it proposes a change, you see a confirmation card, you click Apply — connect an AI provider, set your default model, add a connected tool, or edit an assistant. You stay in control; it does the legwork.
 - **Every assistant now opens with suggested starting cards** (Concierge and Cowork included), so you're never staring at a blank box. The home screen is cleaner.
 
 ### Wayland Core engine

--- a/installer/scripts/postinstall.mjs
+++ b/installer/scripts/postinstall.mjs
@@ -17,7 +17,7 @@ import { fileURLToPath } from 'node:url';
 
 // Kept in lockstep with scripts/prepareWaylandCore.js DEFAULT_WCORE_VERSION by
 // scripts/stage-wcore-bump.mjs. Do not hand-edit; run that tool so both move.
-const WCORE_VERSION = 'v0.12.17';
+const WCORE_VERSION = 'v0.12.19';
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PAYLOAD = resolve(HERE, '..', 'payload');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Wayland",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "description": "The local-first desktop AI agent that drives every AI CLI on your machine - Claude Code, Codex, Gemini and more, on your keys.",
   "keywords": [],
   "license": "AGPL-3.0-or-later",

--- a/scripts/bundled-wcore-shasums.json
+++ b/scripts/bundled-wcore-shasums.json
@@ -1,5 +1,13 @@
 {
   "_comment": "Authoritative SHA-256 checksums for bundled wayland-core release archives (the downloaded .tar.gz / .zip assets), keyed by release tag then asset filename. Mirrors scripts/bundled-bun-shasums.json. Source of truth: the SHASUMS published alongside each signed FerroxLabs/wayland-core release. The downloaded archive is verified against this file BEFORE it is extracted, copied, or executed. Update this file in lockstep with DEFAULT_WCORE_VERSION in scripts/prepareWaylandCore.js and regenerate on every engine version bump.",
+  "v0.12.19": {
+    "wayland-core-v0.12.19-aarch64-apple-darwin.tar.gz": "sha256:a05b102abe834888451a1d1289e5b703a69617e190630c1a6b7654e2e99cc35d",
+    "wayland-core-v0.12.19-x86_64-apple-darwin.tar.gz": "sha256:ddea7129b86d7c68c783b1ff452ed49b252ebbb824e671dc50e46d5cbe68003f",
+    "wayland-core-v0.12.19-aarch64-unknown-linux-gnu.tar.gz": "sha256:5ef05d6845a6209dd224ddeb276656a93f73b095527cdd631f07c8aa84d2bf68",
+    "wayland-core-v0.12.19-x86_64-unknown-linux-gnu.tar.gz": "sha256:56a08b5234da05503d5e566d7b7137fce09168f03c2123ccd4b4575594bd6a4e",
+    "wayland-core-v0.12.19-aarch64-pc-windows-msvc.zip": "sha256:9854517ebd0b134541e5708a67b48c6c8830676948967198ae442d7af3e01630",
+    "wayland-core-v0.12.19-x86_64-pc-windows-msvc.zip": "sha256:83dd4d656a103a89795075fccfc42ec31edf4d9da066cd46af563cfec66eef5e"
+  },
   "v0.12.17": {
     "wayland-core-v0.12.17-aarch64-apple-darwin.tar.gz": "sha256:281a7290c0c92c950fac6472d0a041e91898ffdc3c74a6f59468fad4bb65632e",
     "wayland-core-v0.12.17-x86_64-apple-darwin.tar.gz": "sha256:f701a8b6832b6a102751cec2b162da7b00cf9f18afa268d6b62a1abafe90a626",

--- a/scripts/prepareWaylandCore.js
+++ b/scripts/prepareWaylandCore.js
@@ -184,7 +184,7 @@ function verifyArchiveChecksum(archivePath, expectedHex, assetName, tag) {
 // FerroxLabs/wayland-core; Desktop integrates against a specific tag rather
 // than tracking `latest` so version drift can't sneak in via a release made
 // while a CI build is mid-flight. Override with WCORE_VERSION=... when bumping.
-const DEFAULT_WCORE_VERSION = 'v0.12.17';
+const DEFAULT_WCORE_VERSION = 'v0.12.19';
 
 function getVersion() {
   return (process.env.WCORE_VERSION || DEFAULT_WCORE_VERSION).trim();


### PR DESCRIPTION
**STAGED — HOLD for Sean's go (mic eyeball + publish approval). Do not merge/tag without sign-off.**

Bundles engine v0.12.17 → **v0.12.19**, carrying the GHSA-8r7g-7556-hj3j security batch, and adopts the wire-Force gate + closes the remote cron escalation surface (#495). Also ships #494 (project workspace) and #496 (signed-build voice).

### Local validation (done)
- `stage-wcore-bump v0.12.19`: 6 shasums pinned, verified by real download.
- Bundled binary = `wayland-core 0.12.19`; GHSA gate strings present (boot-only wire-Force opt-in, approval-bridge secret, SetMode-refused).
- Local **signed** build (Developer ID: Ferrox Labs), `verify-packaged-resources` **PASS**, DMG built.
- Packaged-artifact Bug A check: Info.plist `NSMicrophoneUsageDescription` present, signed entitlements include `com.apple.security.device.audio-input`, version 0.11.9.

### Publish (held)
Tag `v0.11.9` NOT pushed. Pushing it triggers build-and-release.yml (6-platform signed + smoke + npm publish). Held for Sean's 2-min mic grant on the local signed .app, then merge + tag.