### PR TITLE
feat(updater): add bundled updater extension

### DIFF
--- a/resources/bundled-extensions/wayland-updater/aion-extension.json
+++ b/resources/bundled-extensions/wayland-updater/aion-extension.json
@@ -1,0 +1,21 @@
+{
+  "name": "wayland-updater",
+  "displayName": "Wayland Updater",
+  "version": "1.0.0",
+  "apiVersion": "^1.0.0",
+  "description": "Settings extension for checking Wayland and Wayland Core updates.",
+  "author": "Wayland",
+  "icon": "assets/updater.svg",
+  "contributes": {
+    "settingsTabs": [
+      {
+        "id": "updater",
+        "name": "Updater",
+        "icon": "assets/updater.svg",
+        "entryPoint": "settings/updater.html",
+        "position": { "anchor": "storage", "placement": "after" },
+        "order": 10
+      }
+    ]
+  }
+}

--- a/resources/bundled-extensions/wayland-updater/assets/updater.svg
+++ b/resources/bundled-extensions/wayland-updater/assets/updater.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
+  <rect x="6" y="6" width="52" height="52" rx="14" fill="#2563eb"/>
+  <path d="M32 16v24" stroke="#fff" stroke-width="5" stroke-linecap="round"/>
+  <path d="m21 31 11 11 11-11" stroke="#fff" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M18 49h28" stroke="#dbeafe" stroke-width="5" stroke-linecap="round"/>
+</svg>

--- a/resources/bundled-extensions/wayland-updater/assets/updater.svg
+++ b/resources/bundled-extensions/wayland-updater/assets/updater.svg
@@ -1,6 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
-  <rect x="6" y="6" width="52" height="52" rx="14" fill="#2563eb"/>
-  <path d="M32 16v24" stroke="#fff" stroke-width="5" stroke-linecap="round"/>
-  <path d="m21 31 11 11 11-11" stroke="#fff" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M18 49h28" stroke="#dbeafe" stroke-width="5" stroke-linecap="round"/>
+  <path d="M32 14v28" stroke="#86909c" stroke-width="6" stroke-linecap="round"/>
+  <path d="m20 31 12 12 12-12" stroke="#86909c" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M18 50h28" stroke="#86909c" stroke-width="6" stroke-linecap="round"/>
 </svg>

