### PR TITLE
fix(wcore): terminalize dangling tool cards on turn end (#486)

### DIFF
--- a/src/renderer/pages/conversation/Messages/hooks.ts
+++ b/src/renderer/pages/conversation/Messages/hooks.ts
@@ -447,6 +447,72 @@ export const useClearErrorTips = () => {
   }, [update]);
 };
 
+/**
+ * Tool-card statuses that render a live spinner (see MessageToolGroup: a card is
+ * "loading" for any status other than Success/Error/Canceled). When a turn ends,
+ * a card left in one of these implies the tool is still running. (#486)
+ */
+const DANGLING_TOOL_STATUSES = new Set(['Executing', 'Confirming', 'Pending']);
+
+/**
+ * Defense-in-depth for #486 (root cause is core: wayland-core#133 call_id
+ * instability drops the terminal tool-card frame). On turn end the global
+ * running flags are cleared, but individual tool_group cards can be left in
+ * Executing/Confirming/Pending and keep spinning forever. This terminalizes
+ * any such dangling card to `Canceled` — the honest terminal: the turn ended,
+ * so the tool's real outcome was never reported to the UI. It never rewrites a
+ * card that already reached a terminal state (Success/Error/Canceled), and if a
+ * genuine late tool_group frame arrives after finish, composeMessage merges the
+ * real status back over `Canceled`, so this is non-destructive.
+ *
+ * Pure + referential-identity preserving: returns the same list reference when
+ * nothing is dangling so React can skip the re-render (the common case).
+ *
+ * LIMITATION (by design): this only reconciles the in-memory renderer list. The
+ * card's DB record was persisted by WCoreManager when the (incomplete) Executing
+ * frame arrived and is NOT rewritten here, so reloading the conversation
+ * re-reads `Executing` and the spinner returns. Durable, DB-side correctness
+ * requires the root fix in core (wayland-core#133); this hook is the
+ * live-session defense-in-depth only.
+ */
+export function reconcileDanglingToolGroups(list: TMessage[]): TMessage[] {
+  let listChanged = false;
+  const next = list.map((message) => {
+    if (message.type !== 'tool_group' || !Array.isArray(message.content)) {
+      return message;
+    }
+    let cardChanged = false;
+    const content = message.content.map((tool) => {
+      if (tool && DANGLING_TOOL_STATUSES.has(tool.status)) {
+        cardChanged = true;
+        return { ...tool, status: 'Canceled' as const };
+      }
+      return tool;
+    });
+    if (!cardChanged) return message;
+    listChanged = true;
+    return { ...message, content };
+  });
+  return listChanged ? next : list;
+}
+
+/**
+ * Returns a callback that terminalizes any tool card left spinning after a turn
+ * ends (stream_end / error). See reconcileDanglingToolGroups. Deferred by one
+ * macrotask so it runs AFTER useAddOrUpdateMessage's batched flush commits this
+ * turn's final tool_group frames; otherwise it would flip a card the flush then
+ * re-adds as Executing. Mirrors useClearErrorTips. (#486)
+ */
+export const useReconcileDanglingToolCards = () => {
+  const update = useUpdateMessageList();
+
+  return useCallback(() => {
+    setTimeout(() => {
+      update((list) => reconcileDanglingToolGroups(list));
+    });
+  }, [update]);
+};
+
 export const useMessageLstCache = (key: string) => {
   const update = useUpdateMessageList();
   useEffect(() => {

--- a/src/renderer/pages/conversation/platforms/wcore/useWCoreMessage.ts
+++ b/src/renderer/pages/conversation/platforms/wcore/useWCoreMessage.ts
@@ -9,7 +9,11 @@ import { transformMessage } from '@/common/chat/chatLib';
 import type { IResponseMessage } from '@/common/adapter/ipcBridge';
 import type { TChatConversation, TokenUsageData } from '@/common/config/storage';
 import type { ThoughtData } from '@/renderer/components/chat/ThoughtDisplay';
-import { useAddOrUpdateMessage, useClearErrorTips } from '@/renderer/pages/conversation/Messages/hooks';
+import {
+  useAddOrUpdateMessage,
+  useClearErrorTips,
+  useReconcileDanglingToolCards,
+} from '@/renderer/pages/conversation/Messages/hooks';
 import { useTabResumeEffect } from '@/renderer/hooks/system/useTabResumeEffect';
 import { isToolUnsupportedErrorMessage } from '@/renderer/utils/model/errorDetection';
 import i18n from '@/renderer/services/i18n';
@@ -32,6 +36,7 @@ export const useWCoreMessage = (
   const onConfigChangedRef = useRef(onConfigChanged);
   const addOrUpdateMessage = useAddOrUpdateMessage();
   const clearErrorTips = useClearErrorTips();
+  const reconcileDanglingToolCards = useReconcileDanglingToolCards();
   const [streamRunning, setStreamRunning] = useState(false);
   const [hasActiveTools, setHasActiveTools] = useState(false);
   const [waitingResponse, setWaitingResponse] = useState(false);
@@ -175,6 +180,13 @@ export const useWCoreMessage = (
             setStreamRunning(false);
             setWaitingResponse(false);
             setThought({ subject: '', description: '' });
+            // Turn ended: clearing the GLOBAL running flags above stops the
+            // "Processing" spinner, but any individual tool card left in
+            // Executing/Confirming/Pending keeps spinning forever (#486, root
+            // cause wayland-core#133). Terminalize dangling cards. Deferred one
+            // macrotask so it runs after this turn's final tool_group frames
+            // commit; a genuine late frame still wins via composeMessage.
+            reconcileDanglingToolCards();
             // Only drop transient mid-turn error tips (e.g. wcore's non-fatal
             // "Cache full miss: TtlExpiry") when the turn actually SUCCEEDED. A
             // turn that ENDS in an error must keep its error tip — that banner is
@@ -267,6 +279,9 @@ export const useWCoreMessage = (
             setHasActiveTools(false);
             hasActiveToolsRef.current = false;
             setThought({ subject: '', description: '' });
+            // An error also ends the turn, so terminalize any tool card left
+            // spinning (same #486 defense-in-depth as the finish path).
+            reconcileDanglingToolCards();
             // Mark the turn as currently ended-in-error; a later content/tool_group
             // frame clears this if the turn actually continues and succeeds.
             turnEndedInErrorRef.current = true;
@@ -300,7 +315,7 @@ export const useWCoreMessage = (
       }
     });
     // Note: hasActiveTools and streamRunning are accessed via refs to avoid re-subscription
-  }, [conversation_id, addOrUpdateMessage, onError, clearErrorTips]);
+  }, [conversation_id, addOrUpdateMessage, onError, clearErrorTips, reconcileDanglingToolCards]);
 
   useEffect(() => {
     let cancelled = false;
@@ -365,6 +380,10 @@ export const useWCoreMessage = (
         waitingResponseRef.current = false;
         setHasActiveTools(false);
         hasActiveToolsRef.current = false;
+        // The turn is over: terminalize any tool card still spinning, same as
+        // the finish/error paths. Covers the case where finish fired while the
+        // tab was backgrounded (its deferred reconcile may be timer-throttled). (#486)
+        reconcileDanglingToolCards();
       } else if (isRunning && !streamRunningRef.current) {
         setStreamRunning(true);
         streamRunningRef.current = true;
@@ -372,7 +391,7 @@ export const useWCoreMessage = (
         waitingResponseRef.current = true;
       }
     });
-  }, [conversation_id, setStreamRunning, setWaitingResponse, setHasActiveTools]);
+  }, [conversation_id, setStreamRunning, setWaitingResponse, setHasActiveTools, reconcileDanglingToolCards]);
 
   useTabResumeEffect(reconcileRunningOnResume, [conversation_id]);
 

