### PR TITLE
fix(wcore): #504 render AskUserQuestion choices + return the picked answer [lane: BH2]

### DIFF
--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -181,9 +181,11 @@ export const conversation = {
   confirmation: {
     add: buildEmitter<IConfirmation<any> & { conversation_id: string }>('confirmation.add'),
     update: buildEmitter<IConfirmation<any> & { conversation_id: string }>('confirmation.update'),
-    confirm: buildProvider<IBridgeResponse, { conversation_id: string; msg_id: string; data: any; callId: string }>(
-      'confirmation.confirm'
-    ),
+    confirm: buildProvider<
+      IBridgeResponse,
+      // #504: `answer` carries an AskUserQuestion choice back to the engine.
+      { conversation_id: string; msg_id: string; data: any; callId: string; answer?: string }
+    >('confirmation.confirm'),
     list: buildProvider<IConfirmation<any>[], { conversation_id: string }>('confirmation.list'),
     remove: buildEmitter<{ conversation_id: string; id: string }>('confirmation.remove'),
   },

--- a/src/common/chat/chatLib.ts
+++ b/src/common/chat/chatLib.ts
@@ -226,6 +226,19 @@ export type IMessageToolGroup = IMessage<
             toolDisplayName: string;
             serverName: string;
           }
+        >
+      // #504: AskUserQuestion-class prompt. The engine sends these as an `info`
+      // category tool named `AskUserQuestion` (there is no `question` engine
+      // ToolCategory), with the prompt buried in args - so wcore/index.ts
+      // detects them by name and lifts `question`/`header`/`choices` out of the
+      // args here, and the renderer shows the choices as selectable answers.
+      | IMessageToolGroupConfirmationDetailsBase<
+          'question',
+          {
+            question: string;
+            header?: string;
+            choices: Array<{ label: string; description?: string }>;
+          }
         >;
   }>
 >;
@@ -546,6 +559,14 @@ export interface IConfirmation<Option extends any = any> {
     label: string;
     value: Option;
     params?: Record<string, string>; // Translation interpolation parameters
+    /**
+     * #504: for an AskUserQuestion prompt, the chosen option's answer text sent
+     * back to the engine via the approval channel (tool_approve.answer). Absent
+     * for ordinary approve/deny options.
+     */
+    answer?: string;
+    /** #504: optional secondary line shown under a choice (its description). */
+    description?: string;
   }>;
   /**
    * Command type for exec confirmations (e.g., 'curl', 'npm', 'git')

--- a/src/process/agent/wcore/index.ts
+++ b/src/process/agent/wcore/index.ts
@@ -17,6 +17,7 @@ import { getToolKeyStore } from './toolKeyStore';
 import { hydrateModelForSpawn } from '@process/providers/ipc/modelRegistryIpc';
 import { killChild } from '@process/agent/acp/utils';
 import type { WCoreEvent, WCoreCommand, WCoreCapabilities } from './protocol';
+import { parseQuestionTool } from './questionTool';
 
 const WCORE_PROJECT_CONFIG = '.wcore.toml';
 
@@ -742,6 +743,15 @@ export class WCoreAgent {
   private mapConfirmationDetails(event: WCoreEvent & { type: 'tool_request' }) {
     const { tool } = event;
 
+    // #504: AskUserQuestion arrives as an `info`-category tool (the engine has
+    // no `question` ToolCategory), with the question + choices inside args. It
+    // used to fall through to the `info` branch and render an empty approval
+    // box. Detect it by name and lift the choices out so the renderer can show
+    // them as selectable answers. The name guard mirrors the engine's own
+    // answer-synth guard (tool_name == "AskUserQuestion").
+    const question = parseQuestionTool(tool);
+    if (question) return question;
+
     switch (tool.category) {
       case 'edit':
         return {
@@ -799,8 +809,11 @@ export class WCoreAgent {
     this.sendCommand({ type: 'stop' });
   }
 
-  approveTool(callId: string, scope: 'once' | 'always' = 'once'): void {
-    this.sendCommand({ type: 'tool_approve', call_id: callId, scope });
+  approveTool(callId: string, scope: 'once' | 'always' = 'once', answer?: string): void {
+    // `answer` carries an AskUserQuestion choice back through the approval
+    // channel (see WCoreCommand.tool_approve). Only attach when present so a
+    // plain approval keeps its exact prior wire shape.
+    this.sendCommand({ type: 'tool_approve', call_id: callId, scope, ...(answer ? { answer } : {}) });
   }
 
   denyTool(callId: string, reason = ''): void {

--- a/src/process/agent/wcore/protocol.ts
+++ b/src/process/agent/wcore/protocol.ts
@@ -290,7 +290,12 @@ export type WCoreEvent =
 export type WCoreCommand =
   | { type: 'message'; msg_id: string; content: string; files?: string[] }
   | { type: 'stop' }
-  | { type: 'tool_approve'; call_id: string; scope: 'once' | 'always' }
+  // `answer` (wayland-core v0.9.3+, additive) threads an AskUserQuestion-class
+  // tool's chosen option back through the approval channel; the engine
+  // synthesizes the tool result from it (guarded engine-side on
+  // tool_name == "AskUserQuestion"). Omitted for a plain approval; older
+  // engines ignore the extra field (serde default None).
+  | { type: 'tool_approve'; call_id: string; scope: 'once' | 'always'; answer?: string }
   | { type: 'tool_deny'; call_id: string; reason?: string }
   // W7 S4 HITL: resume a suspended turn waiting on an `approval_required`.
   // Engine-side resolve is idempotent — a stale/duplicate token is ignored.

--- a/src/process/agent/wcore/questionTool.ts
+++ b/src/process/agent/wcore/questionTool.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * #504 AskUserQuestion rendering.
+ *
+ * The engine surfaces `AskUserQuestion` as an ordinary `info`-category
+ * `tool_request` (wayland-core has no `question` ToolCategory), with the prompt
+ * buried inside `tool.args`:
+ *
+ *   { question: string, header?: string, multiSelect?: boolean,
+ *     options: [{ label: string, description: string }] }
+ *
+ * The old desktop code mapped it to the generic `info` confirmation, which
+ * rendered an empty approval box (issue #504). This module lifts the question +
+ * choices out of the args so the renderer can show them as selectable answers.
+ *
+ * The chosen option's `label` is sent back over the approval channel
+ * (`tool_approve.answer`, wayland-core v0.9.3+); the engine feeds that label to
+ * the model as the tool's output. The name guard here mirrors the engine's own
+ * answer-synth guard (`tool_name == "AskUserQuestion"`), so we only render the
+ * choice UI when the answer channel is actually honored.
+ */
+
+import type { ToolInfo } from './protocol';
+
+/** The engine tool whose answer routes back via `tool_approve.answer`. */
+export const ASK_USER_QUESTION_TOOL = 'AskUserQuestion';
+
+export type QuestionChoice = { label: string; description?: string };
+
+export type QuestionConfirmation = {
+  type: 'question';
+  title: string;
+  question: string;
+  header?: string;
+  choices: QuestionChoice[];
+};
+
+function trimmedString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+/** Normalize one raw option entry (object `{label,description}` or bare string). */
+function normalizeChoice(raw: unknown): QuestionChoice | null {
+  if (typeof raw === 'string') {
+    const label = raw.trim();
+    return label ? { label } : null;
+  }
+  if (raw && typeof raw === 'object') {
+    const rec = raw as Record<string, unknown>;
+    const label = trimmedString(rec.label) ?? trimmedString(rec.value);
+    if (!label) return null;
+    const description = trimmedString(rec.description);
+    return description ? { label, description } : { label };
+  }
+  return null;
+}
+
+/** Pull the choice list from args - `options` (AskUserQuestion) or `choices`. */
+function extractChoices(args: Record<string, unknown>): QuestionChoice[] {
+  const source = Array.isArray(args.options) ? args.options : Array.isArray(args.choices) ? args.choices : [];
+  const seen = new Set<string>();
+  const choices: QuestionChoice[] = [];
+  for (const raw of source) {
+    const choice = normalizeChoice(raw);
+    // Dedupe by label: the answer channel is keyed on the label, so duplicate
+    // labels would be indistinguishable when the engine synthesizes the result.
+    if (choice && !seen.has(choice.label)) {
+      seen.add(choice.label);
+      choices.push(choice);
+    }
+  }
+  return choices;
+}
+
+/**
+ * Parse an AskUserQuestion-class `tool_request` into structured question
+ * details, or `null` if `tool` is not a renderable question prompt (wrong name,
+ * or no usable choices - in which case the caller falls back to the generic
+ * confirmation rather than showing an empty choice list).
+ */
+export function parseQuestionTool(tool: Pick<ToolInfo, 'name' | 'args' | 'description'>): QuestionConfirmation | null {
+  if (tool?.name !== ASK_USER_QUESTION_TOOL) return null;
+  const args = (tool.args ?? {}) as Record<string, unknown>;
+  const choices = extractChoices(args);
+  if (choices.length === 0) return null;
+
+  const question = trimmedString(args.question) ?? trimmedString(tool.description) ?? ASK_USER_QUESTION_TOOL;
+  const header = trimmedString(args.header);
+  return {
+    type: 'question',
+    title: header ?? question,
+    question,
+    header,
+    choices,
+  };
+}

