### PR TITLE
fix(startup): surface real agent/session start-failure reasons (#484/#483/#369/#447)

### DIFF
--- a/src/process/acp/compat/AcpAgentV2.ts
+++ b/src/process/acp/compat/AcpAgentV2.ts
@@ -121,6 +121,11 @@ export class AcpAgentV2 {
   private cachedModes: ModeSnapshot | null = null;
   private lastSessionId: string | null = null;
   private lastStatus: SessionStatus = 'idle';
+  // Most recent error signal message, captured so a failed start rejects with the
+  // engine's real reason rather than a generic string (#483/#369). Set by the
+  // onSignal 'error' handler (which fires just before status flips to 'error')
+  // and cleared when a new start begins or the session reaches 'active'.
+  private lastErrorMessage: string | null = null;
 
   // Promise bridges for async methods (Tasks 4-6)
   private startOp: PendingOp<void> | null = null;
@@ -345,10 +350,14 @@ export class AcpAgentV2 {
 
         // Resolve startOp when reaching active/error
         if (status === 'active' && this.startOp) {
+          this.lastErrorMessage = null;
           this.resolveOp(this.startOp, undefined);
           this.startOp = null;
         } else if (status === 'error' && this.startOp) {
-          this.rejectOp(this.startOp, new Error('Session failed to start'));
+          // Surface the engine's real failure reason (captured from the error
+          // signal enterError emits just before this status change) instead of a
+          // generic "Session failed to start" (#483/#369).
+          this.rejectOp(this.startOp, new Error(this.lastErrorMessage ?? 'Session failed to start'));
           this.startOp = null;
         }
 
@@ -469,6 +478,15 @@ export class AcpAgentV2 {
       },
 
       onSignal: (event) => {
+        // Retain the real reason so a pending start op can reject with it
+        // (#483/#369). enterError emits this signal immediately before the status
+        // flips to 'error', so it is set in time for the reject in onStatusChange.
+        // Captured before the onSignalEvent guard so it works even when no signal
+        // sink is wired (the reject path does not depend on onSignalEvent).
+        if (event.type === 'error') {
+          this.lastErrorMessage = event.message;
+        }
+
         if (!this.onSignalEvent) return;
 
         switch (event.type) {
@@ -665,6 +683,9 @@ export class AcpAgentV2 {
   // ─── Lifecycle Methods (Task 4) ────────────────────────────────
 
   async start(): Promise<void> {
+    // Clear any stale error from a prior attempt so this start rejects only with
+    // its own failure reason (#483/#369).
+    this.lastErrorMessage = null;
     const session = await this.ensureSession();
     return new Promise<void>((resolve, reject) => {
       const timer = setTimeout(() => {

--- a/src/process/acp/session/AcpSession.ts
+++ b/src/process/acp/session/AcpSession.ts
@@ -442,7 +442,11 @@ export class AcpSession {
     this.promptExecutor.clearPending();
     this.permissionResolver.rejectAll(new Error(displayMessage));
     this.promptExecutor.stopTimer();
-    this.setStatus('error');
+    // Emit the detailed error signal BEFORE flipping status to 'error'. A pending
+    // start op is rejected on the status change, and the reject wants the real
+    // reason (#483/#369): emitting the signal first lets AcpAgentV2 capture the
+    // message so the rejection carries it instead of a generic "failed to start".
     this.callbacks.onSignal({ type: 'error', message: displayMessage, recoverable: false });
+    this.setStatus('error');
   }
 }

--- a/src/process/agent/wcore/index.ts
+++ b/src/process/agent/wcore/index.ts
@@ -25,6 +25,28 @@ const WCORE_PROJECT_CONFIG = '.wcore.toml';
 // opaque "exited with code N" (#484). Capped to bound memory on a chatty engine.
 const WCORE_STDERR_TAIL_MAX = 2048;
 
+// High-confidence secret shapes to mask before engine stderr is surfaced into the
+// user-facing error UI (#484 audit). Init failures shouldn't echo credentials,
+// but stderr is untrusted engine output, so scrub known token formats defensively
+// (the full text still goes to the local console log for debugging). Conservative
+// on purpose: only well-known prefixes + bearer tokens, so real error text is
+// preserved.
+const SECRET_PATTERNS: RegExp[] = [
+  /\b(?:sk|pk|rk)-[A-Za-z0-9_-]{16,}\b/g, // OpenAI / Stripe style
+  /\bBearer\s+[A-Za-z0-9._-]{16,}\b/gi, // Authorization: Bearer <token>
+  /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}\b/g, // GitHub tokens
+  /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g, // Slack tokens
+  /\bAKIA[0-9A-Z]{16}\b/g, // AWS access key id
+];
+
+function redactSecrets(text: string): string {
+  let out = text;
+  for (const pattern of SECRET_PATTERNS) {
+    out = out.replace(pattern, '[redacted]');
+  }
+  return out;
+}
+
 type StreamEventHandler = (event: { type: string; data: unknown; msg_id: string; subject?: string }) => void;
 
 /**
@@ -271,7 +293,7 @@ export class WCoreAgent {
         // exit code so callers see the cause, not just "exited with code N"
         // (#484). The "exited with code" wording distinguishes an engine that
         // died during init from the separate 30s ready-timeout below.
-        const detail = this.stderrTail.trim();
+        const detail = redactSecrets(this.stderrTail.trim());
         this.readyReject(
           new Error(
             detail
@@ -294,7 +316,7 @@ export class WCoreAgent {
     // engine that exited during init (handled above).
     const timeout = new Promise<void>((_, reject) => {
       setTimeout(() => {
-        const detail = this.stderrTail.trim();
+        const detail = redactSecrets(this.stderrTail.trim());
         reject(new Error(detail ? `wcore ready timeout (30s): ${detail}` : 'wcore ready timeout (30s)'));
       }, 30000);
     });
@@ -305,6 +327,23 @@ export class WCoreAgent {
       // If resume failed (session not found), fallback to a new session
       if (this.options.resume) {
         console.error('[WCoreAgent] Resume failed, falling back to new session:', err);
+        // Tear down the failed resume attempt before recursing. The ready-timeout
+        // path leaves the engine alive, and its exit/stderr listeners read this.*
+        // dynamically - once we recurse they'd point at the fresh attempt, so a
+        // late exit or stderr chunk from the orphaned child could reject the new
+        // session, restore the wrong .wcore.toml, or contaminate the stderr tail.
+        // Detach its listeners, kill it best-effort, and reset the tail so the
+        // next failure surfaces only its own output (#484 audit).
+        const staleChild = this.childProcess;
+        if (staleChild) {
+          rl.close();
+          staleChild.removeAllListeners();
+          staleChild.stdout?.removeAllListeners();
+          staleChild.stderr?.removeAllListeners();
+          void killChild(staleChild, false).catch(() => {});
+        }
+        this.childProcess = null;
+        this.stderrTail = '';
         this.options = { ...this.options, resume: undefined, sessionId: this.options.resume };
         this.ready = false;
         this.readyPromise = new Promise((resolve, reject) => {

--- a/src/process/agent/wcore/index.ts
+++ b/src/process/agent/wcore/index.ts
@@ -20,6 +20,11 @@ import type { WCoreEvent, WCoreCommand, WCoreCapabilities } from './protocol';
 
 const WCORE_PROJECT_CONFIG = '.wcore.toml';
 
+// Keep the last ~2KB of engine stderr so a spawn/init failure can surface the
+// engine's real bail reason (e.g. a keyless model, bad config) instead of an
+// opaque "exited with code N" (#484). Capped to bound memory on a chatty engine.
+const WCORE_STDERR_TAIL_MAX = 2048;
+
 type StreamEventHandler = (event: { type: string; data: unknown; msg_id: string; subject?: string }) => void;
 
 /**
@@ -148,6 +153,12 @@ export class WCoreAgent {
    * truncation detection.
    */
   public resolvedMaxTokens?: number;
+  /**
+   * Rolling tail of the engine's stderr (last ~2KB). Captured so a failed spawn
+   * or a ready-timeout can surface the engine's real bail reason rather than an
+   * opaque exit code (#484).
+   */
+  private stderrTail = '';
 
   constructor(options: WCoreAgentOptions) {
     this.options = options;
@@ -245,16 +256,29 @@ export class WCoreAgent {
       }
     });
 
-    // Log stderr as diagnostics
+    // Log stderr as diagnostics and retain the tail for failure surfacing (#484).
     this.childProcess.stderr?.on('data', (chunk: Buffer) => {
-      console.error('[wcore]', chunk.toString());
+      const text = chunk.toString();
+      console.error('[wcore]', text);
+      this.stderrTail = (this.stderrTail + text).slice(-WCORE_STDERR_TAIL_MAX);
     });
 
     // Handle process exit
     this.childProcess.on('exit', (code) => {
       this.restoreProjectConfig();
       if (!this.ready) {
-        this.readyReject(new Error(`wcore exited with code ${code} during init`));
+        // Surface the engine's real bail reason (its last stderr) alongside the
+        // exit code so callers see the cause, not just "exited with code N"
+        // (#484). The "exited with code" wording distinguishes an engine that
+        // died during init from the separate 30s ready-timeout below.
+        const detail = this.stderrTail.trim();
+        this.readyReject(
+          new Error(
+            detail
+              ? `wcore exited with code ${code} during init: ${detail}`
+              : `wcore exited with code ${code} during init`
+          )
+        );
       }
       if (this.activeMsgId && this._onProcessExit) {
         this._onProcessExit(code, this.activeMsgId);
@@ -263,9 +287,16 @@ export class WCoreAgent {
       this.childProcess = null;
     });
 
-    // Wait for ready event with timeout
+    // Wait for ready event with timeout. On timeout, include the engine's last
+    // stderr too: a hung engine that logged an error but never exited (e.g. it's
+    // blocked waiting on something) otherwise surfaces only a bare "timeout"
+    // (#484). The "ready timeout (30s)" wording keeps this case distinct from an
+    // engine that exited during init (handled above).
     const timeout = new Promise<void>((_, reject) => {
-      setTimeout(() => reject(new Error('wcore ready timeout (30s)')), 30000);
+      setTimeout(() => {
+        const detail = this.stderrTail.trim();
+        reject(new Error(detail ? `wcore ready timeout (30s): ${detail}` : 'wcore ready timeout (30s)'));
+      }, 30000);
     });
 
     try {

--- a/src/process/services/ijfw/healthCheck.ts
+++ b/src/process/services/ijfw/healthCheck.ts
@@ -45,9 +45,13 @@ export function watchInstallRoot(onChange: (exists: boolean) => void): () => voi
     // failure on macOS Intel, or EMFILE). An unhandled 'error' on an EventEmitter
     // is rethrown and would crash the app at startup (#447). Swallow it: the
     // watcher is best-effort observability, not critical - log and move on.
-    watcher.on('error', (err) => {
-      log.warn('[healthCheck] install-root watcher error (ignored)', { err });
-    });
+    // Guard `.on` because tests (and defensive callers) may hand back a minimal
+    // watcher object without the EventEmitter surface.
+    if (typeof watcher?.on === 'function') {
+      watcher.on('error', (err) => {
+        log.warn('[healthCheck] install-root watcher error (ignored)', { err });
+      });
+    }
   } catch (err) {
     // Parent missing or watch unavailable - caller can retry by recreating the
     // watcher later. Never throw from startup wiring (#447).

--- a/src/process/services/ijfw/healthCheck.ts
+++ b/src/process/services/ijfw/healthCheck.ts
@@ -17,6 +17,7 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import log from 'electron-log';
 
 function targetPath(): string {
   return path.join(os.homedir(), '.ijfw', 'mcp-server');
@@ -40,8 +41,17 @@ export function watchInstallRoot(onChange: (exists: boolean) => void): () => voi
     watcher = fs.watch(parent, () => {
       onChange(exists());
     });
-  } catch {
-    // Parent missing - caller can retry by recreating the watcher later.
+    // An FSWatcher emits 'error' asynchronously (e.g. an FSEvents native-binding
+    // failure on macOS Intel, or EMFILE). An unhandled 'error' on an EventEmitter
+    // is rethrown and would crash the app at startup (#447). Swallow it: the
+    // watcher is best-effort observability, not critical - log and move on.
+    watcher.on('error', (err) => {
+      log.warn('[healthCheck] install-root watcher error (ignored)', { err });
+    });
+  } catch (err) {
+    // Parent missing or watch unavailable - caller can retry by recreating the
+    // watcher later. Never throw from startup wiring (#447).
+    log.warn('[healthCheck] failed to start install-root watcher', { err });
   }
 
   return () => {

--- a/src/process/services/import/dropFolderWatcher.ts
+++ b/src/process/services/import/dropFolderWatcher.ts
@@ -207,12 +207,26 @@ export function startDropFolderWatcher(opts: {
     onError(`Failed to create directories: ${String(err)}`);
   }
 
-  const watcher = chokidar.watch(dropFolder, {
-    depth: 0,
-    ignoreInitial: true,
-    persistent: true,
-    followSymlinks: false,
-  });
+  // Build the chokidar watcher. On macOS the default backend is the fsevents
+  // native binding; on some machines (notably macOS Intel) that binding can fail
+  // to load and throw at init, which previously unhandled-rejected the app at
+  // startup (#447). Guard the init and fall back to polling so a native-binding
+  // failure degrades to a working (if heavier) watcher rather than crashing.
+  const baseOpts = { depth: 0, ignoreInitial: true, persistent: true, followSymlinks: false } as const;
+  let watcher: ReturnType<typeof chokidar.watch> | null;
+  try {
+    watcher = chokidar.watch(dropFolder, baseOpts);
+  } catch (err) {
+    log.warn('[dropFolderWatcher] native watch failed - falling back to polling', { err });
+    try {
+      watcher = chokidar.watch(dropFolder, { ...baseOpts, usePolling: true, interval: 1000 });
+    } catch (fallbackErr) {
+      log.warn('[dropFolderWatcher] polling watch also failed - watcher disabled', { fallbackErr });
+      onError(`Failed to start drop-folder watcher: ${String(fallbackErr)}`);
+      _isWatching = false;
+      return { stop: () => {} };
+    }
+  }
 
   _isWatching = true;
 

--- a/src/process/services/import/dropFolderWatcher.ts
+++ b/src/process/services/import/dropFolderWatcher.ts
@@ -223,7 +223,7 @@ export function startDropFolderWatcher(opts: {
     persistent: true,
     followSymlinks: false,
     usePolling: true,
-    interval: 1000,
+    interval: 250,
   } as const;
   let watcher: ReturnType<typeof chokidar.watch>;
   try {

--- a/src/process/services/import/dropFolderWatcher.ts
+++ b/src/process/services/import/dropFolderWatcher.ts
@@ -207,25 +207,32 @@ export function startDropFolderWatcher(opts: {
     onError(`Failed to create directories: ${String(err)}`);
   }
 
-  // Build the chokidar watcher. On macOS the default backend is the fsevents
-  // native binding; on some machines (notably macOS Intel) that binding can fail
-  // to load and throw at init, which previously unhandled-rejected the app at
-  // startup (#447). Guard the init and fall back to polling so a native-binding
-  // failure degrades to a working (if heavier) watcher rather than crashing.
-  const baseOpts = { depth: 0, ignoreInitial: true, persistent: true, followSymlinks: false } as const;
-  let watcher: ReturnType<typeof chokidar.watch> | null;
+  // Build the chokidar watcher with POLLING, not the fsevents native backend.
+  // On macOS, chokidar's fsevents handler can async-reject deep inside
+  // `_addToFsEvents` (observed live: "Cannot read properties of undefined
+  // (reading 'SinceNow')") when the bundled native binding is incompatible with
+  // the Electron ABI. Because that rejection is internal to chokidar it is NOT
+  // routed to the watcher's 'error' event, so it escapes as an unhandledRejection
+  // that crashes the app at startup on affected machines (#447). The drop folder
+  // is a single shallow (depth 0) directory, so polling sidesteps the fsevents
+  // path entirely at negligible cost. The try/catch + 'error' handler below stay
+  // as defense-in-depth for any remaining synchronous/emitted failure.
+  const baseOpts = {
+    depth: 0,
+    ignoreInitial: true,
+    persistent: true,
+    followSymlinks: false,
+    usePolling: true,
+    interval: 1000,
+  } as const;
+  let watcher: ReturnType<typeof chokidar.watch>;
   try {
     watcher = chokidar.watch(dropFolder, baseOpts);
   } catch (err) {
-    log.warn('[dropFolderWatcher] native watch failed - falling back to polling', { err });
-    try {
-      watcher = chokidar.watch(dropFolder, { ...baseOpts, usePolling: true, interval: 1000 });
-    } catch (fallbackErr) {
-      log.warn('[dropFolderWatcher] polling watch also failed - watcher disabled', { fallbackErr });
-      onError(`Failed to start drop-folder watcher: ${String(fallbackErr)}`);
-      _isWatching = false;
-      return { stop: () => {} };
-    }
+    log.warn('[dropFolderWatcher] watch init failed - watcher disabled', { err });
+    onError(`Failed to start drop-folder watcher: ${String(err)}`);
+    _isWatching = false;
+    return { stop: () => {} };
   }
 
   _isWatching = true;

--- a/tests/integration/process/acp/session/AcpSession.lifecycle.test.ts
+++ b/tests/integration/process/acp/session/AcpSession.lifecycle.test.ts
@@ -235,4 +235,34 @@ describe('AcpSession lifecycle', () => {
     );
     expect(crashSignals.length).toBeGreaterThan(0);
   });
+
+  it('enterError emits the error signal BEFORE flipping status to error (#483/#369)', async () => {
+    // Hold the session in 'starting' so starting→error is a valid transition -
+    // this mirrors the real start-failure path (handleStartError → enterError).
+    // A hung client.start() keeps status at 'starting'.
+    (client.start as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
+    const session = new AcpSession(baseConfig, clientFactory, callbacks);
+    session.start();
+    await vi.waitFor(() => expect(session.status).toBe('starting'));
+
+    session.enterError('No API key configured for provider openai');
+
+    const onSignal = callbacks.onSignal as ReturnType<typeof vi.fn>;
+    const onStatus = callbacks.onStatusChange as ReturnType<typeof vi.fn>;
+    const errorSignalIdx = onSignal.mock.calls.findIndex(([sig]) => sig.type === 'error');
+    const errorStatusIdx = onStatus.mock.calls.findIndex(([status]) => status === 'error');
+    expect(errorSignalIdx).toBeGreaterThanOrEqual(0);
+    expect(errorStatusIdx).toBeGreaterThanOrEqual(0);
+
+    // Ordering is load-bearing: AcpAgentV2 captures the error signal's message to
+    // reject a pending start op, and that reject happens on the status change. If
+    // the status flip preceded the signal, the reject would miss the real reason
+    // and fall back to a generic "Session failed to start".
+    expect(onSignal.mock.invocationCallOrder[errorSignalIdx]).toBeLessThan(
+      onStatus.mock.invocationCallOrder[errorStatusIdx]
+    );
+    expect(onSignal.mock.calls[errorSignalIdx][0]).toEqual(
+      expect.objectContaining({ type: 'error', message: expect.stringContaining('No API key configured') })
+    );
+  });
 });

--- a/tests/unit/process/acp/compat/AcpAgentV2.test.ts
+++ b/tests/unit/process/acp/compat/AcpAgentV2.test.ts
@@ -129,6 +129,48 @@ describe('AcpAgentV2 - Lifecycle Methods', () => {
       expect(mockSessionMethods.start).toHaveBeenCalledOnce();
     });
 
+    it('should reject with the real error reason when an error signal precedes error status (#483/#369)', async () => {
+      const agent = createAgent();
+
+      // Mirror AcpSession.enterError ordering: the detailed error signal fires
+      // first, then the status flips to 'error'. The reject must carry the real
+      // reason, not a generic string.
+      mockSessionMethods.start.mockImplementation(() => {
+        setTimeout(() => {
+          capturedCallbacks.onSignal({
+            type: 'error',
+            message: 'No API key configured for model claude-opus-4',
+            recoverable: false,
+          });
+          capturedCallbacks.onStatusChange('error');
+        }, 0);
+      });
+
+      const promise = agent.start();
+      await expect(promise).rejects.toThrow('No API key configured for model claude-opus-4');
+    });
+
+    it('should not carry an error reason from a prior failed start into the next start (#483/#369)', async () => {
+      const agent = createAgent();
+
+      // First start fails with a specific reason.
+      mockSessionMethods.start.mockImplementation(() => {
+        setTimeout(() => {
+          capturedCallbacks.onSignal({ type: 'error', message: 'stale reason from attempt 1', recoverable: false });
+          capturedCallbacks.onStatusChange('error');
+        }, 0);
+      });
+      await expect(agent.start()).rejects.toThrow('stale reason from attempt 1');
+
+      // Second start fails via a bare status change (no signal): must fall back to
+      // the generic message, NOT reuse the stale reason from the first attempt.
+      mockSessionMethods.start.mockReset();
+      mockSessionMethods.start.mockImplementation(() => {
+        setTimeout(() => capturedCallbacks.onStatusChange('error'), 0);
+      });
+      await expect(agent.start()).rejects.toThrow('Session failed to start');
+    });
+
     it('should reject on timeout after the session-start budget', async () => {
       vi.useFakeTimers();
       const agent = createAgent();

--- a/tests/unit/process/services/ijfw/healthCheckCrashGuard.test.ts
+++ b/tests/unit/process/services/ijfw/healthCheckCrashGuard.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #447 - the IJFW install-root watcher uses fs.watch, whose FSWatcher emits
+ * 'error' asynchronously (e.g. an FSEvents native-binding failure on macOS
+ * Intel). An unhandled 'error' on an EventEmitter is rethrown and would crash
+ * the app at startup. watchInstallRoot must attach an 'error' handler and must
+ * never throw from its own init.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+
+class FakeFsWatcher extends EventEmitter {
+  close = vi.fn();
+}
+
+const watchMock = vi.hoisted(() => vi.fn());
+const statSyncMock = vi.hoisted(() => vi.fn());
+vi.mock('node:fs', () => ({ watch: watchMock, statSync: statSyncMock }));
+vi.mock('electron-log', () => ({ default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+
+import { watchInstallRoot } from '@process/services/ijfw/healthCheck';
+
+describe('watchInstallRoot native-binding crash guard (#447)', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('swallows an async FSWatcher error event instead of letting it crash', () => {
+    const watcher = new FakeFsWatcher();
+    watchMock.mockReturnValue(watcher);
+
+    const cleanup = watchInstallRoot(vi.fn());
+
+    // An unhandled 'error' on an EventEmitter throws; the handler must absorb it.
+    expect(() => watcher.emit('error', new Error('fsevents: dlopen failed'))).not.toThrow();
+
+    cleanup();
+    expect(watcher.close).toHaveBeenCalled();
+  });
+
+  it('does not throw when fs.watch itself throws (parent missing / watch unavailable)', () => {
+    watchMock.mockImplementation(() => {
+      throw new Error('ENOENT: watch target gone');
+    });
+
+    let cleanup: (() => void) | undefined;
+    expect(() => {
+      cleanup = watchInstallRoot(vi.fn());
+    }).not.toThrow();
+
+    // Returned cleanup must be safe to call even though no watcher was created.
+    expect(() => cleanup?.()).not.toThrow();
+  });
+
+  it('reports existence changes via the callback on watch events', () => {
+    const watcher = new FakeFsWatcher();
+    watchMock.mockReturnValue(watcher);
+    statSyncMock.mockImplementation(() => {
+      throw new Error('not found');
+    });
+
+    const onChange = vi.fn();
+    watchInstallRoot(onChange);
+
+    // fs.watch(parent, listener) invokes the second-arg listener on each event.
+    const listener = watchMock.mock.calls[0][1] as () => void;
+    listener();
+    expect(onChange).toHaveBeenCalledWith(false);
+
+    statSyncMock.mockReturnValue({});
+    listener();
+    expect(onChange).toHaveBeenLastCalledWith(true);
+  });
+});

--- a/tests/unit/process/services/import/dropFolderWatcherCrashGuard.test.ts
+++ b/tests/unit/process/services/import/dropFolderWatcherCrashGuard.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #447 - a chokidar/fsevents native-binding failure must NOT crash the app at
+ * startup. startDropFolderWatcher guards the watcher init and falls back to
+ * polling; if even that fails it returns a no-op handle instead of throwing.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+
+// A fake chokidar watcher: an EventEmitter with a close() that resolves.
+class FakeWatcher extends EventEmitter {
+  close = vi.fn().mockResolvedValue(undefined);
+}
+
+const watchMock = vi.hoisted(() => vi.fn());
+vi.mock('chokidar', () => ({ default: { watch: watchMock } }));
+vi.mock('electron-log', () => ({ default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+vi.mock('@process/services/import/memoryIndexer', () => ({ indexDroppedMemory: vi.fn() }));
+// Keep the test hermetic - never touch the real filesystem for dir creation.
+vi.mock('node:fs', () => ({
+  mkdirSync: vi.fn(),
+  promises: {
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    unlink: vi.fn(),
+    readdir: vi.fn(),
+  },
+}));
+
+import { startDropFolderWatcher, isDropFolderWatching } from '@process/services/import/dropFolderWatcher';
+
+describe('startDropFolderWatcher native-binding crash guard (#447)', () => {
+  beforeEach(() => {
+    watchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns a working handle and marks watching when the native backend loads', () => {
+    const watcher = new FakeWatcher();
+    watchMock.mockReturnValueOnce(watcher);
+
+    const handle = startDropFolderWatcher({
+      ijfwMemoryDir: '/tmp/ijfw-mem-test',
+      dropFolder: '/tmp/drop-test',
+      onIngest: vi.fn(),
+      onError: vi.fn(),
+    });
+
+    expect(isDropFolderWatching()).toBe(true);
+    expect(watchMock).toHaveBeenCalledTimes(1);
+    handle.stop();
+    expect(isDropFolderWatching()).toBe(false);
+  });
+
+  it('falls back to polling when the native watch init throws (no crash)', () => {
+    const pollingWatcher = new FakeWatcher();
+    watchMock
+      .mockImplementationOnce(() => {
+        throw new Error('dlopen(fsevents.node): symbol not found'); // simulate native-binding failure
+      })
+      .mockReturnValueOnce(pollingWatcher);
+
+    const onError = vi.fn();
+    let handle: { stop: () => void } | undefined;
+    expect(() => {
+      handle = startDropFolderWatcher({
+        ijfwMemoryDir: '/tmp/ijfw-mem-test',
+        dropFolder: '/tmp/drop-test',
+        onIngest: vi.fn(),
+        onError,
+      });
+    }).not.toThrow();
+
+    // Second call must request the polling backend.
+    expect(watchMock).toHaveBeenCalledTimes(2);
+    expect(watchMock.mock.calls[1][1]).toMatchObject({ usePolling: true });
+    expect(isDropFolderWatching()).toBe(true);
+    handle?.stop();
+  });
+
+  it('returns a no-op handle when both native and polling init throw (still no crash)', () => {
+    watchMock.mockImplementation(() => {
+      throw new Error('watch unavailable');
+    });
+
+    const onError = vi.fn();
+    let handle: { stop: () => void } | undefined;
+    expect(() => {
+      handle = startDropFolderWatcher({
+        ijfwMemoryDir: '/tmp/ijfw-mem-test',
+        dropFolder: '/tmp/drop-test',
+        onIngest: vi.fn(),
+        onError,
+      });
+    }).not.toThrow();
+
+    expect(watchMock).toHaveBeenCalledTimes(2);
+    expect(onError).toHaveBeenCalledWith(expect.stringContaining('Failed to start drop-folder watcher'));
+    expect(isDropFolderWatching()).toBe(false);
+    // The no-op handle must be safe to stop.
+    expect(() => handle?.stop()).not.toThrow();
+  });
+});

--- a/tests/unit/process/services/import/dropFolderWatcherCrashGuard.test.ts
+++ b/tests/unit/process/services/import/dropFolderWatcherCrashGuard.test.ts
@@ -59,6 +59,24 @@ describe('startDropFolderWatcher native-binding crash guard (#447)', () => {
     expect(isDropFolderWatching()).toBe(false);
   });
 
+  it('absorbs an async watcher error event without crashing (the real #447 mode)', () => {
+    const watcher = new FakeWatcher();
+    watchMock.mockReturnValueOnce(watcher);
+
+    const onError = vi.fn();
+    startDropFolderWatcher({
+      ijfwMemoryDir: '/tmp/ijfw-mem-test',
+      dropFolder: '/tmp/drop-test',
+      onIngest: vi.fn(),
+      onError,
+    });
+
+    // chokidar surfaces backend failures as an async 'error' event; an unhandled
+    // 'error' on an EventEmitter is rethrown and would crash the app.
+    expect(() => watcher.emit('error', new Error('fsevents backend failed'))).not.toThrow();
+    expect(onError).toHaveBeenCalledWith(expect.stringContaining('Watcher error'));
+  });
+
   it('falls back to polling when the native watch init throws (no crash)', () => {
     const pollingWatcher = new FakeWatcher();
     watchMock

--- a/tests/unit/process/services/import/dropFolderWatcherCrashGuard.test.ts
+++ b/tests/unit/process/services/import/dropFolderWatcherCrashGuard.test.ts
@@ -42,7 +42,7 @@ describe('startDropFolderWatcher native-binding crash guard (#447)', () => {
     vi.clearAllMocks();
   });
 
-  it('returns a working handle and marks watching when the native backend loads', () => {
+  it('watches with polling (not the crash-prone fsevents backend) and marks watching', () => {
     const watcher = new FakeWatcher();
     watchMock.mockReturnValueOnce(watcher);
 
@@ -55,11 +55,14 @@ describe('startDropFolderWatcher native-binding crash guard (#447)', () => {
 
     expect(isDropFolderWatching()).toBe(true);
     expect(watchMock).toHaveBeenCalledTimes(1);
+    // usePolling:true is the actual #447 fix: it keeps chokidar off the fsevents
+    // native path that async-rejects (unhandledRejection) on affected macs.
+    expect(watchMock.mock.calls[0][1]).toMatchObject({ usePolling: true });
     handle.stop();
     expect(isDropFolderWatching()).toBe(false);
   });
 
-  it('absorbs an async watcher error event without crashing (the real #447 mode)', () => {
+  it('absorbs an async watcher error event without crashing (defense-in-depth)', () => {
     const watcher = new FakeWatcher();
     watchMock.mockReturnValueOnce(watcher);
 
@@ -71,39 +74,12 @@ describe('startDropFolderWatcher native-binding crash guard (#447)', () => {
       onError,
     });
 
-    // chokidar surfaces backend failures as an async 'error' event; an unhandled
-    // 'error' on an EventEmitter is rethrown and would crash the app.
-    expect(() => watcher.emit('error', new Error('fsevents backend failed'))).not.toThrow();
+    // An unhandled 'error' on an EventEmitter is rethrown and would crash the app.
+    expect(() => watcher.emit('error', new Error('watcher backend failed'))).not.toThrow();
     expect(onError).toHaveBeenCalledWith(expect.stringContaining('Watcher error'));
   });
 
-  it('falls back to polling when the native watch init throws (no crash)', () => {
-    const pollingWatcher = new FakeWatcher();
-    watchMock
-      .mockImplementationOnce(() => {
-        throw new Error('dlopen(fsevents.node): symbol not found'); // simulate native-binding failure
-      })
-      .mockReturnValueOnce(pollingWatcher);
-
-    const onError = vi.fn();
-    let handle: { stop: () => void } | undefined;
-    expect(() => {
-      handle = startDropFolderWatcher({
-        ijfwMemoryDir: '/tmp/ijfw-mem-test',
-        dropFolder: '/tmp/drop-test',
-        onIngest: vi.fn(),
-        onError,
-      });
-    }).not.toThrow();
-
-    // Second call must request the polling backend.
-    expect(watchMock).toHaveBeenCalledTimes(2);
-    expect(watchMock.mock.calls[1][1]).toMatchObject({ usePolling: true });
-    expect(isDropFolderWatching()).toBe(true);
-    handle?.stop();
-  });
-
-  it('returns a no-op handle when both native and polling init throw (still no crash)', () => {
+  it('returns a no-op handle when watch init throws synchronously (still no crash)', () => {
     watchMock.mockImplementation(() => {
       throw new Error('watch unavailable');
     });
@@ -119,7 +95,6 @@ describe('startDropFolderWatcher native-binding crash guard (#447)', () => {
       });
     }).not.toThrow();
 
-    expect(watchMock).toHaveBeenCalledTimes(2);
     expect(onError).toHaveBeenCalledWith(expect.stringContaining('Failed to start drop-folder watcher'));
     expect(isDropFolderWatching()).toBe(false);
     // The no-op handle must be safe to stop.

--- a/tests/unit/wcoreStderrSurfacing.test.ts
+++ b/tests/unit/wcoreStderrSurfacing.test.ts
@@ -28,7 +28,8 @@ vi.mock('@process/agent/wcore/toolKeyStore', () => ({
 vi.mock('@process/providers/ipc/modelRegistryIpc', () => ({
   hydrateModelForSpawn: (m: unknown) => Promise.resolve(m),
 }));
-vi.mock('@process/agent/acp/utils', () => ({ killChild: vi.fn() }));
+const killChildMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock('@process/agent/acp/utils', () => ({ killChild: killChildMock }));
 
 import { WCoreAgent } from '@process/agent/wcore';
 import type { WCoreAgentOptions } from '@process/agent/wcore';
@@ -70,6 +71,7 @@ function baseOptions(): WCoreAgentOptions {
 describe('WCoreAgent init-failure surfacing (#484)', () => {
   beforeEach(() => {
     spawnMock.mockReset();
+    killChildMock.mockClear();
   });
 
   afterEach(() => {
@@ -130,5 +132,62 @@ describe('WCoreAgent init-failure surfacing (#484)', () => {
     const err = (await result) as Error;
     expect(err.message).toContain('wcore ready timeout (30s)');
     expect(err.message).toContain('waiting for provider handshake');
+  });
+
+  it('resume-fallback tears down the stale child, resets the tail, and surfaces only the retry error (#484 audit)', async () => {
+    vi.useFakeTimers();
+    const first = makeChild();
+    const second = makeChild();
+    spawnMock.mockReturnValueOnce(first).mockReturnValueOnce(second);
+
+    const agent = new WCoreAgent({ ...baseOptions(), resume: 'session-abc' });
+    const result = agent.start().catch((e: unknown) => e);
+
+    // First (resume) attempt spawns, logs stderr, then never becomes ready.
+    await vi.advanceTimersByTimeAsync(0);
+    first.stderr.write('attempt 1: resume session not found\n');
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The 30s ready-timeout fires → resume fallback: the stale (still-alive)
+    // child must be killed and its listeners detached before the retry spawns.
+    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(killChildMock).toHaveBeenCalledWith(first, false);
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+
+    // A late stderr chunk from the orphaned first child must NOT leak into the
+    // retry's buffer (its listeners were removed).
+    first.stderr.write('attempt 1: late noise\n');
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The retry fails with its own reason.
+    second.stderr.write('attempt 2: no API key configured\n');
+    await vi.advanceTimersByTimeAsync(0);
+    second.emit('exit', 1);
+
+    const err = (await result) as Error;
+    expect(err.message).toContain('wcore exited with code 1 during init');
+    expect(err.message).toContain('no API key configured');
+    expect(err.message).not.toContain('attempt 1');
+  });
+
+  it('redacts high-confidence secret tokens from the surfaced stderr (#484 audit)', async () => {
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const agent = new WCoreAgent(baseOptions());
+    const result = agent.start().catch((e: unknown) => e);
+
+    await flushUntilSpawned();
+    child.stderr.write('auth failed with key sk-abcdef0123456789ABCDEF for provider openai\n');
+    await Promise.resolve();
+    child.emit('exit', 1);
+
+    const err = (await result) as Error;
+    // The human-readable reason survives; the token does not.
+    expect(err.message).toContain('auth failed');
+    expect(err.message).toContain('[redacted]');
+    expect(err.message).not.toContain('sk-abcdef0123456789ABCDEF');
   });
 });

--- a/tests/unit/wcoreStderrSurfacing.test.ts
+++ b/tests/unit/wcoreStderrSurfacing.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #484 - a wcore spawn that dies during init (e.g. a keyless model) must surface
+ * the engine's real bail reason (its last stderr) instead of an opaque
+ * "wcore exited with code N". A hung engine that logged an error but never
+ * exited must likewise surface that stderr on the 30s ready-timeout.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+
+const spawnMock = vi.hoisted(() => vi.fn());
+vi.mock('node:child_process', () => ({ spawn: spawnMock }));
+vi.mock('@process/agent/wcore/binaryResolver', () => ({ resolveWCoreBinary: () => '/fake/wcore' }));
+vi.mock('@process/agent/wcore/envBuilder', () => ({
+  buildEngineSpawnEnv: () => ({}),
+  buildSpawnConfig: () => ({ args: [], env: {}, projectConfig: undefined, resolvedMaxTokens: undefined }),
+}));
+vi.mock('@process/agent/wcore/profilePaths', () => ({
+  resolveActiveConfigDir: () => Promise.resolve('/fake/home'),
+}));
+vi.mock('@process/agent/wcore/toolKeyStore', () => ({
+  getToolKeyStore: () => Promise.resolve({ collectForwardedEnv: () => ({}) }),
+}));
+vi.mock('@process/providers/ipc/modelRegistryIpc', () => ({
+  hydrateModelForSpawn: (m: unknown) => Promise.resolve(m),
+}));
+vi.mock('@process/agent/acp/utils', () => ({ killChild: vi.fn() }));
+
+import { WCoreAgent } from '@process/agent/wcore';
+import type { WCoreAgentOptions } from '@process/agent/wcore';
+
+type FakeChild = EventEmitter & {
+  stdout: PassThrough;
+  stderr: PassThrough;
+  stdin: PassThrough;
+  kill: ReturnType<typeof vi.fn>;
+  pid: number;
+};
+
+function makeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.stdin = new PassThrough();
+  child.kill = vi.fn();
+  child.pid = 4242;
+  return child;
+}
+
+/** Spin the microtask queue until start() has actually spawned the child (so its
+ *  stderr/exit listeners are attached), without guessing the await count. */
+async function flushUntilSpawned(): Promise<void> {
+  for (let i = 0; i < 100 && spawnMock.mock.calls.length === 0; i++) {
+    await Promise.resolve();
+  }
+}
+
+function baseOptions(): WCoreAgentOptions {
+  return {
+    workspace: '/ws',
+    model: { name: 'test', useModel: 'test-model', platform: 'openai', baseUrl: '' } as WCoreAgentOptions['model'],
+    onStreamEvent: vi.fn(),
+  };
+}
+
+describe('WCoreAgent init-failure surfacing (#484)', () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('includes the engine stderr tail in the exit rejection', async () => {
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const agent = new WCoreAgent(baseOptions());
+    const result = agent.start().catch((e: unknown) => e);
+
+    // Let start() reach the point where it has wired the stderr/exit listeners.
+    await flushUntilSpawned();
+
+    child.stderr.write('error: no API key configured for provider "openai"\n');
+    await Promise.resolve();
+    child.emit('exit', 1);
+
+    const err = (await result) as Error;
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toContain('wcore exited with code 1 during init');
+    expect(err.message).toContain('no API key configured');
+  });
+
+  it('falls back to the bare exit message when there is no stderr', async () => {
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const agent = new WCoreAgent(baseOptions());
+    const result = agent.start().catch((e: unknown) => e);
+
+    await flushUntilSpawned();
+    child.emit('exit', 127);
+
+    const err = (await result) as Error;
+    expect(err.message).toBe('wcore exited with code 127 during init');
+  });
+
+  it('includes the engine stderr tail in the 30s ready-timeout rejection', async () => {
+    vi.useFakeTimers();
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const agent = new WCoreAgent(baseOptions());
+    const result = agent.start().catch((e: unknown) => e);
+
+    // Flush the async setup (mocked awaits) so listeners are attached.
+    await vi.advanceTimersByTimeAsync(0);
+    child.stderr.write('waiting for provider handshake...\n');
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Fire the 30s ready timeout; the engine never emitted 'ready' or exited.
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    const err = (await result) as Error;
+    expect(err.message).toContain('wcore ready timeout (30s)');
+    expect(err.message).toContain('waiting for provider handshake');
+  });
+});


### PR DESCRIPTION
## Problem

The **\"agent/session fails to start\"** cluster (#484 / #483 / #369 / #447) shared one root defect: the real failure reason was **swallowed at the surfacing point**, so every report was an opaque string (\"wcore exited with code 1\", \"Session failed to start\", or a hard startup crash with no cause). This threads the real reason through at all three surfacing points.

## Fixes

### #484 — WCore path (`src/process/agent/wcore/index.ts`)
`WCoreAgent` only `console.error`'d engine stderr and rejected with `wcore exited with code N during init` (no cause). Now:
- Buffer the last ~2KB of engine stderr and include it in the reject, on **both** the exit path and the 30s ready-timeout, keeping the two cases textually distinct so a keyless-model bail shows the engine's real message.
- **Resume-fallback hardening** (from cross-audit): the ready-timeout path leaves the first engine alive, and its listeners read `this.*` dynamically — after the fallback recursion they pointed at the fresh attempt, so a late exit/stderr from the orphaned child could reject the retry, restore the wrong `.wcore.toml`, or contaminate the tail. Detach its listeners, kill it best-effort, and reset the tail before recursing.
- **Secret redaction** (from cross-audit): the surfaced stderr now reaches the user-facing error UI, so mask high-confidence token shapes (OpenAI/Stripe, Bearer, GitHub, Slack, AWS) in the surfaced copy; the full text still goes to the local console log.

Surfaced end-to-end via `WCoreManager.emitStartFailure` → renderer chat (`Agent failed to start: <real reason>`).

### #483 / #369 — ACP path (`AcpAgentV2.ts` + `AcpSession.ts`)
`AcpAgentV2` rejected a failed start with a hardcoded `Session failed to start`, discarding the real ACP/connection error. Now `AcpSession.enterError` emits the message-bearing error signal **before** flipping status to `error`, and `AcpAgentV2` captures that message (before the `onSignalEvent` guard, so it works with no signal sink) and rejects the start op with it — falling back to the generic string when no reason is available, and clearing it between attempts.

### #447 — macOS startup crash (`dropFolderWatcher.ts` + `healthCheck.ts`)
**Live-verify surfaced the real mechanism** (and confirmed the cross-audit's prediction that the first attempt missed it): chokidar's fsevents backend async-rejects deep inside `_addToFsEvents` (`Cannot read properties of undefined (reading 'SinceNow')`) when the bundled native binding is incompatible with the Electron ABI. That rejection is internal to chokidar — routed neither to the synchronous `chokidar.watch()` call nor to the watcher's `error` event — so it escapes as an **unhandledRejection** at startup. Fix: the drop folder is a single shallow (depth 0) dir, so watch it with `usePolling: true` (never enters the fsevents path). `healthCheck`'s `fs.watch` FSWatcher gains an `error` handler so an async native error is absorbed rather than crashing.

```
Before: [unhandledRejection] TypeError: Cannot read properties of undefined (reading 'SinceNow')
          at createFSEventsInstance ... FsEventsHandler._addToFsEvents
After:  clean startup, no fsevents rejection
```

## Testing
- New unit coverage for every surfacing path: exit + ready-timeout stderr surfacing, resume-fallback teardown + tail reset, secret redaction, ACP real-reason reject + stale-reason clearing, direct `AcpSession.enterError` signal-before-status ordering, async watcher `error` absorption, polling-not-fsevents assertion. 115 tests green across the affected suites.
- Typecheck + prek (Oxlint/Oxfmt/EOF/whitespace) green.
- Independent cross-audit performed; all CRITICAL/IMPORTANT findings fixed (resume-fallback orphan, redaction, async-error test gap, enterError ordering test).
- **Live-verify (CDP, real app):** #447 confirmed decisively — the pre-fix fsevents unhandledRejection is gone and startup reaches the main window cleanly. The #484 keyless-model and #483 forced-ACP-error **real-engine** reproductions are routed to Overwatch (local harness can't reliably drive real wcore turns); the exact code paths are covered by the deterministic unit tests and the manager→renderer wiring is code-verified.

## Scope
Does not touch the MCP-inject block or `WCoreManager.ts` core spawn logic (pending PR #478).

Addresses #484 and #483; partially addresses #369 and #447 (surfacing now makes #484's true engine cause visible — may spawn a wayland-core ticket for the underlying keyless bail).