--- a/tests/unit/renderer/reconcileDanglingToolCards.dom.test.tsx
+++ b/tests/unit/renderer/reconcileDanglingToolCards.dom.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// #486 defense-in-depth: when a turn ends (stream_end / error) any tool card
+// left in Executing/Confirming/Pending must be terminalized so its spinner
+// stops. Covers the pure reconcile plus the live hook through the real
+// MessageListProvider (the batched, deferred update path).
+
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  MessageListProvider,
+  reconcileDanglingToolGroups,
+  useAddOrUpdateMessage,
+  useMessageList,
+  useReconcileDanglingToolCards,
+  useUpdateMessageList,
+} from '@/renderer/pages/conversation/Messages/hooks';
+import type { TMessage } from '@/common/chat/chatLib';
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    database: {
+      getConversationMessages: { invoke: vi.fn().mockResolvedValue([]) },
+    },
+  },
+}));
+
+type Tool = { callId: string; name: string; status: string; description?: string };
+
+const toolGroup = (id: string, tools: Tool[]): TMessage =>
+  ({
+    id,
+    msg_id: id,
+    conversation_id: 'conv-1',
+    type: 'tool_group',
+    content: tools,
+  }) as unknown as TMessage;
+
+const statusesOf = (msg: TMessage) => (msg.content as unknown as Tool[]).map((t) => t.status);
+
+describe('reconcileDanglingToolGroups (pure)', () => {
+  it('terminalizes an Executing card to Canceled', () => {
+    const list = [toolGroup('g1', [{ callId: 'c1', name: 'ReadFile', status: 'Executing' }])];
+    const next = reconcileDanglingToolGroups(list);
+    expect(statusesOf(next[0])).toEqual(['Canceled']);
+  });
+
+  it('terminalizes Confirming and Pending too', () => {
+    const list = [
+      toolGroup('g1', [
+        { callId: 'c1', name: 'A', status: 'Confirming' },
+        { callId: 'c2', name: 'B', status: 'Pending' },
+      ]),
+    ];
+    const next = reconcileDanglingToolGroups(list);
+    expect(statusesOf(next[0])).toEqual(['Canceled', 'Canceled']);
+  });
+
+  it('leaves already-terminal cards untouched and preserves list identity when nothing dangles', () => {
+    const list = [
+      toolGroup('g1', [
+        { callId: 'c1', name: 'A', status: 'Success' },
+        { callId: 'c2', name: 'B', status: 'Error' },
+        { callId: 'c3', name: 'C', status: 'Canceled' },
+      ]),
+      {
+        id: 't1',
+        msg_id: 't1',
+        conversation_id: 'conv-1',
+        type: 'text',
+        content: { content: 'hi' },
+      } as unknown as TMessage,
+    ];
+    const next = reconcileDanglingToolGroups(list);
+    // Referential identity preserved so React can skip the re-render.
+    expect(next).toBe(list);
+    expect(statusesOf(next[0])).toEqual(['Success', 'Error', 'Canceled']);
+  });
+
+  it('only rewrites the cards that dangle within a mixed group', () => {
+    const list = [
+      toolGroup('g1', [
+        { callId: 'c1', name: 'A', status: 'Success' },
+        { callId: 'c2', name: 'B', status: 'Executing' },
+      ]),
+    ];
+    const next = reconcileDanglingToolGroups(list);
+    expect(statusesOf(next[0])).toEqual(['Success', 'Canceled']);
+    // Untouched tool object kept by reference.
+    expect((next[0].content as unknown as Tool[])[0]).toBe((list[0].content as unknown as Tool[])[0]);
+  });
+});
+
+// Live hook through the real provider: a turn ends with a dangling Executing
+// card; invoking the reconcile callback must (after its deferred macrotask)
+// flip the persisted card to a terminal state.
+const Harness = ({ seed, lateFrame }: { seed: TMessage[]; lateFrame?: TMessage }) => {
+  const update = useUpdateMessageList();
+  const addOrUpdate = useAddOrUpdateMessage();
+  const reconcile = useReconcileDanglingToolCards();
+  const messages = useMessageList();
+  return (
+    <div>
+      <button type='button' onClick={() => update(() => seed)}>
+        seed
+      </button>
+      <button type='button' onClick={() => reconcile()}>
+        end-turn
+      </button>
+      <button type='button' onClick={() => lateFrame && addOrUpdate(lateFrame, false)}>
+        late-frame
+      </button>
+      <pre data-testid='msgs'>{JSON.stringify(messages)}</pre>
+    </div>
+  );
+};
+
+describe('useReconcileDanglingToolCards (live provider)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('turn ending with a dangling Executing card -> card becomes terminal', async () => {
+    render(
+      <MessageListProvider value={[]}>
+        <Harness seed={[toolGroup('g1', [{ callId: 'c1', name: 'ReadFile', status: 'Executing' }])]} />
+      </MessageListProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'seed' }));
+    await waitFor(() => expect(screen.getByTestId('msgs').textContent).toContain('Executing'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'end-turn' }));
+
+    await waitFor(() => {
+      const content = screen.getByTestId('msgs').textContent ?? '';
+      expect(content).toContain('Canceled');
+      expect(content).not.toContain('Executing');
+    });
+  });
+
+  // Safety property: the reconcile is non-destructive. If a genuine late
+  // tool_group frame arrives AFTER the reconcile flipped the card to Canceled,
+  // composeMessage's merge-by-callId must let the real status win (guards the
+  // JSDoc claim against future merge-strategy drift).
+  it('a genuine late tool_group frame overwrites the Canceled placeholder', async () => {
+    render(
+      <MessageListProvider value={[]}>
+        <Harness
+          seed={[toolGroup('g1', [{ callId: 'c1', name: 'ReadFile', status: 'Executing' }])]}
+          lateFrame={toolGroup('g1', [{ callId: 'c1', name: 'ReadFile', status: 'Success' }])}
+        />
+      </MessageListProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'seed' }));
+    await waitFor(() => expect(screen.getByTestId('msgs').textContent).toContain('Executing'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'end-turn' }));
+    await waitFor(() => expect(screen.getByTestId('msgs').textContent).toContain('Canceled'));
+
+    // Real terminal frame lands late.
+    fireEvent.click(screen.getByRole('button', { name: 'late-frame' }));
+    await waitFor(() => {
+      const content = screen.getByTestId('msgs').textContent ?? '';
+      expect(content).toContain('Success');
+      expect(content).not.toContain('Canceled');
+    });
+  });
+});


