### PR TITLE
fix(#523): right-click paste, shadow-DOM copy, visible scrollbar

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,7 @@ import { onCloseToTrayChanged, onLanguageChanged } from './process/bridge/system
 import { setInitialLanguage } from '@process/services/i18n';
 import { workerTaskManager } from './process/task/workerTaskManagerSingleton';
 import { setupApplicationMenu } from './process/utils/appMenu';
+import { attachContextMenu } from './process/utils/contextMenu';
 import { startWebServer } from './process/webserver';
 import { initializeZoomFactor, setupZoomForWindow } from './process/utils/zoom';
 import { getOrCreateAnalyticsId } from './process/utils/analyticsId';
@@ -351,6 +352,10 @@ app.on('web-contents-created', (_event, contents) => {
   // Deny window.open() for every contents. The main renderer routes external
   // links through shell.openExternal; guests have no legitimate popup need.
   contents.setWindowOpenHandler(() => ({ action: 'deny' }));
+
+  // Wire a native right-click menu (cut/copy/paste/spellcheck). Electron has no
+  // default context menu, so without this paste-via-mouse is impossible (#523).
+  attachContextMenu(contents);
 
   // Only add the guest navigation lock to webview contents. The main window's
   // own will-navigate guard (in createWindow) already fully constrains it, and

--- a/src/process/utils/contextMenu.ts
+++ b/src/process/utils/contextMenu.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { WebContents } from 'electron';
+import { BrowserWindow, Menu, MenuItem } from 'electron';
+
+/**
+ * Wire a native context menu (right-click) for a webContents.
+ *
+ * Electron ships no default right-click menu, so without this there is no way to
+ * Paste an API key or Copy text via the mouse (#523). The menu is built from the
+ * hit-test `params` so it only offers actions that make sense at the click point:
+ * editable inputs get Cut/Copy/Paste/Select All + spellcheck suggestions; a plain
+ * text selection gets Copy; a right-click on empty, non-editable chrome shows no
+ * menu at all (rather than a useless empty one).
+ *
+ * Copy uses `role: 'copy'`, which fires the DOM copy event that the renderer's
+ * shadow-copy handler intercepts, so copying agent messages (rendered inside an
+ * open shadow root) works here too.
+ */
+export function attachContextMenu(contents: WebContents): void {
+  contents.on('context-menu', (_event, params) => {
+    const menu = new Menu();
+    const { editFlags, isEditable, selectionText, dictionarySuggestions, misspelledWord } = params;
+    const hasSelection = selectionText.trim().length > 0;
+
+    // Spellcheck suggestions for a misspelled word under the cursor.
+    if (isEditable && misspelledWord) {
+      if (dictionarySuggestions.length === 0) {
+        menu.append(new MenuItem({ label: 'No suggestions', enabled: false }));
+      } else {
+        for (const suggestion of dictionarySuggestions) {
+          menu.append(new MenuItem({ label: suggestion, click: () => contents.replaceMisspelling(suggestion) }));
+        }
+      }
+      menu.append(
+        new MenuItem({
+          label: 'Add to Dictionary',
+          click: () => contents.session.addWordToSpellCheckerDictionary(misspelledWord),
+        })
+      );
+      menu.append(new MenuItem({ type: 'separator' }));
+    }
+
+    if (isEditable && editFlags.canCut) menu.append(new MenuItem({ role: 'cut' }));
+    if (hasSelection && editFlags.canCopy) menu.append(new MenuItem({ role: 'copy' }));
+    if (isEditable && editFlags.canPaste) menu.append(new MenuItem({ role: 'paste' }));
+
+    if ((isEditable || hasSelection) && editFlags.canSelectAll) {
+      if (menu.items.length > 0) menu.append(new MenuItem({ type: 'separator' }));
+      menu.append(new MenuItem({ role: 'selectAll' }));
+    }
+
+    // Nothing actionable at this point (e.g. right-click on empty chrome).
+    if (menu.items.length === 0) return;
+
+    const window = BrowserWindow.fromWebContents(contents) ?? undefined;
+    menu.popup({ window });
+  });
+}

--- a/src/process/utils/contextMenu.ts
+++ b/src/process/utils/contextMenu.ts
@@ -20,12 +20,20 @@ import { BrowserWindow, Menu, MenuItem } from 'electron';
  * Copy uses `role: 'copy'`, which fires the DOM copy event that the renderer's
  * shadow-copy handler intercepts, so copying agent messages (rendered inside an
  * open shadow root) works here too.
+ *
+ * This is intentionally attached to every webContents, including untrusted guest
+ * `<webview>`s: the menu only ever exposes cut/copy/paste/selectAll/spellcheck
+ * gated on `editFlags` (no devtools / navigation / open-external), and Paste into
+ * a guest input is already reachable via Ctrl+V, so it adds no new capability.
  */
 export function attachContextMenu(contents: WebContents): void {
   contents.on('context-menu', (_event, params) => {
     const menu = new Menu();
     const { editFlags, isEditable, selectionText, dictionarySuggestions, misspelledWord } = params;
-    const hasSelection = selectionText.trim().length > 0;
+    // Use Chromium's own `canCopy` for the Copy/Select-All gating: it reflects the
+    // frame selection (which includes open shadow-root selections) whereas
+    // `selectionText` can be empty for a selection that lives in a shadow root.
+    const hasSelection = editFlags.canCopy || selectionText.trim().length > 0;
 
     // Spellcheck suggestions for a misspelled word under the cursor.
     if (isEditable && misspelledWord) {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -87,6 +87,7 @@ import { useAuth } from './hooks/context/AuthContext';
 import { ConversationHistoryProvider } from './hooks/context/ConversationHistoryContext';
 import HOC from './utils/ui/HOC';
 import { canonicalizeWebUiRoute } from './utils/canonicalizeRoute';
+import { installShadowCopyHandler } from './utils/shadowSelection';
 
 // Patch Korean locale with missing properties from English locale
 const koKRComplete = {
@@ -157,6 +158,10 @@ const Main = () => {
 const App = HOC.Wrapper(Config)(Main);
 
 void registerPwa();
+
+// Enable Ctrl+C / context-menu Copy of agent messages, which render inside an
+// open shadow root where the native copy path reads an empty selection (#523).
+installShadowCopyHandler();
 
 // Reconcile a mixed path/hash URL (e.g. `/assistants#/guid`) before the
 // HashRouter mounts, so the rendered route matches the visible path (#151).

--- a/src/renderer/pages/conversation/Messages/components/SelectionReplyButton.tsx
+++ b/src/renderer/pages/conversation/Messages/components/SelectionReplyButton.tsx
@@ -7,40 +7,12 @@
 import { Quote } from 'lucide-react';
 import type { TMessage } from '@/common/chat/chatLib';
 import { emitter } from '@/renderer/utils/emitter';
+import { getEffectiveSelection } from '@/renderer/utils/shadowSelection';
 import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 type ReplyPos = { top: number; left: number; text: string; msgId: string; msgPos: string };
-
-/**
- * Get the current selection, checking Shadow DOM roots if needed.
- * MarkdownView renders inside Shadow DOM, so document.getSelection() may
- * return a collapsed/empty selection while the real selection lives inside
- * a shadowRoot.
- */
-function getEffectiveSelection(target: EventTarget | null): Selection | null {
-  // First try the standard selection
-  const docSel = document.getSelection();
-  if (docSel && !docSel.isCollapsed && docSel.toString().trim()) {
-    return docSel;
-  }
-
-  // If standard selection is empty, search for selection inside Shadow DOM
-  // Walk up from the mouseup target to find a shadow host
-  let el = target instanceof Node ? target : null;
-  while (el) {
-    if (el instanceof Element && el.shadowRoot) {
-      const shadowSel = (el.shadowRoot as unknown as { getSelection?: () => Selection | null }).getSelection?.();
-      if (shadowSel && !shadowSel.isCollapsed && shadowSel.toString().trim()) {
-        return shadowSel;
-      }
-    }
-    el = el.parentNode;
-  }
-
-  return docSel;
-}
 
 /**
  * Find the closest message container from a selection's anchor node.

--- a/src/renderer/styles/themes/base.css
+++ b/src/renderer/styles/themes/base.css
@@ -99,26 +99,33 @@ body {
 
 /* Custom scrollbar styles */
 ::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
+  width: 8px;
+  height: 8px;
 }
 
 ::-webkit-scrollbar-track {
   background: transparent;
 }
 
+/* Paint a subtle thumb by default so it's visible without hover. A transparent
+   default meant the thumb never appeared on touchscreens / no-hover input, so
+   users could not see there was anything to scroll (#523). */
 ::-webkit-scrollbar-thumb {
-  background: transparent;
-  border-radius: 3px;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 4px;
   transition: background 0.3s;
 }
 
+[data-theme='dark'] ::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.2);
+}
+
 ::-webkit-scrollbar-thumb:hover {
-  background: rgba(0, 0, 0, 0.2);
+  background: rgba(0, 0, 0, 0.35);
 }
 
 [data-theme='dark'] ::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.35);
 }
 
 /* Hide scrollbar while keeping scroll behavior */
@@ -129,12 +136,4 @@ body {
 
 .scrollbar-hide::-webkit-scrollbar {
   display: none;
-}
-
-*:hover::-webkit-scrollbar-thumb {
-  background: rgba(0, 0, 0, 0.1);
-}
-
-[data-theme='dark'] *:hover::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.1);
 }

--- a/src/renderer/utils/shadowSelection.ts
+++ b/src/renderer/utils/shadowSelection.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Get the current selection, checking Shadow DOM roots if needed.
+ *
+ * MarkdownView (ShadowView) renders agent messages inside an OPEN shadow root,
+ * so `document.getSelection()` returns a collapsed/empty selection while the
+ * real selection lives inside a shadowRoot. This walks up from `target` to find
+ * a shadow host and reads that root's selection instead.
+ */
+export function getEffectiveSelection(target: EventTarget | null): Selection | null {
+  // First try the standard selection.
+  const docSel = document.getSelection();
+  if (docSel && !docSel.isCollapsed && docSel.toString().trim()) {
+    return docSel;
+  }
+
+  // If the standard selection is empty, search for a selection inside Shadow DOM.
+  // Walk up from the event target to find a shadow host.
+  let el: Node | null = target instanceof Node ? target : null;
+  while (el) {
+    if (el instanceof Element && el.shadowRoot) {
+      const shadowSel = (el.shadowRoot as unknown as { getSelection?: () => Selection | null }).getSelection?.();
+      if (shadowSel && !shadowSel.isCollapsed && shadowSel.toString().trim()) {
+        return shadowSel;
+      }
+    }
+    el = el.parentNode;
+  }
+
+  return docSel;
+}
+
+/**
+ * Install a global `copy` handler that copies text selected inside an open
+ * shadow root (agent messages render there — issue #523).
+ *
+ * Chromium's native Copy (Ctrl+C and the context-menu Copy, both routed through
+ * webContents.copy()) reads `document.getSelection()`, which is empty for a
+ * selection that lives in a shadow root — so copy silently does nothing. We only
+ * intervene when the document-level selection is empty AND a shadow-root
+ * selection exists, so normal input / textarea / plain-DOM copy is untouched.
+ *
+ * @returns a disposer that removes the listener.
+ */
+export function installShadowCopyHandler(): () => void {
+  const onCopy = (e: ClipboardEvent): void => {
+    // Leave normal copies alone: if the document selection already has text,
+    // the native copy works fine and we must not override it.
+    const docSel = document.getSelection();
+    if (docSel && !docSel.isCollapsed && docSel.toString().trim()) {
+      return;
+    }
+
+    const sel = getEffectiveSelection(e.target);
+    if (!sel || sel.isCollapsed) return;
+    const text = sel.toString();
+    if (!text.trim()) return;
+
+    if (e.clipboardData) {
+      e.clipboardData.setData('text/plain', text);
+      e.preventDefault();
+    }
+  };
+
+  document.addEventListener('copy', onCopy, true);
+  return () => document.removeEventListener('copy', onCopy, true);
+}

--- a/tests/unit/renderer/shadowSelection.dom.test.ts
+++ b/tests/unit/renderer/shadowSelection.dom.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getEffectiveSelection, installShadowCopyHandler } from '@/renderer/utils/shadowSelection';
+
+/** Build a fake Selection with the given (non-collapsed) text. */
+function fakeSelection(text: string, collapsed = false): Selection {
+  return {
+    isCollapsed: collapsed,
+    toString: () => text,
+  } as unknown as Selection;
+}
+
+/** Attach a shadow host whose shadowRoot.getSelection() returns `sel`. */
+function shadowHostWithSelection(sel: Selection | null): HTMLElement {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  const root = host.attachShadow({ mode: 'open' });
+  // jsdom does not implement ShadowRoot.getSelection(); stub it.
+  (root as unknown as { getSelection: () => Selection | null }).getSelection = () => sel;
+  return host;
+}
+
+/** Dispatch a synthetic `copy` event with a working clipboardData bag. */
+function dispatchCopy(target: EventTarget): { written: Record<string, string>; defaultPrevented: boolean } {
+  const written: Record<string, string> = {};
+  const event = new Event('copy', { bubbles: true, cancelable: true }) as ClipboardEvent;
+  Object.defineProperty(event, 'clipboardData', {
+    value: { setData: (type: string, data: string) => (written[type] = data) },
+  });
+  Object.defineProperty(event, 'target', { value: target });
+  document.dispatchEvent(event);
+  return { written, defaultPrevented: event.defaultPrevented };
+}
+
+describe('getEffectiveSelection', () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+  });
+
+  it('returns the document selection when it has text', () => {
+    const docSel = fakeSelection('hello from doc');
+    vi.spyOn(document, 'getSelection').mockReturnValue(docSel);
+    expect(getEffectiveSelection(document.body)?.toString()).toBe('hello from doc');
+  });
+
+  it('falls through to a shadow-root selection when the document selection is empty', () => {
+    vi.spyOn(document, 'getSelection').mockReturnValue(fakeSelection('', true));
+    const host = shadowHostWithSelection(fakeSelection('agent message text'));
+    expect(getEffectiveSelection(host)?.toString()).toBe('agent message text');
+  });
+
+  it('returns the (empty) document selection when no shadow selection exists', () => {
+    const empty = fakeSelection('', true);
+    vi.spyOn(document, 'getSelection').mockReturnValue(empty);
+    const host = shadowHostWithSelection(fakeSelection('', true));
+    expect(getEffectiveSelection(host)).toBe(empty);
+  });
+});
+
+describe('installShadowCopyHandler', () => {
+  let dispose: () => void;
+
+  beforeEach(() => {
+    dispose = installShadowCopyHandler();
+  });
+  afterEach(() => {
+    dispose();
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+  });
+
+  it('copies shadow-root selection text when the document selection is empty', () => {
+    vi.spyOn(document, 'getSelection').mockReturnValue(fakeSelection('', true));
+    const host = shadowHostWithSelection(fakeSelection('shadow copied text'));
+    const { written, defaultPrevented } = dispatchCopy(host);
+    expect(written['text/plain']).toBe('shadow copied text');
+    expect(defaultPrevented).toBe(true);
+  });
+
+  it('leaves a normal (non-empty document) selection to the native copy', () => {
+    vi.spyOn(document, 'getSelection').mockReturnValue(fakeSelection('typed in an input'));
+    const { written, defaultPrevented } = dispatchCopy(document.body);
+    expect(written['text/plain']).toBeUndefined();
+    expect(defaultPrevented).toBe(false);
+  });
+
+  it('does nothing when there is no selection anywhere', () => {
+    vi.spyOn(document, 'getSelection').mockReturnValue(fakeSelection('', true));
+    const host = shadowHostWithSelection(fakeSelection('', true));
+    const { written, defaultPrevented } = dispatchCopy(host);
+    expect(written['text/plain']).toBeUndefined();
+    expect(defaultPrevented).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #523.

Three copy/paste + scrolling usability failures reported together (Discord: J3star + others).

## Fixes

**1. Right-click Paste/Copy did nothing** — Electron ships no default context menu and none was wired anywhere.
Added `src/process/utils/contextMenu.ts` (`attachContextMenu`) and call it from the existing `app.on('web-contents-created')` handler in `src/index.ts`, so every window (main + popouts + ambient) gets a native menu. The menu is built from the hit-test `params` — editable inputs get Cut/Copy/Paste/Select All + spellcheck suggestions; a plain selection gets Copy; a right-click on empty non-editable chrome shows nothing (no useless empty menu).

**2. Ctrl+C on agent messages copied nothing** (Ctrl+V worked) — messages render inside an OPEN shadow root (`ShadowView.tsx`), where Chromium's native Copy reads an empty `document.getSelection()`.
Added `installShadowCopyHandler()` in `src/renderer/utils/shadowSelection.ts`, installed once in `main.tsx`: a global `copy` listener that intervenes ONLY when the document selection is empty, reads the shadow-root selection, and writes it to the clipboard. Extracted the shared `getEffectiveSelection` helper out of `SelectionReplyButton.tsx` (now imports it). Normal input/textarea/DOM copy is untouched.

**3. Scrollbar thumb invisible on touch/no-hover** — the thumb was `transparent` by default and only colored on `:hover`, so it never painted on touchscreens.
`base.css`: gave the thumb a subtle non-transparent default (light + dark), kept the hover emphasis, widened to 8px. Removed the now-conflicting `*:hover::-webkit-scrollbar-thumb` rules (they set a lower opacity than the new default).

## Verification
- Typecheck: pass. oxlint (new files): 0 warnings/0 errors. oxfmt: clean.
- New unit tests `tests/unit/renderer/shadowSelection.dom.test.ts` (6 cases) cover the shadow-selection helper + copy-handler paths (including the "leave normal copy alone" guard). Pass.
- Independent adversarial cross-audit + CDP live-verify: see PR comment.
