### PR TITLE
fix(chat): let the user scroll up while the AI streams (#479)

### DIFF
--- a/src/renderer/pages/conversation/Messages/MessageList.tsx
+++ b/src/renderer/pages/conversation/Messages/MessageList.tsx
@@ -405,6 +405,7 @@ const ConversationMessageList: React.FC<{
   } = useAutoScroll({
     messages: list,
     itemCount: processedList.length,
+    conversationId,
   });
 
   useEffect(() => {

--- a/src/renderer/pages/conversation/Messages/useAutoScroll.ts
+++ b/src/renderer/pages/conversation/Messages/useAutoScroll.ts
@@ -28,6 +28,13 @@ const PROGRAMMATIC_SCROLL_GUARD_MS = 150;
 // distance a real read-history scroll travels.
 const USER_SCROLL_UP_DELTA = 24;
 
+// How long a wheel/touch scroll-up gesture keeps onScroll exempt from the
+// programmatic guard (ms). Long enough to cover the onScroll(s) a single wheel
+// notch / touch drag produces, short enough that a later unrelated reflow scroll
+// is still guarded. Refreshed on every gesture event so continuous scrolling
+// (trackpad momentum) stays exempt for its whole duration.
+const USER_SCROLL_INTENT_MS = 200;
+
 // Lightweight streaming signature for the in-place auto-scroll effect.
 // followOutput only fires on item-count change; ACP/Gemini grow the last
 // message's text in place, so we additionally key on the last message's text
@@ -51,6 +58,12 @@ interface UseAutoScrollOptions {
   messages: TMessage[];
   /** Total item count for scroll target */
   itemCount: number;
+  /**
+   * Active conversation id. When it changes the scroll-up latch is reset so a
+   * paused auto-follow from one chat never carries into the next (the list view
+   * is reused across conversation switches, it does not remount).
+   */
+  conversationId?: string;
 }
 
 interface UseAutoScrollReturn {
@@ -72,7 +85,7 @@ interface UseAutoScrollReturn {
   hideScrollButton: () => void;
 }
 
-export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): UseAutoScrollReturn {
+export function useAutoScroll({ messages, itemCount, conversationId }: UseAutoScrollOptions): UseAutoScrollReturn {
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const [scrollerEl, setScrollerEl] = useState<HTMLElement | null>(null);
   const [showScrollButton, setShowScrollButton] = useState(false);
@@ -89,6 +102,10 @@ export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): Us
   const lastProgrammaticScrollTimeRef = useRef(0);
   const scrollerElRef = useRef<HTMLElement | null>(null);
   const followOutputTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Timestamp until which a real user scroll gesture (wheel / touch drag up) is
+  // in flight. While inside this window, handleScroll bypasses the programmatic
+  // guard so the resulting onScroll is evaluated on its true main-scroller delta.
+  const userScrollIntentUntilRef = useRef(0);
 
   // Capture Virtuoso's scroll container
   const handleScrollerRef = useCallback((ref: HTMLElement | Window | null) => {
@@ -148,6 +165,55 @@ export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): Us
     };
   }, [scrollerEl]);
 
+  // Mark a real user scroll-up gesture (wheel / touch drag up) as in flight.
+  // Programmatic scrollTop changes NEVER emit wheel/touch events, so this is a
+  // reliable "the user is driving" signal. But rather than latch here directly,
+  // we only open a short intent window and let handleScroll decide from the
+  // MAIN scroller's actual delta. That matters two ways:
+  //   - wheel/touch events bubble, so a gesture that scrolls a nested overflow
+  //     child (code block, diff, tool panel) also reaches this listener; letting
+  //     the main-scroller delta decide means a child-consumed scroll (main list
+  //     did not move) never falsely pauses auto-follow.
+  //   - during fast streaming the programmatic guard is continuously refreshed
+  //     and would otherwise swallow the user's scroll-up in handleScroll (#479);
+  //     the intent window exempts the ensuing onScroll from that guard.
+  useEffect(() => {
+    if (!scrollerEl) return;
+
+    const markIntent = () => {
+      userScrollIntentUntilRef.current = Date.now() + USER_SCROLL_INTENT_MS;
+    };
+
+    const onWheel = (e: WheelEvent) => {
+      if (e.deltaY < 0) markIntent();
+    };
+
+    let lastTouchY: number | null = null;
+    const onTouchStart = (e: TouchEvent) => {
+      lastTouchY = e.touches[0]?.clientY ?? null;
+    };
+    const onTouchMove = (e: TouchEvent) => {
+      const y = e.touches[0]?.clientY ?? null;
+      if (y === null || lastTouchY === null) {
+        lastTouchY = y;
+        return;
+      }
+      // Finger dragging down (clientY increases) reveals earlier content, i.e.
+      // the content scrolls up - the user is reading back through history.
+      if (y - lastTouchY > 0) markIntent();
+      lastTouchY = y;
+    };
+
+    scrollerEl.addEventListener('wheel', onWheel, { passive: true });
+    scrollerEl.addEventListener('touchstart', onTouchStart, { passive: true });
+    scrollerEl.addEventListener('touchmove', onTouchMove, { passive: true });
+    return () => {
+      scrollerEl.removeEventListener('wheel', onWheel);
+      scrollerEl.removeEventListener('touchstart', onTouchStart);
+      scrollerEl.removeEventListener('touchmove', onTouchMove);
+    };
+  }, [scrollerEl]);
+
   // Scroll to bottom helper - only for user messages and button clicks
   const scrollToBottom = useCallback(
     (behavior: 'smooth' | 'auto' = 'smooth') => {
@@ -196,10 +262,20 @@ export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): Us
   // A full 150ms guard here caused jitter: user scrolls up → guard blocks detection
   // → atBottomStateChange(false) scrolls back → cycle.
   const handleAtBottomStateChange = useCallback((atBottom: boolean) => {
+    // The scroll-up latch is authoritative. Once the user has scrolled up, ONLY
+    // an explicit resume (the scroll-to-bottom button -> hideScrollButton, or
+    // sending a message) may clear it. A transient atBottom=true from a mid-stream
+    // layout shift, or from a small scroll-up still inside Virtuoso's 100px
+    // atBottomThreshold, must NOT clear the latch or snap the user down - that
+    // fight was the #479 bug. Keep the button visible while paused.
+    if (userScrolledRef.current) {
+      setShowScrollButton(true);
+      return;
+    }
+
     setShowScrollButton(!atBottom);
 
     if (atBottom) {
-      userScrolledRef.current = false;
       // Short guard: expire 50ms from now (not the full PROGRAMMATIC_SCROLL_GUARD_MS)
       lastProgrammaticScrollTimeRef.current = Date.now() - (PROGRAMMATIC_SCROLL_GUARD_MS - 50);
       // Close any residual gap within atBottomThreshold (e.g. after ThoughtDisplay
@@ -212,8 +288,8 @@ export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): Us
           el.scrollTop = el.scrollHeight - el.clientHeight;
         }
       }
-    } else if (!userScrolledRef.current) {
-      // Layout shift pushed us off bottom - scroll back to bottom immediately.
+    } else {
+      // Layout shift pushed us off bottom while still following - snap back.
       const el = scrollerElRef.current;
       if (el) {
         lastProgrammaticScrollTimeRef.current = Date.now();
@@ -226,21 +302,42 @@ export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): Us
   const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
     const target = e.target as HTMLDivElement;
     const currentScrollTop = target.scrollTop;
+    const delta = currentScrollTop - lastScrollTopRef.current;
 
-    // Ignore scroll events shortly after a programmatic scroll or container resize
+    // Resume auto-follow when the user scrolls back to the TRUE bottom (gap ~0).
+    // Runs BEFORE the programmatic guard: the guard only suppresses false
+    // scroll-UP latching, it must never block a genuine return to the bottom
+    // (e.g. wheeling straight back down within the guard window would otherwise
+    // leave the latch stuck). Uses the true bottom, not Virtuoso's 100px
+    // atBottomThreshold, so a deliberate small scroll-up is never mistaken for
+    // "back at the bottom". While latched, no programmatic scroll runs (every
+    // auto-scroll effect is gated on !userScrolledRef.current), so a delta > 0
+    // reaching the bottom here is always user-driven.
+    if (userScrolledRef.current && delta > 0) {
+      const gap = target.scrollHeight - target.clientHeight - currentScrollTop;
+      if (gap <= 2) {
+        userScrolledRef.current = false;
+        setShowScrollButton(false);
+      }
+    }
+
+    // Ignore scroll events shortly after a programmatic scroll or container
+    // resize - UNLESS a real user wheel/touch gesture is in flight, in which
+    // case this onScroll reflects the user's own movement and must be evaluated.
     const timeSinceGuard = Date.now() - lastProgrammaticScrollTimeRef.current;
-    if (timeSinceGuard < PROGRAMMATIC_SCROLL_GUARD_MS) {
+    const userGestureInFlight = Date.now() < userScrollIntentUntilRef.current;
+    if (!userGestureInFlight && timeSinceGuard < PROGRAMMATIC_SCROLL_GUARD_MS) {
       lastScrollTopRef.current = currentScrollTop;
       return;
     }
 
-    const delta = currentScrollTop - lastScrollTopRef.current;
     // Require a larger upward jump than the resting jitter a mid-stream layout
     // shift (orbit/ThoughtDisplay appearing, Virtuoso reflow) can emit, so a
     // spurious small negative delta doesn't permanently kill auto-follow. A
     // real read-history scroll-up travels well past this and still pauses follow.
     if (delta < -USER_SCROLL_UP_DELTA) {
       userScrolledRef.current = true;
+      setShowScrollButton(true);
     }
 
     // When in auto-follow mode and Virtuoso is scrolling down (following content),
@@ -320,6 +417,14 @@ export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): Us
     };
     // streamingSignature changes on in-place text growth as well as count change.
   }, [streamingSig]);
