### PR TITLE
fix(webserver): allow trusted-proxy public origin for CORS out-of-the-box (#524)

### DIFF
--- a/src/process/webserver/setup.ts
+++ b/src/process/webserver/setup.ts
@@ -4,13 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Express } from 'express';
+import type { Express, Request } from 'express';
 import express from 'express';
 import cors from 'cors';
 import cookieParser from 'cookie-parser';
 import csrf from 'tiny-csrf';
 import crypto from 'crypto';
 import { AuthMiddleware } from '@process/webserver/auth/middleware/AuthMiddleware';
+import { classifyClientTrust } from '@process/webserver/middleware/networkTrust';
 import { errorHandler } from './middleware/errorHandler';
 import { attachCsrfToken } from './middleware/security';
 
@@ -96,7 +97,7 @@ function parseAllowedOriginsEnv(): string[] {
     .filter((origin): origin is string => Boolean(origin));
 }
 
-function getConfiguredOrigins(port: number, allowRemote: boolean): Set<string> {
+export function getConfiguredOrigins(port: number, allowRemote: boolean): Set<string> {
   // Localhost is always permitted. Network interface auto-detection was removed
   // because, on coffee-shop wifi / VPN / Docker bridges, it silently exposed the
   // API with `credentials: true` to every routable origin the box could see.
@@ -106,9 +107,7 @@ function getConfiguredOrigins(port: number, allowRemote: boolean): Set<string> {
 
   if (allowRemote) {
     if (envOrigins.length === 0) {
-      console.warn(
-        '[security] remote mode without WAYLAND_ALLOWED_ORIGINS: only localhost allowed'
-      );
+      console.warn('[security] remote mode without WAYLAND_ALLOWED_ORIGINS: only localhost allowed');
     } else {
       // In remote mode, WAYLAND_ALLOWED_ORIGINS is the explicit allowlist.
       for (const origin of envOrigins) {
@@ -159,16 +158,80 @@ export function setupTrustProxy(app: Express): void {
   app.set('trust proxy', trusted);
 }
 
-export function setupCors(app: Express, port: number, allowRemote: boolean): void {
-  const allowedOrigins = getConfiguredOrigins(port, allowRemote);
+/**
+ * Read a SINGLE-valued forwarded header. The only topology whose forwarded headers
+ * we believe is a single trusted hop (see deriveTrustedProxyOrigin), which sets
+ * exactly one value. A comma-joined or repeated header means a multi-hop chain or a
+ * client-supplied value the proxy appended/preserved - and the leftmost token is the
+ * LEAST-trusted (client) end, so we must NOT pick it. We fail closed to undefined and
+ * let the operator use SERVER_BASE_URL for genuine multi-hop deployments.
+ */
+function singleForwardedValue(header: string | string[] | undefined): string | undefined {
+  // A repeated header (Express joins duplicates with ', ') arrives as a string
+  // for most headers, but some can be arrays - reject anything that isn't one entry.
+  let raw: string | undefined;
+  if (Array.isArray(header)) {
+    if (header.length !== 1) return undefined;
+    raw = header[0];
+  } else {
+    raw = header;
+  }
+  if (!raw || raw.includes(',')) return undefined;
+  const value = raw.trim();
+  return value || undefined;
+}
 
-  app.use(
-    cors({
+/**
+ * Derive the public origin a TRUSTED reverse proxy is fronting, from its forwarded
+ * headers, so a TLS-terminated self-hosted deploy (e.g. Caddy on the same host)
+ * gets its public origin CORS-allowed OUT OF THE BOX - without the operator having
+ * to set SERVER_BASE_URL / WAYLAND_ALLOWED_ORIGINS (#524).
+ *
+ * SECURITY (trust model): the forwarded headers are believed ONLY when the request's
+ * DIRECT socket peer is a trusted proxy - loopback, Tailscale CGNAT, or an opt-in
+ * `WAYLAND_OPERATOR_CIDRS` range - per `classifyClientTrust(req.socket.remoteAddress)`,
+ * the same non-spoofable gate the operator-trust model uses. Trust is read from the
+ * raw socket peer, NEVER from `req.ip`/XFF (which a public attacker can forge).
+ *
+ * A request whose direct peer is public (someone hitting the app port directly, or a
+ * reverse proxy we do not trust) NEVER has its `X-Forwarded-Host` believed, so an
+ * attacker cannot self-allowlist an origin. This returns a SINGLE normalized origin
+ * (never a wildcard) that is then matched against the request's browser-set `Origin`.
+ *
+ * Note: behind a loopback proxy the DIRECT peer is always the proxy, so every proxied
+ * request classifies `operator`; the real per-request gate is then the `Origin` match
+ * plus the single-value requirement below - a browser cannot forge `X-Forwarded-Host`
+ * on a cross-origin credentialed request (the preflight OPTIONS never carries it).
+ */
+export function deriveTrustedProxyOrigin(req: Request): string | null {
+  if (classifyClientTrust(req.socket?.remoteAddress) !== 'operator') {
+    return null;
+  }
+
+  const host = singleForwardedValue(req.headers['x-forwarded-host']);
+  if (!host) return null;
+
+  const proto = singleForwardedValue(req.headers['x-forwarded-proto'])?.toLowerCase();
+  const scheme = proto === 'http' || proto === 'https' ? proto : req.protocol || 'https';
+  return normalizeOrigin(`${scheme}://${host}`);
+}
+
+/**
+ * Build the CORS middleware. Uses the per-request delegate form so the allowlist can
+ * be augmented, additively, with the trusted-proxy origin (see deriveTrustedProxyOrigin)
+ * on top of the static allowlist (localhost + SERVER_BASE_URL + WAYLAND_ALLOWED_ORIGINS).
+ */
+export function makeCorsMiddleware(allowedOrigins: Set<string>) {
+  return cors<Request>((req, callback) => {
+    // Per-request: only widens for a request that arrived via a trusted proxy.
+    const forwardedOrigin = deriveTrustedProxyOrigin(req);
+
+    callback(null, {
       credentials: true,
-      origin(origin, callback) {
+      origin(origin, cb) {
         if (!origin) {
           // Requests like curl or same-origin don't send an Origin header
-          callback(null, true);
+          cb(null, true);
           return;
         }
 
@@ -177,20 +240,25 @@ export function setupCors(app: Express, port: number, allowRemote: boolean): voi
         // allowing them effectively whitelists any attacker-controlled page
         // that can spawn such a context.
         if (origin === 'null') {
-          callback(null, false);
+          cb(null, false);
           return;
         }
 
         const normalizedOrigin = normalizeOrigin(origin);
-        if (normalizedOrigin && allowedOrigins.has(normalizedOrigin)) {
-          callback(null, true);
+        if (normalizedOrigin && (allowedOrigins.has(normalizedOrigin) || normalizedOrigin === forwardedOrigin)) {
+          cb(null, true);
           return;
         }
 
-        callback(null, false);
+        cb(null, false);
       },
-    })
-  );
+    });
+  });
+}
+
+export function setupCors(app: Express, port: number, allowRemote: boolean): void {
+  const allowedOrigins = getConfiguredOrigins(port, allowRemote);
+  app.use(makeCorsMiddleware(allowedOrigins));
 }
 
 /**

--- a/tests/unit/webserver/corsProxyOrigin.test.ts
+++ b/tests/unit/webserver/corsProxyOrigin.test.ts
@@ -1,0 +1,185 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Request } from 'express';
+import { deriveTrustedProxyOrigin, getConfiguredOrigins, makeCorsMiddleware } from '@process/webserver/setup';
+
+/**
+ * #524 - a self-hosted server behind a reverse TLS proxy (e.g. Caddy on the same
+ * host) must get its public origin CORS-allowed WITHOUT the operator setting
+ * SERVER_BASE_URL / WAYLAND_ALLOWED_ORIGINS, but ONLY when the request arrived via a
+ * trusted proxy hop. A public peer spoofing X-Forwarded-Host must NOT be trusted.
+ */
+
+const PORT = 25808;
+
+type HeaderBag = Record<string, string | string[] | undefined>;
+
+function restoreEnv(k: string, v: string | undefined): void {
+  if (v === undefined) delete process.env[k];
+  else process.env[k] = v;
+}
+
+function fakeReq(opts: {
+  origin?: string;
+  method?: string;
+  remoteAddress?: string;
+  headers?: HeaderBag;
+  protocol?: string;
+}): Request {
+  const headers: HeaderBag = { ...opts.headers };
+  if (opts.origin !== undefined) headers.origin = opts.origin;
+  return {
+    method: opts.method ?? 'POST',
+    headers,
+    protocol: opts.protocol ?? 'http',
+    socket: { remoteAddress: opts.remoteAddress },
+  } as unknown as Request;
+}
+
+/** Minimal res double capturing headers the cors middleware sets. */
+function fakeRes() {
+  const store = new Map<string, string>();
+  return {
+    statusCode: 200,
+    setHeader(key: string, value: string) {
+      store.set(key.toLowerCase(), value);
+    },
+    getHeader(key: string) {
+      return store.get(key.toLowerCase());
+    },
+    end() {},
+  };
+}
+
+/**
+ * Run the real cors middleware for a request and return the resolved
+ * Access-Control-Allow-Origin header (undefined if the origin was rejected).
+ */
+function runCors(allowed: Set<string>, req: Request): string | undefined {
+  const mw = makeCorsMiddleware(allowed);
+  const res = fakeRes();
+  const next = vi.fn();
+  // cors resolves the delegate synchronously here (our origin fn is sync).
+  mw(req as never, res as never, next as never);
+  return res.getHeader('access-control-allow-origin');
+}
+
+describe('#524 CORS trusted-proxy forwarded-origin', () => {
+  const savedCidrs = process.env.WAYLAND_OPERATOR_CIDRS;
+  const savedBase = process.env.SERVER_BASE_URL;
+  const savedAllowed = process.env.WAYLAND_ALLOWED_ORIGINS;
+
+  beforeEach(() => {
+    delete process.env.WAYLAND_OPERATOR_CIDRS;
+    delete process.env.SERVER_BASE_URL;
+    delete process.env.WAYLAND_ALLOWED_ORIGINS;
+  });
+  afterEach(() => {
+    restoreEnv('WAYLAND_OPERATOR_CIDRS', savedCidrs);
+    restoreEnv('SERVER_BASE_URL', savedBase);
+    restoreEnv('WAYLAND_ALLOWED_ORIGINS', savedAllowed);
+  });
+
+  it('(a) trusted loopback proxy + X-Forwarded-Host, no SERVER_BASE_URL -> forwarded origin is allowed (ACAO present)', () => {
+    const allowed = getConfiguredOrigins(PORT, false); // no env set
+    const req = fakeReq({
+      origin: 'https://wayland.customer.com',
+      remoteAddress: '127.0.0.1', // Caddy on the same host = trusted loopback hop
+      headers: {
+        'x-forwarded-host': 'wayland.customer.com',
+        'x-forwarded-proto': 'https',
+      },
+    });
+
+    // The derived origin exactly matches the public origin, nothing wildcarded.
+    expect(deriveTrustedProxyOrigin(req)).toBe('https://wayland.customer.com');
+    expect(runCors(allowed, req)).toBe('https://wayland.customer.com');
+  });
+
+  it('(b) untrusted public peer spoofing X-Forwarded-Host -> NOT allowed (no ACAO)', () => {
+    const allowed = getConfiguredOrigins(PORT, true); // remote mode, no allowlist env
+    const req = fakeReq({
+      origin: 'https://evil.example.com',
+      remoteAddress: '203.0.113.7', // public direct peer, NOT a trusted proxy
+      headers: {
+        'x-forwarded-host': 'evil.example.com',
+        'x-forwarded-proto': 'https',
+      },
+    });
+
+    // Direct peer is untrusted, so the forwarded header is never believed.
+    expect(deriveTrustedProxyOrigin(req)).toBeNull();
+    expect(runCors(allowed, req)).toBeUndefined();
+  });
+
+  it('(c) SERVER_BASE_URL still works (explicit allowlist preserved, additive)', () => {
+    process.env.SERVER_BASE_URL = 'https://explicit.customer.com';
+    const allowed = getConfiguredOrigins(PORT, true);
+    const req = fakeReq({
+      origin: 'https://explicit.customer.com',
+      remoteAddress: '203.0.113.9', // even a public peer: matched via static allowlist
+    });
+    expect(runCors(allowed, req)).toBe('https://explicit.customer.com');
+  });
+
+  it('does not believe X-Forwarded-Host when the loopback proxy did not set one', () => {
+    const allowed = getConfiguredOrigins(PORT, false);
+    const req = fakeReq({
+      origin: 'https://wayland.customer.com',
+      remoteAddress: '127.0.0.1',
+      // no x-forwarded-host header
+    });
+    expect(deriveTrustedProxyOrigin(req)).toBeNull();
+    expect(runCors(allowed, req)).toBeUndefined();
+  });
+
+  it('rejects a MULTI-VALUED X-Forwarded-Host from a trusted hop (client-injected leftmost token not picked)', () => {
+    const allowed = getConfiguredOrigins(PORT, false);
+    // A client pre-seeded evil.com and the proxy appended the real host.
+    const commaJoined = fakeReq({
+      origin: 'https://evil.example.com',
+      remoteAddress: '127.0.0.1',
+      headers: {
+        'x-forwarded-host': 'evil.example.com, wayland.customer.com',
+        'x-forwarded-proto': 'https',
+      },
+    });
+    expect(deriveTrustedProxyOrigin(commaJoined)).toBeNull();
+    expect(runCors(allowed, commaJoined)).toBeUndefined();
+
+    // Repeated header (array form) is likewise not a single trusted hop.
+    const repeated = fakeReq({
+      origin: 'https://evil.example.com',
+      remoteAddress: '127.0.0.1',
+      headers: {
+        'x-forwarded-host': ['evil.example.com', 'wayland.customer.com'],
+        'x-forwarded-proto': 'https',
+      },
+    });
+    expect(deriveTrustedProxyOrigin(repeated)).toBeNull();
+    expect(runCors(allowed, repeated)).toBeUndefined();
+  });
+
+  it('defaults scheme to the trusted req.protocol when X-Forwarded-Proto is absent', () => {
+    const req = fakeReq({
+      origin: 'http://wayland.customer.com',
+      remoteAddress: '127.0.0.1',
+      protocol: 'http',
+      headers: { 'x-forwarded-host': 'wayland.customer.com' },
+    });
+    expect(deriveTrustedProxyOrigin(req)).toBe('http://wayland.customer.com');
+  });
+
+  it('localhost origin still works and Origin: null is rejected', () => {
+    const allowed = getConfiguredOrigins(PORT, false);
+    expect(runCors(allowed, fakeReq({ origin: `http://localhost:${PORT}`, remoteAddress: '127.0.0.1' }))).toBe(
+      `http://localhost:${PORT}`
+    );
+    expect(runCors(allowed, fakeReq({ origin: 'null', remoteAddress: '127.0.0.1' }))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What & why

Fixes the self-hosted / behind-a-reverse-TLS-proxy case of #524. On a deploy where the operator fronts Wayland's WebUI with a TLS-terminating reverse proxy (e.g. Caddy on the same host, connecting to the app over loopback), the credentialed provider-connect POST failed CORS: `getConfiguredOrigins()` only ever contained `localhost` + whatever the operator manually set via `SERVER_BASE_URL` / `WAYLAND_ALLOWED_ORIGINS`. It never contained the **public** origin, so no `Access-Control-Allow-Origin` was returned and the credentialed preflight `OPTIONS` was rejected -- the Connect button spins forever. We can't set env vars on customer boxes, so this has to work out-of-the-box.

(Complements #527, which surfaces the connect error to the user; this addresses the underlying CORS rejection.)

## The change (`src/process/webserver/setup.ts`)

- `deriveTrustedProxyOrigin(req)`: derives the public origin from `X-Forwarded-Host` + `X-Forwarded-Proto`, but **only when the request's direct socket peer is trusted**.
- `setupCors` now builds the CORS middleware via the per-request delegate form (`makeCorsMiddleware`), so the static allowlist is augmented -- **additively** -- with the derived trusted-proxy origin. Static behavior (`localhost`, `SERVER_BASE_URL`, `WAYLAND_ALLOWED_ORIGINS`, `Origin: null` rejection, opaque-origin rejection) is unchanged.
- `singleForwardedValue`: forwarded headers must be **single-valued**; a comma-joined or repeated header fails closed (see trust model).

## Trust model (the security-sensitive part)

Forwarded headers are believed **only** when `classifyClientTrust(req.socket.remoteAddress) === 'operator'` -- i.e. the *direct* peer is loopback, Tailscale CGNAT, or an opt-in `WAYLAND_OPERATOR_CIDRS` range. This is the same non-spoofable gate the operator-trust model already uses (`networkTrust.ts`), and it reads the **raw socket peer**, never `req.ip`/`X-Forwarded-For` (which a public attacker can forge). `setupTrustProxy` runs before `setupCors` and trusts only `loopback + WAYLAND_OPERATOR_CIDRS`, so `req.ip`/`req.secure`/`req.protocol` stay non-spoofable.

- Forwarded origin **is** trusted: request arrived via loopback (same-host Caddy) or an allowlisted operator hop -> derive `scheme://host`, add exactly that one origin (never a wildcard) to the per-request allowlist.
- Forwarded origin **is NOT** trusted: direct peer is public -> `X-Forwarded-Host` is ignored entirely, allowlist unchanged. An untrusted client cannot self-allowlist an origin.

Why a malicious page can't abuse it via a *legitimate* remote user (who does sit behind the trusted proxy): the derived origin comes from `X-Forwarded-Host`, not from the attacker-controlled `Origin`. A browser cannot set `X-Forwarded-Host` on a cross-origin credentialed request without a preflight, and the preflight `OPTIONS` does not carry that custom header -- so during the CORS decision the derived origin is the real public host and `Origin: evil.com` never matches. Simple (non-preflighted) cross-origin requests can't set `X-Forwarded-Host` at all. Multi-valued/repeated `X-Forwarded-Host` (multi-hop or client-injected) fails closed rather than trusting the leftmost client-controlled token; genuine multi-hop deployments use `SERVER_BASE_URL`.

CSRF is not weakened: the fix only ever reflects an origin equal to the browser `Origin` AND to a legit derived/allowlisted origin (the same app front-end); no attacker-controllable origin is added. WebSockets are out of scope -- the upgrade path bypasses CORS and is gated by JWT token auth (`WebSocketManager.validateConnection`), not Origin.

## Independent security cross-audit

An independent adversarial audit traced all reflection paths: no CRITICAL/HIGH live bypass (untrusted-peer reflection blocked by the trust gate; the browser XFH-injection path blocked by CORS preflight semantics; CSRF/trust-source sound). Two MED findings:
1. `X-Forwarded-Host` multi-value handling -- **fixed in this PR** (`singleForwardedValue` fails closed on comma-joined/repeated headers instead of picking the leftmost client token).
2. `100.64.0.0/10` unconditionally treated as `operator` in `networkTrust.ts` -- **pre-existing**, touches a shared trust gate (also used by destructive-action escalation), not browser-exploitable for CORS. Deferred with a tracked issue: #529.

## Tests (`tests/unit/webserver/corsProxyOrigin.test.ts`)

- (a) trusted loopback proxy + `X-Forwarded-Host`, no `SERVER_BASE_URL` -> forwarded origin allowed, ACAO present. PASS
- (b) untrusted public peer spoofing `X-Forwarded-Host` -> not allowed, no ACAO. PASS
- (c) `SERVER_BASE_URL` still works (additive). PASS
- multi-valued/repeated `X-Forwarded-Host` from a trusted hop -> not derived, no ACAO. PASS
- no `X-Forwarded-Host` from a trusted proxy -> not derived; scheme falls back to trusted `req.protocol`; localhost still works; `Origin: null` rejected. PASS

Typecheck, oxlint, oxfmt green.

## Remaining gate (Overwatch follow-up, before merge)

Live-verify on a real droplet: deploy behind Caddy **without** `SERVER_BASE_URL`, confirm the provider-connect POST succeeds end-to-end, and confirm a spoofed cross-origin request is still blocked. Not merging until that passes.

Refs #524