### PR DESCRIPTION
## What

Fixes #486 — tool step cards keep showing an active spinner after the tool calls have completed.

The wcore `finish`/`error` handlers in `useWCoreMessage` cleared only the **global** running flags (`streamRunning`/`waitingResponse`/`hasActiveTools`), so any individual `tool_group` card left in `Executing`/`Confirming`/`Pending` kept spinning forever.

**Root cause is core** (wayland-core#133 — call_id instability drops the terminal tool-card frame). This PR is the **desktop defense-in-depth**: on turn end, terminalize any card still in a spinner status.

## How

- New `reconcileDanglingToolGroups` (pure) + `useReconcileDanglingToolCards` hook in `Messages/hooks.ts`. Flips `Executing`/`Confirming`/`Pending` → `Canceled` (the honest terminal — the real outcome was never delivered to the UI; inventing Success/Error would lie).
- Called from `useWCoreMessage`'s `finish`, `error`, and tab-resume paths.
- Deferred one macrotask (mirrors `useClearErrorTips`) so it runs *after* `useAddOrUpdateMessage`'s batched flush commits the turn's final frames.
- Pure + referential-identity preserving (React skips the re-render on normal turns).
- **Non-destructive:** a genuine late `tool_group` frame still wins via `composeMessage`'s merge-by-callId.

## Scope / limitation

In-memory renderer reconcile only. The card's DB record was persisted as `Executing` when the incomplete frame arrived and is **not** rewritten here, so a reload re-reads `Executing` and the spinner returns. Durable DB-side correctness requires the root fix in **wayland-core#133**. Documented in the JSDoc.

## Verification

- **Unit tests** (`reconcileDanglingToolCards.dom.test.tsx`, 6 passing): pure reconcile (Executing/Confirming/Pending → Canceled, terminal untouched, identity preserved, mixed groups), live-provider hook (dangling Executing → terminal), and the late-frame-overwrites-Canceled safety property.
- **Typecheck** `tsc --noEmit`: clean. **oxlint/oxfmt**: clean.
- **Independent cross-audit** (adversarial subagent): no BLOCKER/HIGH. Confirmed no false-positive on legitimately in-flight cards, no Confirming-UI breakage (finish doesn't fire during the HITL pause), no resume race, wcore-only blast radius. Its MEDIUM (DB reload) is documented above; its two LOW findings (tab-resume reconcile + late-frame test) are fixed in this PR.
- **Live-verify** (running app, CDP): drove a real Flux turn that ran a Bash tool. Card correctly showed its spinner *during* ~28s execution (no premature cancel), and after the turn ended (in a provider error — the known DeepSeek/Flux `tools[].function.name` 400, a Flux-side bug) the tool group collapsed to a terminal state with **0 spinners** and the composer unlocked. This exercised the error-path reconcile end-to-end.

Closes #486