### PR TITLE
fix(team): budget mailbox prompt content

### DIFF
--- a/src/process/team/prompts/formatHelpers.ts
+++ b/src/process/team/prompts/formatHelpers.ts
@@ -1,14 +1,66 @@
 import type { TeamAgent, MailboxMessage } from '../types';
 
+const DEFAULT_MESSAGE_CHAR_LIMIT = 6000;
+const DEFAULT_TOTAL_CHAR_LIMIT = 30000;
+
+export type FormatMessagesOptions = {
+  messageCharLimit?: number;
+  totalCharLimit?: number;
+};
+
+function clampPositive(value: number | undefined, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
+}
+
+function formatContentForPrompt(message: MailboxMessage, limit: number): string {
+  const content = message.content ?? '';
+  if (content.length <= limit) return content;
+
+  const summary = message.summary?.trim();
+  const prefix = summary ? `Summary: ${summary}\n\n` : '';
+  const available = Math.max(0, limit - prefix.length);
+  const excerpt = available > 0 ? content.slice(0, available) : '';
+  return `${prefix}${excerpt}\n...[truncated ${content.length - excerpt.length} chars from mailbox message before prompt assembly]`;
+}
+
+function withTotalBudget(lines: string[], limit: number): string {
+  const selected: string[] = [];
+  let used = 0;
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const separator = selected.length > 0 ? 1 : 0;
+    if (used + separator + line.length <= limit) {
+      selected.push(line);
+      used += separator + line.length;
+      continue;
+    }
+
+    const remaining = Math.max(0, limit - used - separator);
+    if (remaining > 120) {
+      selected.push(`${line.slice(0, remaining)}\n...[truncated unread mailbox bundle before prompt assembly]`);
+    }
+    const omitted = lines.length - i - (remaining > 120 ? 1 : 0);
+    if (omitted > 0) selected.push(`...[omitted ${omitted} additional mailbox message(s) due to prompt budget]`);
+    break;
+  }
+  return selected.join('\n');
+}
+
 /** Format mailbox messages, resolving sender names from the agents list. */
-export function formatMessages(messages: MailboxMessage[], agents: TeamAgent[]): string {
+export function formatMessages(
+  messages: MailboxMessage[],
+  agents: TeamAgent[],
+  options: FormatMessagesOptions = {}
+): string {
   if (messages.length === 0) return 'No unread messages.';
-  return messages
-    .map((m) => {
-      const filesNote = m.files?.length ? `\nFiles: ${m.files.join(', ')}` : '';
-      if (m.fromAgentId === 'user') return `[From User] ${m.content}${filesNote}`;
-      const sender = agents.find((a) => a.slotId === m.fromAgentId);
-      return `[From ${sender?.agentName ?? m.fromAgentId}] ${m.content}${filesNote}`;
-    })
-    .join('\n');
+  const messageLimit = clampPositive(options.messageCharLimit, DEFAULT_MESSAGE_CHAR_LIMIT);
+  const totalLimit = clampPositive(options.totalCharLimit, DEFAULT_TOTAL_CHAR_LIMIT);
+  const lines = messages.map((m) => {
+    const filesNote = m.files?.length ? `\nFiles: ${m.files.join(', ')}` : '';
+    const content = formatContentForPrompt(m, messageLimit);
+    if (m.fromAgentId === 'user') return `[From User] ${content}${filesNote}`;
+    const sender = agents.find((a) => a.slotId === m.fromAgentId);
+    return `[From ${sender?.agentName ?? m.fromAgentId}] ${content}${filesNote}`;
+  });
+  return withTotalBudget(lines, totalLimit);
 }

--- a/src/process/team/prompts/formatHelpers.ts
+++ b/src/process/team/prompts/formatHelpers.ts
@@ -1,16 +1,7 @@
 import type { TeamAgent, MailboxMessage } from '../types';
 
-const DEFAULT_MESSAGE_CHAR_LIMIT = 6000;
-const DEFAULT_TOTAL_CHAR_LIMIT = 30000;
-
-export type FormatMessagesOptions = {
-  messageCharLimit?: number;
-  totalCharLimit?: number;
-};
-
-function clampPositive(value: number | undefined, fallback: number): number {
-  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
-}
+const MESSAGE_CHAR_LIMIT = 6000;
+const TOTAL_CHAR_LIMIT = 30000;
 
 function formatContentForPrompt(message: MailboxMessage, limit: number): string {
   const content = message.content ?? '';
@@ -47,20 +38,14 @@ function withTotalBudget(lines: string[], limit: number): string {
 }
 
 /** Format mailbox messages, resolving sender names from the agents list. */
-export function formatMessages(
-  messages: MailboxMessage[],
-  agents: TeamAgent[],
-  options: FormatMessagesOptions = {}
-): string {
+export function formatMessages(messages: MailboxMessage[], agents: TeamAgent[]): string {
   if (messages.length === 0) return 'No unread messages.';
-  const messageLimit = clampPositive(options.messageCharLimit, DEFAULT_MESSAGE_CHAR_LIMIT);
-  const totalLimit = clampPositive(options.totalCharLimit, DEFAULT_TOTAL_CHAR_LIMIT);
   const lines = messages.map((m) => {
     const filesNote = m.files?.length ? `\nFiles: ${m.files.join(', ')}` : '';
-    const content = formatContentForPrompt(m, messageLimit);
+    const content = formatContentForPrompt(m, MESSAGE_CHAR_LIMIT);
     if (m.fromAgentId === 'user') return `[From User] ${content}${filesNote}`;
     const sender = agents.find((a) => a.slotId === m.fromAgentId);
     return `[From ${sender?.agentName ?? m.fromAgentId}] ${content}${filesNote}`;
   });
-  return withTotalBudget(lines, totalLimit);
+  return withTotalBudget(lines, TOTAL_CHAR_LIMIT);
 }

--- a/tests/unit/process/team/formatHelpers.test.ts
+++ b/tests/unit/process/team/formatHelpers.test.ts
@@ -21,4 +21,38 @@ describe('formatMessages', () => {
     ];
     expect(formatMessages(msgs, agents)).toContain('[From Researcher] Done');
   });
+
+  it('truncates oversized mailbox messages before prompt assembly', () => {
+    const msgs: MailboxMessage[] = [
+      {
+        id: 'm1',
+        teamId: 't1',
+        toAgentId: 'slot-1',
+        fromAgentId: 'slot-2',
+        content: 'x'.repeat(100),
+        summary: 'Long research result',
+        type: 'message',
+      },
+    ];
+
+    const formatted = formatMessages(msgs, [], { messageCharLimit: 40, totalCharLimit: 500 });
+
+    expect(formatted).toContain('Summary: Long research result');
+    expect(formatted).toContain('truncated');
+    expect(formatted.length).toBeLessThan(140);
+  });
+
+  it('caps the total unread mailbox bundle included in a wake prompt', () => {
+    const msgs: MailboxMessage[] = [
+      { id: 'm1', teamId: 't1', toAgentId: 'slot-1', fromAgentId: 'user', content: 'a'.repeat(80), type: 'message' },
+      { id: 'm2', teamId: 't1', toAgentId: 'slot-1', fromAgentId: 'user', content: 'b'.repeat(80), type: 'message' },
+      { id: 'm3', teamId: 't1', toAgentId: 'slot-1', fromAgentId: 'user', content: 'c'.repeat(80), type: 'message' },
+    ];
+
+    const formatted = formatMessages(msgs, [], { messageCharLimit: 100, totalCharLimit: 130 });
+
+    expect(formatted).toContain('[From User]');
+    expect(formatted).toContain('omitted');
+    expect(formatted.length).toBeLessThan(240);
+  });
 });