--- a/src/process/bridge/conversationBridge.ts
+++ b/src/process/bridge/conversationBridge.ts
@@ -721,10 +721,10 @@ export function initConversationBridge(
 
   // Generic confirmMessage - dispatches based on conversation type
 
-  ipcBridge.conversation.confirmation.confirm.provider(async ({ conversation_id, msg_id, data, callId }) => {
+  ipcBridge.conversation.confirmation.confirm.provider(async ({ conversation_id, msg_id, data, callId, answer }) => {
     const task = workerTaskManager.getTask(conversation_id);
     if (!task) return { success: false, msg: 'conversation not found' };
-    task.confirm(msg_id, callId, data);
+    task.confirm(msg_id, callId, data, answer);
     return { success: true };
   });
   ipcBridge.conversation.confirmation.list.provider(async ({ conversation_id }) => {

--- a/src/process/channels/gateway/ActionExecutor.ts
+++ b/src/process/channels/gateway/ActionExecutor.ts
@@ -217,6 +217,17 @@ function getConfirmationPrompt(details: { type: string; title?: string; [key: st
       return `🔧 <b>MCP Tool Confirmation</b>\nTool: <code>${escapeHtml(details.toolDisplayName || details.toolName || 'Unknown tool')}</code>\nServer: <code>${escapeHtml(details.serverName || 'Unknown server')}</code>\n\nAllow calling this tool?`;
     case 'info':
       return `ℹ️ <b>Information Confirmation</b>\n${escapeHtml(details.prompt || '')}\n\nContinue?`;
+    case 'question': {
+      // #504: surface the question + its choices on remote channels. Selecting
+      // a specific choice (the `answer` return path) is desktop-only for now -
+      // remote answering is a channels-lane follow-up.
+      const choiceLines = Array.isArray(details.choices)
+        ? details.choices
+            .map((c: { label?: string }, i: number) => `${i + 1}. ${escapeHtml(c?.label || '')}`)
+            .join('\n')
+        : '';
+      return `❓ <b>${escapeHtml(details.question || details.title || 'Question')}</b>\n${choiceLines}`;
+    }
     default:
       return 'Please confirm the operation';
   }
@@ -448,19 +459,13 @@ export class ActionExecutor {
       // themselves. Everyone else goes through the pairing flow.
       if (!isAuthorized) {
         if (message.isOwner) {
-          const ownerUser = await this.pairingService.authorizeOwner(
-            user.id,
-            platform,
-            user.displayName ?? user.id
-          );
+          const ownerUser = await this.pairingService.authorizeOwner(user.id, platform, user.displayName ?? user.id);
           // authorizeOwner returns null only when the DB write failed. Do NOT
           // fall through to the getChannelUserByPlatform lookup below: it would
           // find nothing and send the owner the misleading "re-pair your
           // account" message. Report the real internal error and stop.
           if (!ownerUser) {
-            console.error(
-              `[ActionExecutor] authorizeOwner failed (DB write) for owner ${user.id} on ${platform}`
-            );
+            console.error(`[ActionExecutor] authorizeOwner failed (DB write) for owner ${user.id} on ${platform}`);
             await context.sendMessage({
               type: 'text',
               text: '❌ Internal error saving your account. Please try again.',

--- a/src/process/task/BaseAgentManager.ts
+++ b/src/process/task/BaseAgentManager.ts
@@ -66,8 +66,10 @@ class BaseAgentManager<Data, ConfirmationOption extends any = any>
       const autoOption = data.options[0];
 
       // Delay slightly to allow the agent to reach a stable state if needed
+      // (#504: pass the option's answer so a yolo-auto-confirmed question sends
+      // the first choice instead of an empty answer the engine would error on).
       setTimeout(() => {
-        void this.confirm(data.id, data.callId, autoOption.value);
+        void this.confirm(data.id, data.callId, autoOption.value, autoOption.answer);
       }, 50);
       return;
     }
@@ -81,7 +83,9 @@ class BaseAgentManager<Data, ConfirmationOption extends any = any>
     this.confirmations = [...this.confirmations, data];
     this.emitter.emitConfirmationAdd(this.conversation_id, data);
   }
-  confirm(_msg_id: string, callId: string, _data: ConfirmationOption) {
+  // #504: `_answer` threads an AskUserQuestion choice back through subclasses
+  // that support it (WCoreManager); ignored by the rest.
+  confirm(_msg_id: string, callId: string, _data: ConfirmationOption, _answer?: string) {
     // Find the confirmation to remove (match by callId)
     const confirmationToRemove = this.confirmations.find((p) => p.callId === callId);
 

--- a/src/process/task/GeminiAgentManager.ts
+++ b/src/process/task/GeminiAgentManager.ts
@@ -686,6 +686,19 @@ export class GeminiAgentManager extends BaseAgentManager<
           );
         }
         break;
+      case 'question':
+        {
+          // #504: AskUserQuestion is a wcore engine tool, so Gemini does not
+          // emit it; this arm exists for confirmationDetails-union
+          // exhaustiveness. Surface the question + a plain proceed/cancel.
+          question = confirmationDetails.question;
+          description = confirmationDetails.header ?? '';
+          options.push(
+            { label: t('messages.confirmation.yesAllowOnce'), value: ToolConfirmationOutcome.ProceedOnce },
+            { label: t('messages.confirmation.no'), value: ToolConfirmationOutcome.Cancel }
+          );
+        }
+        break;
       default: {
         const mcpProps = confirmationDetails;
         question = t('messages.confirmation.allowMCPTool', {

--- a/src/process/task/IAgentManager.ts
+++ b/src/process/task/IAgentManager.ts
@@ -24,7 +24,8 @@ export interface IAgentManager {
 
   sendMessage(data: unknown): Promise<void>;
   stop(): Promise<void>;
-  confirm(msgId: string, callId: string, data: unknown): void;
+  // #504: `answer` threads an AskUserQuestion choice back to the engine.
+  confirm(msgId: string, callId: string, data: unknown, answer?: string): void;
   getConfirmations(): IConfirmation[];
   /**
    * Terminate the agent and wait for its child process to actually exit.

--- a/src/process/task/WCoreManager.ts
+++ b/src/process/task/WCoreManager.ts
@@ -504,10 +504,22 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
     const type = content.confirmationDetails?.type;
 
     if (this.currentMode === 'yolo') {
-      this.agent?.approveTool(content.callId, 'once');
+      // #504: a question needs an answer, not a bare approval - approving an
+      // AskUserQuestion with no answer makes the engine run its loud-defensive
+      // execute() fallback and error. In full-auto, pick the first choice so
+      // the turn proceeds instead of wedging.
+      if (type === 'question') {
+        const first =
+          content.confirmationDetails?.type === 'question' ? content.confirmationDetails.choices[0] : undefined;
+        this.agent?.approveTool(content.callId, 'once', first?.label);
+      } else {
+        this.agent?.approveTool(content.callId, 'once');
+      }
       return true;
     }
     if (this.currentMode === 'auto_edit') {
+      // Never auto-answer a question - it requires a real user choice, so it
+      // falls through to the confirmation dialog.
       if (type === 'edit' || type === 'info') {
         this.agent?.approveTool(content.callId, 'once');
         return true;
@@ -533,18 +545,32 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
         continue;
       }
 
-      // Show confirmation dialog to user
-      const options = [
-        { label: 'messages.confirmation.yesAllowOnce', value: ToolConfirmationOutcome.ProceedOnce },
-        { label: 'messages.confirmation.yesAllowAlways', value: ToolConfirmationOutcome.ProceedAlways },
-        { label: 'messages.confirmation.no', value: ToolConfirmationOutcome.Cancel },
-      ];
+      // Show confirmation dialog to user. #504: an AskUserQuestion renders its
+      // choices as the options (each carries its `answer` label back to the
+      // engine), instead of the generic allow/deny buttons.
+      const details = content.confirmationDetails;
+      const options =
+        details?.type === 'question'
+          ? [
+              ...details.choices.map((choice) => ({
+                label: choice.label,
+                value: ToolConfirmationOutcome.ProceedOnce,
+                answer: choice.label,
+                ...(choice.description ? { description: choice.description } : {}),
+              })),
+              { label: 'messages.confirmation.no', value: ToolConfirmationOutcome.Cancel },
+            ]
+          : [
+              { label: 'messages.confirmation.yesAllowOnce', value: ToolConfirmationOutcome.ProceedOnce },
+              { label: 'messages.confirmation.yesAllowAlways', value: ToolConfirmationOutcome.ProceedAlways },
+              { label: 'messages.confirmation.no', value: ToolConfirmationOutcome.Cancel },
+            ];
 
       this.addConfirmation({
-        title: content.confirmationDetails?.title || content.name || '',
+        title: (details?.type === 'question' ? details.question : details?.title) || content.name || '',
         id: content.callId,
         action,
-        description: content.description || '',
+        description: (details?.type === 'question' ? details.header : content.description) || '',
         callId: content.callId,
         options,
         commandType,
@@ -1365,7 +1391,7 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
     }
   }
 
-  confirm(id: string, callId: string, data: string) {
+  confirm(id: string, callId: string, data: string, answer?: string) {
     // Store "always allow" in approval store
     if (data === ToolConfirmationOutcome.ProceedAlways) {
       const confirmation = this.confirmations.find((c) => c.callId === callId);
@@ -1382,7 +1408,9 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
         this.agent.denyTool(callId, 'User cancelled');
       } else {
         const scope = data === ToolConfirmationOutcome.ProceedAlways ? 'always' : 'once';
-        this.agent.approveTool(callId, scope);
+        // #504: `answer` carries the picked AskUserQuestion choice back to the
+        // engine (undefined for a plain approval).
+        this.agent.approveTool(callId, scope, answer);
       }
     }
   }

--- a/src/renderer/pages/conversation/Messages/components/MessageToolGroup.tsx
+++ b/src/renderer/pages/conversation/Messages/components/MessageToolGroup.tsx
@@ -94,6 +94,13 @@ const useConfirmationButtons = (
           );
         }
         break;
+      case 'question':
+        // #504: an AskUserQuestion is answered in the confirmation dialog
+        // (ConversationChatConfirm), whose options carry the choice's `answer`
+        // back to the engine. The inline card only displays the question +
+        // choices (see the `node` switch), so no inline buttons here.
+        question = '';
+        break;
       default: {
         const mcpProps = confirmationDetails;
         question = t('messages.confirmation.allowMCPTool', {
@@ -178,6 +185,22 @@ const ConfirmationDetails: React.FC<{
         return <span className='text-t-primary'>{confirmationDetails.prompt}</span>;
       case 'mcp':
         return <span className='text-t-primary'>{confirmationDetails.toolDisplayName}</span>;
+      case 'question':
+        // #504: show the question and its choices (read-only). The actual pick
+        // is made in the confirmation dialog, which returns the chosen answer.
+        return (
+          <div className='text-t-primary'>
+            <div className='font-medium'>{confirmationDetails.question}</div>
+            <ul className='mt-6px pl-18px list-disc'>
+              {confirmationDetails.choices.map((choice, i) => (
+                <li key={choice.label + i}>
+                  <span>{choice.label}</span>
+                  {choice.description && <span className='text-t-secondary'> — {choice.description}</span>}
+                </li>
+              ))}
+            </ul>
+          </div>
+        );
     }
   }, [confirmationDetails]);
 
@@ -198,7 +221,7 @@ const ConfirmationDetails: React.FC<{
       ) : (
         node
       )}
-      {content.status === 'Confirming' && (
+      {content.status === 'Confirming' && confirmationDetails.type !== 'question' && (
         <>
           <div className='mt-10px text-t-primary'>{question}</div>
           <Radio.Group direction='vertical' size='mini' value={selected} onChange={setSelected}>
@@ -543,11 +566,7 @@ const MessageToolGroup: React.FC<IMessageToolGroupProps> = ({ message }) => {
                       ? 'warning'
                       : 'info'
               }
-              icon={
-                isLoading && (
-                  <Loader2 size={12} color={iconColors.primary} className='loading lh-[1] flex' />
-                )
-              }
+              icon={isLoading && <Loader2 size={12} color={iconColors.primary} className='loading lh-[1] flex' />}
               content={
                 <div>
                   <Tag className={'mr-4px'}>

--- a/src/renderer/pages/conversation/Messages/components/MessageToolGroupSummary.tsx
+++ b/src/renderer/pages/conversation/Messages/components/MessageToolGroupSummary.tsx
@@ -40,6 +40,7 @@ const ToolGroupMapper = (m: IMessageToolGroup): ToolItem[] => {
     if (type === 'exec') desc = confirmationDetails.command;
     if (type === 'info') desc = confirmationDetails.urls?.join(';') || confirmationDetails.title;
     if (type === 'mcp') desc = confirmationDetails.serverName + ':' + confirmationDetails.toolName;
+    if (type === 'question') desc = confirmationDetails.question; // #504
 
     // Input: use full description (for error it's JSON.stringify(args), for success it's invocation description)
     // When confirmationDetails exists (Confirming state), use structured details instead

--- a/src/renderer/pages/conversation/components/ConversationChatConfirm.tsx
+++ b/src/renderer/pages/conversation/components/ConversationChatConfirm.tsx
@@ -143,6 +143,7 @@ const ConversationChatConfirm: React.FC<PropsWithChildren<{ conversation_id: str
         callId: confirmation.callId,
         msg_id: confirmation.id,
         data: option.value,
+        answer: option.answer, // #504: the picked AskUserQuestion choice
       });
     };
 
@@ -272,9 +273,13 @@ const ConversationChatConfirm: React.FC<PropsWithChildren<{ conversation_id: str
           <div className='shrink-0'>
             {confirmation.options.map((option, index) => {
               const label = $t(option.label, option.params);
-              // Determine shortcut hint for this option
-              const shortcut =
-                index === 0
+              // #504: an AskUserQuestion choice carries an `answer`; number those
+              // so the 1-9 keyboard shortcuts line up. Ordinary approve/deny keep
+              // their Enter/Y/A/Esc hints.
+              const isChoice = option.answer != null;
+              const shortcut = isChoice
+                ? String(index + 1)
+                : index === 0
                   ? 'Enter'
                   : option.value === 'cancel'
                     ? 'Esc'
@@ -293,15 +298,21 @@ const ConversationChatConfirm: React.FC<PropsWithChildren<{ conversation_id: str
                       callId: confirmation.callId,
                       msg_id: confirmation.id,
                       data: option.value,
+                      answer: option.answer, // #504: the picked AskUserQuestion choice
                     });
                   }}
                   key={label + option.value + index}
-                  className='b-1px b-solid min-h-30px b-[var(--border-base)] rd-8px px-12px py-6px leading-snug hover:bg-[var(--bg-hover)] cursor-pointer mt-10px flex items-center gap-8px color-[var(--text-primary)]'
+                  className='b-1px b-solid min-h-30px b-[var(--border-base)] rd-8px px-12px py-6px leading-snug hover:bg-[var(--bg-hover)] cursor-pointer mt-10px flex items-start gap-8px color-[var(--text-primary)]'
                 >
-                  <span className='inline-flex items-center justify-center px-4px h-18px rd-4px bg-[var(--bg-2)] text-11px text-[var(--text-secondary)] font-mono shrink-0'>
+                  <span className='inline-flex items-center justify-center px-4px h-18px rd-4px bg-[var(--bg-2)] text-11px text-[var(--text-secondary)] font-mono shrink-0 mt-1px'>
                     {shortcut}
                   </span>
-                  <span className='min-w-0'>{label}</span>
+                  <span className='min-w-0'>
+                    <span>{label}</span>
+                    {option.description && (
+                      <span className='block text-12px color-[var(--text-secondary)] mt-2px'>{option.description}</span>
+                    )}
+                  </span>
                 </div>
               );
             })}

--- a/src/renderer/pages/conversation/components/ConversationChatConfirm.tsx
+++ b/src/renderer/pages/conversation/components/ConversationChatConfirm.tsx
@@ -309,7 +309,20 @@ const ConversationChatConfirm: React.FC<PropsWithChildren<{ conversation_id: str
                     {shortcut}
                   </span>
                   <span className='min-w-0'>
-                    <span>{label}</span>
+                    <span>
+                      {label}
+                      {/* #504: the first choice is the one yolo/full-auto
+                          auto-picks (choices[0]), so flag it as the recommended
+                          answer. Visual only - the sent answer is unchanged. */}
+                      {isChoice && index === 0 && (
+                        <span
+                          data-testid='confirm-question-recommended'
+                          className='ml-6px inline-flex items-center px-6px h-16px rd-4px bg-[var(--bg-2)] text-10px color-[var(--text-secondary)] align-middle'
+                        >
+                          {$t('messages.confirmation.recommended')}
+                        </span>
+                      )}
+                    </span>
                     {option.description && (
                       <span className='block text-12px color-[var(--text-secondary)] mt-2px'>{option.description}</span>
                     )}

--- a/src/renderer/pages/conversation/components/ConversationChatConfirm.tsx
+++ b/src/renderer/pages/conversation/components/ConversationChatConfirm.tsx
@@ -302,6 +302,7 @@ const ConversationChatConfirm: React.FC<PropsWithChildren<{ conversation_id: str
                     });
                   }}
                   key={label + option.value + index}
+                  data-testid={option.answer != null ? 'confirm-question-choice' : 'confirm-option'}
                   className='b-1px b-solid min-h-30px b-[var(--border-base)] rd-8px px-12px py-6px leading-snug hover:bg-[var(--bg-hover)] cursor-pointer mt-10px flex items-start gap-8px color-[var(--text-primary)]'
                 >
                   <span className='inline-flex items-center justify-center px-4px h-18px rd-4px bg-[var(--bg-2)] text-11px text-[var(--text-secondary)] font-mono shrink-0 mt-1px'>

--- a/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/src/renderer/services/i18n/i18n-keys.d.ts
@@ -1589,6 +1589,7 @@ export type I18nKey =
   | 'messages.confirmation.applyChange'
   | 'messages.confirmation.no'
   | 'messages.confirmation.proceed'
+  | 'messages.confirmation.recommended'
   | 'messages.confirmation.yesAllowAlways'
   | 'messages.confirmation.yesAllowOnce'
   | 'messages.confirmation.yesAlwaysAllowServer'

--- a/src/renderer/services/i18n/locales/en-US/messages.json
+++ b/src/renderer/services/i18n/locales/en-US/messages.json
@@ -71,7 +71,8 @@
     "yesAllowAlways": "Yes, allow always",
     "yesAlwaysAllowTool": "Yes, always allow tool \"{{toolName}}\" from server \"{{serverName}}\"",
     "yesAlwaysAllowServer": "Yes, always allow all tools from server \"{{serverName}}\"",
-    "no": "No (esc)"
+    "no": "No (esc)",
+    "recommended": "Recommended"
   },
   "slash.customBadge": "Custom",
   "runaway": {

--- a/tests/e2e/specs/wcore-ask-user-question.e2e.ts
+++ b/tests/e2e/specs/wcore-ask-user-question.e2e.ts
@@ -1,0 +1,91 @@
+/**
+ * #504 AskUserQuestion - in-app live verification.
+ *
+ * Drives the REAL production wiring in the launched Electron app against a real
+ * wayland-core engine session: the agent calls the `AskUserQuestion` tool, and
+ * the approval prompt must render the QUESTION and its CHOICES as selectable
+ * options (issue #504 was an empty approval box), then send the picked choice
+ * back to the engine via the approval channel (`tool_approve.answer`), so the
+ * turn resumes instead of erroring.
+ *
+ * The deterministic layers (parsing args→choices, and click→answer over the
+ * confirm IPC) are covered by the vitest suites (questionTool,
+ * ConversationChatConfirm.dom). This spec proves the end-to-end
+ * engine→render→answer path those unit tests stub.
+ *
+ * Gate: needs a wcore-capable model selectable in the app AND a model that
+ * actually calls the tool. Skips cleanly otherwise so CI without keys stays
+ * green.
+ */
+import path from 'path';
+import fs from 'fs';
+import { test, expect } from '../fixtures';
+import { goToGuid, selectAgent, sendMessageFromGuid } from '../helpers';
+
+const SCREENSHOT_DIR = '/tmp/504-verify';
+
+function ensureDir() {
+  fs.mkdirSync(SCREENSHOT_DIR, { recursive: true });
+}
+
+const MODEL_PLACEHOLDERS = new Set(['select model', 'no model', 'choose model', '']);
+
+async function selectedModelLabel(page: import('@playwright/test').Page): Promise<string> {
+  const btn = page.locator('button.sendbox-model-btn.guid-config-btn').first();
+  if (!(await btn.isVisible({ timeout: 8_000 }).catch(() => false))) return '';
+  const text = (await btn.textContent().catch(() => ''))?.trim() ?? '';
+  return MODEL_PLACEHOLDERS.has(text.toLowerCase()) ? '' : text;
+}
+
+// Three unmistakable choice labels we instruct the model to use, so we can
+// assert they render in the approval prompt (not an empty box).
+const CHOICES = ['Sunrise Red', 'Forest Green', 'Ocean Blue'];
+const ASK_PROMPT =
+  'Call your AskUserQuestion tool right now to ask me which theme color I prefer. ' +
+  `Provide exactly three options with these labels: "${CHOICES[0]}", "${CHOICES[1]}", "${CHOICES[2]}". ` +
+  'Invoke the tool immediately - do not answer in plain text.';
+
+test.describe('#504 AskUserQuestion (in-app, real engine)', () => {
+  test('renders the question choices in the approval prompt and returns the picked answer', async ({ page }) => {
+    ensureDir();
+    await goToGuid(page);
+    await selectAgent(page, 'wcore');
+
+    const modelLabel = await selectedModelLabel(page);
+    test.skip(!modelLabel, 'no wcore model selected (no provider) - skipping live drive');
+    console.log(`[#504] driving live wcore AskUserQuestion with model="${modelLabel}"`);
+
+    await sendMessageFromGuid(page, ASK_PROMPT);
+
+    // The approval prompt must surface the choices as selectable options. If the
+    // model never calls the tool (some models won't), skip rather than fail red.
+    const choiceOption = page.getByTestId('confirm-question-choice');
+    const appeared = await choiceOption
+      .first()
+      .waitFor({ state: 'visible', timeout: 90_000 })
+      .then(() => true)
+      .catch(() => false);
+    test.skip(!appeared, 'model did not call AskUserQuestion within timeout - skipping (non-deterministic tool call)');
+
+    await page.screenshot({ path: path.join(SCREENSHOT_DIR, '01-question-rendered.png') });
+
+    // #504 core assertion: the question's choices render (NOT an empty box).
+    const optionTexts = await choiceOption.allTextContents();
+    const joined = optionTexts.join(' | ');
+    console.log(`[#504] rendered choices: ${joined}`);
+    for (const choice of CHOICES) {
+      expect(joined, `choice "${choice}" must render in the approval prompt`).toContain(choice);
+    }
+
+    // Pick the second choice - the label is sent back as `answer` and the engine
+    // synthesizes the tool result, so the turn resumes instead of erroring.
+    const picked = CHOICES[1];
+    await page.getByTestId('confirm-question-choice').filter({ hasText: picked }).first().click();
+
+    // The prompt clears (answer accepted) and the engine keeps going: the
+    // choices option must disappear.
+    await expect(page.getByTestId('confirm-question-choice').first()).toBeHidden({ timeout: 30_000 });
+    await page.screenshot({ path: path.join(SCREENSHOT_DIR, '02-after-pick.png') });
+    console.log(`[#504] picked="${picked}"; approval prompt cleared (answer accepted by engine)`);
+  });
+});

--- a/tests/unit/BaseAgentManagerDecouple.test.ts
+++ b/tests/unit/BaseAgentManagerDecouple.test.ts
@@ -101,9 +101,10 @@ describe('BaseAgentManager with injected emitter', () => {
     });
     // Confirmation should NOT be added to the list
     expect(agent.getConfirmations()).toHaveLength(0);
-    // After the 50 ms delay, confirm should be called
+    // After the 50 ms delay, confirm should be called. #504: the option's
+    // `answer` (undefined here) is threaded through for AskUserQuestion support.
     await new Promise((r) => setTimeout(r, 80));
-    expect(confirmSpy).toHaveBeenCalledWith('conf1', 'call1', 'proceed');
+    expect(confirmSpy).toHaveBeenCalledWith('conf1', 'call1', 'proceed', undefined);
   });
 
   it('addConfirmation does NOT auto-confirm in yoloMode when options is empty', () => {

--- a/tests/unit/process/agent/wcore/questionTool.test.ts
+++ b/tests/unit/process/agent/wcore/questionTool.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * #504 AskUserQuestion parsing. The engine sends AskUserQuestion as an
+ * `info`-category tool with the prompt buried in args; parseQuestionTool lifts
+ * the question + choices out so the renderer can show selectable answers.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseQuestionTool, ASK_USER_QUESTION_TOOL } from '@/process/agent/wcore/questionTool';
+import type { ToolInfo } from '@/process/agent/wcore/protocol';
+
+const tool = (over: Partial<ToolInfo>): ToolInfo => ({
+  name: ASK_USER_QUESTION_TOOL,
+  category: 'info',
+  description: '',
+  args: {},
+  ...over,
+});
+
+describe('parseQuestionTool (#504)', () => {
+  it('parses AskUserQuestion options ({label, description}) into choices', () => {
+    const result = parseQuestionTool(
+      tool({
+        args: {
+          question: 'Which offer structure fits?',
+          header: 'Nail the offer',
+          options: [
+            { label: 'Founding Member deal', description: 'Paid now via Gumroad' },
+            { label: 'Free core + paid Pro', description: 'Open-source base' },
+          ],
+        },
+      })
+    );
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('question');
+    expect(result!.question).toBe('Which offer structure fits?');
+    expect(result!.header).toBe('Nail the offer');
+    expect(result!.title).toBe('Nail the offer'); // header preferred as title
+    expect(result!.choices).toEqual([
+      { label: 'Founding Member deal', description: 'Paid now via Gumroad' },
+      { label: 'Free core + paid Pro', description: 'Open-source base' },
+    ]);
+  });
+
+  it('supports a bare `choices: string[]` shape and falls back to the question as title', () => {
+    const result = parseQuestionTool(tool({ args: { question: 'Pick one', choices: ['Alpha', 'Beta', '  '] } }));
+    expect(result!.choices).toEqual([{ label: 'Alpha' }, { label: 'Beta' }]); // blank dropped
+    expect(result!.title).toBe('Pick one'); // no header → question is the title
+    expect(result!.header).toBeUndefined();
+  });
+
+  it('returns null for a non-AskUserQuestion tool (answer channel would be ignored engine-side)', () => {
+    expect(parseQuestionTool(tool({ name: 'clarify', args: { choices: ['a', 'b'] } }))).toBeNull();
+    expect(parseQuestionTool(tool({ name: 'Bash', args: { command: 'ls' } }))).toBeNull();
+  });
+
+  it('returns null when there are no usable choices (so it falls back to the generic confirmation)', () => {
+    expect(parseQuestionTool(tool({ args: { question: 'q', options: [] } }))).toBeNull();
+    expect(parseQuestionTool(tool({ args: { question: 'q' } }))).toBeNull();
+    expect(parseQuestionTool(tool({ args: { options: [{ description: 'no label' }] } }))).toBeNull();
+  });
+
+  it('dedupes choices by label (the answer channel is keyed on the label)', () => {
+    const result = parseQuestionTool(
+      tool({ args: { question: 'q', options: [{ label: 'A' }, { label: 'A' }, { label: 'B' }] } })
+    );
+    expect(result!.choices).toEqual([{ label: 'A' }, { label: 'B' }]);
+  });
+
+  it('falls back to the tool description, then the tool name, when args.question is missing', () => {
+    const withDesc = parseQuestionTool(tool({ description: 'desc?', args: { choices: ['a'] } }));
+    expect(withDesc!.question).toBe('desc?');
+    const withNothing = parseQuestionTool(tool({ description: '', args: { choices: ['a'] } }));
+    expect(withNothing!.question).toBe(ASK_USER_QUESTION_TOOL);
+  });
+
+  it('does not throw on malformed args', () => {
+    expect(() => parseQuestionTool(tool({ args: undefined as never }))).not.toThrow();
+    expect(() => parseQuestionTool(tool({ args: { options: 'not-an-array' } as never }))).not.toThrow();
+  });
+});

--- a/tests/unit/renderer/conversation/ConversationChatConfirm.dom.test.tsx
+++ b/tests/unit/renderer/conversation/ConversationChatConfirm.dom.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * #504: the AskUserQuestion approval prompt must render its choices (not an
+ * empty box) and send the picked choice back to the engine as `answer`.
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const confirmInvoke = vi.fn(() => Promise.resolve({ success: true }));
+const listInvoke = vi.fn();
+const checkInvoke = vi.fn(() => Promise.resolve(false));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
+  }),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    conversation: {
+      confirmation: {
+        list: { invoke: (...a: unknown[]) => listInvoke(...a) },
+        confirm: { invoke: (...a: unknown[]) => confirmInvoke(...a) },
+        add: { on: vi.fn(() => () => {}) },
+        remove: { on: vi.fn(() => () => {}) },
+        update: { on: vi.fn(() => () => {}) },
+      },
+      approval: { check: { invoke: (...a: unknown[]) => checkInvoke(...a) } },
+    },
+  },
+}));
+
+vi.mock('@/renderer/hooks/context/ConversationContext', () => ({
+  useConversationContextSafe: () => ({ type: 'wcore' }),
+}));
+
+vi.mock('@/renderer/utils/common', () => ({
+  removeStack: () => () => {},
+}));
+
+vi.mock('@arco-design/web-react', () => ({
+  Divider: () => <hr />,
+  Typography: {
+    Ellipsis: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  },
+}));
+
+import ConversationChatConfirm from '@/renderer/pages/conversation/components/ConversationChatConfirm';
+
+const CONVERSATION_ID = 'conv-504';
+
+const questionConfirmation = {
+  conversation_id: CONVERSATION_ID,
+  id: 'call-1',
+  callId: 'call-1',
+  action: 'question',
+  title: 'Which offer structure fits Wayland?',
+  description: 'Nail the offer',
+  options: [
+    { label: 'Founding Member deal', value: 'proceed_once', answer: 'Founding Member deal', description: 'Paid now' },
+    { label: 'Free core + paid Pro', value: 'proceed_once', answer: 'Free core + paid Pro' },
+    { label: 'messages.confirmation.no', value: 'cancel' },
+  ],
+};
+
+describe('ConversationChatConfirm — AskUserQuestion (#504)', () => {
+  beforeEach(() => {
+    confirmInvoke.mockClear();
+    listInvoke.mockReset();
+    listInvoke.mockResolvedValue([questionConfirmation]);
+  });
+
+  it('renders the question and its choices instead of an empty prompt', async () => {
+    render(
+      <ConversationChatConfirm conversation_id={CONVERSATION_ID}>
+        <div>child</div>
+      </ConversationChatConfirm>
+    );
+
+    expect(await screen.findByText('Which offer structure fits Wayland?')).toBeTruthy();
+    expect(screen.getByText('Founding Member deal')).toBeTruthy();
+    expect(screen.getByText('Free core + paid Pro')).toBeTruthy();
+    expect(screen.getByText('Paid now')).toBeTruthy(); // choice description surfaced
+  });
+
+  it('sends the picked choice as `answer` over the confirm channel', async () => {
+    render(
+      <ConversationChatConfirm conversation_id={CONVERSATION_ID}>
+        <div>child</div>
+      </ConversationChatConfirm>
+    );
+
+    const choice = await screen.findByText('Free core + paid Pro');
+    fireEvent.click(choice);
+
+    await waitFor(() => expect(confirmInvoke).toHaveBeenCalled());
+    expect(confirmInvoke).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversation_id: CONVERSATION_ID,
+        callId: 'call-1',
+        data: 'proceed_once',
+        answer: 'Free core + paid Pro',
+      })
+    );
+  });
+});

