### PR TITLE
fix(mcp): #448 spawn filesystem MCP with its required directory arg [lane: BH2]

### DIFF
--- a/src/common/mcp/normalizeMcpServer.ts
+++ b/src/common/mcp/normalizeMcpServer.ts
@@ -1,0 +1,154 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IMcpServerTransport } from '@/common/config/storage';
+
+/**
+ * The upstream reference filesystem MCP server. It reads the directories it is
+ * allowed to touch from POSITIONAL CLI arguments
+ * (`mcp-server-filesystem <allowed-directory> [additional-directories...]`), NOT
+ * from an environment variable. When launched with zero directories it prints
+ * its usage string and exits, which surfaces to the user as the opaque
+ * `MCP error -32000: Connection closed` (issue #448 / #438).
+ *
+ * The catalog entry historically modelled the allowed directories as an
+ * `ALLOWED_DIRS` env var, which the server silently ignores, so every install
+ * spawned it with no directory and it never connected. We translate that intent
+ * into real positional args here, defaulting to the user's home folder (matching
+ * the setup guide's documented promise) when the user hasn't narrowed the scope.
+ *
+ * Lives in `common` (no `node:path`) so the SAME transform runs at install-time
+ * in the renderer (baking the dirs into the persisted record, which every spawn
+ * consumer reads) AND as idempotent defense-in-depth in the main-process
+ * connection-test / agent-sync paths.
+ */
+const FILESYSTEM_PACKAGE = '@modelcontextprotocol/server-filesystem';
+
+/** Env var the catalog used to (ineffectually) carry the allowed directories. */
+const ALLOWED_DIRS_ENV = 'ALLOWED_DIRS';
+
+/** True when this element is the filesystem package id (bare or `@version`-pinned). */
+function isFilesystemPackageArg(arg: string): boolean {
+  return arg === FILESYSTEM_PACKAGE || arg.startsWith(`${FILESYSTEM_PACKAGE}@`);
+}
+
+/**
+ * Portable join used only to expand a leading `~`. Avoids `node:path` so this
+ * module is safe to import in the sandboxed renderer. Infers the separator from
+ * the home directory itself (`C:\Users\me` -> `\`, `/Users/me` -> `/`).
+ */
+function joinUnderHome(homedir: string, rest: string): string {
+  const sep = homedir.includes('\\') && !homedir.includes('/') ? '\\' : '/';
+  return `${homedir.replace(/[/\\]+$/, '')}${sep}${rest.replace(/^[/\\]+/, '')}`;
+}
+
+/**
+ * Reject a value containing a C0/C1 control char or DEL. Mirrors the guard in
+ * validateMcpEnv (which no longer sees ALLOWED_DIRS once it moves to argv), so a
+ * newline/NUL can't ride into a directory arg and break a downstream CLI config
+ * serializer. Implemented via char codes so the source carries no control bytes.
+ */
+function hasControlChar(value: string): boolean {
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) return true;
+  }
+  return false;
+}
+
+/**
+ * Expand a leading `~` to the home directory. Leaves an already-absolute or
+ * relative path otherwise untouched (the server itself rejects non-absolute
+ * paths; we don't second-guess it here).
+ */
+function expandHome(dir: string, homedir: string): string {
+  const trimmed = dir.trim();
+  if (trimmed === '~') return homedir;
+  if (trimmed.startsWith('~/') || trimmed.startsWith('~\\')) {
+    return joinUnderHome(homedir, trimmed.slice(2));
+  }
+  return trimmed;
+}
+
+/**
+ * Resolve the effective list of allowed directories for the filesystem server
+ * from (a) any directories already present as positional args and (b) the legacy
+ * comma-separated `ALLOWED_DIRS` env value. Falls back to `[homedir]` when the
+ * user hasn't specified any.
+ *
+ * A token that begins with `-` is dropped: moving values out of `env` (where
+ * {@link validateMcpEnv} rejects a leading `-`) into argv would otherwise let a
+ * crafted `ALLOWED_DIRS=--flag` ride into the child's argv as an option
+ * (argument injection). Tokens with control characters are dropped for the same
+ * defense-in-depth reason. Directories are always absolute paths, never flags.
+ */
+export function resolveFilesystemAllowedDirs(
+  existingDirs: readonly string[],
+  envValue: string | undefined,
+  homedir: string
+): string[] {
+  const fromEnv = (envValue ?? '').split(',');
+  const seen = new Set<string>();
+  const dirs: string[] = [];
+  for (const raw of [...existingDirs, ...fromEnv]) {
+    const dir = expandHome(raw ?? '', homedir);
+    if (dir.length === 0 || dir.startsWith('-') || hasControlChar(dir)) continue;
+    if (seen.has(dir)) continue;
+    seen.add(dir);
+    dirs.push(dir);
+  }
+  return dirs.length > 0 ? dirs : [homedir];
+}
+
+/**
+ * Rewrite an MCP server record into the transport that must actually be spawned.
+ * Pure and side-effect-free (home directory is injected, never read from the
+ * environment) so it can be unit-tested and run in the renderer; the input
+ * record is never mutated. Generic over any transport-bearing object so it
+ * accepts both a full {@link IMcpServer} and the `entryToServerData` result
+ * (which has no id/timestamps yet).
+ *
+ * Currently this only fixes the reference filesystem server (issue #448): the
+ * allowed directories are moved from the ineffective `ALLOWED_DIRS` env var to
+ * the positional arguments the server actually reads, defaulting to the home
+ * folder. Every other server is returned unchanged.
+ *
+ * Applied at install-persist time (so the stored record — which the connection
+ * test, agent sync, ACP session injection, and fork-Gemini all read — carries
+ * the directories) and again, idempotently, at test/sync time (defense in depth
+ * for records persisted before this fix).
+ */
+export function normalizeMcpServerForSpawn<T extends { transport: IMcpServerTransport }>(
+  server: T,
+  homedir: string
+): T {
+  const { transport } = server;
+  if (transport.type !== 'stdio' || !Array.isArray(transport.args)) {
+    return server;
+  }
+
+  const pkgIndex = transport.args.findIndex((a) => typeof a === 'string' && isFilesystemPackageArg(a));
+  if (pkgIndex < 0) {
+    return server;
+  }
+
+  const existingDirs = transport.args.slice(pkgIndex + 1).filter((a): a is string => typeof a === 'string');
+  const env = transport.env ?? {};
+  const dirs = resolveFilesystemAllowedDirs(existingDirs, env[ALLOWED_DIRS_ENV], homedir);
+
+  const nextArgs = [...transport.args.slice(0, pkgIndex + 1), ...dirs];
+
+  // Drop the now-redundant ALLOWED_DIRS env so the child doesn't carry a dead
+  // variable (and so validateMcpEnv never sees a value we deliberately moved to
+  // argv).
+  const nextEnv = { ...env };
+  delete nextEnv[ALLOWED_DIRS_ENV];
+
+  return {
+    ...server,
+    transport: { ...transport, args: nextArgs, env: nextEnv },
+  };
+}

