### PR TITLE
fix(wcore): render AskUserQuestion choices instead of a blank prompt (#504)

### DIFF
--- a/src/common/chat/chatLib.ts
+++ b/src/common/chat/chatLib.ts
@@ -226,6 +226,19 @@ export type IMessageToolGroup = IMessage<
             toolDisplayName: string;
             serverName: string;
           }
+        >
+      // #504: AskUserQuestion — a structured multiple-choice prompt. Carries the
+      // question + choices so the UI can render selectable options instead of a
+      // blank allow/deny dialog. Single-answer only: the engine's answer channel
+      // is a single string, so the engine's `multiSelect` hint is not carried
+      // here (a multi-select question degrades to one chosen option).
+      | IMessageToolGroupConfirmationDetailsBase<
+          'question',
+          {
+            question: string;
+            header?: string;
+            options: Array<{ label: string; description: string; preview?: string }>;
+          }
         >;
   }>
 >;
@@ -552,6 +565,32 @@ export interface IConfirmation<Option extends any = any> {
    * Used for "always allow" permission memory
    */
   commandType?: string;
+}
+
+/**
+ * #504 AskUserQuestion answer channel.
+ *
+ * A confirmation option's `value` is a plain string sent verbatim back to the
+ * agent manager as the confirm outcome. For AskUserQuestion prompts we need to
+ * carry WHICH choice the user picked (its label) rather than a generic
+ * allow/deny outcome. We encode the chosen label into the option value with a
+ * sentinel prefix so `WCoreManager.confirm` can distinguish an ask_user answer
+ * from a normal ToolConfirmationOutcome and thread it back through
+ * `tool_approve.answer`.
+ *
+ * These helpers live in `common/` (not `WCoreManager`) because the renderer
+ * (MessageToolGroup) must encode option values and cannot import the
+ * node-dependent manager module.
+ */
+export const ASK_USER_ANSWER_PREFIX = 'ask_user_answer::';
+
+export function encodeAskUserAnswer(label: string): string {
+  return ASK_USER_ANSWER_PREFIX + label;
+}
+
+/** Returns the decoded label if `value` is an ask_user answer, else `null`. */
+export function decodeAskUserAnswer(value: string): string | null {
+  return value.startsWith(ASK_USER_ANSWER_PREFIX) ? value.slice(ASK_USER_ANSWER_PREFIX.length) : null;
 }
 
 /**

--- a/src/process/agent/wcore/index.ts
+++ b/src/process/agent/wcore/index.ts
@@ -16,9 +16,51 @@ import { resolveActiveConfigDir } from './profilePaths';
 import { getToolKeyStore } from './toolKeyStore';
 import { hydrateModelForSpawn } from '@process/providers/ipc/modelRegistryIpc';
 import { killChild } from '@process/agent/acp/utils';
-import type { WCoreEvent, WCoreCommand, WCoreCapabilities } from './protocol';
+import type { WCoreEvent, WCoreCommand, WCoreCapabilities, ToolInfo } from './protocol';
 
 const WCORE_PROJECT_CONFIG = '.wcore.toml';
+
+/**
+ * #504: Build a `question`-type confirmation from an AskUserQuestion tool
+ * request. Defensive against payload drift — the engine schema
+ * (ask_user_question.rs) requires `question` + `options[].{label,description}`,
+ * but we tolerate missing/malformed fields so a bad payload degrades to a
+ * readable prompt instead of the blank dialog reported in #504:
+ *  - non-string `question`/`header` fall back to the tool description / undefined
+ *  - `options` that aren't an array, or entries without a string `label`, are dropped
+ *  - an empty `options` list still renders the question (with only a Cancel path)
+ *
+ * Single-answer only: the engine's answer channel is a single
+ * `ToolApprove.answer: Option<String>` (commands.rs), so the host renders
+ * single-select and returns exactly one chosen label. The engine's optional
+ * `multiSelect` hint is intentionally not carried into the UI — honoring it
+ * would require a multi-value answer channel on the engine side (tracked
+ * separately); a multi-select question degrades to picking one option.
+ *
+ * Exported for unit testing (the method that calls it is private).
+ */
+export function buildAskUserConfirmation(tool: Pick<ToolInfo, 'description' | 'args'>) {
+  const args = (tool.args ?? {}) as Record<string, unknown>;
+  const question = typeof args.question === 'string' && args.question.length > 0 ? args.question : tool.description;
+  const header = typeof args.header === 'string' && args.header.length > 0 ? args.header : undefined;
+  const rawOptions = Array.isArray(args.options) ? args.options : [];
+  const options = rawOptions
+    .filter((o): o is Record<string, unknown> => !!o && typeof o === 'object')
+    .map((o) => ({
+      label: typeof o.label === 'string' ? o.label : '',
+      description: typeof o.description === 'string' ? o.description : '',
+      ...(typeof o.preview === 'string' ? { preview: o.preview } : {}),
+    }))
+    .filter((o) => o.label.length > 0);
+
+  return {
+    type: 'question' as const,
+    title: header ?? tool.description,
+    question,
+    ...(header !== undefined ? { header } : {}),
+    options,
+  };
+}
 
 type StreamEventHandler = (event: { type: string; data: unknown; msg_id: string; subject?: string }) => void;
 
