### PR TITLE
fix(shutdown): reap orphaned wayland-core / ACP engine children on quit (#443)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1137,6 +1137,10 @@ type CleanupModules = {
   // #139: reap webhook tunnel CLIs (cloudflared/ngrok/tailscale) on quit so
   // their long-lived child processes don't orphan past the app.
   tunnel: typeof import('@process/channels/tunnel');
+  // #443: last-resort reaper for wayland-core / ACP engine children. Runs after
+  // the graceful per-agent kill to force-kill any child left over (e.g. when the
+  // per-step budget truncates a slow kill), so engine processes never orphan.
+  agentChildren: typeof import('@process/agent/agentChildRegistry');
 };
 let _cleanupModulesPromise: Promise<CleanupModules> | undefined;
 
@@ -1152,6 +1156,7 @@ const prefetchCleanupModules = (): Promise<CleanupModules> => {
     import('@process/services/cron/cronServiceSingleton'),
     import('@process/bridge/fileWatchBridge'),
     import('@process/channels/tunnel'),
+    import('@process/agent/agentChildRegistry'),
   ]).then(
     ([
       ambient,
@@ -1164,6 +1169,7 @@ const prefetchCleanupModules = (): Promise<CleanupModules> => {
       cron,
       fileWatch,
       tunnel,
+      agentChildren,
     ]) => ({
       ambient,
       channels,
@@ -1175,6 +1181,7 @@ const prefetchCleanupModules = (): Promise<CleanupModules> => {
       cron,
       fileWatch,
       tunnel,
+      agentChildren,
     })
   );
 };
@@ -1315,6 +1322,11 @@ app.on('before-quit', async () => {
       safeImport('cron', () => import('@process/services/cron/cronServiceSingleton')),
       safeImport('fileWatch', () => import('@process/bridge/fileWatchBridge')),
       safeImport('tunnel', () => import('@process/channels/tunnel')),
+      // #443: must be in the fallback list too - the fallback path is hit exactly
+      // when the prefetch rejected (e.g. a native module failed to load, common
+      // on Windows - the platform this reaper targets), so omitting it here would
+      // silently disable the reaper in the case it is most needed.
+      safeImport('agentChildren', () => import('@process/agent/agentChildRegistry')),
     ]);
     const out: Partial<CleanupModules> = {};
     for (const [k, v] of entries) {
@@ -1459,6 +1471,21 @@ app.on('before-quit', async () => {
       pptPreviewStep,
       fileWatchStep,
     ]);
+
+    // #443: last-resort engine-child reaper. Runs AFTER the graceful path above
+    // (workerStep -> WorkerTaskManager.clear() -> per-agent kill), so normally
+    // there is nothing left. It force-kills any wayland-core / ACP child still
+    // alive - e.g. when a per-agent graceful kill was truncated by its 2s budget,
+    // or a child was spawned outside a tracked manager - so engine processes
+    // never orphan past the app (the "two sets of Wayland" report).
+    await withTimeout(
+      'killAllAgentChildren',
+      (async () => {
+        if (!mods.agentChildren) return;
+        await mods.agentChildren.killAllAgentChildren();
+      })(),
+      PER_STEP_TIMEOUT_MS
+    );
   };
 
   // Master ceiling: hard 10s upper bound on the entire cleanup phase.

--- a/src/process/agent/acp/AcpConnection.ts
+++ b/src/process/agent/acp/AcpConnection.ts
@@ -28,6 +28,7 @@ import path from 'path';
 import { connectClaude, connectCodebuddy, connectCodex, spawnGenericBackend } from './acpConnectors';
 import type { SpawnResult } from './acpConnectors';
 import { killChild, readTextFile, writeJsonRpcMessage, writeTextFile } from './utils';
+import { trackAgentChild } from '@process/agent/agentChildRegistry';
 // W4 audit CRIT-1 (2026-05-19): route ACP fs ops through the imported-team
 // sandbox gate before falling back to the legacy direct-fs helpers.
 import { gateAcpFileOp } from '@process/team/sandbox/acpFileOpGate';
@@ -182,6 +183,11 @@ export class AcpConnection {
   private async spawnAndSetup(result: SpawnResult, backend: string): Promise<void> {
     this.child = result.child;
     this.isDetached = result.isDetached;
+    // #443: register with the last-resort reaper so a quit that truncates the
+    // graceful per-agent kill still force-kills this backend child (auto-removed
+    // on exit / disconnect). Pass isDetached so the reaper group-kills it exactly
+    // like terminateChild does.
+    trackAgentChild(this.child, this.isDetached);
     await this.setupChildProcessHandlers(backend);
   }
 
@@ -1187,21 +1193,16 @@ export class AcpConnection {
   // teams fall through to the unchanged legacy direct-fs path.
   private async handleReadOperation(params: { path: string; sessionId?: string }): Promise<{ content: string }> {
     const conversationId = this.conversationId ?? '';
-    const gated = await gateAcpFileOp(
-      conversationId,
-      'read',
-      { path: params.path },
-      async () => {
-        const resolvedReadPath = this.resolveWorkspacePath(params.path);
-        this.onFileOperation({
-          method: 'fs/read_text_file',
-          path: resolvedReadPath,
-          sessionId: params.sessionId || '',
-        });
-        const { content } = await readTextFile(resolvedReadPath);
-        return { kind: 'read' as const, content };
-      }
-    );
+    const gated = await gateAcpFileOp(conversationId, 'read', { path: params.path }, async () => {
+      const resolvedReadPath = this.resolveWorkspacePath(params.path);
+      this.onFileOperation({
+        method: 'fs/read_text_file',
+        path: resolvedReadPath,
+        sessionId: params.sessionId || '',
+      });
+      const { content } = await readTextFile(resolvedReadPath);
+      return { kind: 'read' as const, content };
+    });
     if (gated.kind !== 'read') {
       throw new Error('handleReadOperation: gate returned non-read result');
     }

--- a/src/process/agent/agentChildRegistry.ts
+++ b/src/process/agent/agentChildRegistry.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Last-resort registry of live agent engine child processes (wayland-core over
+ * `--json-stream`, and ACP backend CLIs).
+ *
+ * #443: the primary teardown path is per-agent and graceful -
+ * `WorkerTaskManager.clear()` in before-quit awaits each manager's `kill()`,
+ * which runs `WCoreAgent.kill()` / `AcpConnection.disconnect()` -> `killChild`.
+ * That path is correct but not sufficient on its own to guarantee no orphans on
+ * quit:
+ *   - `clear()` runs under a 2s per-step budget in before-quit, while a single
+ *     graceful `killChild` can take up to 3s (POSIX SIGTERM grace) / 5s (Windows
+ *     taskkill). A slow or SIGTERM-ignoring engine child can therefore be left
+ *     mid-kill when the budget elapses, orphaning `wayland-core` past the app.
+ *   - a child spawned outside a tracked manager would never be reaped at all.
+ *
+ * This registry backs a hard, fast last-resort reaper (`killAllAgentChildren`)
+ * wired as the final before-quit step. It runs AFTER the graceful path, so in
+ * the common case there is nothing left to kill; it only force-kills stragglers.
+ */
+import type { ChildProcess } from 'node:child_process';
+import { killChild } from '@process/agent/acp/utils';
+
+// Maps each live child to whether it was spawned detached (its own process
+// group), so the reaper can group-kill it exactly like the graceful path.
+const liveAgentChildren = new Map<ChildProcess, boolean>();
+
+/**
+ * Track a freshly spawned engine child so the before-quit reaper can force-kill
+ * it if the graceful per-agent teardown does not reach it in time. The child is
+ * removed automatically on its own `exit`, so a child that dies normally (or via
+ * the graceful `killChild`) leaves the registry without any extra bookkeeping.
+ *
+ * @param isDetached whether the child was spawned with `detached: true` (needs a
+ *   process-group kill), mirroring what the owning manager passes to `killChild`.
+ */
+export function trackAgentChild(child: ChildProcess | null | undefined, isDetached = false): void {
+  if (!child) return;
+  liveAgentChildren.set(child, isDetached);
+  // Auto-remove when the child is gone. Listen on all three terminal events, not
+  // just `exit`: a spawn failure (ENOENT etc.) emits `error` and NO `exit`, so
+  // relying on `exit` alone would leak that child in the registry for the whole
+  // session. `delete` is idempotent, so whichever fires first wins.
+  const drop = () => liveAgentChildren.delete(child);
+  child.once('exit', drop);
+  child.once('error', drop);
+  child.once('close', drop);
+}
+
+/** Number of engine children currently tracked (test/introspection helper). */
+export function liveAgentChildCount(): number {
+  return liveAgentChildren.size;
+}
+
+/**
+ * Force-kill every still-live engine child. Called from before-quit as a final
+ * safety net. Uses a short SIGTERM grace before SIGKILL escalation (POSIX) /
+ * `taskkill /T /F` (Windows) via the shared {@link killChild}, since the app is
+ * exiting and we cannot afford the full graceful wait. Best-effort: killing an
+ * already-dead pid is a no-op, so overlap with the graceful path is harmless.
+ */
+export async function killAllAgentChildren(sigtermGraceMs = 500): Promise<void> {
+  const children = [...liveAgentChildren.entries()];
+  liveAgentChildren.clear();
+  if (children.length === 0) return;
+  await Promise.allSettled(children.map(([child, isDetached]) => killChild(child, isDetached, sigtermGraceMs)));
+}

--- a/src/process/agent/wcore/index.ts
+++ b/src/process/agent/wcore/index.ts
@@ -16,6 +16,7 @@ import { resolveActiveConfigDir } from './profilePaths';
 import { getToolKeyStore } from './toolKeyStore';
 import { hydrateModelForSpawn } from '@process/providers/ipc/modelRegistryIpc';
 import { killChild } from '@process/agent/acp/utils';
+import { trackAgentChild } from '@process/agent/agentChildRegistry';
 import type { WCoreEvent, WCoreCommand, WCoreCapabilities } from './protocol';
 import { parseQuestionTool } from './questionTool';
 
@@ -234,6 +235,10 @@ export class WCoreAgent {
       stdio: ['pipe', 'pipe', 'pipe'],
       cwd: this.options.workspace,
     });
+    // #443: register with the last-resort reaper so a quit that truncates the
+    // graceful per-agent kill still force-kills this engine child (auto-removed
+    // on exit / graceful kill).
+    trackAgentChild(this.childProcess);
 
     // Parse stdout JSON Lines
     const rl = createInterface({ input: this.childProcess.stdout! });

--- a/tests/unit/agentChildRegistry.test.ts
+++ b/tests/unit/agentChildRegistry.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * #443: the last-resort engine-child reaper. The graceful per-agent kill
+ * (WorkerTaskManager.clear -> manager.kill -> killChild) is the primary path;
+ * this registry-backed reaper runs as the final before-quit step and force-kills
+ * any wayland-core / ACP child still alive, so engine processes never orphan past
+ * the app ("two sets of Wayland").
+ *
+ * These tests spawn REAL child processes (POSIX) to exercise the actual kill,
+ * mirroring tests/unit/acpKillChild.test.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawn } from 'child_process';
+import { isProcessAlive } from '../../src/process/agent/acp/utils';
+import { trackAgentChild, killAllAgentChildren, liveAgentChildCount } from '../../src/process/agent/agentChildRegistry';
+
+const describeIfPosix = process.platform === 'win32' ? describe.skip : describe;
+
+describeIfPosix('agentChildRegistry - last-resort reaper (#443)', () => {
+  it('force-kills every tracked child and empties the registry', async () => {
+    const a = spawn('sleep', ['60']);
+    const b = spawn('sleep', ['60']);
+    trackAgentChild(a);
+    trackAgentChild(b);
+    expect(liveAgentChildCount()).toBe(2);
+    expect(isProcessAlive(a.pid!)).toBe(true);
+    expect(isProcessAlive(b.pid!)).toBe(true);
+
+    // Short grace so the SIGTERM->SIGKILL escalation path doesn't pay the full
+    // production wait; behavior is identical.
+    await killAllAgentChildren(250);
+
+    expect(isProcessAlive(a.pid!)).toBe(false);
+    expect(isProcessAlive(b.pid!)).toBe(false);
+    expect(liveAgentChildCount()).toBe(0);
+  });
+
+  it('group-kills a detached child tree when tracked as detached', async () => {
+    // Parent spawns two grandchildren in its own process group.
+    const parent = spawn('bash', ['-c', 'sleep 60 & sleep 60 & wait'], { detached: true });
+    parent.unref();
+    trackAgentChild(parent, true);
+    await new Promise((r) => setTimeout(r, 300)); // let grandchildren spawn
+    expect(isProcessAlive(parent.pid!)).toBe(true);
+
+    await killAllAgentChildren(250);
+
+    expect(isProcessAlive(parent.pid!)).toBe(false);
+    expect(liveAgentChildCount()).toBe(0);
+  });
+
+  it('reaps a child even when it ignores SIGTERM (SIGKILL escalation)', async () => {
+    const child = spawn('bash', ['-c', 'trap "" TERM; sleep 60']);
+    trackAgentChild(child);
+    await new Promise((r) => setTimeout(r, 200)); // let the trap install
+    expect(isProcessAlive(child.pid!)).toBe(true);
+
+    await killAllAgentChildren(250);
+
+    expect(isProcessAlive(child.pid!)).toBe(false);
+    expect(liveAgentChildCount()).toBe(0);
+  });
+
+  it('auto-removes a child that exits on its own (no leak, nothing to reap)', async () => {
+    const child = spawn('sleep', ['0.05']);
+    trackAgentChild(child);
+    expect(liveAgentChildCount()).toBe(1);
+
+    // Wait for natural exit; the once("exit") handler must drop it from the set.
+    await new Promise<void>((resolve) => child.once('exit', () => resolve()));
+    // exit handlers fire on the same tick set; yield once to be safe.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(liveAgentChildCount()).toBe(0);
+
+    // Reaping an empty registry is a no-op.
+    await expect(killAllAgentChildren(250)).resolves.toBeUndefined();
+  });
+
+  it('auto-removes a child that fails to spawn (error, no exit) so it does not leak', async () => {
+    // A spawn failure emits `error` and NO `exit`; the registry must still drop it.
+    const child = spawn('wayland-nonexistent-binary-xyz-123', []);
+    trackAgentChild(child);
+    await new Promise<void>((resolve) => child.once('error', () => resolve()));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(liveAgentChildCount()).toBe(0);
+  });
+
+  it('ignores null/undefined children', () => {
+    const before = liveAgentChildCount();
+    trackAgentChild(null);
+    trackAgentChild(undefined);
+    expect(liveAgentChildCount()).toBe(before);
+  });
+});


### PR DESCRIPTION
## What & why

#443 (Windows): after closing the app, `wayland-core` engine children (and sometimes the app) keep running — "two sets of Wayland".

### Investigation (root-cause refinement)

The per-agent graceful teardown the issue implies is *missing* actually **already exists**: `before-quit` runs `WorkerTaskManager.clear()`, which awaits each manager's `kill()`; `WCoreManager.kill()` and `AcpAgentManager.kill()` both override to call `agent.kill()` → `WCoreAgent.kill()` / `AcpConnection.disconnect()` → `killChild()` (SIGTERM→SIGKILL / Windows `taskkill /T /F`).

That path is correct but **not sufficient on its own**:
- `clear()` runs under a **2s per-step budget** in before-quit, while a single `killChild` can take up to **3s** (POSIX SIGTERM grace) / **5s** (Windows `taskkill` timeout). A slow or SIGTERM-ignoring engine child can be left mid-kill when the budget elapses → orphan.
- a child spawned outside a tracked manager is never reaped.

## Fix — last-resort engine-child reaper

- **`agentChildRegistry`** (new): tracks every spawned engine child (`WCoreAgent` + ACP `AcpConnection`) with its `detached` flag, auto-removing on `exit`/`error`/`close` (`error` covers spawn failures that never emit `exit`, so the registry can't leak).
- **`killAllAgentChildren()`**: force-kills all survivors via the shared `killChild` (short grace → SIGKILL / `taskkill /T /F`), group-killing detached trees.
- Wired as the **final** `before-quit` step, *after* the graceful path, so normally there's nothing left — it only catches stragglers. Added to **both** the prefetched cleanup modules **and** the fallback `loadModules` path (the fallback is hit exactly when the prefetch rejected — e.g. a native module failed to load on Windows — so omitting it there would silently disable the reaper when it's most needed).

## Verification

- **Unit tests** (`tests/unit/agentChildRegistry.test.ts`, real child processes, POSIX): force-kills all tracked children + empties the registry; **group-kills a detached child tree**; SIGKILL-escalates a SIGTERM-ignoring child; auto-removes a naturally-exited child; **auto-removes a failed spawn (`error`, no `exit`) — no leak**; ignores null.
- **Independent cross-audit** found one real defect — the fallback `loadModules` path omitted `agentChildren`, silently skipping the reaper exactly on the prefetch-rejection case (common on Windows). **Fixed.** All other angles (destructuring order, double-kill safety, detached kill, master-ceiling, import cycles) audited clean.
- **Mac sanity check**: built app boots with the change; a real turn spawns a tracked `wayland-core` process tree (node wrapper → binary); the reaper (`killAllAgentChildren`/`trackAgentChild`) is compiled into the shipped `out/main/index.js` before-quit step. `typecheck` + `oxlint` + `oxfmt` + `prek` green.

## Notes for the Windows verify (routing to Overwatch)

While tracing this I found two adjacent factors worth a Windows check, since they may be what the reporter actually saw:
1. **Close-to-tray is ON by default** — the main window's `close` handler `preventDefault()`s and hides to tray unless `getIsQuitting()` (src/index.ts:756). So clicking X **keeps the app (and its wcore children) running by design**; a real quit (tray "Quit" / Cmd+Q, which sets `isQuitting`) runs before-quit and now the reaper. The "app doesn't fully close" perception may be this UX, not a leak.
2. Locally (mac) the wcore children self-exit on parent-stdin EOF when the app process dies; on Windows they don't, so the reaper matters more there.

This PR fixes the genuine quit-time orphan gap (budget-truncation + untracked children). Whether the report is primarily that, close-to-tray UX, or a single-instance-lock issue on Windows should be confirmed on the Windows box.

Refs #443