--- a/tests/unit/process/team/formatHelpers.test.ts
+++ b/tests/unit/process/team/formatHelpers.test.ts
@@ -29,30 +29,35 @@ describe('formatMessages', () => {
         teamId: 't1',
         toAgentId: 'slot-1',
         fromAgentId: 'slot-2',
-        content: 'x'.repeat(100),
+        content: 'x'.repeat(8000),
         summary: 'Long research result',
         type: 'message',
       },
     ];
 
-    const formatted = formatMessages(msgs, [], { messageCharLimit: 40, totalCharLimit: 500 });
+    const formatted = formatMessages(msgs, []);
 
     expect(formatted).toContain('Summary: Long research result');
     expect(formatted).toContain('truncated');
-    expect(formatted.length).toBeLessThan(140);
+    // Single message capped at the 6000-char per-message limit (+ label/suffix).
+    expect(formatted.length).toBeLessThan(6200);
   });
 
   it('caps the total unread mailbox bundle included in a wake prompt', () => {
     const msgs: MailboxMessage[] = [
-      { id: 'm1', teamId: 't1', toAgentId: 'slot-1', fromAgentId: 'user', content: 'a'.repeat(80), type: 'message' },
-      { id: 'm2', teamId: 't1', toAgentId: 'slot-1', fromAgentId: 'user', content: 'b'.repeat(80), type: 'message' },
-      { id: 'm3', teamId: 't1', toAgentId: 'slot-1', fromAgentId: 'user', content: 'c'.repeat(80), type: 'message' },
+      { id: 'm1', teamId: 't1', toAgentId: 'slot-1', fromAgentId: 'user', content: 'a'.repeat(6000), type: 'message' },
+      { id: 'm2', teamId: 't1', toAgentId: 'slot-1', fromAgentId: 'user', content: 'b'.repeat(6000), type: 'message' },
+      { id: 'm3', teamId: 't1', toAgentId: 'slot-1', fromAgentId: 'user', content: 'c'.repeat(6000), type: 'message' },
+      { id: 'm4', teamId: 't1', toAgentId: 'slot-1', fromAgentId: 'user', content: 'd'.repeat(6000), type: 'message' },
+      { id: 'm5', teamId: 't1', toAgentId: 'slot-1', fromAgentId: 'user', content: 'e'.repeat(6000), type: 'message' },
+      { id: 'm6', teamId: 't1', toAgentId: 'slot-1', fromAgentId: 'user', content: 'f'.repeat(6000), type: 'message' },
     ];
 
-    const formatted = formatMessages(msgs, [], { messageCharLimit: 100, totalCharLimit: 130 });
+    const formatted = formatMessages(msgs, []);
 
     expect(formatted).toContain('[From User]');
     expect(formatted).toContain('omitted');
-    expect(formatted.length).toBeLessThan(240);
+    // Bundle capped at the 30000-char total limit (+ truncation/omitted notes).
+    expect(formatted.length).toBeLessThan(30300);
   });
 });


### PR DESCRIPTION
## Summary
- cap individual team mailbox messages before they are inserted into teammate wake prompts
- cap the total unread mailbox bundle included in a single prompt
- prefer a message summary when available so long teammate reports do not overflow GPT-5.5 context

## Why
Team chats can forward large `team_send_message` outputs into another agent's unread mailbox. Those unread messages are later replayed into the next wake prompt. A single huge teammate report, or several medium reports, can push the request above the model context ceiling and stop the run even after compaction.

## Tests
- `bunx vitest run tests/unit/process/team/formatHelpers.test.ts tests/unit/team-TeamMcpServer.test.ts tests/integration/team-mcp-server.test.ts`
- `bun run typecheck`
- `bun run format:check src/process/team/prompts/formatHelpers.ts tests/unit/process/team/formatHelpers.test.ts`
