### PR TITLE
fix(model): correct context-meter window for Opus 4.6+/Sonnet 4.6 (1M)

### DIFF
--- a/src/renderer/utils/model/modelContextLimits.ts
+++ b/src/renderer/utils/model/modelContextLimits.ts
@@ -40,16 +40,29 @@ const MODEL_CONTEXT_LIMITS: Record<string, number> = {
   o3: 200_000,
   'o3-mini': 200_000,
 
-  // Claude family
-  'claude-opus-4.5': 200_000,
-  'claude-haiku-4.5': 200_000,
-  'claude-sonnet-4.5': 1_000_000,
-  'claude-opus-4.1': 200_000,
+  // Claude family. Keys use the real (hyphenated) catalog model ids the app
+  // passes here, and values follow the models.dev provider snapshot
+  // (resources/modelsdev-snapshot.json): only Opus 4.6+ and Sonnet 4.6 ship a
+  // 1M window; Opus 4.0/4.1/4.5, Sonnet 4.0/4.5, and Haiku 4.x are 200K. The
+  // bare `claude-opus-4` / `claude-sonnet-4` / `claude-haiku-4` entries are the
+  // fuzzy fallback for dated or variant ids (e.g. `claude-opus-4-20250514`);
+  // longest-match means the versioned keys above win for known 1M models.
+  'claude-opus-4-8': 1_000_000,
+  'claude-opus-4-7': 1_000_000,
+  'claude-opus-4-6': 1_000_000,
+  'claude-opus-4-5': 200_000,
+  'claude-opus-4-1': 200_000,
   'claude-opus-4': 200_000,
-  'claude-sonnet-4': 1_000_000,
-  'claude-3.7-sonnet': 200_000,
-  'claude-3.5-haiku': 200_000,
+  'claude-sonnet-4-6': 1_000_000,
+  'claude-sonnet-4-5': 200_000,
+  'claude-sonnet-4': 200_000,
+  'claude-haiku-4-5': 200_000,
+  'claude-haiku-4': 200_000,
+  'claude-3-7-sonnet': 200_000,
+  'claude-3-5-haiku': 200_000,
+  'claude-3-5-sonnet': 200_000,
   'claude-3-opus': 200_000,
+  'claude-3-sonnet': 200_000,
   'claude-3-haiku': 200_000,
 };
 

--- a/tests/unit/modelContextLimits.test.ts
+++ b/tests/unit/modelContextLimits.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_CONTEXT_LIMIT, getModelContextLimit } from '@/renderer/utils/model/modelContextLimits';
+
+describe('getModelContextLimit', () => {
+  const M = 1_000_000;
+  const K200 = 200_000;
+
+  describe('Opus 4.x context windows (issue #477)', () => {
+    // The reported bug: the current model id resolved to 200K via the bare
+    // `claude-opus-4` fuzzy fallback, so the context meter showed a 200K
+    // denominator for a 1M-window session. It must resolve to 1M.
+    it('resolves claude-opus-4-8 to the 1M window', () => {
+      expect(getModelContextLimit('claude-opus-4-8')).toBe(M);
+    });
+
+    it('resolves the opus-4-8 dated/variant id via fuzzy longest-match to 1M', () => {
+      expect(getModelContextLimit('claude-opus-4-8-20260101')).toBe(M);
+    });
+
+    it('is case-insensitive for opus-4-8', () => {
+      expect(getModelContextLimit('Claude-Opus-4-8')).toBe(M);
+    });
+
+    it('resolves opus 4.6 and 4.7 to 1M', () => {
+      expect(getModelContextLimit('claude-opus-4-7')).toBe(M);
+      expect(getModelContextLimit('claude-opus-4-6')).toBe(M);
+    });
+
+    // Per the models.dev snapshot these are genuinely 200K — the issue's
+    // premise that "all Opus 4.x is 1M" is incorrect for 4.0/4.1/4.5.
+    it('keeps opus 4.0/4.1/4.5 at 200K', () => {
+      expect(getModelContextLimit('claude-opus-4-5')).toBe(K200);
+      expect(getModelContextLimit('claude-opus-4-1')).toBe(K200);
+      expect(getModelContextLimit('claude-opus-4-0')).toBe(K200);
+      // dated Opus 4.0 id falls through to the bare `claude-opus-4` fallback
+      expect(getModelContextLimit('claude-opus-4-20250514')).toBe(K200);
+    });
+  });
+
+  describe('Sonnet 4.x context windows', () => {
+    it('resolves sonnet 4.6 to 1M', () => {
+      expect(getModelContextLimit('claude-sonnet-4-6')).toBe(M);
+    });
+
+    // Regression guard: the old bare `claude-sonnet-4` = 1M key over-reported
+    // Sonnet 4.5 / 4.0 (real 200K) as 1M.
+    it('keeps sonnet 4.5/4.0 at 200K (no longer over-reported)', () => {
+      expect(getModelContextLimit('claude-sonnet-4-5')).toBe(K200);
+      expect(getModelContextLimit('claude-sonnet-4-5-20250929')).toBe(K200);
+      expect(getModelContextLimit('claude-sonnet-4-0')).toBe(K200);
+    });
+  });
+
+  describe('other known models', () => {
+    it('resolves haiku 4.5 to 200K', () => {
+      expect(getModelContextLimit('claude-haiku-4-5')).toBe(K200);
+      expect(getModelContextLimit('claude-haiku-4-5-20251001')).toBe(K200);
+    });
+
+    it('resolves legacy Claude 3 models to 200K (not the 1M default)', () => {
+      expect(getModelContextLimit('claude-3-opus-20240229')).toBe(K200);
+      expect(getModelContextLimit('claude-3-sonnet-20240229')).toBe(K200);
+      expect(getModelContextLimit('claude-3-5-sonnet-20241022')).toBe(K200);
+      expect(getModelContextLimit('claude-3-haiku-20240307')).toBe(K200);
+    });
+
+    it('resolves a Gemini id exactly', () => {
+      expect(getModelContextLimit('gemini-2.5-pro')).toBe(1_048_576);
+    });
+  });
+
+  describe('fallbacks', () => {
+    it('returns the default for unknown or empty model names', () => {
+      expect(getModelContextLimit('some-unknown-model')).toBe(DEFAULT_CONTEXT_LIMIT);
+      expect(getModelContextLimit('')).toBe(DEFAULT_CONTEXT_LIMIT);
+      expect(getModelContextLimit(undefined)).toBe(DEFAULT_CONTEXT_LIMIT);
+      expect(getModelContextLimit(null)).toBe(DEFAULT_CONTEXT_LIMIT);
+    });
+  });
+});