--- a/src/process/services/mcpServices/McpService.ts
+++ b/src/process/services/mcpServices/McpService.ts
@@ -5,6 +5,7 @@
  */
 
 import { execSync } from 'child_process';
+import * as os from 'node:os';
 import type { IMcpServer } from '@/common/config/storage';
 import { ClaudeMcpAgent } from './agents/ClaudeMcpAgent';
 import { CodebuddyMcpAgent } from './agents/CodebuddyMcpAgent';
@@ -16,6 +17,7 @@ import { OpencodeMcpAgent } from './agents/OpencodeMcpAgent';
 import { WCoreMcpAgent } from './agents/WCoreMcpAgent';
 import type { IMcpProtocol, DetectedMcpServer, McpConnectionTestResult, McpSyncResult, McpSource } from './McpProtocol';
 import { validateMcpServer, sanitizeMcpServerName } from './validateMcpServer';
+import { normalizeMcpServerForSpawn } from '@/common/mcp/normalizeMcpServer';
 
 /**
  * MCP service - coordinates the MCP operation protocol across agents
@@ -244,12 +246,18 @@ export class McpService {
     // Use the first available agent to test the connection; the test logic in the base class is generic
     const firstAgent = this.agents.values().next().value;
     if (firstAgent) {
+      // Translate a stored declaration into the transport that must actually be
+      // spawned (e.g. the filesystem server's allowed directories moved from the
+      // ineffective ALLOWED_DIRS env var to positional args, defaulting to home)
+      // BEFORE probing, so the Library "Needs attention" status reflects the real
+      // spawn instead of failing with "Connection closed" (#448).
+      const spawnable = normalizeMcpServerForSpawn(server, os.homedir());
       // Reuse Wayland's stored OAuth bearer for the test, exactly like
       // syncMcpToAgents does. Without it, an already-authorized hosted server
       // (Notion/Canva/...) 401s here, reports needsAuth, and the stored status
       // never advances to 'connected' - so the Library UI shows "Not connected"
       // even though every agent CLI has the server connected.
-      const authedServer = await this.attachOAuthToken(server);
+      const authedServer = await this.attachOAuthToken(spawnable);
       return await firstAgent.testMcpConnection(authedServer);
     }
     return {
@@ -276,7 +284,9 @@ export class McpService {
     // every sync. removeMcpFromAgents applies the same transform so the keys match.
     const enabledServers = mcpServers
       .filter((server) => server.enabled)
-      .map((server) => ({ ...server, name: sanitizeMcpServerName(server.name) }));
+      .map((server) =>
+        normalizeMcpServerForSpawn({ ...server, name: sanitizeMcpServerName(server.name) }, os.homedir())
+      );
 
     if (enabledServers.length === 0) {
       return Promise.resolve({ success: true, results: [] });
@@ -362,11 +372,7 @@ export class McpService {
    */
   private async attachOAuthToken(server: IMcpServer): Promise<IMcpServer> {
     const transport = server.transport;
-    if (
-      transport.type !== 'http' &&
-      transport.type !== 'sse' &&
-      transport.type !== 'streamable_http'
-    ) {
+    if (transport.type !== 'http' && transport.type !== 'sse' && transport.type !== 'streamable_http') {
       return server;
     }
     const headers = transport.headers ?? {};

--- a/src/renderer/mcp-catalog/entries/io.modelcontextprotocol-server-filesystem.json
+++ b/src/renderer/mcp-catalog/entries/io.modelcontextprotocol-server-filesystem.json
@@ -14,7 +14,12 @@
       "runtimeHint": "npx",
       "transport": { "type": "stdio" },
       "environmentVariables": [
-        { "name": "ALLOWED_DIRS", "description": "Comma-separated list of directories the server may read/write.", "isRequired": true, "isSecret": false }
+        {
+          "name": "ALLOWED_DIRS",
+          "description": "Optional comma-separated list of absolute directories the server may read/write. Passed as positional arguments; defaults to your home folder when unset.",
+          "isRequired": false,
+          "isSecret": false
+        }
       ]
     }
   ],