--- a/tests/unit/renderer/conversation/ConversationChatConfirm.dom.test.tsx
+++ b/tests/unit/renderer/conversation/ConversationChatConfirm.dom.test.tsx
@@ -90,6 +90,23 @@ describe('ConversationChatConfirm — AskUserQuestion (#504)', () => {
     expect(screen.getByText('Paid now')).toBeTruthy(); // choice description surfaced
   });
 
+  it('marks only the first choice (the yolo auto-pick) as Recommended', async () => {
+    render(
+      <ConversationChatConfirm conversation_id={CONVERSATION_ID}>
+        <div>child</div>
+      </ConversationChatConfirm>
+    );
+
+    // Wait for the choices to render, then assert exactly one Recommended badge
+    // and that it sits on the first choice (choices[0], the auto-picked one).
+    await screen.findByText('Founding Member deal');
+    const badges = screen.getAllByTestId('confirm-question-recommended');
+    expect(badges).toHaveLength(1);
+
+    const firstChoice = screen.getByText('Founding Member deal').closest('[data-testid="confirm-question-choice"]');
+    expect(firstChoice?.contains(badges[0])).toBe(true);
+  });
+
   it('sends the picked choice as `answer` over the confirm channel', async () => {
     render(
       <ConversationChatConfirm conversation_id={CONVERSATION_ID}>


### PR DESCRIPTION
## #504 AskUserQuestion — render the choices, return the pick

Closes the empty-approval-prompt bug: when the agent calls the engine's
`AskUserQuestion` tool (a structured multiple-choice question), the desktop
showed an approval box with no question and no choices, and there was no way to
send the user's selection back — so the tool errored.

### Root cause (verified against wayland-core source, not guessed)
- The engine has **no `question` ToolCategory** (`ToolCategory` = Info|Edit|Exec|Mcp). `AskUserQuestion` is emitted as an ordinary **`info`** tool named `AskUserQuestion`, with `{ question, header?, options:[{label,description}] }` buried in `args` → it fell through to the generic `info` confirmation (empty title/description, generic Allow/Deny).
- The **answer channel already exists engine-side** (wayland-core v0.9.3, `tool_approve.answer: Option<String>`); the engine synthesizes the tool result from the chosen option's **label**, guarded on `tool_name == "AskUserQuestion"`. The desktop simply never populated it. **So this is a desktop-only fix.**

### What this does (desktop)
1. **Detect by name** (not a category the engine never sends): a new pure `questionTool.ts` lifts `question`/`header`/`options` out of args into a new `question` `confirmationDetails` variant (depth/shape-hardened parser, dedupes by label).
2. **Render the choices** as the approval options (dialog `ConversationChatConfirm`), each carrying its `answer` (the label). Inline message card + summary show the question read-only; Gemini/base managers handle the new variant for exhaustiveness.
3. **Return the pick**: `tool_approve` gains an additive `answer?`; `approveTool` / `confirm` / the confirm IPC / bridge all thread it. The engine synthesizes the result and the turn resumes.
4. **Auto-modes**: full-auto (yolo) answers with the first choice (a bare approval would make the engine's loud-defensive `execute()` error); auto-edit and the "always-allow" store never auto-answer a question.
5. Remote-channel confirm prompt now shows the question + choices (was a display regression to a generic "Please confirm").

### Tests / verification
- `questionTool` unit suite; `ConversationChatConfirm.dom` asserts choices render + the pick is sent as `answer`.
- **Independent cross-audit** (non-author) — verdict safe; answer reaches the engine as the option label, verified hop-by-hop; one finding fixed (remote display).
- **LIVE-VERIFIED** (real engine, `flux-standard`): `tests/e2e/specs/wcore-ask-user-question.e2e.ts` — the agent calls `AskUserQuestion`, the prompt renders all three choices + descriptions (not empty), picking one sends the label back and the turn resumes with no error.
- prek green (TS/Oxlint/Oxfmt/EOF/whitespace/UI-tokens); typecheck clean.

### Follow-up (out of desktop lane)
Selecting a specific choice from a **remote messaging channel** (threading `answer` through the channel confirm callback) is a channels-lane follow-up — remote AskUserQuestion answering was already unsupported pre-#504.

I am the author — I will not self-merge.
