### PR TITLE
fix(wcore): terminalize dangling tool cards on stream_end (#486)

### DIFF
--- a/src/renderer/pages/conversation/platforms/wcore/useWCoreMessage.ts
+++ b/src/renderer/pages/conversation/platforms/wcore/useWCoreMessage.ts
@@ -59,6 +59,18 @@ export const useWCoreMessage = (
   // to decide whether the error tip is fatal (keep) or transient (clear). (#101)
   const turnEndedInErrorRef = useRef(false);
 
+  // #486: tool cards (callId -> last active status) the backend has reported as
+  // active (Executing/Confirming/Pending) but not yet terminalized with a
+  // matching-callId completion frame. The engine can end a turn without
+  // delivering that frame (root cause wayland-core#133, the ChatGPT-subscription
+  // parallel/builtin path), which strands the step-panel spinner after the
+  // assistant has already responded. On stream_end we terminalize whatever is
+  // left here as defense-in-depth, mirroring the resume-time running reconcile.
+  // The prior status decides the terminal status (an Executing tool most likely
+  // finished; a Pending/Confirming one never ran), so we never assert a false
+  // success on a tool that never executed.
+  const activeToolCallsRef = useRef<Map<string, string>>(new Map());
+
   useEffect(() => {
     onConfigChangedRef.current = onConfigChanged;
   }, [onConfigChanged]);
@@ -153,6 +165,13 @@ export const useWCoreMessage = (
           setStreamRunning(true);
           streamRunningRef.current = true;
           turnEndedInErrorRef.current = false;
+          // #486: a new turn starts fresh. Drop any tool cards left tracked as
+          // active by a prior turn that ended without a `finish` (e.g. an error
+          // frame with no trailing stream_end), so they can't be mistakenly
+          // terminalized against THIS turn's finish. Note we deliberately do NOT
+          // clear on `error`: a mid-turn error can be transient and followed by
+          // more tool activity in the same turn, which must stay tracked.
+          activeToolCallsRef.current.clear();
           // Don't reset waitingResponse here - let tool completion flow handle it
           break;
         case 'finish':
@@ -190,6 +209,37 @@ export const useWCoreMessage = (
             if (hasContentInTurnRef.current && !turnEndedInError) {
               clearErrorTips();
             }
+
+            // #486 defense-in-depth: the turn has ended, so no tool can still be
+            // running. Terminalize any card the engine left active (missing
+            // completion frame) so the step-panel spinner stops. We emit a
+            // status-only update per callId: composeMessage merges by callId and
+            // spreads over the existing card, so the name / resultDisplay /
+            // description are preserved and a real completion frame that arrives
+            // later still wins. If the turn errored, everything is Error;
+            // otherwise an Executing tool most likely finished (Success), while
+            // a Pending/Confirming one never actually ran (Canceled) — so we
+            // never paint a false success on a tool that never executed.
+            if (activeToolCallsRef.current.size > 0) {
+              const data = Array.from(activeToolCallsRef.current.entries()).map(([callId, priorStatus]) => ({
+                callId,
+                status: turnEndedInError ? 'Error' : priorStatus === 'Executing' ? 'Success' : 'Canceled',
+              }));
+              activeToolCallsRef.current.clear();
+              addOrUpdateMessage(
+                transformMessage({
+                  type: 'tool_group',
+                  data,
+                  msg_id: message.msg_id,
+                  conversation_id,
+                })
+              );
+            }
+            // The turn is over: clear the global active-tools flag too, so the
+            // combined `running` state can settle even if the last frame we saw
+            // for a tool was non-terminal.
+            setHasActiveTools(false);
+            hasActiveToolsRef.current = false;
           }
           break;
         case 'tool_group':
@@ -206,10 +256,23 @@ export const useWCoreMessage = (
             }
 
             // Check if any tools are executing or awaiting confirmation
-            const tools = message.data as Array<{ status: string; name?: string }>;
+            const tools = message.data as Array<{ status: string; name?: string; callId?: string }>;
             const activeStatuses = new Set(['Executing', 'Confirming', 'Pending']);
             const hasActive = tools.some((tool) => activeStatuses.has(tool.status));
             const wasActive = hasActiveToolsRef.current;
+
+            // #486: maintain the per-callId active set (callId -> its current
+            // active status) so stream_end can terminalize any card the engine
+            // never completed. Terminal frames (Success/Error/Canceled) drop the
+            // card from the set.
+            for (const tool of tools) {
+              if (!tool.callId) continue;
+              if (activeStatuses.has(tool.status)) {
+                activeToolCallsRef.current.set(tool.callId, tool.status);
+              } else {
+                activeToolCallsRef.current.delete(tool.callId);
+              }
+            }
 
             setHasActiveTools(hasActive);
             hasActiveToolsRef.current = hasActive; // Sync update ref immediately
@@ -309,6 +372,7 @@ export const useWCoreMessage = (
     setTokenUsage(null);
     hasContentInTurnRef.current = false;
     turnEndedInErrorRef.current = false;
+    activeToolCallsRef.current.clear();
     setHasHydratedRunningState(false);
 
     // Check actual conversation status from backend before resetting all running states
@@ -386,6 +450,7 @@ export const useWCoreMessage = (
     setThought({ subject: '', description: '' });
     hasContentInTurnRef.current = false;
     turnEndedInErrorRef.current = false;
+    activeToolCallsRef.current.clear();
     // Clear active message ID to prevent filtering events from new messages after stop
     activeMsgIdRef.current = null;
   }, []);

--- a/tests/unit/renderer/wcoreFinishReconcile.dom.test.tsx
+++ b/tests/unit/renderer/wcoreFinishReconcile.dom.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// @vitest-environment jsdom
+
+/**
+ * #486 defense-in-depth: the wcore engine can end a turn without delivering a
+ * matching-callId tool completion frame (root cause wayland-core#133), leaving
+ * a step-panel card stuck Executing/Confirming after the assistant already
+ * responded. useWCoreMessage's `finish` handler now terminalizes any still-active
+ * card. These tests drive the REAL hook through its ipcBridge responseStream
+ * handler (transformMessage is real) and assert the reconcile fires only for
+ * dangling cards, with the right terminal status.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type StreamEvent = { type: string; data: unknown; msg_id: string; conversation_id: string };
+let streamHandler: ((e: StreamEvent) => void) | null = null;
+const addOrUpdateMessage = vi.fn();
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    conversation: {
+      responseStream: {
+        on: (cb: (e: StreamEvent) => void) => {
+          streamHandler = cb;
+          return () => {
+            streamHandler = null;
+          };
+        },
+      },
+      get: { invoke: () => Promise.resolve({ status: 'idle', type: 'wcore' }) },
+      update: { invoke: () => Promise.resolve() },
+    },
+  },
+}));
+
+vi.mock('@/renderer/pages/conversation/Messages/hooks', () => ({
+  useAddOrUpdateMessage: () => addOrUpdateMessage,
+  useClearErrorTips: () => vi.fn(),
+}));
+
+vi.mock('@/renderer/hooks/system/useTabResumeEffect', () => ({
+  useTabResumeEffect: () => {},
+}));
+
+vi.mock('@/renderer/services/i18n', () => ({
+  default: { t: (key: string) => key },
+}));
+
+import { useWCoreMessage } from '@/renderer/pages/conversation/platforms/wcore/useWCoreMessage';
+
+const CONV = 'conv1';
+const emit = (e: Partial<StreamEvent> & { type: string }) =>
+  act(() => {
+    streamHandler?.({ msg_id: 'm1', conversation_id: CONV, data: {}, ...e });
+  });
+
+const toolCard = (callId: string, status: string, name = 'read_file') => ({
+  callId,
+  name,
+  description: '',
+  status,
+  renderOutputAsMarkdown: false,
+});
+
+// Pull the tool_group updates the hook pushed to the message list.
+const toolGroupCalls = () =>
+  addOrUpdateMessage.mock.calls
+    .map(([m]) => m)
+    .filter(
+      (m): m is { type: 'tool_group'; content: Array<{ callId: string; status: string }> } => m?.type === 'tool_group'
+    );
+
+describe('useWCoreMessage finish-time tool reconcile (#486)', () => {
+  beforeEach(() => {
+    streamHandler = null;
+    addOrUpdateMessage.mockClear();
+  });
+
+  it('terminalizes a card left Executing when the turn finishes cleanly', () => {
+    renderHook(() => useWCoreMessage(CONV));
+    expect(streamHandler).toBeTruthy();
+
+    emit({ type: 'tool_group', data: [toolCard('c1', 'Executing')] });
+    emit({ type: 'finish', data: {} });
+
+    const groups = toolGroupCalls();
+    const last = groups[groups.length - 1];
+    expect(last.content[0].callId).toBe('c1');
+    expect(last.content[0].status).toBe('Success');
+  });
+
+  it('marks the dangling card Error when the turn ends in error', () => {
+    renderHook(() => useWCoreMessage(CONV));
+
+    emit({ type: 'tool_group', data: [toolCard('c1', 'Executing')] });
+    emit({ type: 'finish', data: { finish_reason: 'error' } });
+
+    const last = toolGroupCalls().at(-1)!;
+    expect(last.content[0].status).toBe('Error');
+  });
+
+  it('does not paint false Success on a card that never ran (Confirming/Pending -> Canceled)', () => {
+    renderHook(() => useWCoreMessage(CONV));
+
+    emit({ type: 'tool_group', data: [toolCard('c1', 'Confirming'), toolCard('c2', 'Pending')] });
+    emit({ type: 'finish', data: {} });
+
+    const last = toolGroupCalls().at(-1)!;
+    const byId = Object.fromEntries(last.content.map((t) => [t.callId, t.status]));
+    // clean finish, but neither tool actually executed -> Canceled, not Success
+    expect(byId).toEqual({ c1: 'Canceled', c2: 'Canceled' });
+  });
+
+  it('emits a status-only update (no name) so composeMessage cannot clobber the card', () => {
+    renderHook(() => useWCoreMessage(CONV));
+
+    emit({ type: 'tool_group', data: [toolCard('c1', 'Executing', 'read_file')] });
+    emit({ type: 'finish', data: {} });
+
+    const last = toolGroupCalls().at(-1)!;
+    expect(last.content[0]).toEqual({ callId: 'c1', status: 'Success' });
+  });
+
+  it('clears tracking on a new turn start so a prior dangling card cannot leak', () => {
+    renderHook(() => useWCoreMessage(CONV));
+
+    // Turn 1 leaves c1 dangling then ends via an error frame with NO finish.
+    emit({ type: 'tool_group', data: [toolCard('c1', 'Executing')] });
+    emit({ type: 'error', data: { error: { code: 'x', message: 'boom', retryable: false } } });
+    // Turn 2 starts fresh and finishes cleanly with no tools of its own.
+    emit({ type: 'start', data: {} });
+    const beforeFinish = addOrUpdateMessage.mock.calls.length;
+    emit({ type: 'finish', data: {} });
+
+    // c1 must NOT be terminalized against turn 2's finish.
+    expect(addOrUpdateMessage.mock.calls.length).toBe(beforeFinish);
+  });
+
+  it('does NOT re-emit for a card the engine already completed', () => {
+    renderHook(() => useWCoreMessage(CONV));
+
+    emit({ type: 'tool_group', data: [toolCard('c1', 'Executing')] });
+    emit({ type: 'tool_group', data: [toolCard('c1', 'Success')] });
+    const beforeFinish = addOrUpdateMessage.mock.calls.length;
+    emit({ type: 'finish', data: {} });
+
+    // finish must add no further tool_group update — the card was already terminal
+    expect(addOrUpdateMessage.mock.calls.length).toBe(beforeFinish);
+  });
+
+  it('reconciles only the still-dangling card among parallel calls', () => {
+    renderHook(() => useWCoreMessage(CONV));
+
+    emit({ type: 'tool_group', data: [toolCard('c1', 'Executing', 'read_file')] });
+    emit({ type: 'tool_group', data: [toolCard('c2', 'Executing', 'skill_view')] });
+    emit({ type: 'tool_group', data: [toolCard('c1', 'Success', 'read_file')] });
+    emit({ type: 'finish', data: {} });
+
+    const last = toolGroupCalls().at(-1)!;
+    // only c2 (never completed) is terminalized by the reconcile
+    expect(last.content.map((t) => t.callId)).toEqual(['c2']);
+    expect(last.content[0].status).toBe('Success');
+  });
+});

--- a/tests/unit/wcoreToolReconcileMerge.test.ts
+++ b/tests/unit/wcoreToolReconcileMerge.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * #486: the finish-time reconcile in useWCoreMessage emits a STATUS-ONLY
+ * tool_group update per dangling callId. This guards the two guarantees that
+ * makes safe, at the composeMessage merge layer it relies on:
+ *   1. flipping status preserves the card's name / resultDisplay / description,
+ *   2. a real completion frame that arrives AFTER the synthetic finish update
+ *      still wins (status + result get overwritten by the real frame).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { composeMessage, transformMessage } from '@/common/chat/chatLib';
+import type { IResponseMessage } from '@/common/adapter/ipcBridge';
+
+const toolGroup = (data: unknown): IResponseMessage => ({
+  type: 'tool_group',
+  data,
+  msg_id: 'm1',
+  conversation_id: 'conv1',
+});
+
+const firstCard = (list: ReturnType<typeof composeMessage>) => {
+  const msg = list.find((m) => m.type === 'tool_group') as { content: Array<Record<string, unknown>> } | undefined;
+  return msg?.content[0];
+};
+
+describe('#486 finish-time tool reconcile — composeMessage merge guarantees', () => {
+  it('a status-only update flips status but preserves name/result/description', () => {
+    let list = composeMessage(
+      transformMessage(
+        toolGroup([
+          {
+            callId: 'c1',
+            name: 'read_file',
+            description: 'Reading handoff.md',
+            status: 'Executing',
+            resultDisplay: 'partial output',
+          },
+        ])
+      ),
+      []
+    );
+
+    // The finish reconcile emits status-only (what useWCoreMessage now sends).
+    list = composeMessage(transformMessage(toolGroup([{ callId: 'c1', status: 'Success' }])), list);
+
+    const card = firstCard(list)!;
+    expect(card.status).toBe('Success');
+    expect(card.name).toBe('read_file');
+    expect(card.description).toBe('Reading handoff.md');
+    expect(card.resultDisplay).toBe('partial output');
+  });
+
+  it('a real completion frame arriving after the synthetic update still wins', () => {
+    let list = composeMessage(
+      transformMessage(toolGroup([{ callId: 'c1', name: 'skill_view', status: 'Executing' }])),
+      []
+    );
+    // synthetic finish reconcile
+    list = composeMessage(transformMessage(toolGroup([{ callId: 'c1', status: 'Success' }])), list);
+    // late REAL frame from the engine
+    list = composeMessage(
+      transformMessage(toolGroup([{ callId: 'c1', status: 'Error', resultDisplay: 'boom' }])),
+      list
+    );
+
+    const card = firstCard(list)!;
+    expect(card.status).toBe('Error');
+    expect(card.resultDisplay).toBe('boom');
+    expect(card.name).toBe('skill_view');
+  });
+});


### PR DESCRIPTION
## What

Secondary/defense-in-depth desktop fix for #486 (stuck tool-step spinners), per the Overwatch renderer-vs-core ruling. **Primary root cause is core** — the engine can end a turn without delivering a matching-callId `tool_result` on the ChatGPT-subscription parallel/builtin path (filed as **wayland-core#133**). This PR does *not* depend on that fix; it makes the desktop resilient regardless.

## Why

The renderer merges tool cards strictly by `callId`, so a card only leaves `Executing`/`Confirming` when a completion frame with the matching `callId` arrives. When the engine drops that frame, the card spins forever — after the assistant has already responded. The `finish`/stream_end handler previously cleared only *global* running state, never the per-card status.

## How

`src/renderer/pages/conversation/platforms/wcore/useWCoreMessage.ts`:
- Track active tool cards by `callId` → current active status as `tool_group` frames arrive (terminal frames drop them).
- On `stream_end`, terminalize whatever is still active. **Terminal status is chosen by prior status so we never paint a false success:** `Executing → Success` (it most likely ran, just missing the result frame), `Pending`/`Confirming → Canceled` (never ran / awaited an approval the finished turn can't honor), and everything → `Error` if the turn failed.
- The synthetic update is **status-only** (`{callId, status}`): composeMessage's callId merge (`{...tool, ...newToolData}`) preserves the card's name/result/description, and a real completion frame arriving later still wins.
- Tracking is cleared on the next turn's `start` (so a prior turn that ended without a `finish` — e.g. `tool_panicked` with no trailing stream_end — can't leak a stale card into this turn's finish). Deliberately **not** cleared on `error`, since a mid-turn error can be transient and followed by more tool activity in the same turn.
- Also clears the global `hasActiveTools` flag on finish so combined running state settles.

## Tests / verification

- `tests/unit/renderer/wcoreFinishReconcile.dom.test.tsx` (7 cases) drives the **real hook** through its `responseStream` handler + real `transformMessage`: Executing→Success, error→Error, Confirming/Pending→Canceled (no false success), status-only emit, parallel (only the dangling card flips), already-completed (no re-emit), and the cross-turn stale-leak guard (start clears tracking).
- `tests/unit/wcoreToolReconcileMerge.test.ts` (2 cases) exercises the `composeMessage` merge the fix relies on: status-only update preserves name/result/description; a late real frame still wins.
- `bun run typecheck` green; `prek run --from-ref origin/main --to-ref HEAD` green (TypeScript / Oxlint / Oxfmt / UI-tokens). No i18n impact (status enum values, not new strings).
- Independent adversarial cross-audit ran and found a stale-map cross-turn leak (error/start not clearing the ref) and a Pending/Confirming→false-Success semantics issue; **both fixed** (clear-on-start; status-differentiated terminal), plus a name-clobber avoided via status-only emit, plus the two merge-guarantee tests added.
- In-app smoke: the built branch boots clean with the change (no runtime errors). End-to-end in-app repro (a real ChatGPT-subscription parallel session that triggers the core frame-drop, then observing the spinner clear on finish) needs wayland-core#133 reproduced on demand → routed to Overwatch/Windows.

#486 closes when core #133 lands + this desktop reconcile ships.

Refs #486