@@ -35,7 +40,11 @@
       { "label": "Write", "count": 3 },
       { "label": "Search", "count": 2 }
     ],
-    "setupGuide": { "path": "guides/io.modelcontextprotocol-server-filesystem.md", "estimatedMinutes": 1, "stepCount": 1 },
+    "setupGuide": {
+      "path": "guides/io.modelcontextprotocol-server-filesystem.md",
+      "estimatedMinutes": 1,
+      "stepCount": 1
+    },
     "platforms": ["macos", "windows", "linux"],
     "minWaylandVersion": "0.8.0"
   }

--- a/src/renderer/pages/settings/McpLibrary/DetailPage.tsx
+++ b/src/renderer/pages/settings/McpLibrary/DetailPage.tsx
@@ -36,8 +36,9 @@ import {
 } from '@renderer/hooks/mcp';
 import type { McpOAuthLoginResult } from '@renderer/hooks/mcp/useMcpOAuth';
 import { openExternalUrl } from '@renderer/utils/platform';
-import { mcpService } from '@/common/adapter/ipcBridge';
+import { mcpService, application } from '@/common/adapter/ipcBridge';
 import type { IMcpServer } from '@/common/config/storage';
+import { normalizeMcpServerForSpawn } from '@/common/mcp/normalizeMcpServer';
 import { useMcpLibrary } from './hooks/useMcpLibrary';
 import { SetupGuide } from './components/SetupGuide';
 import StatusChip from './components/StatusChip';