@@ -742,6 +784,16 @@ export class WCoreAgent {
   private mapConfirmationDetails(event: WCoreEvent & { type: 'tool_request' }) {
     const { tool } = event;
 
+    // #504: AskUserQuestion renders a structured multiple-choice prompt. The
+    // shipped engine still tags it as `info` (ask_user_question.rs
+    // category() -> Info), so we detect by name as well as the forward-additive
+    // `question` category. Without this, the args fall through to the `info`
+    // arm below and get JSON.stringify'd into an unreadable blob (the empty
+    // prompt reported in #504).
+    if (tool.category === 'question' || tool.name === 'AskUserQuestion' || tool.name === 'ask_user') {
+      return buildAskUserConfirmation(tool);
+    }
+
     switch (tool.category) {
       case 'edit':
         return {
@@ -799,8 +851,16 @@ export class WCoreAgent {
     this.sendCommand({ type: 'stop' });
   }
 
-  approveTool(callId: string, scope: 'once' | 'always' = 'once'): void {
-    this.sendCommand({ type: 'tool_approve', call_id: callId, scope });
+  // `answer` (#504) carries the user's AskUserQuestion choice; the engine
+  // synthesizes the tool result from it (wcore-agent orchestration). Omitted
+  // for normal tool approvals so pre-v0.9.3 engines see the legacy wire shape.
+  approveTool(callId: string, scope: 'once' | 'always' = 'once', answer?: string): void {
+    this.sendCommand({
+      type: 'tool_approve',
+      call_id: callId,
+      scope,
+      ...(answer !== undefined ? { answer } : {}),
+    });
   }
 
   denyTool(callId: string, reason = ''): void {

--- a/src/process/agent/wcore/protocol.ts
+++ b/src/process/agent/wcore/protocol.ts
@@ -18,7 +18,12 @@
 // Agent -> Client Events (stdout)
 // ============================================
 
-export type ToolCategory = 'info' | 'edit' | 'exec' | 'mcp';
+// `question` (#504): AskUserQuestion-class tools that present a structured
+// multiple-choice prompt. The shipped engine (≤0.12.x) still tags
+// AskUserQuestion as `info` (ask_user_question.rs category() -> Info), so the
+// host detects it by tool name too (see mapConfirmationDetails). This variant
+// is forward-additive for when the engine starts emitting `question` directly.
+export type ToolCategory = 'info' | 'edit' | 'exec' | 'mcp' | 'question';
 
 export type ToolInfo = {
   name: string;
@@ -290,7 +295,12 @@ export type WCoreEvent =
 export type WCoreCommand =
   | { type: 'message'; msg_id: string; content: string; files?: string[] }
   | { type: 'stop' }
-  | { type: 'tool_approve'; call_id: string; scope: 'once' | 'always' }
+  // `answer` (#504) carries the user's AskUserQuestion choice back through the
+  // approval channel. Engine v0.9.3+ (`ToolApprove.answer: Option<String>`,
+  // wcore-protocol/commands.rs) synthesizes the tool result from it; pre-v0.9.3
+  // engines ignore the extra field (serde default), so this is safe to always
+  // omit when absent.
+  | { type: 'tool_approve'; call_id: string; scope: 'once' | 'always'; answer?: string }
   | { type: 'tool_deny'; call_id: string; reason?: string }
   // W7 S4 HITL: resume a suspended turn waiting on an `approval_required`.
   // Engine-side resolve is idempotent — a stale/duplicate token is ignored.

--- a/src/process/task/GeminiAgentManager.ts
+++ b/src/process/task/GeminiAgentManager.ts
@@ -7,7 +7,7 @@
 import { channelEventBus } from '@process/channels/agent/ChannelEventBus';
 import { ipcBridge } from '@/common';
 import type { CronMessageMeta, IMessageText, IMessageToolGroup, TMessage } from '@/common/chat/chatLib';
-import { transformMessage } from '@/common/chat/chatLib';
+import { transformMessage, encodeAskUserAnswer, decodeAskUserAnswer } from '@/common/chat/chatLib';
 import type { IResponseMessage } from '@/common/adapter/ipcBridge';
 import type { IMcpServer, TProviderWithModel } from '@/common/config/storage';
 import { ProcessConfig, getSkillsDir } from '@process/utils/initStorage';
@@ -621,8 +621,10 @@ export class GeminiAgentManager extends BaseAgentManager<
     let question: string;
     let description: string;
     const options: Array<{
+      // #504: AskUserQuestion options carry an encoded choice label; all other
+      // confirmations use a ToolConfirmationOutcome.
       label: string;
-      value: ToolConfirmationOutcome;
+      value: ToolConfirmationOutcome | string;
       params?: Record<string, string>;
     }> = [];
     switch (confirmationDetails.type) {
@@ -684,6 +686,24 @@ export class GeminiAgentManager extends BaseAgentManager<
               value: ToolConfirmationOutcome.Cancel,
             }
           );
+        }
+        break;
+      case 'question':
+        {
+          // #504: AskUserQuestion — one selectable option per choice plus a
+          // Cancel. Each option value carries the encoded choice label so the
+          // manager threads it back through the approval channel.
+          question = confirmationDetails.question;
+          description = confirmationDetails.header
+            ? `${confirmationDetails.header}\n\n${confirmationDetails.question}`
+            : confirmationDetails.question;
+          for (const opt of confirmationDetails.options) {
+            options.push({
+              label: opt.description ? `${opt.label} — ${opt.description}` : opt.label,
+              value: encodeAskUserAnswer(opt.label),
+            });
+          }
+          options.push({ label: t('messages.confirmation.no'), value: ToolConfirmationOutcome.Cancel });
         }
         break;
       default: {
@@ -1188,8 +1208,12 @@ export class GeminiAgentManager extends BaseAgentManager<
     }
 
     super.confirm(id, callId, data);
-    // Send confirmation to worker, using callId as message type
-    return this.postMessagePromise(callId, data);
+    // #504: AskUserQuestion is a wcore-only tool, so a `question` confirmation
+    // never reaches this manager in practice. Decode defensively anyway so an
+    // encoded answer value is never forwarded raw (kept symmetric with
+    // WCoreManager.confirm); a normal outcome decodes to null and passes through.
+    const answer = decodeAskUserAnswer(data);
+    return this.postMessagePromise(callId, answer ?? data);
   }
 
   // Manually trigger context reload

--- a/src/process/task/WCoreManager.ts
+++ b/src/process/task/WCoreManager.ts
@@ -6,7 +6,7 @@
 
 import { ipcBridge } from '@/common';
 import type { IMessageToolGroup, TMessage } from '@/common/chat/chatLib';
-import { transformMessage } from '@/common/chat/chatLib';
+import { transformMessage, decodeAskUserAnswer, encodeAskUserAnswer } from '@/common/chat/chatLib';
 import { buildResumeSeedTranscript } from '@process/task/resumeSeed';
 import type { IResponseMessage } from '@/common/adapter/ipcBridge';
 import { channelEventBus } from '@process/channels/agent/ChannelEventBus';
@@ -503,6 +503,13 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
   private tryAutoApprove(content: IMessageToolGroup['content'][number]): boolean {
     const type = content.confirmationDetails?.type;
 
+    // #504: AskUserQuestion always needs a human answer — auto-approving it
+    // (even in yolo) would send `tool_approve` with no `answer`, which the
+    // engine can't synthesize a result from and its execute() fallback fails
+    // loud. Always surface the choices. This mirrors the engine's own carve-out
+    // (orchestration requires approval for AskUserQuestion in every mode).
+    if (type === 'question') return false;
+
     if (this.currentMode === 'yolo') {
       this.agent?.approveTool(content.callId, 'once');
       return true;
@@ -533,18 +540,38 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
         continue;
       }
 
-      // Show confirmation dialog to user
-      const options = [
-        { label: 'messages.confirmation.yesAllowOnce', value: ToolConfirmationOutcome.ProceedOnce },
-        { label: 'messages.confirmation.yesAllowAlways', value: ToolConfirmationOutcome.ProceedAlways },
-        { label: 'messages.confirmation.no', value: ToolConfirmationOutcome.Cancel },
-      ];
+      // Show confirmation dialog to user.
+      const details = content.confirmationDetails;
+      let options: Array<{ label: string; value: string; params?: Record<string, string> }>;
+      let description = content.description || '';
+
+      if (details?.type === 'question') {
+        // #504: AskUserQuestion — one selectable option per choice. The option
+        // value carries the chosen label (via the ask_user answer sentinel) so
+        // `confirm` can thread it back through `tool_approve.answer`. Choice
+        // labels are user-facing literals, not i18n keys, so the renderer's
+        // `$t()` falls back to them verbatim.
+        options = details.options.map((o) => ({
+          label: o.description ? `${o.label} — ${o.description}` : o.label,
+          value: encodeAskUserAnswer(o.label),
+        }));
+        options.push({ label: 'messages.confirmation.no', value: ToolConfirmationOutcome.Cancel });
+        // `title` already carries the header (buildAskUserConfirmation), so the
+        // body shows just the question to avoid duplicating the header.
+        description = details.question;
+      } else {
+        options = [
+          { label: 'messages.confirmation.yesAllowOnce', value: ToolConfirmationOutcome.ProceedOnce },
+          { label: 'messages.confirmation.yesAllowAlways', value: ToolConfirmationOutcome.ProceedAlways },
+          { label: 'messages.confirmation.no', value: ToolConfirmationOutcome.Cancel },
+        ];
+      }
 
       this.addConfirmation({
         title: content.confirmationDetails?.title || content.name || '',
         id: content.callId,
         action,
-        description: content.description || '',
+        description,
         callId: content.callId,
         options,
         commandType,
@@ -1366,8 +1393,14 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
   }
 
   confirm(id: string, callId: string, data: string) {
+    // #504: AskUserQuestion answer — `data` carries the chosen label. Approve
+    // the tool with the answer attached so the engine synthesizes the result
+    // from it. Never stored in the "always allow" memory (each question is
+    // one-shot).
+    const askUserAnswer = decodeAskUserAnswer(data);
+
     // Store "always allow" in approval store
-    if (data === ToolConfirmationOutcome.ProceedAlways) {
+    if (askUserAnswer === null && data === ToolConfirmationOutcome.ProceedAlways) {
       const confirmation = this.confirmations.find((c) => c.callId === callId);
       if (confirmation?.action) {
         const keys = WCoreApprovalStore.createKeysFromConfirmation(confirmation.action, confirmation.commandType);
@@ -1378,7 +1411,9 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
     super.confirm(id, callId, data);
 
     if (this.agent) {
-      if (data === ToolConfirmationOutcome.Cancel) {
+      if (askUserAnswer !== null) {
+        this.agent.approveTool(callId, 'once', askUserAnswer);
+      } else if (data === ToolConfirmationOutcome.Cancel) {
         this.agent.denyTool(callId, 'User cancelled');
       } else {
         const scope = data === ToolConfirmationOutcome.ProceedAlways ? 'always' : 'once';

--- a/src/renderer/pages/conversation/Messages/components/MessageToolGroup.tsx
+++ b/src/renderer/pages/conversation/Messages/components/MessageToolGroup.tsx
@@ -7,6 +7,7 @@
 import { Copy, Download, Loader2 } from 'lucide-react';
 import { ipcBridge } from '@/common';
 import type { IMessageToolGroup } from '@/common/chat/chatLib';
+import { encodeAskUserAnswer } from '@/common/chat/chatLib';
 import { iconColors } from '@/renderer/styles/colors';
 import { Alert, Button, Image, Message, Radio, Tag, Tooltip } from '@arco-design/web-react';
 import React, { useCallback, useContext, useMemo, useState } from 'react';
@@ -44,7 +45,9 @@ const useConfirmationButtons = (
   return useMemo(() => {
     if (!confirmationDetails) return {};
     let question: string;
-    const options: Array<{ label: string; value: ToolConfirmationOutcome }> = [];
+    // Value is usually a ToolConfirmationOutcome, but AskUserQuestion (#504)
+    // options carry the encoded choice label instead.
+    const options: Array<{ label: string; value: ToolConfirmationOutcome | string }> = [];
     switch (confirmationDetails.type) {
       case 'edit':
         {
@@ -92,6 +95,21 @@ const useConfirmationButtons = (
             },
             { label: t('messages.confirmation.no'), value: ToolConfirmationOutcome.Cancel }
           );
+        }
+        break;
+      case 'question':
+        {
+          // #504: AskUserQuestion — render each choice as a selectable option.
+          question = confirmationDetails.header
+            ? `${confirmationDetails.header} — ${confirmationDetails.question}`
+            : confirmationDetails.question;
+          for (const opt of confirmationDetails.options) {
+            options.push({
+              label: opt.description ? `${opt.label} — ${opt.description}` : opt.label,
+              value: encodeAskUserAnswer(opt.label),
+            });
+          }
+          options.push({ label: t('messages.confirmation.no'), value: ToolConfirmationOutcome.Cancel });
         }
         break;
       default: {
@@ -154,9 +172,13 @@ const EditConfirmationDiff: React.FC<{ diff: string; fileName: string; title: st
   );
 };
 
-const ConfirmationDetails: React.FC<{
+// Exported for #504 render tests (asserts AskUserQuestion choices render and
+// are selectable). Not part of the module's public UI surface otherwise.
+export const ConfirmationDetails: React.FC<{
   content: IMessageToolGroupProps['message']['content'][number];
-  onConfirm: (outcome: ToolConfirmationOutcome) => void;
+  // AskUserQuestion (#504) sends an encoded choice label rather than a
+  // ToolConfirmationOutcome; both go over the same confirm channel as strings.
+  onConfirm: (outcome: ToolConfirmationOutcome | string) => void;
 }> = ({ content, onConfirm }) => {
   const { t } = useTranslation();
   const { confirmationDetails } = content;
@@ -178,12 +200,16 @@ const ConfirmationDetails: React.FC<{
         return <span className='text-t-primary'>{confirmationDetails.prompt}</span>;
       case 'mcp':
         return <span className='text-t-primary'>{confirmationDetails.toolDisplayName}</span>;
+      case 'question':
+        // The question text is rendered once as the prompt line below (built by
+        // useConfirmationButtons); no separate body node to avoid duplication.
+        return null;
     }
   }, [confirmationDetails]);
 
   const { question = '', options = [] } = useConfirmationButtons(confirmationDetails, t);
 
-  const [selected, setSelected] = useState<ToolConfirmationOutcome | null>(null);
+  const [selected, setSelected] = useState<ToolConfirmationOutcome | string | null>(null);
 
   const isConfirm = content.status === 'Confirming';
 
@@ -543,11 +569,7 @@ const MessageToolGroup: React.FC<IMessageToolGroupProps> = ({ message }) => {
                       ? 'warning'
                       : 'info'
               }
-              icon={
-                isLoading && (
-                  <Loader2 size={12} color={iconColors.primary} className='loading lh-[1] flex' />
-                )
-              }
+              icon={isLoading && <Loader2 size={12} color={iconColors.primary} className='loading lh-[1] flex' />}
               content={
                 <div>
                   <Tag className={'mr-4px'}>

--- a/tests/unit/AskUserConfirm.dom.test.tsx
+++ b/tests/unit/AskUserConfirm.dom.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// #504: the AskUserQuestion confirmation must render its choices (not a blank
+// dialog) and each choice must be selectable, sending the encoded answer back
+// through the confirm channel. This renders the real ConfirmationDetails
+// component from MessageToolGroup with a `question` confirmation.
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ASK_USER_ANSWER_PREFIX } from '@/common/chat/chatLib';
+
+// i18n: return defaultValue/key verbatim so choice labels (which are literals,
+// not i18n keys) read stable.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown> & { defaultValue?: string }) => opts?.defaultValue ?? key,
+  }),
+}));
+
+// Heavy sibling module that pulls electron/IPC transitively; ConfirmationDetails
+// only needs the ImagePreviewContext symbol to exist.
+vi.mock('../../src/renderer/pages/conversation/Messages/MessageList', () => ({
+  ImagePreviewContext: React.createContext({ inPreviewGroup: false }),
+}));
+
+vi.mock('@/common', () => ({ ipcBridge: {} }));
+
+import { ConfirmationDetails } from '@/renderer/pages/conversation/Messages/components/MessageToolGroup';
+
+const questionContent = {
+  callId: 'call-1',
+  description: 'ask_user: Which backend?',
+  name: 'AskUserQuestion',
+  renderOutputAsMarkdown: false,
+  status: 'Confirming' as const,
+  confirmationDetails: {
+    type: 'question' as const,
+    title: 'Backend selection',
+    question: 'Which backend should I use?',
+    header: 'Backend selection',
+    options: [
+      { label: 'Anthropic', description: 'Claude models' },
+      { label: 'OpenAI', description: 'GPT models' },
+    ],
+  },
+};
+
+describe('ConfirmationDetails — AskUserQuestion (#504)', () => {
+  it('renders the question text and each choice (not blank)', () => {
+    render(<ConfirmationDetails content={questionContent} onConfirm={vi.fn()} />);
+    // Question text is visible (rendered both as the body and the prompt line).
+    expect(screen.getAllByText(/Which backend should I use\?/).length).toBeGreaterThan(0);
+    // Each choice label + description renders as a selectable option.
+    expect(screen.getByText('Anthropic — Claude models')).toBeTruthy();
+    expect(screen.getByText('OpenAI — GPT models')).toBeTruthy();
+  });
+
+  it('sends the encoded chosen label when a choice is selected and confirmed', () => {
+    const onConfirm = vi.fn();
+    render(<ConfirmationDetails content={questionContent} onConfirm={onConfirm} />);
+
+    // Select the second choice, then confirm.
+    fireEvent.click(screen.getByText('OpenAI — GPT models'));
+    fireEvent.click(screen.getByText('messages.confirm'));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledWith(`${ASK_USER_ANSWER_PREFIX}OpenAI`);
+  });
+});

--- a/tests/unit/wcoreAskUserConfirm.test.ts
+++ b/tests/unit/wcoreAskUserConfirm.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// #504: AskUserQuestion confirmation mapping + answer channel.
+//
+// The engine (wayland-core ask_user_question.rs) still tags AskUserQuestion as
+// the `info` ToolCategory, so before this fix its args were JSON.stringify'd
+// into the generic `info` prompt and the dialog rendered blank. These tests
+// pin the mapping that turns an AskUserQuestion tool_request into a structured
+// `question` confirmation, plus the answer-encoding helpers that thread the
+// chosen label back through `tool_approve.answer`.
+
+import { describe, it, expect } from 'vitest';
+import { buildAskUserConfirmation } from '@process/agent/wcore';
+import { encodeAskUserAnswer, decodeAskUserAnswer, ASK_USER_ANSWER_PREFIX } from '@/common/chat/chatLib';
+
+describe('buildAskUserConfirmation (#504 mapping)', () => {
+  it('maps a well-formed AskUserQuestion payload to a question confirmation', () => {
+    const detail = buildAskUserConfirmation({
+      description: 'ask_user: Pick a backend',
+      args: {
+        question: 'Which backend should I use?',
+        header: 'Backend selection',
+        multiSelect: false,
+        options: [
+          { label: 'Anthropic', description: 'Claude models' },
+          { label: 'OpenAI', description: 'GPT models', preview: 'gpt-4o' },
+        ],
+      },
+    });
+
+    expect(detail.type).toBe('question');
+    expect(detail.question).toBe('Which backend should I use?');
+    expect(detail.header).toBe('Backend selection');
+    expect(detail.title).toBe('Backend selection'); // header wins for the title
+    // multiSelect is intentionally NOT carried (single-answer only; see mapping doc).
+    expect('multiSelect' in detail).toBe(false);
+    expect(detail.options).toEqual([
+      { label: 'Anthropic', description: 'Claude models' },
+      { label: 'OpenAI', description: 'GPT models', preview: 'gpt-4o' },
+    ]);
+  });
+
+  it('falls back to the tool description when question is missing, and drops header', () => {
+    const detail = buildAskUserConfirmation({
+      description: 'ask_user: fallback title',
+      args: { options: [{ label: 'Yes', description: '' }] },
+    });
+    expect(detail.question).toBe('ask_user: fallback title');
+    expect(detail.header).toBeUndefined();
+    expect(detail.title).toBe('ask_user: fallback title');
+    expect(detail.options).toEqual([{ label: 'Yes', description: '' }]);
+  });
+
+  it('is defensive against malformed options (non-array, missing/blank labels)', () => {
+    const nonArray = buildAskUserConfirmation({
+      description: 'q',
+      args: { question: 'Q', options: 'not-an-array' },
+    });
+    expect(nonArray.options).toEqual([]);
+
+    const partial = buildAskUserConfirmation({
+      description: 'q',
+      args: {
+        question: 'Q',
+        options: [
+          { label: 'Keep', description: 'ok' },
+          { label: '', description: 'dropped-empty-label' },
+          { description: 'dropped-no-label' },
+          null,
+          'garbage',
+        ],
+      },
+    });
+    // Only the one entry with a non-empty string label survives.
+    expect(partial.options).toEqual([{ label: 'Keep', description: 'ok' }]);
+  });
+
+  it('does not carry the engine multiSelect hint (single-answer only)', () => {
+    // Even when the engine sends multiSelect:true, the confirmation stays
+    // single-answer — the answer channel is a single string.
+    const detail = buildAskUserConfirmation({
+      description: 'q',
+      args: { question: 'Q', multiSelect: true, options: [{ label: 'A', description: 'a' }] },
+    });
+    expect('multiSelect' in detail).toBe(false);
+  });
+});
+
+describe('ask_user answer encoding (#504 answer channel)', () => {
+  it('round-trips a chosen label through encode/decode', () => {
+    const encoded = encodeAskUserAnswer('Use Anthropic');
+    expect(encoded).toBe(`${ASK_USER_ANSWER_PREFIX}Use Anthropic`);
+    expect(decodeAskUserAnswer(encoded)).toBe('Use Anthropic');
+  });
+
+  it('preserves labels that themselves contain the separator characters', () => {
+    const tricky = 'A: b :: c — d';
+    expect(decodeAskUserAnswer(encodeAskUserAnswer(tricky))).toBe(tricky);
+  });
+
+  it('returns null for normal confirmation outcomes (not an answer)', () => {
+    expect(decodeAskUserAnswer('proceed_once')).toBeNull();
+    expect(decodeAskUserAnswer('proceed_always')).toBeNull();
+    expect(decodeAskUserAnswer('cancel')).toBeNull();
+    expect(decodeAskUserAnswer('')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem (#504)

The AskUserQuestion approval prompt rendered **empty** (Windows repro on the issue). Root cause: the wcore engine tags AskUserQuestion as the `info` ToolCategory (`ask_user_question.rs category() -> Info`), so its args were `JSON.stringify`'d into the generic info prompt and the dialog only offered allow/deny — the question text and choices were never surfaced.

## Fix — a real question path, end to end

- **protocol.ts**: add `question` ToolCategory (forward-additive) and an additive `answer?` field on the `tool_approve` command (matches engine v0.9.3 `ToolApprove.answer: Option<String>`).
- **wcore/index.ts**: detect AskUserQuestion by category **or** tool name (the shipped engine still uses `info`), and map the payload into a structured `question` confirmation via a defensive `buildAskUserConfirmation` helper (tolerates malformed/missing fields so a bad payload degrades to a readable prompt, never blank). `approveTool` threads the chosen label as `answer`.
- **chatLib.ts**: `question` confirmationDetails variant + shared `encode/decodeAskUserAnswer` helpers (placed in `common/` because the renderer can't import the node-only `WCoreManager`).
- **WCoreManager**: build one selectable option per choice; `confirm()` decodes the chosen label and sends it as `tool_approve.answer`; **never** auto-approve a question (an answerless approval hits the engine's loud-fail `execute()`), and never store it in "always allow".
- **MessageToolGroup / GeminiAgentManager**: handle the new `question` type in the confirmation switches (type-exhaustive; the floating `ConversationChatConfirm` panel — the primary wcore UI — renders choices generically once fed the new options).

## Payload-shape assumption

Verified against the engine source (`wcore-tools/src/ask_user_question.rs`, `wcore-protocol/src/commands.rs`): schema is `question` / `header` / `multiSelect` / `options[{label, description, preview?}]`, answer returns via `tool_approve.answer`. **Single-answer only**: the answer channel is a single string, so the engine's `multiSelect` hint is intentionally not carried — a multi-select question degrades to one chosen option. True multi-select needs a multi-value engine answer channel (follow-up).

## Tests

- `tests/unit/wcoreAskUserConfirm.test.ts` — mapping (well-formed, missing header, malformed/empty options, single-answer) + answer encode/decode round-trip and non-collision with normal outcomes.
- `tests/unit/AskUserConfirm.dom.test.tsx` — renders the real `ConfirmationDetails` component with a question payload; asserts the question + each choice render (not blank) and selecting a choice emits the encoded answer.

Typecheck, oxlint, oxfmt, and prek all green. 50 WCore/related tests pass.

## Cross-audit

Independent adversarial subagent review (payload assumptions, deny/cancel, answer collision, blast radius, auto-approve, empty options). Findings all fixed: HIGH yolo-mode answerless auto-approval (guarded), MEDIUM multiSelect unhonored (dropped + documented as single-answer), LOW Gemini decode symmetry + LOW duplicate question render.

## Live-verify: NOT DONE

A genuine end-to-end live test requires a built/bundled engine (absent from the worktree), provider credentials, and the model actually choosing to emit an AskUserQuestion turn — not reproducible autonomously. The DOM render test is the automated rendering evidence in lieu of it.

Closes #504.