+
+  // Reset the paused-scroll latch when switching conversations. The list view is
+  // reused across switches (it does not remount), so without this a scroll-up
+  // paused in one chat would leave the next chat stuck not-following.
+  useEffect(() => {
+    userScrolledRef.current = false;
+    setShowScrollButton(false);
+  }, [conversationId]);
 
   // Hide scroll button handler
   const hideScrollButton = useCallback(() => {

--- a/tests/unit/useAutoScroll.dom.test.ts
+++ b/tests/unit/useAutoScroll.dom.test.ts
@@ -299,8 +299,9 @@ describe('useAutoScroll - streaming guard refresh (#2017)', () => {
 
     // followOutput should return false (userScrolled is true)
     expect(result.current.handleFollowOutput(false)).toBe(false);
-    // scroll button should show
-    expect(result.current.showScrollButton).toBe(false); // button shown via atBottomStateChange
+    // #479: a detected scroll-up now surfaces the button directly (the latch
+    // drives it), rather than waiting for atBottomStateChange(false).
+    expect(result.current.showScrollButton).toBe(true);
   });
 
   it('followOutput should set guard so subsequent scroll events are ignored', () => {
@@ -354,7 +355,7 @@ describe('useAutoScroll - streaming guard refresh (#2017)', () => {
     expect(result.current.handleFollowOutput(false)).toBe(false);
   });
 
-  it('atBottomStateChange(true) should reset userScrolled and close residual gap', () => {
+  it('#479: atBottomStateChange(true) must NOT clear the latch or snap while the user is scrolled up', () => {
     const { result } = renderHook(({ messages, itemCount }) => useAutoScroll({ messages, itemCount }), {
       initialProps: { messages: [createMessage('left', '1')], itemCount: 1 },
     });
@@ -366,7 +367,7 @@ describe('useAutoScroll - streaming guard refresh (#2017)', () => {
       result.current.handleScrollerRef(scrollerEl);
     });
 
-    // Simulate user scrolled up then atBottom fires true
+    // Simulate user scrolled up
     act(() => {
       result.current.handleScroll({
         target: { scrollTop: 500, scrollHeight: 1050, clientHeight: 504 },
@@ -378,19 +379,28 @@ describe('useAutoScroll - streaming guard refresh (#2017)', () => {
         target: { scrollTop: 300, scrollHeight: 1050, clientHeight: 504 },
       } as unknown as React.UIEvent<HTMLDivElement>);
     });
+    scrollerEl.scrollTop = 300;
 
     // User scrolled - followOutput returns false
     expect(result.current.handleFollowOutput(false)).toBe(false);
 
-    // atBottomStateChange(true) should reset
+    // A spurious atBottomStateChange(true) (mid-stream layout shift / threshold
+    // band) must be inert: the latch holds, the scroll position is untouched, and
+    // the button stays visible.
     act(() => {
       result.current.handleAtBottomStateChange(true);
     });
 
-    // Should close the gap: scrollTop = scrollHeight - clientHeight
-    expect(scrollerEl.scrollTop).toBe(1050 - 504);
-    // followOutput should return 'auto' again
+    expect(scrollerEl.scrollTop).toBe(300); // NOT snapped to bottom
+    expect(result.current.handleFollowOutput(false)).toBe(false); // still paused
+    expect(result.current.showScrollButton).toBe(true);
+
+    // Only the explicit resume (button -> hideScrollButton) re-enables auto-follow.
+    act(() => {
+      result.current.hideScrollButton();
+    });
     expect(result.current.handleFollowOutput(false)).toBe('auto');
+    expect(result.current.showScrollButton).toBe(false);
   });
 
   it('atBottomStateChange(false) should scroll back when not user-scrolled (layout shift)', () => {
@@ -473,6 +483,227 @@ describe('useAutoScroll - streaming guard refresh (#2017)', () => {
     });
 
     expect(scrollerEl.scrollTop).toBe(1000 - 504);
+  });
+
+  it('#479: a wheel-up opens an intent window so the ensuing onScroll latches inside the guard window', () => {
+    const { result } = renderHook(({ messages, itemCount }) => useAutoScroll({ messages, itemCount }), {
+      initialProps: { messages: [createMessage('left', '1')], itemCount: 1 },
+    });
+
+    const scrollerEl = createScrollerEl({ clientHeight: 504, scrollHeight: 1050, scrollTop: 500 });
+    act(() => {
+      result.current.handleScrollerRef(scrollerEl);
+    });
+
+    // Fast streaming keeps the onScroll guard continuously fresh...
+    act(() => {
+      result.current.handleFollowOutput(false);
+    });
+    // ...and set the last-scroll baseline (this event is guarded -> early return).
+    act(() => {
+      result.current.handleScroll({
+        target: { scrollTop: 500, scrollHeight: 1050, clientHeight: 504 },
+      } as unknown as React.UIEvent<HTMLDivElement>);
+    });
+
+    // A real wheel-up opens the intent window; the resulting onScroll (main list
+    // actually moved up) is now evaluated despite the fresh guard -> latch.
+    act(() => {
+      scrollerEl.dispatchEvent(new WheelEvent('wheel', { deltaY: -120 }));
+    });
+    act(() => {
+      result.current.handleScroll({
+        target: { scrollTop: 300, scrollHeight: 1050, clientHeight: 504 },
+      } as unknown as React.UIEvent<HTMLDivElement>);
+    });
+
+    expect(result.current.handleFollowOutput(false)).toBe(false);
+    expect(result.current.showScrollButton).toBe(true);
+  });
+
+  it('#479: a wheel-DOWN does not open the intent window (no latch)', () => {
+    const { result } = renderHook(({ messages, itemCount }) => useAutoScroll({ messages, itemCount }), {
+      initialProps: { messages: [createMessage('left', '1')], itemCount: 1 },
+    });
+
+    const scrollerEl = createScrollerEl({ clientHeight: 504, scrollHeight: 1050, scrollTop: 500 });
+    act(() => {
+      result.current.handleScrollerRef(scrollerEl);
+    });
+
+    act(() => {
+      scrollerEl.dispatchEvent(new WheelEvent('wheel', { deltaY: 120 }));
+    });
+
+    expect(result.current.handleFollowOutput(false)).toBe('auto');
+    expect(result.current.showScrollButton).toBe(false);
+  });
+
+  it('#479: a wheel-up consumed by a scrollable child (main list did not move) does NOT latch', () => {
+    const { result } = renderHook(({ messages, itemCount }) => useAutoScroll({ messages, itemCount }), {
+      initialProps: { messages: [createMessage('left', '1')], itemCount: 1 },
+    });
+
+    const scrollerEl = createScrollerEl({ clientHeight: 504, scrollHeight: 1050, scrollTop: 500 });
+    act(() => {
+      result.current.handleScrollerRef(scrollerEl);
+    });
+
+    act(() => {
+      result.current.handleFollowOutput(false);
+    });
+    // baseline
+    act(() => {
+      result.current.handleScroll({
+        target: { scrollTop: 500, scrollHeight: 1050, clientHeight: 504 },
+      } as unknown as React.UIEvent<HTMLDivElement>);
+    });
+
+    // Wheel bubbles from a nested overflow child; the child consumed it, so the
+    // MAIN scroller did not move. onScroll fires with delta 0 -> no false latch.
+    act(() => {
+      scrollerEl.dispatchEvent(new WheelEvent('wheel', { deltaY: -120 }));
+    });
+    act(() => {
+      result.current.handleScroll({
+        target: { scrollTop: 500, scrollHeight: 1050, clientHeight: 504 },
+      } as unknown as React.UIEvent<HTMLDivElement>);
+    });
+
+    expect(result.current.handleFollowOutput(false)).toBe('auto');
+    expect(result.current.showScrollButton).toBe(false);
+  });
+
+  it('#479: after a wheel-latch, scrolling back to the bottom resumes even while the guard is still fresh', () => {
+    const { result } = renderHook(({ messages, itemCount }) => useAutoScroll({ messages, itemCount }), {
+      initialProps: { messages: [createMessage('left', '1')], itemCount: 1 },
+    });
+
+    const scrollerEl = createScrollerEl({ clientHeight: 504, scrollHeight: 1050, scrollTop: 500 });
+    act(() => {
+      result.current.handleScrollerRef(scrollerEl);
+    });
+
+    // Guard freshly set by streaming, baseline established.
+    act(() => {
+      result.current.handleFollowOutput(false);
+    });
+    act(() => {
+      result.current.handleScroll({
+        target: { scrollTop: 500, scrollHeight: 1050, clientHeight: 504 },
+      } as unknown as React.UIEvent<HTMLDivElement>);
+    });
+
+    // Wheel-up + up-scroll latches.
+    act(() => {
+      scrollerEl.dispatchEvent(new WheelEvent('wheel', { deltaY: -120 }));
+    });
+    act(() => {
+      result.current.handleScroll({
+        target: { scrollTop: 300, scrollHeight: 1050, clientHeight: 504 },
+      } as unknown as React.UIEvent<HTMLDivElement>);
+    });
+    expect(result.current.handleFollowOutput(false)).toBe(false);
+    expect(result.current.showScrollButton).toBe(true);
+
+    // User scrolls straight back to the true bottom (gap 0) - no timer advance,
+    // so the guard is still fresh. Resume runs before the guard, so it fires and
+    // the latch clears WITHOUT needing the scroll-to-bottom button.
+    act(() => {
+      result.current.handleScroll({
+        target: { scrollTop: 1050 - 504, scrollHeight: 1050, clientHeight: 504 },
+      } as unknown as React.UIEvent<HTMLDivElement>);
+    });
+
+    expect(result.current.handleFollowOutput(false)).toBe('auto');
+    expect(result.current.showScrollButton).toBe(false);
+  });
+
+  it('#479: scrolling back to the true bottom resumes auto-follow', () => {
+    const { result } = renderHook(({ messages, itemCount }) => useAutoScroll({ messages, itemCount }), {
+      initialProps: { messages: [createMessage('left', '1')], itemCount: 1 },
+    });
+
+    // Latch via a real scroll-up (guard expired).
+    act(() => {
+      result.current.handleScroll({
+        target: { scrollTop: 500, scrollHeight: 1000, clientHeight: 500 },
+      } as unknown as React.UIEvent<HTMLDivElement>);
+    });
+    vi.advanceTimersByTime(200);
+    act(() => {
+      result.current.handleScroll({
+        target: { scrollTop: 300, scrollHeight: 1000, clientHeight: 500 },
+      } as unknown as React.UIEvent<HTMLDivElement>);
+    });
+    expect(result.current.handleFollowOutput(false)).toBe(false);
+    expect(result.current.showScrollButton).toBe(true);
+
+    // User scrolls back down to the true bottom (gap 0): resume.
+    vi.advanceTimersByTime(200);
+    act(() => {
+      result.current.handleScroll({
+        target: { scrollTop: 500, scrollHeight: 1000, clientHeight: 500 },
+      } as unknown as React.UIEvent<HTMLDivElement>);
+    });
+
+    expect(result.current.handleFollowOutput(false)).toBe('auto');
+    expect(result.current.showScrollButton).toBe(false);
+  });
+
+  it('#479: a small scroll-up within the atBottomThreshold still pauses (does not count as at-bottom)', () => {
+    const { result } = renderHook(({ messages, itemCount }) => useAutoScroll({ messages, itemCount }), {
+      initialProps: { messages: [createMessage('left', '1')], itemCount: 1 },
+    });
+
+    // Establish a baseline then a decisive up-move that lands only ~40px from the
+    // bottom - within Virtuoso's 100px atBottomThreshold, but gap > 2 so it is NOT
+    // treated as the true bottom and the latch holds.
+    act(() => {
+      result.current.handleScroll({
+        target: { scrollTop: 500, scrollHeight: 1000, clientHeight: 500 },
+      } as unknown as React.UIEvent<HTMLDivElement>);
+    });
+    vi.advanceTimersByTime(200);
+    act(() => {
+      result.current.handleScroll({
+        target: { scrollTop: 460, scrollHeight: 1000, clientHeight: 500 },
+      } as unknown as React.UIEvent<HTMLDivElement>);
+    });
+
+    expect(result.current.handleFollowOutput(false)).toBe(false);
+    expect(result.current.showScrollButton).toBe(true);
+  });
+
+  it('#479: switching conversation resets the paused latch', () => {
+    const { result, rerender } = renderHook(
+      ({ messages, itemCount, conversationId }) => useAutoScroll({ messages, itemCount, conversationId }),
+      {
+        initialProps: { messages: [createMessage('left', '1')], itemCount: 1, conversationId: 'conv-a' },
+      }
+    );
+
+    // Pause in conversation A.
+    act(() => {
+      result.current.handleScroll({
+        target: { scrollTop: 500, scrollHeight: 1000, clientHeight: 500 },
+      } as unknown as React.UIEvent<HTMLDivElement>);
+    });
+    vi.advanceTimersByTime(200);
+    act(() => {
+      result.current.handleScroll({
+        target: { scrollTop: 300, scrollHeight: 1000, clientHeight: 500 },
+      } as unknown as React.UIEvent<HTMLDivElement>);
+    });
+    expect(result.current.handleFollowOutput(false)).toBe(false);
+
+    // Switch to conversation B - latch must clear.
+    act(() => {
+      rerender({ messages: [createMessage('left', '9')], itemCount: 1, conversationId: 'conv-b' });
+    });
+
+    expect(result.current.handleFollowOutput(false)).toBe('auto');
+    expect(result.current.showScrollButton).toBe(false);
   });
 
   it('container resize should NOT correct when user has scrolled up', () => {


### PR DESCRIPTION
## What & why

Closes the auto-scroll fight described in #479: while the AI streams, the user could not scroll up to read earlier output — the view kept snapping back to the bottom.

Root cause was in `useAutoScroll.ts`. The scroll-up latch (`userScrolledRef`) was defeated two ways:
1. A transient `atBottomStateChange(true)` (mid-stream layout shift, or a small scroll-up still inside Virtuoso's 100px `atBottomThreshold`) cleared the latch and snapped the reader to the bottom.
2. `onScroll` detection is suppressed by the programmatic-scroll guard, which is continuously refreshed during fast streaming — so the user's scroll-up was swallowed and never latched.

## Change (make the latch authoritative)

- `handleAtBottomStateChange` no longer clears the latch or snaps while the user is scrolled up; it keeps the button visible. Auto-follow resumes **only** on an explicit user action: the scroll-to-bottom button, sending a message, or scrolling back to the true bottom.
- A `wheel`/`touch` up-gesture opens a short **intent window**; the ensuing `onScroll` is then evaluated on the **main scroller's real delta** even inside the guard window. Because the decision uses the main-scroller delta, a gesture consumed by a nested overflow child (code block, diff, tool panel) never falsely pauses auto-follow.
- Resume-at-true-bottom runs **before** the guard, so returning to the bottom can never leave the latch stuck.
- Reset the latch on conversation switch (the list view is reused, not remounted) — `MessageList.tsx` now passes `conversationId`.

No new heuristics beyond the existing `USER_SCROLL_UP_DELTA` latch; the intent window is a short, gesture-scoped exemption from the existing programmatic guard.

## Verification

- **Unit tests** (`tests/unit/useAutoScroll.dom.test.ts`, 21 → adds #479 cases; both autoscroll suites 26 pass): latch holds vs `atBottomStateChange(true)`; wheel-up opens intent → `onScroll` latches inside the guard window; child-consumed wheel (main list didn't move) does **not** latch; wheel-down doesn't pause; resume at true bottom even while the guard is fresh; small scroll-up within the threshold still pauses; conversation switch resets the latch.
- **Independent cross-audit** ran and found two real defects — a stuck-latch (resume behind the guard) and a false-latch (child wheel bubbling). Both fixed at the root by the intent-window + resume-before-guard design; re-verified.
- **Live-verify** (packaged build, CDP :9333, real Virtuoso scroller): at bottom → button hidden; wheel-up → latch + button shows + position holds; content grows below while latched → position holds (no snap-back); scroll back to true bottom → latch clears + button hides. A real AI stream couldn't be driven locally (the only local model, `gemma3:4b`, rejects the agent's injected tools with a 400), so content-growth was simulated via the DOM; the streaming-guard immunity is covered by the unit tests.
- `bun run typecheck`, oxlint, oxfmt, and `prek run --from-ref ferrox/main --to-ref HEAD` all green.

Refs #479