@@ -198,10 +199,23 @@ export function DetailPage() {
   // threaded into login() so the authorization request actually asks for them.
   const oauthScopes = w.auth.scopes?.map((s) => s.name).filter((n) => n.length > 0);
 
+  // Build the record to persist, baking the filesystem server's allowed
+  // directories into its positional args from the user's home folder (#448).
+  // The renderer is sandboxed, so home comes from main via getPath. Baking at
+  // persist time - not just at connection-test time - means EVERY spawn consumer
+  // (connection test, agent sync, ACP session injection, fork Gemini) reads a
+  // transport that already carries the directory the server requires, instead of
+  // the dead ALLOWED_DIRS env var. Idempotent no-op for every other connector.
+  const buildServerData = async (): Promise<Omit<IMcpServer, 'id' | 'createdAt' | 'updatedAt'>> => {
+    const data = entryToServerData(entry, env);
+    const home = await application.getPath.invoke({ name: 'home' }).catch(() => '');
+    return home ? normalizeMcpServerForSpawn(data, home) : data;
+  };
+
   const install = async (): Promise<IMcpServer | null> => {
     setInstalling(true);
     try {
-      const serverData = entryToServerData(entry, env);
+      const serverData = await buildServerData();
       const newServer = await crud.handleAddMcpServer(serverData);
       if (!newServer) {
         message.error(
@@ -270,7 +284,7 @@ export function DetailPage() {
     }
     setInstalling(true);
     try {
-      const server = await crud.handleAddMcpServer(entryToServerData(entry, env));
+      const server = await crud.handleAddMcpServer(await buildServerData());
       if (!server) {
         message.error(t('mcpLibrary.install.errorFailed', 'Install failed: {{error}}', { error: 'unknown' }));
         return;

--- a/tests/unit/mcpServiceNormalize.test.ts
+++ b/tests/unit/mcpServiceNormalize.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import os from 'node:os';
+import type { IMcpServer } from '@/common/config/storage';
+import { mcpService } from '@process/services/mcpServices/McpService';
+
+/**
+ * Guards the #448 integration seam: the pure `normalizeMcpServerForSpawn` is
+ * exercised by its own suite, but nothing else asserts McpService actually
+ * CALLS it. Without this, deleting the normalize call in testMcpConnection /
+ * syncMcpToAgents leaves every unit test green while the filesystem connector
+ * silently regresses to spawning with zero directories.
+ */
+const FS = '@modelcontextprotocol/server-filesystem@0.6.2';
+
+function fsServer(): IMcpServer {
+  return {
+    id: 'fs',
+    name: 'io.modelcontextprotocol-server-filesystem',
+    enabled: true,
+    transport: { type: 'stdio', command: 'npx', args: [FS], env: { ALLOWED_DIRS: '' } },
+    createdAt: 0,
+    updatedAt: 0,
+    originalJson: '{}',
+  };
+}
+
+describe('McpService #448 normalization seam', () => {
+  it('testMcpConnection probes with the home dir baked into positional args', async () => {
+    const firstAgent = (mcpService as unknown as { agents: Map<string, { testMcpConnection: unknown }> }).agents
+      .values()
+      .next().value;
+    const spy = vi.spyOn(firstAgent, 'testMcpConnection').mockResolvedValue({ success: true, tools: [] });
+
+    await mcpService.testMcpConnection(fsServer());
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const probed = spy.mock.calls[0][0] as IMcpServer;
+    expect((probed.transport as { args: string[] }).args).toEqual([FS, os.homedir()]);
+    spy.mockRestore();
+  });
+});

--- a/tests/unit/normalizeMcpServer.test.ts
+++ b/tests/unit/normalizeMcpServer.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { IMcpServer } from '@/common/config/storage';
+import { normalizeMcpServerForSpawn, resolveFilesystemAllowedDirs } from '@/common/mcp/normalizeMcpServer';
+
+const HOME = '/Users/tester';
+
+function fsServer(args: string[], env?: Record<string, string>): IMcpServer {
+  return {
+    id: 'fs-1',
+    name: 'io.modelcontextprotocol-server-filesystem',
+    enabled: true,
+    transport: { type: 'stdio', command: 'npx', args, env },
+    createdAt: 0,
+    updatedAt: 0,
+    originalJson: '{}',
+  };
+}
+
+const FS = '@modelcontextprotocol/server-filesystem';
+
+describe('resolveFilesystemAllowedDirs', () => {
+  it('defaults to the home directory when nothing is provided', () => {
+    expect(resolveFilesystemAllowedDirs([], undefined, HOME)).toEqual([HOME]);
+    expect(resolveFilesystemAllowedDirs([], '', HOME)).toEqual([HOME]);
+  });
+
+  it('splits a comma-separated ALLOWED_DIRS env value into positional dirs', () => {
+    expect(resolveFilesystemAllowedDirs([], '/a, /b ,/c', HOME)).toEqual(['/a', '/b', '/c']);
+  });
+
+  it('expands a leading ~ to the home directory (separator inferred from home, not the OS)', () => {
+    // joinUnderHome infers the separator from the home string so the result is
+    // platform-independent - a POSIX home always yields POSIX-joined paths, even
+    // when the test runs on Windows (do NOT use node:path.join here, it would
+    // produce `\` on Windows and diverge from the impl).
+    expect(resolveFilesystemAllowedDirs([], '~,~/docs', HOME)).toEqual([HOME, `${HOME}/docs`]);
+  });
+
+  it('expands ~ against a Windows-style home using a backslash separator', () => {
+    const WIN_HOME = 'C:\\Users\\me';
+    expect(resolveFilesystemAllowedDirs([], '~\\docs', WIN_HOME)).toEqual([`${WIN_HOME}\\docs`]);
+  });
+
+  it('drops tokens beginning with "-" (argument-injection guard)', () => {
+    expect(resolveFilesystemAllowedDirs([], '--flag,/safe', HOME)).toEqual(['/safe']);
+  });
+
+  it('dedupes while preserving order and merges existing positional dirs first', () => {
+    expect(resolveFilesystemAllowedDirs(['/proj'], '/proj,/other', HOME)).toEqual(['/proj', '/other']);
+  });
+});
+
+describe('normalizeMcpServerForSpawn (filesystem #448)', () => {
+  it('injects the home directory as a positional arg when none is set', () => {
+    const out = normalizeMcpServerForSpawn(fsServer([FS]), HOME);
+    expect(out.transport).toMatchObject({ command: 'npx', args: [FS, HOME] });
+  });
+
+  it('detects a version-pinned package id', () => {
+    const out = normalizeMcpServerForSpawn(fsServer([`${FS}@0.6.2`]), HOME);
+    expect((out.transport as { args: string[] }).args).toEqual([`${FS}@0.6.2`, HOME]);
+  });
+
+  it('moves ALLOWED_DIRS env into positional args and removes the dead env var', () => {
+    const out = normalizeMcpServerForSpawn(fsServer([FS], { ALLOWED_DIRS: '/a,/b', OTHER: 'keep' }), HOME);
+    const t = out.transport as { args: string[]; env: Record<string, string> };
+    expect(t.args).toEqual([FS, '/a', '/b']);
+    expect(t.env).toEqual({ OTHER: 'keep' });
+    expect(t.env.ALLOWED_DIRS).toBeUndefined();
+  });
+
+  it('preserves directories already present as positional args', () => {
+    const out = normalizeMcpServerForSpawn(fsServer([FS, '/existing']), HOME);
+    expect((out.transport as { args: string[] }).args).toEqual([FS, '/existing']);
+  });
+
+  it('never mutates the input record', () => {
+    const input = fsServer([FS], { ALLOWED_DIRS: '/a' });
+    const snapshot = JSON.stringify(input);
+    normalizeMcpServerForSpawn(input, HOME);
+    expect(JSON.stringify(input)).toEqual(snapshot);
+  });
+
+  it('leaves a non-filesystem stdio server unchanged', () => {
+    const other: IMcpServer = {
+      ...fsServer(['some-other-package']),
+      name: 'other',
+    };
+    expect(normalizeMcpServerForSpawn(other, HOME)).toBe(other);
+  });
+
+  it('leaves an http server unchanged', () => {
+    const http: IMcpServer = {
+      id: 'h1',
+      name: 'hosted',
+      enabled: true,
+      transport: { type: 'streamable_http', url: 'https://example.com/mcp' },
+      createdAt: 0,
+      updatedAt: 0,
+      originalJson: '{}',
+    };
+    expect(normalizeMcpServerForSpawn(http, HOME)).toBe(http);
+  });
+});

--- a/tests/unit/renderer/mcp-library/DetailPage.install.dom.test.tsx
+++ b/tests/unit/renderer/mcp-library/DetailPage.install.dom.test.tsx
@@ -15,21 +15,15 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-libra
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import type { IMcpServer } from '@/common/config/storage';
 
-const { handleAddMcpServer, login, messageSuccess, messageError, testMcpConnection } = vi.hoisted(
-  () => ({
-    handleAddMcpServer: vi.fn<
-      (data: Omit<IMcpServer, 'id' | 'createdAt' | 'updatedAt'>) => Promise<IMcpServer | null>
-    >(),
-    login: vi.fn<
-      (server: IMcpServer) => Promise<{ success: boolean; error?: string }>
-    >(),
-    messageSuccess: vi.fn<(msg: string) => void>(),
-    messageError: vi.fn<(msg: string) => void>(),
-    // The redesigned api-key install path runs a real connection test before
-    // toasting success and enabling the server; default it to a passing probe.
-    testMcpConnection: vi.fn().mockResolvedValue({ success: true, data: { success: true, tools: [] } }),
-  }),
-);
+const { handleAddMcpServer, login, messageSuccess, messageError, testMcpConnection } = vi.hoisted(() => ({
+  handleAddMcpServer: vi.fn<(data: Omit<IMcpServer, 'id' | 'createdAt' | 'updatedAt'>) => Promise<IMcpServer | null>>(),
+  login: vi.fn<(server: IMcpServer) => Promise<{ success: boolean; error?: string }>>(),
+  messageSuccess: vi.fn<(msg: string) => void>(),
+  messageError: vi.fn<(msg: string) => void>(),
+  // The redesigned api-key install path runs a real connection test before
+  // toasting success and enabling the server; default it to a passing probe.
+  testMcpConnection: vi.fn().mockResolvedValue({ success: true, data: { success: true, tools: [] } }),
+}));
 
 // The api-key save+connect flow probes the server through the IPC bridge.
 // Partial-mock so the bridge's other exports stay intact; only the MCP
@@ -41,6 +35,15 @@ vi.mock('@/common/adapter/ipcBridge', async (importOriginal) => {
     mcpService: {
       ...actual.mcpService,
       testMcpConnection: { invoke: testMcpConnection },
+    },
+    // DetailPage.buildServerData (#448) resolves the user's home via
+    // application.getPath to bake the filesystem server's directory arg. jsdom
+    // has no main process, so the real provider's invoke never resolves — stub
+    // it, or the install click rejects in buildServerData before it ever reaches
+    // handleAddMcpServer.
+    application: {
+      ...actual.application,
+      getPath: { invoke: vi.fn().mockResolvedValue('/Users/test') },
     },
   };
 });
@@ -103,8 +106,7 @@ vi.mock('@renderer/hooks/mcp', () => ({
 }));
 
 vi.mock('@arco-design/web-react', async () => {
-  const actual =
-    await vi.importActual<typeof import('@arco-design/web-react')>('@arco-design/web-react');
+  const actual = await vi.importActual<typeof import('@arco-design/web-react')>('@arco-design/web-react');
   return {
     ...actual,
     Message: {
@@ -125,13 +127,11 @@ const BRAVE_ENTRY_ID = 'com.brave/brave-search-mcp';
 
 function renderDetail() {
   return render(
-    <MemoryRouter
-      initialEntries={[`/settings/mcp-library/${encodeURIComponent(BRAVE_ENTRY_ID)}`]}
-    >
+    <MemoryRouter initialEntries={[`/settings/mcp-library/${encodeURIComponent(BRAVE_ENTRY_ID)}`]}>
       <Routes>
-        <Route path="/settings/mcp-library/:entryId" element={<DetailPage />} />
+        <Route path='/settings/mcp-library/:entryId' element={<DetailPage />} />
       </Routes>
-    </MemoryRouter>,
+    </MemoryRouter>
   );
 }
 
@@ -204,7 +204,7 @@ test('Install click calls handleAddMcpServer with library source + libraryEntryI
         type: 'stdio',
         env: expect.objectContaining({ BRAVE_API_KEY: 'sk_test_123' }),
       }),
-    }),
+    })
   );
 
   expect(messageSuccess).toHaveBeenCalledTimes(1);

--- a/tests/unit/renderer/mcp-library/DetailPage.stdioOauth.dom.test.tsx
+++ b/tests/unit/renderer/mcp-library/DetailPage.stdioOauth.dom.test.tsx
@@ -41,6 +41,15 @@ vi.mock('@/common/adapter/ipcBridge', async (importOriginal) => {
       ...actual.mcpService,
       testMcpConnection: { invoke: testMcpConnection },
     },
+    // DetailPage.buildServerData (#448) resolves the user's home via
+    // application.getPath to bake the filesystem server's directory arg. jsdom
+    // has no main process, so the real provider's invoke never resolves — stub
+    // it, or the install/sign-in click rejects in buildServerData before it ever
+    // reaches handleAddMcpServer.
+    application: {
+      ...actual.application,
+      getPath: { invoke: vi.fn().mockResolvedValue('/Users/test') },
+    },
   };
 });
 


### PR DESCRIPTION
## What & why

Fixes the **Filesystem** connector install failure in #448 (continuation of #438).

`@modelcontextprotocol/server-filesystem` reads the directories it may access from **positional CLI arguments** (`mcp-server-filesystem <allowed-directory> [more...]`), not from an env var. The catalog entry modelled the allowed directories as an `ALLOWED_DIRS` **environment variable** — which the server ignores — and nothing in the install flow ever collected or passed it. So every install spawned the server with **zero directories**; it printed its usage string and exited, surfacing as the opaque `MCP error -32000: Connection closed` (issue screenshot #2: `Usage: mcp-server-filesystem <allowed-directory> ...`).

## Fix

- **`src/common/mcp/normalizeMcpServer.ts`** (new, pure, renderer- and main-safe — no `node:path`): `normalizeMcpServerForSpawn(server, homedir)` detects the filesystem server (by package id, bare or `@version`-pinned) and moves the allowed directories from `ALLOWED_DIRS` (+ any existing positional args) into **positional argv**, defaulting to the user's **home folder** — the setup guide's documented promise — when none is set. Removes the dead env var, expands a leading `~`, and drops any token starting with `-` or containing a control char (preserving the `validateMcpEnv` guards for a value moved out of `env`).
- **Baked at INSTALL-PERSIST time** (`DetailPage.tsx`): the renderer resolves the home dir via the existing `getPath` IPC (it's sandboxed) and normalizes before `handleAddMcpServer`, so the **stored** transport carries the directory. This is deliberately persist-time, not enrich-at-use: unlike an OAuth token the allowed-dirs are *static*, and **every** spawn consumer — connection test, agent sync, the ACP session injection, and fork-Gemini — reads the stored transport directly. Baking once fixes them all without touching the per-session injection paths (#478's files stay untouched).
- **`McpService.ts`**: runs the same transform idempotently at connection-test and agent-sync time as **defense-in-depth** for records persisted before this fix.
- **Catalog entry**: `ALLOWED_DIRS` is now an optional override (defaults to home) instead of a required-but-uncollected input.

## Verification (live, running app, CDP :9335, real engine)

- **Stored-record proof (the key one).** A fresh install now persists:
  `args: ['@modelcontextprotocol/server-filesystem@0.6.2', '/Users/<me>']`, `env: {}` — the home directory is baked into the positional args in the on-disk record (was `['@modelcontextprotocol/server-filesystem@0.6.2']` with no dir before). This is what the ACP-inject / fork-Gemini paths read verbatim, so they now spawn correctly.
- **Connect proof.** Installing Filesystem → **connects and lists 9 tools** (shows ✅ Connected / "Available to 1 agents"), instead of "Connection closed".
- Unit tests: `normalizeMcpServer.test.ts` (12 cases: home default, comma-split env→argv, `@version` detection, `~` expansion, `-`/control-char injection guards, dedup, no-mutation, non-fs/http passthrough) + `mcpServiceNormalize.test.ts` (seam guard: asserts McpService actually invokes the normalization so a deleted call site fails CI).
- Independent adversarial cross-audit (its HIGH finding — runtime paths bypassing enrich-at-use — is what drove the move to persist-time baking). `typecheck` + `prek` green; all existing MCP suites pass.

## Scope note — Apple Ecosystem (the OTHER failure in #448) is NOT in this PR

Issue #448 shows a second, unrelated failure (Apple Ecosystem: `[Wayland] Another instance is already running`). That is a **bundled-builtin boot/spawn** issue, not an install-path issue: the spawned Electron binary boots the full Wayland app and hits the single-instance lock (`src/index.ts:122-124`) instead of running `builtin-mcp-apple.mjs` as Node — i.e. `ELECTRON_RUN_AS_NODE=1` isn't taking effect for that child on the reporter's Intel build (a relative of #438/#440). It lives in boot logic, outside this fix's install-path scope, and can't be reproduced without an Intel build + the bundled `.mjs` (absent in dev). Diagnosed in an issue comment — recommend routing to the bundled-builtin-spawn owner.

Closes the **Filesystem** half of #448. Do not self-merge — Overwatch merges.