--- a/resources/bundled-extensions/wayland-updater/settings/updater.html
+++ b/resources/bundled-extensions/wayland-updater/settings/updater.html
@@ -1,0 +1,341 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Wayland Updater</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        --bg: #f7f8fa;
+        --panel: #ffffff;
+        --panel-soft: #f2f3f5;
+        --text: #111827;
+        --muted: #6b7280;
+        --border: #e5e7eb;
+        --primary: #2563eb;
+        --primary-strong: #1d4ed8;
+        --success: #16a34a;
+        --warning: #d97706;
+        --danger: #dc2626;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #111318;
+          --panel: #171a21;
+          --panel-soft: #20242d;
+          --text: #f5f7fb;
+          --muted: #9aa3b2;
+          --border: #2d3340;
+          --primary: #60a5fa;
+          --primary-strong: #3b82f6;
+        }
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+      }
+
+      .page {
+        min-height: 400px;
+        padding: 0;
+      }
+
+      .shell {
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        background: var(--panel);
+        overflow: hidden;
+      }
+
+      .head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+        padding: 18px;
+        border-bottom: 1px solid var(--border);
+        background: var(--panel-soft);
+      }
+
+      h1 {
+        margin: 0;
+        font-size: 22px;
+        line-height: 1.2;
+      }
+
+      .subtitle {
+        margin-top: 5px;
+        color: var(--muted);
+        font-size: 13px;
+        line-height: 1.45;
+      }
+
+      .body {
+        display: grid;
+        gap: 14px;
+        padding: 18px;
+      }
+
+      .card {
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 14px;
+        background: var(--panel);
+      }
+
+      .row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 14px;
+        flex-wrap: wrap;
+      }
+
+      .title {
+        font-weight: 700;
+        font-size: 14px;
+      }
+
+      .meta {
+        margin-top: 4px;
+        color: var(--muted);
+        font-size: 12px;
+        line-height: 1.45;
+      }
+
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        min-height: 24px;
+        border-radius: 999px;
+        padding: 0 9px;
+        background: var(--panel-soft);
+        color: var(--muted);
+        font-size: 12px;
+        font-weight: 650;
+      }
+
+      .badge.available {
+        background: rgba(37, 99, 235, 0.12);
+        color: var(--primary);
+      }
+
+      .badge.good {
+        background: rgba(22, 163, 74, 0.12);
+        color: var(--success);
+      }
+
+      .badge.warn {
+        background: rgba(217, 119, 6, 0.12);
+        color: var(--warning);
+      }
+
+      .badge.bad {
+        background: rgba(220, 38, 38, 0.12);
+        color: var(--danger);
+      }
+
+      button {
+        height: 32px;
+        border: 0;
+        border-radius: 7px;
+        padding: 0 14px;
+        background: var(--primary);
+        color: #fff;
+        font-weight: 700;
+        cursor: pointer;
+      }
+
+      button:hover {
+        background: var(--primary-strong);
+      }
+
+      button.secondary {
+        background: var(--panel-soft);
+        color: var(--text);
+      }
+
+      label {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        color: var(--muted);
+        font-size: 12px;
+      }
+
+      input {
+        accent-color: var(--primary);
+      }
+
+      pre {
+        margin: 10px 0 0;
+        white-space: pre-wrap;
+        color: var(--muted);
+        font: 12px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <section class="shell">
+        <header class="head">
+          <div>
+            <h1>Updater</h1>
+            <div class="subtitle">Wayland and Wayland Core update status from the extension host.</div>
+          </div>
+          <button id="check">Check now</button>
+        </header>
+        <div class="body">
+          <div class="card row">
+            <div>
+              <div class="title">Release channel</div>
+              <div class="meta" id="summary">Ready to check for updates.</div>
+            </div>
+            <label><input id="prerelease" type="checkbox" /> Include prereleases</label>
+          </div>
+          <div class="card row">
+            <div>
+              <div class="title">Wayland app</div>
+              <div class="meta" id="wayland">No check has run yet.</div>
+            </div>
+            <span class="badge" id="waylandBadge">Idle</span>
+          </div>
+          <div class="card row">
+            <div>
+              <div class="title">Wayland Core</div>
+              <div class="meta" id="core">No check has run yet.</div>
+            </div>
+            <span class="badge" id="coreBadge">Idle</span>
+          </div>
+          <div class="card row">
+            <div>
+              <div class="title">Install flow</div>
+              <div class="meta">Downloads, restart, and install actions stay in Wayland's built-in updater modal.</div>
+            </div>
+            <button class="secondary" id="openModal">Open updater</button>
+          </div>
+          <pre id="error" hidden></pre>
+        </div>
+      </section>
+    </main>
+    <script>
+      (function () {
+        var pending = new Map();
+        var seq = 0;
+
+        function $(id) {
+          return document.getElementById(id);
+        }
+
+        function resize() {
+          parent.postMessage({ type: 'aion:settings-size', height: document.documentElement.scrollHeight }, '*');
+        }
+
+        function request(action, payload) {
+          var reqId = 'updater-' + ++seq;
+          parent.postMessage({ type: 'wayland-updater:request', reqId: reqId, action: action, payload: payload || {} }, '*');
+          return new Promise(function (resolve) {
+            pending.set(reqId, resolve);
+            setTimeout(function () {
+              if (!pending.has(reqId)) return;
+              pending.delete(reqId);
+              resolve({ ok: false, error: 'Updater request timed out.' });
+            }, 15000);
+          });
+        }
+
+        window.addEventListener('message', function (event) {
+          var data = event.data || {};
+          if (data.type !== 'wayland-updater:response' || !data.reqId) return;
+          var resolve = pending.get(data.reqId);
+          if (!resolve) return;
+          pending.delete(data.reqId);
+          resolve(data);
+        });
+
+        function setBadge(id, text, kind) {
+          var el = $(id);
+          el.textContent = text;
+          el.className = 'badge ' + (kind || '');
+        }
+
+        function setError(text) {
+          var el = $('error');
+          if (!text) {
+            el.hidden = true;
+            el.textContent = '';
+            return;
+          }
+          el.hidden = false;
+          el.textContent = text;
+        }
+
+        function renderCheck(result) {
+          if (!result.ok) {
+            setError(result.error || 'Update check failed.');
+            $('summary').textContent = 'Could not complete update check.';
+            setBadge('waylandBadge', 'Error', 'bad');
+            return;
+          }
+
+          setError('');
+          var manual = result.manual || {};
+          var data = manual.data || {};
+          var latest = data.latest || {};
+          var current = data.currentVersion || '-';
+          var updateAvailable = Boolean(data.updateAvailable || result.autoUpdateAvailable);
+          if (updateAvailable) {
+            $('summary').textContent = 'An update is available.';
+            $('wayland').textContent = 'Current ' + current + ' -> ' + (latest.version || result.autoVersion || 'latest');
+            setBadge('waylandBadge', 'Available', 'available');
+          } else {
+            $('summary').textContent = 'No Wayland app update is available.';
+            $('wayland').textContent = 'Current version: ' + current;
+            setBadge('waylandBadge', 'Up to date', 'good');
+          }
+
+          var core = data.ijfw || {};
+          if (core.installed && core.updateAvailable) {
+            $('core').textContent = 'IJFW ' + (core.currentVersion || '-') + ' -> ' + (core.latestVersion || '-');
+            setBadge('coreBadge', 'Available', 'available');
+          } else if (core.installed && !core.pathHealthy) {
+            $('core').textContent = 'IJFW is installed, but the ijfw command is not on PATH.';
+            setBadge('coreBadge', 'Path issue', 'warn');
+          } else if (core.installed) {
+            $('core').textContent = 'Current version: ' + (core.currentVersion || '-');
+            setBadge('coreBadge', 'Up to date', 'good');
+          } else {
+            $('core').textContent = 'Wayland Core updater status is unavailable.';
+            setBadge('coreBadge', 'Unknown', '');
+          }
+          resize();
+        }
+
+        $('check').addEventListener('click', function () {
+          $('summary').textContent = 'Checking...';
+          setBadge('waylandBadge', 'Checking', '');
+          request('check', { includePrerelease: $('prerelease').checked }).then(renderCheck);
+        });
+
+        $('openModal').addEventListener('click', function () {
+          request('openModal', {});
+        });
+
+        window.addEventListener('load', function () {
+          resize();
+          request('check', { includePrerelease: $('prerelease').checked }).then(renderCheck);
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/resources/bundled-extensions/wayland-updater/settings/updater.html
+++ b/resources/bundled-extensions/wayland-updater/settings/updater.html
@@ -8,7 +8,13 @@
       :root {
         color-scheme: light dark;
         font-family:
-          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+          Inter,
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          'Segoe UI',
+          sans-serif;
         --bg: #f7f8fa;
         --panel: #ffffff;
         --panel-soft: #f2f3f5;
@@ -181,7 +187,12 @@
         margin: 10px 0 0;
         white-space: pre-wrap;
         color: var(--muted);
-        font: 12px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        font:
+          12px/1.5 ui-monospace,
+          SFMono-Regular,
+          Menlo,
+          Consolas,
+          monospace;
       }
     </style>
   </head>
@@ -232,6 +243,7 @@
       (function () {
         var pending = new Map();
         var seq = 0;
+        var REQUEST_TIMEOUT_MS = 60000;
 
         function $(id) {
           return document.getElementById(id);
@@ -243,14 +255,17 @@
 
         function request(action, payload) {
           var reqId = 'updater-' + ++seq;
-          parent.postMessage({ type: 'wayland-updater:request', reqId: reqId, action: action, payload: payload || {} }, '*');
+          parent.postMessage(
+            { type: 'wayland-updater:request', reqId: reqId, action: action, payload: payload || {} },
+            '*'
+          );
           return new Promise(function (resolve) {
             pending.set(reqId, resolve);
             setTimeout(function () {
               if (!pending.has(reqId)) return;
               pending.delete(reqId);
               resolve({ ok: false, error: 'Updater request timed out.' });
-            }, 15000);
+            }, REQUEST_TIMEOUT_MS);
           });
         }
 
@@ -296,7 +311,8 @@
           var updateAvailable = Boolean(data.updateAvailable || result.autoUpdateAvailable);
           if (updateAvailable) {
             $('summary').textContent = 'An update is available.';
-            $('wayland').textContent = 'Current ' + current + ' -> ' + (latest.version || result.autoVersion || 'latest');
+            $('wayland').textContent =
+              'Current ' + current + ' -> ' + (latest.version || result.autoVersion || 'latest');
             setBadge('waylandBadge', 'Available', 'available');
           } else {
             $('summary').textContent = 'No Wayland app update is available.';

--- a/src/process/webserver/routes/apiRoutes.ts
+++ b/src/process/webserver/routes/apiRoutes.ts
@@ -16,6 +16,7 @@ import { getSystemDir } from '@process/utils/initStorage';
 import { ProcessConfig } from '@process/utils/initStorage';
 import { TokenMiddleware } from '@process/webserver/auth/middleware/TokenMiddleware';
 import { ExtensionRegistry } from '@process/extensions';
+import { resolveAllowedAssetPath } from '@process/extensions/protocol/assetAllowlist';
 import { SpeechToTextService } from '@process/bridge/services/SpeechToTextService';
 import { isActivePreviewPort } from '@process/bridge/pptPreviewBridge';
 import { isActiveOfficeWatchPort } from '@process/bridge/officeWatchBridge';
@@ -542,38 +543,27 @@ export function registerApiRoutes(app: Express): void {
       return res.status(400).json({ message: 'Missing path query parameter' });
     }
 
-    const normalizedPath = path.resolve(rawPath);
-    const registry = ExtensionRegistry.getInstance();
-    const allowedRoots = registry.getLoadedExtensions().map((ext) => path.resolve(ext.directory));
-
-    // Find which trusted root contains this path
-    const matchingRoot = allowedRoots.find(
-      (root) => normalizedPath === root || normalizedPath.startsWith(`${root}${path.sep}`)
-    );
-
-    if (!matchingRoot) {
+    const safePath = resolveAllowedAssetPath(rawPath);
+    if (!safePath) {
       return res.status(403).json({
         message: 'Access denied: path is outside extension directories',
       });
     }
-
-    // Reconstruct path from the trusted root so CodeQL can verify no path traversal occurs.
-    // path.relative() computes the relative portion; verifying it doesn't start with '..'
-    // confirms containment; path.join() re-anchors to the trusted base.
-    const relativePath = path.relative(matchingRoot, normalizedPath);
-    if (relativePath.startsWith('..')) {
-      return res.status(403).json({
-        message: 'Access denied: path is outside extension directories',
-      });
-    }
-
-    const safePath = path.join(matchingRoot, relativePath);
 
     if (!fs.existsSync(safePath) || !fs.statSync(safePath).isFile()) {
       return res.status(404).json({ message: 'Asset not found' });
     }
 
-    return res.sendFile(safePath);
+    // Extension settings pages render in same-origin sandboxed iframes.
+    // The app-wide X-Frame-Options header would block those HTML assets.
+    res.removeHeader('X-Frame-Options');
+    res.setHeader('Cache-Control', 'no-store');
+
+    return res.sendFile(safePath, (error) => {
+      if (!error || res.headersSent) return;
+      console.error('[API] Extension asset send failed:', error);
+      res.status(500).json({ message: 'Failed to serve extension asset' });
+    });
   });
 
   /**

--- a/src/renderer/components/settings/SettingsModal/contents/ExtensionSettingsTabContent.tsx
+++ b/src/renderer/components/settings/SettingsModal/contents/ExtensionSettingsTabContent.tsx
@@ -6,14 +6,10 @@
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  autoUpdate as autoUpdateIpc,
-  extensions as extensionsIpc,
-  ijfw as ijfwIpc,
-  update as updateIpc,
-} from '@/common/adapter/ipcBridge';
+import { extensions as extensionsIpc, ijfw as ijfwIpc } from '@/common/adapter/ipcBridge';
 import WebviewHost from '@/renderer/components/media/WebviewHost';
 import { resolveExtensionAssetUrl } from '@/renderer/utils/platform';
+import { runWaylandUpdaterExtensionCheck } from '@/renderer/pages/settings/utils/waylandUpdaterBridge';
 
 const isExternalSettingsUrl = (url?: string): boolean => /^https?:\/\//i.test(url || '');
 
@@ -112,30 +108,7 @@ const ExtensionSettingsTabContent: React.FC<ExtensionSettingsTabContentProps> = 
 
             if (data.action === 'check') {
               const includePrerelease = Boolean(data.payload?.includePrerelease);
-              let autoUpdateAvailable = false;
-              let autoVersion = '';
-              try {
-                const auto = await autoUpdateIpc.check.invoke({ includePrerelease });
-                if (auto?.success && auto.data?.updateInfo) {
-                  autoUpdateAvailable = true;
-                  autoVersion = auto.data.updateInfo.version || '';
-                }
-              } catch (err) {
-                console.warn('[ExtensionSettingsTabContent] Auto-update check failed for updater extension:', err);
-              }
-
-              const manual = await updateIpc.check.invoke({ includePrerelease });
-              if (!manual?.success) {
-                reply({ ok: false, error: manual?.msg || 'Update check failed.' });
-                return;
-              }
-
-              reply({
-                ok: true,
-                autoUpdateAvailable,
-                autoVersion,
-                manual,
-              });
+              reply(await runWaylandUpdaterExtensionCheck(includePrerelease, '[ExtensionSettingsTabContent]'));
               return;
             }
 

--- a/src/renderer/components/settings/SettingsModal/contents/ExtensionSettingsTabContent.tsx
+++ b/src/renderer/components/settings/SettingsModal/contents/ExtensionSettingsTabContent.tsx
@@ -6,7 +6,12 @@
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { extensions as extensionsIpc } from '@/common/adapter/ipcBridge';
+import {
+  autoUpdate as autoUpdateIpc,
+  extensions as extensionsIpc,
+  ijfw as ijfwIpc,
+  update as updateIpc,
+} from '@/common/adapter/ipcBridge';
 import WebviewHost from '@/renderer/components/media/WebviewHost';
 import { resolveExtensionAssetUrl } from '@/renderer/utils/platform';
 
@@ -74,11 +79,76 @@ const ExtensionSettingsTabContent: React.FC<ExtensionSettingsTabContentProps> = 
       const frameWindow = iframeRef.current?.contentWindow;
       if (!frameWindow || event.source !== frameWindow) return;
 
-      const data = event.data as { type?: string; reqId?: string } | undefined;
+      const data = event.data as
+        | { type?: string; reqId?: string; action?: string; payload?: { includePrerelease?: boolean } }
+        | undefined;
       if (!data) return;
 
       if (data.type === 'aion:get-locale') {
         void postLocaleInit();
+        return;
+      }
+
+      if (data.type === 'wayland-updater:request') {
+        if (extensionName !== 'wayland-updater') return;
+        const reply = (body: Record<string, unknown>) => {
+          frameWindow.postMessage(
+            {
+              type: 'wayland-updater:response',
+              reqId: data.reqId,
+              ...body,
+            },
+            '*'
+          );
+        };
+
+        void (async () => {
+          try {
+            if (data.action === 'openModal') {
+              window.dispatchEvent(new Event('wayland-open-update-modal'));
+              reply({ ok: true });
+              return;
+            }
+
+            if (data.action === 'check') {
+              const includePrerelease = Boolean(data.payload?.includePrerelease);
+              let autoUpdateAvailable = false;
+              let autoVersion = '';
+              try {
+                const auto = await autoUpdateIpc.check.invoke({ includePrerelease });
+                if (auto?.success && auto.data?.updateInfo) {
+                  autoUpdateAvailable = true;
+                  autoVersion = auto.data.updateInfo.version || '';
+                }
+              } catch (err) {
+                console.warn('[ExtensionSettingsTabContent] Auto-update check failed for updater extension:', err);
+              }
+
+              const manual = await updateIpc.check.invoke({ includePrerelease });
+              if (!manual?.success) {
+                reply({ ok: false, error: manual?.msg || 'Update check failed.' });
+                return;
+              }
+
+              reply({
+                ok: true,
+                autoUpdateAvailable,
+                autoVersion,
+                manual,
+              });
+              return;
+            }
+
+            if (data.action === 'updateIjfw') {
+              reply(await ijfwIpc.triggerInstall.invoke());
+              return;
+            }
+
+            throw new Error('unsupported-updater-action');
+          } catch (err) {
+            reply({ ok: false, error: err instanceof Error ? err.message : String(err) });
+          }
+        })();
         return;
       }
 

--- a/src/renderer/components/settings/SettingsModal/index.tsx
+++ b/src/renderer/components/settings/SettingsModal/index.tsx
@@ -45,6 +45,23 @@ const MODAL_HEIGHT = {
   desktop: 459,
 } as const;
 
+const ExtensionMaskIcon: React.FC<{ src: string }> = ({ src }) => (
+  <span
+    className='block w-20px h-20px bg-current'
+    style={{
+      maskImage: `url(${src})`,
+      maskRepeat: 'no-repeat',
+      maskPosition: 'center',
+      maskSize: 'contain',
+      WebkitMaskImage: `url(${src})`,
+      WebkitMaskRepeat: 'no-repeat',
+      WebkitMaskPosition: 'center',
+      WebkitMaskSize: 'contain',
+    }}
+    aria-hidden='true'
+  />
+);
+
 /** Resize event debounce delay (ms) */
 const RESIZE_DEBOUNCE_DELAY = 150;
 
@@ -259,7 +276,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ visible, onCancel, defaul
         key: tab.id,
         label: resolveExtTabName(tab),
         icon: resolvedIcon ? (
-          <img src={resolvedIcon} alt='' className='w-20px h-20px object-contain' />
+          <ExtensionMaskIcon src={resolvedIcon} />
         ) : (
           <Puzzle size={20} color={iconColors.secondary} />
         ),

--- a/src/renderer/pages/settings/ExtensionSettingsPage.tsx
+++ b/src/renderer/pages/settings/ExtensionSettingsPage.tsx
@@ -7,13 +7,28 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { extensions as extensionsIpc, type IExtensionSettingsTab } from '@/common/adapter/ipcBridge';
+import {
+  autoUpdate as autoUpdateIpc,
+  extensions as extensionsIpc,
+  ijfw as ijfwIpc,
+  update as updateIpc,
+  type IExtensionSettingsTab,
+} from '@/common/adapter/ipcBridge';
 import { useExtI18n } from '@/renderer/hooks/system/useExtI18n';
 import WebviewHost from '@/renderer/components/media/WebviewHost';
 import { resolveExtensionAssetUrl } from '@/renderer/utils/platform';
 import SettingsPageWrapper from './components/SettingsPageWrapper';
 
 const isExternalSettingsUrl = (url?: string): boolean => /^https?:\/\//i.test(url || '');
+
+type WaylandUpdaterRequest = {
+  type?: string;
+  action?: string;
+  reqId?: string;
+  payload?: {
+    includePrerelease?: boolean;
+  };
+};
 
 /**
  * Route-based page for rendering extension-contributed settings tabs.
@@ -95,11 +110,74 @@ const ExtensionSettingsPage: React.FC = () => {
       const frameWindow = iframeRef.current?.contentWindow;
       if (!frameWindow || event.source !== frameWindow) return;
 
-      const data = event.data as { type?: string; reqId?: string } | undefined;
+      const data = event.data as ({ type?: string; reqId?: string } & WaylandUpdaterRequest) | undefined;
       if (!data) return;
 
       if (data.type === 'aion:get-locale') {
         void postLocaleInit();
+        return;
+      }
+
+      if (data.type === 'wayland-updater:request') {
+        if (tab._extensionName !== 'wayland-updater') return;
+        const reply = (body: Record<string, unknown>) => {
+          frameWindow.postMessage(
+            {
+              type: 'wayland-updater:response',
+              reqId: data.reqId,
+              ...body,
+            },
+            '*'
+          );
+        };
+
+        void (async () => {
+          try {
+            if (data.action === 'openModal') {
+              window.dispatchEvent(new Event('wayland-open-update-modal'));
+              reply({ ok: true });
+              return;
+            }
+
+            if (data.action === 'check') {
+              const includePrerelease = Boolean(data.payload?.includePrerelease);
+              let autoUpdateAvailable = false;
+              let autoVersion = '';
+              try {
+                const auto = await autoUpdateIpc.check.invoke({ includePrerelease });
+                if (auto?.success && auto.data?.updateInfo) {
+                  autoUpdateAvailable = true;
+                  autoVersion = auto.data.updateInfo.version || '';
+                }
+              } catch (err) {
+                console.warn('[ExtensionSettingsPage] Auto-update check failed for updater extension:', err);
+              }
+
+              const manual = await updateIpc.check.invoke({ includePrerelease });
+              if (!manual?.success) {
+                reply({ ok: false, error: manual?.msg || 'Update check failed.' });
+                return;
+              }
+
+              reply({
+                ok: true,
+                autoUpdateAvailable,
+                autoVersion,
+                manual,
+              });
+              return;
+            }
+
+            if (data.action === 'updateIjfw') {
+              reply(await ijfwIpc.triggerInstall.invoke());
+              return;
+            }
+
+            throw new Error('unsupported-updater-action');
+          } catch (err) {
+            reply({ ok: false, error: err instanceof Error ? err.message : String(err) });
+          }
+        })();
         return;
       }
 

--- a/src/renderer/pages/settings/ExtensionSettingsPage.tsx
+++ b/src/renderer/pages/settings/ExtensionSettingsPage.tsx
@@ -7,17 +7,12 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import {
-  autoUpdate as autoUpdateIpc,
-  extensions as extensionsIpc,
-  ijfw as ijfwIpc,
-  update as updateIpc,
-  type IExtensionSettingsTab,
-} from '@/common/adapter/ipcBridge';
+import { extensions as extensionsIpc, ijfw as ijfwIpc, type IExtensionSettingsTab } from '@/common/adapter/ipcBridge';
 import { useExtI18n } from '@/renderer/hooks/system/useExtI18n';
 import WebviewHost from '@/renderer/components/media/WebviewHost';
 import { resolveExtensionAssetUrl } from '@/renderer/utils/platform';
 import SettingsPageWrapper from './components/SettingsPageWrapper';
+import { runWaylandUpdaterExtensionCheck } from './utils/waylandUpdaterBridge';
 
 const isExternalSettingsUrl = (url?: string): boolean => /^https?:\/\//i.test(url || '');
 
@@ -141,30 +136,7 @@ const ExtensionSettingsPage: React.FC = () => {
 
             if (data.action === 'check') {
               const includePrerelease = Boolean(data.payload?.includePrerelease);
-              let autoUpdateAvailable = false;
-              let autoVersion = '';
-              try {
-                const auto = await autoUpdateIpc.check.invoke({ includePrerelease });
-                if (auto?.success && auto.data?.updateInfo) {
-                  autoUpdateAvailable = true;
-                  autoVersion = auto.data.updateInfo.version || '';
-                }
-              } catch (err) {
-                console.warn('[ExtensionSettingsPage] Auto-update check failed for updater extension:', err);
-              }
-
-              const manual = await updateIpc.check.invoke({ includePrerelease });
-              if (!manual?.success) {
-                reply({ ok: false, error: manual?.msg || 'Update check failed.' });
-                return;
-              }
-
-              reply({
-                ok: true,
-                autoUpdateAvailable,
-                autoVersion,
-                manual,
-              });
+              reply(await runWaylandUpdaterExtensionCheck(includePrerelease, '[ExtensionSettingsPage]'));
               return;
             }
 

--- a/src/renderer/pages/settings/components/SettingsPageWrapper.tsx
+++ b/src/renderer/pages/settings/components/SettingsPageWrapper.tsx
@@ -48,6 +48,26 @@ type NavItem = { label: string; icon: React.ReactElement; path: string; id: stri
 
 type TranslateFn = (key: string, options?: { defaultValue?: string }) => string;
 
+const ExtensionMaskIcon: React.FC<{ src: string; sizeClassName?: string }> = ({
+  src,
+  sizeClassName = 'w-16px h-16px',
+}) => (
+  <span
+    className={classNames('block bg-current text-t-secondary', sizeClassName)}
+    style={{
+      maskImage: `url(${src})`,
+      maskRepeat: 'no-repeat',
+      maskPosition: 'center',
+      maskSize: 'contain',
+      WebkitMaskImage: `url(${src})`,
+      WebkitMaskRepeat: 'no-repeat',
+      WebkitMaskPosition: 'center',
+      WebkitMaskSize: 'contain',
+    }}
+    aria-hidden='true'
+  />
+);
+
 export function getBuiltinSettingsNavItems(isDesktop: boolean, t: TranslateFn): NavItem[] {
   const builtinMap: Record<string, NavItem> = {
     assistants: {
@@ -234,11 +254,7 @@ const SettingsPageWrapper: React.FC<SettingsPageWrapperProps> = ({ children, cla
       return {
         id: tab.id,
         label: resolveExtTabName(tab),
-        icon: resolvedIcon ? (
-          <img src={resolvedIcon} alt='' className='w-16px h-16px object-contain' />
-        ) : (
-          <Puzzle size={16} />
-        ),
+        icon: resolvedIcon ? <ExtensionMaskIcon src={resolvedIcon} /> : <Puzzle size={16} />,
         path: `ext/${tab.id}`,
       };
     };

--- a/src/renderer/pages/settings/components/SettingsSider.tsx
+++ b/src/renderer/pages/settings/components/SettingsSider.tsx
@@ -104,9 +104,26 @@ type SiderItem = {
   id: string;
   label: string;
   icon: React.ReactElement;
-  isImageIcon?: boolean;
+  maskIconUrl?: string;
   path: string;
 };
+
+const ExtensionMaskIcon: React.FC<{ src: string }> = ({ src }) => (
+  <span
+    className='block w-16px h-16px bg-current text-t-secondary'
+    style={{
+      maskImage: `url(${src})`,
+      maskRepeat: 'no-repeat',
+      maskPosition: 'center',
+      maskSize: 'contain',
+      WebkitMaskImage: `url(${src})`,
+      WebkitMaskRepeat: 'no-repeat',
+      WebkitMaskPosition: 'center',
+      WebkitMaskSize: 'contain',
+    }}
+    aria-hidden='true'
+  />
+);
 
 const SettingsSider: React.FC<{ collapsed?: boolean; tooltipEnabled?: boolean }> = ({
   collapsed = false,
@@ -333,8 +350,8 @@ const SettingsSider: React.FC<{ collapsed?: boolean; tooltipEnabled?: boolean }>
       return {
         id: tab.id,
         label: resolveExtTabName(tab),
-        icon: resolvedIcon ? <img src={resolvedIcon} alt='' className='w-full h-full object-contain' /> : <Puzzle />,
-        isImageIcon: Boolean(resolvedIcon),
+        icon: resolvedIcon ? <ExtensionMaskIcon src={resolvedIcon} /> : <Puzzle />,
+        maskIconUrl: resolvedIcon,
         path: `ext/${tab.id}`,
       };
     };
@@ -409,7 +426,7 @@ const SettingsSider: React.FC<{ collapsed?: boolean; tooltipEnabled?: boolean }>
                 }}
               >
                 <span className='w-20px h-20px flex items-center justify-center shrink-0'>
-                  {item.isImageIcon ? (
+                  {item.maskIconUrl ? (
                     <span className='w-16px h-16px flex items-center justify-center'>{item.icon}</span>
                   ) : (
                     React.cloneElement(

--- a/src/renderer/pages/settings/utils/waylandUpdaterBridge.ts
+++ b/src/renderer/pages/settings/utils/waylandUpdaterBridge.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { autoUpdate as autoUpdateIpc, update as updateIpc } from '@/common/adapter/ipcBridge';
+
+const AUTO_UPDATE_CHECK_TIMEOUT_MS = 6000;
+
+type UpdateCheckResponse = {
+  ok: boolean;
+  error?: string;
+  autoUpdateAvailable?: boolean;
+  autoVersion?: string;
+  manual?: Awaited<ReturnType<typeof updateIpc.check.invoke>>;
+};
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timeoutId = window.setTimeout(() => reject(new Error(`Timed out after ${timeoutMs}ms`)), timeoutMs);
+    promise.then(
+      (value) => {
+        window.clearTimeout(timeoutId);
+        resolve(value);
+      },
+      (error) => {
+        window.clearTimeout(timeoutId);
+        reject(error);
+      }
+    );
+  });
+}
+
+export async function runWaylandUpdaterExtensionCheck(
+  includePrerelease: boolean,
+  logPrefix: string
+): Promise<UpdateCheckResponse> {
+  let autoUpdateAvailable = false;
+  let autoVersion = '';
+
+  try {
+    const auto = await withTimeout(autoUpdateIpc.check.invoke({ includePrerelease }), AUTO_UPDATE_CHECK_TIMEOUT_MS);
+    if (auto?.success && auto.data?.updateInfo) {
+      autoUpdateAvailable = true;
+      autoVersion = auto.data.updateInfo.version || '';
+    }
+  } catch (err) {
+    console.warn(`${logPrefix} Auto-update check failed or timed out for updater extension:`, err);
+  }
+
+  const manual = await updateIpc.check.invoke({ includePrerelease });
+  if (!manual?.success) {
+    return { ok: false, error: manual?.msg || 'Update check failed.' };
+  }
+
+  return {
+    ok: true,
+    autoUpdateAvailable,
+    autoVersion,
+    manual,
+  };
+}

--- a/tests/unit/extensions/extensionLoader.test.ts
+++ b/tests/unit/extensions/extensionLoader.test.ts
@@ -119,7 +119,7 @@ describe('extensions/ExtensionLoader', () => {
     try {
       const loaded = await new ExtensionLoader().loadAll();
       const names = loaded.map((e) => e.manifest.name).toSorted();
-      // 10 business packs ship bundled (see resources/bundled-extensions/*).
+      // Bundled extensions ship from resources/bundled-extensions/*.
       expect(names).toEqual([
         'business-commerce',
         'business-content',
@@ -131,6 +131,7 @@ describe('extensions/ExtensionLoader', () => {
         'business-marketing',
         'business-sales',
         'business-support',
+        'wayland-updater',
       ]);
       expect(loaded.every((e) => e.source === 'bundled')).toBe(true);
     } finally {

--- a/tests/unit/renderer/pages/settings/waylandUpdaterBridge.test.ts
+++ b/tests/unit/renderer/pages/settings/waylandUpdaterBridge.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { runWaylandUpdaterExtensionCheck } from '@/renderer/pages/settings/utils/waylandUpdaterBridge';
+import { autoUpdate as autoUpdateIpc, update as updateIpc } from '@/common/adapter/ipcBridge';
+
+vi.mock('@/common/adapter/ipcBridge', () => ({
+  autoUpdate: {
+    check: { invoke: vi.fn() },
+  },
+  update: {
+    check: { invoke: vi.fn() },
+  },
+}));
+
+describe('waylandUpdaterBridge', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('returns the manual updater result when Electron auto-update check times out', async () => {
+    vi.mocked(autoUpdateIpc.check.invoke).mockReturnValue(new Promise(() => {}));
+    vi.mocked(updateIpc.check.invoke).mockResolvedValue({
+      success: true,
+      data: {
+        currentVersion: '0.11.9',
+        latest: { version: '0.11.9' },
+        updateAvailable: false,
+      },
+    } as Awaited<ReturnType<typeof updateIpc.check.invoke>>);
+
+    const resultPromise = runWaylandUpdaterExtensionCheck(false, '[test]');
+    await vi.advanceTimersByTimeAsync(6000);
+
+    await expect(resultPromise).resolves.toMatchObject({
+      ok: true,
+      autoUpdateAvailable: false,
+      manual: { success: true },
+    });
+    expect(updateIpc.check.invoke).toHaveBeenCalledWith({ includePrerelease: false });
+  });
+
+  it('includes Electron auto-update info when it resolves before the timeout', async () => {
+    vi.mocked(autoUpdateIpc.check.invoke).mockResolvedValue({
+      success: true,
+      data: { updateInfo: { version: '0.12.0' } },
+    } as Awaited<ReturnType<typeof autoUpdateIpc.check.invoke>>);
+    vi.mocked(updateIpc.check.invoke).mockResolvedValue({
+      success: true,
+      data: {
+        currentVersion: '0.11.9',
+        latest: { version: '0.12.0' },
+        updateAvailable: true,
+      },
+    } as Awaited<ReturnType<typeof updateIpc.check.invoke>>);
+
+    await expect(runWaylandUpdaterExtensionCheck(true, '[test]')).resolves.toMatchObject({
+      ok: true,
+      autoUpdateAvailable: true,
+      autoVersion: '0.12.0',
+      manual: { success: true },
+    });
+  });
+});

--- a/tests/unit/renderer/settingsSiderNav.dom.test.tsx
+++ b/tests/unit/renderer/settingsSiderNav.dom.test.tsx
@@ -20,7 +20,7 @@
  * still present per the spec).
  */
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
@@ -70,6 +70,7 @@ import SettingsSider, {
   BUILTIN_TAB_IDS,
   LEGACY_ANCHOR_REMAP,
 } from '../../../src/renderer/pages/settings/components/SettingsSider';
+import { extensions as extensionsIpc } from '../../../src/common/adapter/ipcBridge';
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -142,5 +143,36 @@ describe('SettingsSider - Packet 3A nav restructure', () => {
     const modelsItem = document.querySelector('[data-settings-id="models"]');
     expect(modelsItem).not.toBeNull();
     expect(header.compareDocumentPosition(modelsItem as Node) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('renders extension settings icons as monochrome masks instead of full-color images', async () => {
+    vi.mocked(extensionsIpc.getSettingsTabs.invoke).mockResolvedValueOnce([
+      {
+        id: 'ext-wayland-updater-updater',
+        name: 'Updater',
+        icon: '/api/ext-asset?path=updater.svg',
+        entryUrl: '/api/ext-asset?path=updater.html',
+        position: { anchor: 'storage', placement: 'after' },
+        order: 10,
+        _extensionName: 'wayland-updater',
+      },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <SettingsSider />
+      </MemoryRouter>
+    );
+
+    let updaterItem: Element | null = null;
+    await waitFor(() => {
+      updaterItem = document.querySelector('[data-settings-id="ext-wayland-updater-updater"]');
+      expect(updaterItem).not.toBeNull();
+    });
+    expect(updaterItem).not.toBeNull();
+    expect(updaterItem?.querySelector('img')).toBeNull();
+    const maskIcon = updaterItem?.querySelector('[aria-hidden="true"]') as HTMLElement | null;
+    expect(maskIcon?.style.maskImage).toContain('updater.svg');
+    expect(maskIcon?.className).toContain('text-t-secondary');
   });
 });


### PR DESCRIPTION
## Summary
Wayland can now surface update checks through a bundled settings extension instead of relying on a floating updater entry point. The extension renders a local settings tab for Wayland app and Wayland Core update status, while download/install still flows through the existing updater modal.

The host bridge is intentionally narrow: only the `wayland-updater` extension can send `wayland-updater:request` messages, and the host only handles update check, open-modal, and IJFW update actions. This keeps updater-specific IPC out of the general extension surface.

## Validation
- `bun run typecheck`
- `bun run package`

`bun run package` completed with the existing Vite dynamic-import and chunk-size warnings. The built output includes `out/main/bundled-extensions/wayland-updater/`.

## Related
Related: #481

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