### PR DESCRIPTION
## What

Fixes the context-usage meter denominator (issue #477). `getModelContextLimit` read a table keyed on **dotted** ids (`claude-opus-4.5`), but the app passes the **real hyphenated** catalog ids (`claude-opus-4-8`). Every Claude id therefore only ever hit the bare `claude-opus-4` / `claude-sonnet-4` fuzzy-prefix fallback — so `claude-opus-4-8` resolved to **200K**, and the meter showed `X / 200K` for a session whose real window is **1M** (and any budgeting keyed off this ceiling was wrong).

## Ground truth (important)

Values come from the app's own provider snapshot `resources/modelsdev-snapshot.json` (models.dev). This **contradicts the issue's premise** that "all Opus 4.x is 1M":

| Model | Real context |
|---|---|
| Opus 4.6 / 4.7 / 4.8, Sonnet 4.6 | **1M** |
| Opus 4.0 / 4.1 / 4.5, Sonnet 4.0 / 4.5, Haiku 4.x | **200K** |

So Opus 4.0/4.1/4.5 correctly stay at 200K. The change also fixes a **latent opposite bug**: the old `claude-sonnet-4` = 1M fallback *over*-reported Sonnet 4.5/4.0 (real 200K) as 1M.

## How

- Re-key the Claude family on real hyphenated ids with snapshot-accurate values.
- Keep bare `claude-opus-4` / `claude-sonnet-4` / `claude-haiku-4` = 200K fallbacks so dated/variant ids (`claude-opus-4-20250514`) still resolve; versioned keys win via longest-match.
- Add previously-missing `claude-3-sonnet` = 200K (was falling through to the 1M default).

**Display-only.** No behavior change beyond the meter denominator; no user-facing strings (no i18n impact).

## Tests / verification

- New `tests/unit/modelContextLimits.test.ts` — 11 tests against the real `getModelContextLimit` source: exact + dated-variant + case-insensitive resolution, both 1M and 200K arms, a regression guard for the Sonnet over-report, and null/empty fallbacks.
- `bun run typecheck` green; `prek run --from-ref origin/main --to-ref HEAD` green (TypeScript / Oxlint / Oxfmt / UI-tokens).
- Independent adversarial cross-audit: traced all 24 catalog Claude ids through the matcher against the snapshot — no regressions, no collisions, callers unaffected (both pass hyphenated `useModel`).

**Not yet done — routed to Overwatch:** rendered-meter live-verify on CDP :9333 needs a branch build + a real Opus session with token usage, which the local harness can't produce (real wcore turns fail locally). Denominator logic itself is verified as above.

Refs #477