### PR TITLE
fix(codex): stop rewriting user ~/.codex/config.toml for sandbox mode (#536)

### DIFF
--- a/src/process/connectors/codex.ts
+++ b/src/process/connectors/codex.ts
@@ -22,7 +22,7 @@
  *
  * Writes are surgical: we replace ONLY the `[model_providers.flux]` block as a
  * text section (regex-anchored), leaving every other table, key, and comment
- * byte-identical. This mirrors `writeCodexSandboxMode`'s text-merge philosophy
+ * byte-identical. This mirrors `setSandboxModeInConfig`'s text-merge philosophy
  * and avoids a comment-dropping full TOML round-trip. Reads use `smol-toml`
  * (already a dependency) to detect the on-disk flux provider for drift.
  */
@@ -45,8 +45,8 @@ type JsonObject = Record<string, unknown>;
 
 /**
  * Resolve codex's config file path. Honors `CODEX_HOME` (else `~/.codex`) via
- * the shared `getCodexConfigPath` so this connector and `writeCodexSandboxMode`
- * always agree on the file they mutate.
+ * the shared `getCodexConfigPath` so this connector and the codex config layer
+ * always agree on the file they read.
  */
 export function resolveCodexConfigPath(): string {
   return getCodexConfigPath();
@@ -155,7 +155,7 @@ export async function setupCodex(ctx: ConnectorContext): Promise<FluxConnectorRe
       parsed = parseToml(raw) as JsonObject;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      throw new Error(`codex config at ${configPath} is not valid TOML: ${message}`);
+      throw new Error(`codex config at ${configPath} is not valid TOML: ${message}`, { cause: err });
     }
     priorBaseURL = readFluxBaseURL(parsed);
   }

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -46,9 +46,9 @@ import { mainWarn, mainError } from '@process/utils/mainLogger';
 import {
   getCodexSandboxModeForSessionMode,
   materializeFluxCodexHome,
+  materializeNativeCodexHome,
   normalizeCodexSandboxMode,
   type CodexSandboxMode,
-  writeCodexSandboxMode,
 } from '@process/task/codexConfig';
 import { materializeFluxClaudeConfigDir } from '@process/task/claudeConfig';
 import { materializeFluxHermesHome } from '@process/task/hermesConfig';
@@ -696,6 +696,20 @@ ${collectedResponses.join('\n')}`;
       }
     }
 
+    // Native (non-Flux) codex spawns: point CODEX_HOME at a Wayland-scoped clone
+    // of the user's ~/.codex so we can set the session sandbox mode WITHOUT ever
+    // writing the user's own config.toml (#536). The clone copies their config
+    // verbatim (model/provider/MCP/settings) + mirrors auth.json, overriding only
+    // sandbox_mode. Flux-routed codex already got its own scoped CODEX_HOME above.
+    if (data.backend === 'codex' && decision.routing !== 'flux') {
+      try {
+        const sandboxMode = normalizeCodexSandboxMode(data.sandboxMode);
+        mergedEnv.CODEX_HOME = await materializeNativeCodexHome(app.getPath('userData'), sandboxMode);
+      } catch (err) {
+        mainWarn('[AcpAgentManager]', 'materializeNativeCodexHome failed', err);
+      }
+    }
+
     // Native (non-Flux) claude slot picks (sonnet/opus/haiku) get no model list
     // from the bridge under subscription/OAuth auth, so an in-place set_model is
     // unreliable. Back the pick with ANTHROPIC_MODEL at spawn so the chosen slot
@@ -934,12 +948,14 @@ ${collectedResponses.join('\n')}`;
     }
 
     if (data.backend === 'codex') {
-      const sandboxMode = getCodexSandboxModeForSessionMode(
+      // #536: resolve the sandbox mode for this session and carry it on `data`
+      // so resolveAgentCliConfig materializes a scoped CODEX_HOME with it. We no
+      // longer write the user's ~/.codex/config.toml. Default is read-only; only
+      // an explicit escalated session mode raises it (see codexConfig.ts).
+      data.sandboxMode = getCodexSandboxModeForSessionMode(
         data.sessionMode || this.currentMode,
-        data.sandboxMode || codexConfig?.sandboxMode || 'workspace-write'
-      ) as CodexSandboxMode;
-      await writeCodexSandboxMode(sandboxMode);
-      data.sandboxMode = sandboxMode;
+        data.sandboxMode || codexConfig?.sandboxMode
+      );
     }
 
     return { cliPath, customArgs, yoloMode };
@@ -2107,9 +2123,11 @@ ${collectedResponses.join('\n')}`;
       const prev = this.currentMode;
       this.currentMode = mode;
       this.yoloMode = this.isYoloMode(mode);
-      const sandboxMode = getCodexSandboxModeForSessionMode(mode, this.options.sandboxMode);
-      this.options.sandboxMode = sandboxMode;
-      await writeCodexSandboxMode(sandboxMode);
+      // #536: persist the resolved sandbox mode on options so the next codex
+      // spawn's scoped CODEX_HOME (materializeNativeCodexHome) carries it. We no
+      // longer write the user's ~/.codex/config.toml. codex-acp has no live
+      // set_mode, so the change applies on the next spawn regardless.
+      this.options.sandboxMode = getCodexSandboxModeForSessionMode(mode, this.options.sandboxMode);
       this.saveSessionMode(mode);
 
       if (this.isYoloMode(prev) && !this.isYoloMode(mode)) {

--- a/src/process/task/codexConfig.ts
+++ b/src/process/task/codexConfig.ts
@@ -7,9 +7,19 @@
 import { isCodexNoSandboxMode } from '@/common/types/codex/codexModes';
 import { FLUX_AUTO_MODEL, FLUX_MODEL_DISPLAY, FLUX_MODEL_IDS, FLUX_SURFACE } from '@/common/config/flux';
 import { parse as parseToml, stringify as stringifyToml } from 'smol-toml';
-import { copyFile, mkdir, readFile, writeFile } from 'fs/promises';
+import { access, copyFile, mkdir, readFile, rm, symlink, writeFile } from 'fs/promises';
 import { homedir } from 'os';
 import { join, posix, win32 } from 'path';
+
+/** True when a path exists (file, dir, or symlink target), false otherwise. */
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 export type CodexSandboxMode = 'read-only' | 'workspace-write' | 'danger-full-access';
 
@@ -109,13 +119,26 @@ function setSandboxModeInConfig(content: string, sandboxMode: CodexSandboxMode):
  *      MCP servers and every custom setting are preserved), then
  *   2. overrides ONLY the top-level `sandbox_mode` with the value Wayland
  *      resolved for this session, and
- *   3. mirrors the user's real `auth.json` into the scoped home so ChatGPT /
- *      API-key login keeps working (codex reads its credential from
- *      `$CODEX_HOME/auth.json`).
+ *   3. SYMLINKS the scoped `auth.json` at the user's real `auth.json` so ChatGPT
+ *      / API-key login keeps working AND a token refresh codex-acp writes into
+ *      the scoped home writes straight through to the user's real file (both
+ *      directions stay in sync; codex reads its credential from
+ *      `$CODEX_HOME/auth.json`). A copy would let a subscription-token refresh
+ *      inside the scoped home be lost on the next re-clone, forcing repeated
+ *      re-auth for ChatGPT-sub users.
  *
- * The user's real `~/.codex` is never written. `userDataDir` is the app's
- * userData path (caller passes `app.getPath('userData')`); `userConfigPath` /
- * `userAuthPath` are injectable so this stays unit-testable without electron.
+ * The user's real `~/.codex` config.toml is never written (that is the whole
+ * point of #536); only auth.json is a symlink through to the user's file.
+ *
+ * Concurrency (known LOW limitation): `codex-home` is a FIXED path
+ * re-materialized per spawn with no lock, so two near-simultaneous native codex
+ * spawns with different sandbox modes can race on config.toml. It fails safe -
+ * the default is read-only, and codex reads config only at startup so a running
+ * process is unaffected by a later re-write. Not worth per-conversation subdirs.
+ *
+ * `userDataDir` is the app's userData path (caller passes
+ * `app.getPath('userData')`); `userConfigPath` / `userAuthPath` are injectable
+ * so this stays unit-testable without electron.
  */
 export async function materializeNativeCodexHome(
   userDataDir: string,
@@ -141,13 +164,28 @@ export async function materializeNativeCodexHome(
   await mkdir(codexHomeDir, { recursive: true });
   await writeFile(configPath, content, 'utf8');
 
-  // Mirror the user's auth.json so native ChatGPT / API-key login survives the
-  // CODEX_HOME redirect. Best-effort: absence just means the user is not logged
-  // in (codex will handle auth itself), never a hard failure.
-  try {
-    await copyFile(userAuthPath, authPath);
-  } catch {
-    // no auth.json to mirror.
+  // Link the user's auth.json THROUGH so native ChatGPT / API-key login survives
+  // the CODEX_HOME redirect and codex-acp's token refresh writes back to the
+  // user's real file (a copy would strand a subscription refresh on re-clone).
+  // Skip entirely when the user has no auth.json (not logged in) - same
+  // graceful-degrade as before. Symlink can fail on Windows without dev mode
+  // (EPERM) or if a plain file is already there (EEXIST); fall back to a copy so
+  // login still works, accepting that a copied token won't write back.
+  if (await pathExists(userAuthPath)) {
+    try {
+      await rm(authPath, { force: true });
+    } catch {
+      // best-effort cleanup of a prior link/file before re-linking.
+    }
+    try {
+      await symlink(userAuthPath, authPath);
+    } catch {
+      try {
+        await copyFile(userAuthPath, authPath);
+      } catch {
+        // could not mirror auth at all - codex will handle auth itself.
+      }
+    }
   }
 
   return codexHomeDir;

--- a/src/process/task/codexConfig.ts
+++ b/src/process/task/codexConfig.ts
@@ -7,26 +7,43 @@
 import { isCodexNoSandboxMode } from '@/common/types/codex/codexModes';
 import { FLUX_AUTO_MODEL, FLUX_MODEL_DISPLAY, FLUX_MODEL_IDS, FLUX_SURFACE } from '@/common/config/flux';
 import { parse as parseToml, stringify as stringifyToml } from 'smol-toml';
-import { mkdir, readFile, writeFile } from 'fs/promises';
+import { copyFile, mkdir, readFile, writeFile } from 'fs/promises';
 import { homedir } from 'os';
-import { dirname, join, posix, win32 } from 'path';
+import { join, posix, win32 } from 'path';
 
 export type CodexSandboxMode = 'read-only' | 'workspace-write' | 'danger-full-access';
-export type SupportedCodexSandboxMode = 'workspace-write' | 'danger-full-access';
 
 const isWindowsStylePath = (value: string): boolean => /^[a-zA-Z]:[\\/]/.test(value) || value.startsWith('\\\\');
 
 const getCodexPathApi = (baseDirectory: string) =>
   process.platform === 'win32' || isWindowsStylePath(baseDirectory) ? win32 : posix;
 
-export function normalizeCodexSandboxMode(sandboxMode?: CodexSandboxMode | null): SupportedCodexSandboxMode {
-  return sandboxMode === 'danger-full-access' ? 'danger-full-access' : 'workspace-write';
+/**
+ * Coerce a caller-supplied fallback sandbox mode. #536: the default is
+ * `read-only` - the LEAST privileged mode - so a Codex spawn never silently
+ * escalates to workspace-write without an explicit user choice. Only an
+ * explicit `danger-full-access` (from a yolo/no-sandbox session mode already
+ * resolved upstream) or `workspace-write` is honored; anything else - including
+ * `undefined` - falls back to read-only.
+ */
+export function normalizeCodexSandboxMode(sandboxMode?: CodexSandboxMode | null): CodexSandboxMode {
+  if (sandboxMode === 'danger-full-access') return 'danger-full-access';
+  if (sandboxMode === 'workspace-write') return 'workspace-write';
+  return 'read-only';
 }
 
+/**
+ * Resolve the sandbox mode for a Codex session mode. #536: with NO explicit
+ * session mode we return `read-only` (was `workspace-write`), so the app never
+ * grants write access the user did not ask for. An explicit escalated mode
+ * (autoEdit/yolo/yoloNoSandbox) still maps correctly:
+ * - a no-sandbox mode -> `danger-full-access`
+ * - any other explicit mode -> `workspace-write`
+ */
 export function getCodexSandboxModeForSessionMode(
   mode?: string | null,
   fallbackMode?: CodexSandboxMode | null
-): SupportedCodexSandboxMode {
+): CodexSandboxMode {
   if (mode) {
     return isCodexNoSandboxMode(mode) ? 'danger-full-access' : 'workspace-write';
   }
@@ -44,40 +61,96 @@ export function getCodexConfigPath(): string {
   return getCodexPathApi(homeDirectory).join(homeDirectory, '.codex', 'config.toml');
 }
 
-export async function writeCodexSandboxMode(sandboxMode: CodexSandboxMode): Promise<void> {
-  const path = getCodexConfigPath();
-  let content = '';
-
-  try {
-    content = await readFile(path, 'utf8');
-  } catch {
-    content = '';
+/** Resolve the user's real `<CODEX_HOME>/auth.json` (default `~/.codex/auth.json`). */
+export function getUserCodexAuthPath(): string {
+  const codexHome = process.env.CODEX_HOME?.trim();
+  if (codexHome) {
+    return getCodexPathApi(codexHome).join(codexHome, 'auth.json');
   }
+  const homeDirectory = homedir();
+  return getCodexPathApi(homeDirectory).join(homeDirectory, '.codex', 'auth.json');
+}
 
+/**
+ * Overwrite (or insert) the top-level `sandbox_mode` key in a codex config.toml
+ * body WITHOUT reformatting the rest. Used only against a Wayland-owned scoped
+ * config - never the user's real file (#536). Mirrors codex's own top-level
+ * placement so the key applies globally.
+ */
+function setSandboxModeInConfig(content: string, sandboxMode: CodexSandboxMode): string {
   const newline = content.includes('\r\n') ? '\r\n' : '\n';
   const sandboxLine = `sandbox_mode = "${sandboxMode}"`;
-  let nextContent: string;
 
   if (/^\s*sandbox_mode\s*=.*$/m.test(content)) {
-    nextContent = content.replace(/^\s*sandbox_mode\s*=.*$/m, sandboxLine);
-  } else {
-    const sectionIndex = content.search(/^\s*\[/m);
-
-    if (sectionIndex >= 0) {
-      const prefix = content.slice(0, sectionIndex).trimEnd();
-      const suffix = content.slice(sectionIndex);
-      nextContent = prefix
-        ? `${prefix}${newline}${sandboxLine}${newline}${newline}${suffix}`
-        : `${sandboxLine}${newline}${newline}${suffix}`;
-    } else if (content.trim().length > 0) {
-      nextContent = `${content.trimEnd()}${newline}${sandboxLine}${newline}`;
-    } else {
-      nextContent = `${sandboxLine}${newline}`;
-    }
+    return content.replace(/^\s*sandbox_mode\s*=.*$/m, sandboxLine);
   }
 
-  await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, nextContent, 'utf8');
+  const sectionIndex = content.search(/^\s*\[/m);
+  if (sectionIndex >= 0) {
+    const prefix = content.slice(0, sectionIndex).trimEnd();
+    const suffix = content.slice(sectionIndex);
+    return prefix
+      ? `${prefix}${newline}${sandboxLine}${newline}${newline}${suffix}`
+      : `${sandboxLine}${newline}${newline}${suffix}`;
+  }
+  if (content.trim().length > 0) {
+    return `${content.trimEnd()}${newline}${sandboxLine}${newline}`;
+  }
+  return `${sandboxLine}${newline}`;
+}
+
+/**
+ * Materialize a Wayland-scoped CODEX_HOME for NATIVE (non-Flux) codex spawns and
+ * return its directory path. #536: Wayland must set the Codex sandbox mode
+ * WITHOUT ever mutating the user's own `~/.codex/config.toml` (a file outside
+ * its workspace, edited with no consent and left persisted after exit). Instead
+ * we point CODEX_HOME at a scoped clone that:
+ *   1. copies the user's real config.toml verbatim (so their model, provider,
+ *      MCP servers and every custom setting are preserved), then
+ *   2. overrides ONLY the top-level `sandbox_mode` with the value Wayland
+ *      resolved for this session, and
+ *   3. mirrors the user's real `auth.json` into the scoped home so ChatGPT /
+ *      API-key login keeps working (codex reads its credential from
+ *      `$CODEX_HOME/auth.json`).
+ *
+ * The user's real `~/.codex` is never written. `userDataDir` is the app's
+ * userData path (caller passes `app.getPath('userData')`); `userConfigPath` /
+ * `userAuthPath` are injectable so this stays unit-testable without electron.
+ */
+export async function materializeNativeCodexHome(
+  userDataDir: string,
+  sandboxMode: CodexSandboxMode = 'read-only',
+  userConfigPath: string = getCodexConfigPath(),
+  userAuthPath: string = getUserCodexAuthPath()
+): Promise<string> {
+  const codexHomeDir = join(userDataDir, 'codex-home');
+  const configPath = join(codexHomeDir, 'config.toml');
+  const authPath = join(codexHomeDir, 'auth.json');
+
+  let userConfig = '';
+  try {
+    userConfig = await readFile(userConfigPath, 'utf8');
+  } catch {
+    // No user config / unreadable - start from an empty body; the scoped home
+    // then carries only the sandbox_mode Wayland sets.
+    userConfig = '';
+  }
+
+  const content = setSandboxModeInConfig(userConfig, sandboxMode);
+
+  await mkdir(codexHomeDir, { recursive: true });
+  await writeFile(configPath, content, 'utf8');
+
+  // Mirror the user's auth.json so native ChatGPT / API-key login survives the
+  // CODEX_HOME redirect. Best-effort: absence just means the user is not logged
+  // in (codex will handle auth itself), never a hard failure.
+  try {
+    await copyFile(userAuthPath, authPath);
+  } catch {
+    // no auth.json to mirror.
+  }
+
+  return codexHomeDir;
 }
 
 /**
@@ -141,41 +214,43 @@ function buildFluxModelCatalogJson(): string {
     { effort: 'medium', description: 'Balances speed and reasoning depth' },
     { effort: 'high', description: 'Greater reasoning depth for complex problems' },
   ];
-  const models = FLUX_MODEL_IDS.map((slug, i): Record<string, unknown> => ({
-    slug,
-    display_name: FLUX_MODEL_DISPLAY[slug],
-    description: 'Flux Router routed model - the right model for each task.',
-    supported_reasoning_levels: reasoningLevels,
-    default_reasoning_level: slug === 'flux-fast' ? 'low' : slug === 'flux-reasoning' ? 'high' : 'medium',
-    shell_type: 'shell_command',
-    visibility: 'list',
-    supported_in_api: true,
-    priority: i,
-    availability_nux: null,
-    upgrade: null,
-    base_instructions:
-      'You are Codex, a coding agent. Collaborate with the user to complete their task in the current workspace.',
-    supports_reasoning_summaries: false,
-    support_verbosity: false,
-    default_verbosity: null,
-    apply_patch_tool_type: 'freeform',
-    web_search_tool_type: 'text',
-    truncation_policy: { mode: 'tokens', limit: FLUX_CONTEXT_WINDOW },
-    supports_parallel_tool_calls: true,
-    supports_image_detail_original: false,
-    context_window: FLUX_CONTEXT_WINDOW,
-    max_context_window: FLUX_CONTEXT_WINDOW,
-    auto_compact_token_limit: FLUX_AUTO_COMPACT_TOKEN_LIMIT,
-    experimental_supported_tools: [],
-    input_modalities: ['text'],
-    supports_search_tool: false,
-  }));
+  const models = FLUX_MODEL_IDS.map(
+    (slug, i): Record<string, unknown> => ({
+      slug,
+      display_name: FLUX_MODEL_DISPLAY[slug],
+      description: 'Flux Router routed model - the right model for each task.',
+      supported_reasoning_levels: reasoningLevels,
+      default_reasoning_level: slug === 'flux-fast' ? 'low' : slug === 'flux-reasoning' ? 'high' : 'medium',
+      shell_type: 'shell_command',
+      visibility: 'list',
+      supported_in_api: true,
+      priority: i,
+      availability_nux: null,
+      upgrade: null,
+      base_instructions:
+        'You are Codex, a coding agent. Collaborate with the user to complete their task in the current workspace.',
+      supports_reasoning_summaries: false,
+      support_verbosity: false,
+      default_verbosity: null,
+      apply_patch_tool_type: 'freeform',
+      web_search_tool_type: 'text',
+      truncation_policy: { mode: 'tokens', limit: FLUX_CONTEXT_WINDOW },
+      supports_parallel_tool_calls: true,
+      supports_image_detail_original: false,
+      context_window: FLUX_CONTEXT_WINDOW,
+      max_context_window: FLUX_CONTEXT_WINDOW,
+      auto_compact_token_limit: FLUX_AUTO_COMPACT_TOKEN_LIMIT,
+      experimental_supported_tools: [],
+      input_modalities: ['text'],
+      supports_search_tool: false,
+    })
+  );
   return JSON.stringify({ models }, null, 2);
 }
 
 export async function materializeFluxCodexHome(
   userDataDir: string,
-  sandboxMode: SupportedCodexSandboxMode = 'workspace-write',
+  sandboxMode: CodexSandboxMode = 'read-only',
   baseURL: string = FLUX_SURFACE.responses,
   userConfigPath: string = getCodexConfigPath(),
   /** Per-conversation reasoning effort. When set, written as `model_reasoning_effort`. */

--- a/tests/unit/process/task/codexNativeSandbox.test.ts
+++ b/tests/unit/process/task/codexNativeSandbox.test.ts
@@ -12,12 +12,13 @@
  *   (a) the user's real config.toml is NEVER written,
  *   (b) the default sandbox mode is read-only (least privilege),
  *   (c) an explicit escalated mode still reaches Codex via the scoped home,
- *   (d) the user's own config + auth.json are carried into the scoped home.
+ *   (d) the user's config is cloned in + auth.json is symlinked through (so a
+ *       token refresh writes back to the user's real file).
  *
  * Uses real temp dirs (no fs mocking) and reads the materialized files back.
  */
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, readFile, rm, stat, writeFile } from 'fs/promises';
+import { lstat, mkdtemp, readFile, readlink, rm, stat, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { parse as parseToml } from 'smol-toml';
@@ -136,15 +137,55 @@ describe('materializeNativeCodexHome (#536 scoped CODEX_HOME)', () => {
     expect(parsedUser.sandbox_mode).toBe('read-only');
   });
 
-  it("mirrors the user's auth.json into the scoped home (native login survives)", async () => {
+  it("symlinks the scoped auth.json at the user's real auth.json (native login survives)", async () => {
     await writeFile(userConfig, 'model = "gpt-5"\n', 'utf8');
     await writeFile(userAuth, JSON.stringify({ tokens: { access_token: 'acc' } }), 'utf8');
 
     const home = await materializeNativeCodexHome(userDataDir, 'read-only', userConfig, userAuth);
-    const mirrored = JSON.parse(await readFile(join(home, 'auth.json'), 'utf8')) as {
-      tokens?: { access_token?: string };
-    };
-    expect(mirrored.tokens?.access_token).toBe('acc');
+    const scopedAuth = join(home, 'auth.json');
+
+    // It is a symlink pointing at the user's real auth.json.
+    const link = await lstat(scopedAuth);
+    expect(link.isSymbolicLink()).toBe(true);
+    expect(await readlink(scopedAuth)).toBe(userAuth);
+
+    // Reading through the link yields the user's token.
+    const seen = JSON.parse(await readFile(scopedAuth, 'utf8')) as { tokens?: { access_token?: string } };
+    expect(seen.tokens?.access_token).toBe('acc');
+  });
+
+  it("a token refresh written through the scoped auth.json lands in the user's real file", async () => {
+    await writeFile(userConfig, 'model = "gpt-5"\n', 'utf8');
+    await writeFile(userAuth, JSON.stringify({ tokens: { access_token: 'old' } }), 'utf8');
+
+    const home = await materializeNativeCodexHome(userDataDir, 'read-only', userConfig, userAuth);
+    // Simulate codex-acp refreshing the token INSIDE the scoped home.
+    await writeFile(join(home, 'auth.json'), JSON.stringify({ tokens: { access_token: 'refreshed' } }), 'utf8');
+
+    const userSide = JSON.parse(await readFile(userAuth, 'utf8')) as { tokens?: { access_token?: string } };
+    expect(userSide.tokens?.access_token).toBe('refreshed');
+  });
+
+  it('re-materialization replaces a stale scoped auth.json (relinks to the current user path)', async () => {
+    await writeFile(userConfig, 'model = "gpt-5"\n', 'utf8');
+    const home = join(userDataDir, 'codex-home');
+    // First spawn: user not logged in yet, then a stale plain file gets left behind.
+    await materializeNativeCodexHome(userDataDir, 'read-only', userConfig, join(userHome, 'absent.json'));
+    await writeFile(join(home, 'auth.json'), 'stale', 'utf8');
+
+    // Now the user logs in; re-materialize must replace the stale file with a link.
+    await writeFile(userAuth, JSON.stringify({ tokens: { access_token: 'fresh' } }), 'utf8');
+    await materializeNativeCodexHome(userDataDir, 'read-only', userConfig, userAuth);
+
+    const scopedAuth = join(home, 'auth.json');
+    expect((await lstat(scopedAuth)).isSymbolicLink()).toBe(true);
+    expect(await readlink(scopedAuth)).toBe(userAuth);
+  });
+
+  it('does not create a scoped auth.json when the user has none (graceful skip)', async () => {
+    await writeFile(userConfig, 'model = "gpt-5"\n', 'utf8');
+    const home = await materializeNativeCodexHome(userDataDir, 'read-only', userConfig, join(userHome, 'nope.json'));
+    await expect(lstat(join(home, 'auth.json'))).rejects.toThrow();
   });
 
   it('degrades gracefully when the user has no config or auth (still writes a valid scoped config)', async () => {

--- a/tests/unit/process/task/codexNativeSandbox.test.ts
+++ b/tests/unit/process/task/codexNativeSandbox.test.ts
@@ -1,0 +1,160 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * #536: Wayland must NOT rewrite the user's own ~/.codex/config.toml to set the
+ * Codex sandbox mode. Instead every native codex spawn gets a Wayland-scoped
+ * CODEX_HOME (materializeNativeCodexHome) whose config.toml Wayland owns. These
+ * tests prove:
+ *   (a) the user's real config.toml is NEVER written,
+ *   (b) the default sandbox mode is read-only (least privilege),
+ *   (c) an explicit escalated mode still reaches Codex via the scoped home,
+ *   (d) the user's own config + auth.json are carried into the scoped home.
+ *
+ * Uses real temp dirs (no fs mocking) and reads the materialized files back.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, readFile, rm, stat, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { parse as parseToml } from 'smol-toml';
+import {
+  getCodexSandboxModeForSessionMode,
+  materializeNativeCodexHome,
+  normalizeCodexSandboxMode,
+} from '@process/task/codexConfig';
+
+describe('normalizeCodexSandboxMode (#536 default read-only)', () => {
+  it('defaults to read-only when nothing explicit is provided', () => {
+    expect(normalizeCodexSandboxMode()).toBe('read-only');
+    expect(normalizeCodexSandboxMode(null)).toBe('read-only');
+    expect(normalizeCodexSandboxMode(undefined)).toBe('read-only');
+  });
+
+  it('honors an explicit escalated mode', () => {
+    expect(normalizeCodexSandboxMode('workspace-write')).toBe('workspace-write');
+    expect(normalizeCodexSandboxMode('danger-full-access')).toBe('danger-full-access');
+  });
+
+  it('coerces read-only through unchanged', () => {
+    expect(normalizeCodexSandboxMode('read-only')).toBe('read-only');
+  });
+});
+
+describe('getCodexSandboxModeForSessionMode (#536)', () => {
+  it('yields read-only with no explicit session mode and no fallback', () => {
+    expect(getCodexSandboxModeForSessionMode(null)).toBe('read-only');
+    expect(getCodexSandboxModeForSessionMode(undefined)).toBe('read-only');
+  });
+
+  it('respects an escalated fallback when no session mode is set', () => {
+    expect(getCodexSandboxModeForSessionMode(null, 'workspace-write')).toBe('workspace-write');
+    expect(getCodexSandboxModeForSessionMode(undefined, 'danger-full-access')).toBe('danger-full-access');
+  });
+
+  it('maps an explicit non-yolo session mode to workspace-write', () => {
+    expect(getCodexSandboxModeForSessionMode('default')).toBe('workspace-write');
+    expect(getCodexSandboxModeForSessionMode('autoEdit')).toBe('workspace-write');
+  });
+
+  it('maps an explicit no-sandbox (yolo) session mode to danger-full-access', () => {
+    expect(getCodexSandboxModeForSessionMode('yoloNoSandbox')).toBe('danger-full-access');
+  });
+});
+
+describe('materializeNativeCodexHome (#536 scoped CODEX_HOME)', () => {
+  let userDataDir: string;
+  let userHome: string;
+  let userConfig: string;
+  let userAuth: string;
+
+  beforeEach(async () => {
+    userDataDir = await mkdtemp(join(tmpdir(), 'native-codex-data-'));
+    userHome = await mkdtemp(join(tmpdir(), 'native-codex-user-'));
+    userConfig = join(userHome, 'config.toml');
+    userAuth = join(userHome, 'auth.json');
+  });
+
+  afterEach(async () => {
+    await rm(userDataDir, { recursive: true, force: true }).catch(() => {});
+    await rm(userHome, { recursive: true, force: true }).catch(() => {});
+  });
+
+  const readScopedConfig = async (home: string): Promise<string> => readFile(join(home, 'config.toml'), 'utf8');
+
+  it("NEVER writes the user's real config.toml, only the scoped clone", async () => {
+    const original = [
+      '# my codex config',
+      'model = "gpt-5"',
+      'sandbox_mode = "read-only"',
+      '',
+      '[features]',
+      'hooks = true',
+      '',
+    ].join('\n');
+    await writeFile(userConfig, original, 'utf8');
+    const before = await stat(userConfig);
+
+    const home = await materializeNativeCodexHome(userDataDir, 'workspace-write', userConfig, userAuth);
+
+    // The scoped home is inside userData, NOT the user's home.
+    expect(home).toBe(join(userDataDir, 'codex-home'));
+    expect(home).not.toBe(userHome);
+
+    // The user's real file is byte-identical + mtime unchanged (never touched).
+    const after = await stat(userConfig);
+    expect(await readFile(userConfig, 'utf8')).toBe(original);
+    expect(after.mtimeMs).toBe(before.mtimeMs);
+
+    // The scoped clone carries the escalated mode + preserves user settings + comments.
+    const scoped = await readScopedConfig(home);
+    expect(scoped).toContain('sandbox_mode = "workspace-write"');
+    expect(scoped).toContain('# my codex config');
+    expect(scoped).toContain('model = "gpt-5"');
+    expect(scoped).toContain('[features]');
+    expect(scoped).toContain('hooks = true');
+  });
+
+  it('defaults the scoped sandbox_mode to read-only', async () => {
+    await writeFile(userConfig, 'model = "gpt-5"\n', 'utf8');
+    const home = await materializeNativeCodexHome(userDataDir, undefined, userConfig, userAuth);
+    const parsed = parseToml(await readScopedConfig(home)) as { sandbox_mode?: string; model?: string };
+    expect(parsed.sandbox_mode).toBe('read-only');
+    expect(parsed.model).toBe('gpt-5');
+  });
+
+  it('overrides an existing user sandbox_mode with the escalated mode in the scoped clone', async () => {
+    await writeFile(userConfig, ['model = "gpt-5"', 'sandbox_mode = "read-only"', ''].join('\n'), 'utf8');
+    const home = await materializeNativeCodexHome(userDataDir, 'danger-full-access', userConfig, userAuth);
+    const parsed = parseToml(await readScopedConfig(home)) as { sandbox_mode?: string };
+    expect(parsed.sandbox_mode).toBe('danger-full-access');
+    // And the user's file still says read-only.
+    const parsedUser = parseToml(await readFile(userConfig, 'utf8')) as { sandbox_mode?: string };
+    expect(parsedUser.sandbox_mode).toBe('read-only');
+  });
+
+  it("mirrors the user's auth.json into the scoped home (native login survives)", async () => {
+    await writeFile(userConfig, 'model = "gpt-5"\n', 'utf8');
+    await writeFile(userAuth, JSON.stringify({ tokens: { access_token: 'acc' } }), 'utf8');
+
+    const home = await materializeNativeCodexHome(userDataDir, 'read-only', userConfig, userAuth);
+    const mirrored = JSON.parse(await readFile(join(home, 'auth.json'), 'utf8')) as {
+      tokens?: { access_token?: string };
+    };
+    expect(mirrored.tokens?.access_token).toBe('acc');
+  });
+
+  it('degrades gracefully when the user has no config or auth (still writes a valid scoped config)', async () => {
+    const home = await materializeNativeCodexHome(
+      userDataDir,
+      'read-only',
+      join(userHome, 'nope.toml'),
+      join(userHome, 'nope.json')
+    );
+    const parsed = parseToml(await readScopedConfig(home)) as { sandbox_mode?: string };
+    expect(parsed.sandbox_mode).toBe('read-only');
+  });
+});


### PR DESCRIPTION
## Problem (#536)

Wayland rewrote `sandbox_mode` inside the user's own `~/.codex/config.toml` on **every** Codex spawn (`initAgent`) and **every** `setMode` -- a file outside its workspace, mutated with no consent, and left persisted after the app exits.

- `codexConfig.ts` `writeCodexSandboxMode()` mutated `~/.codex/config.toml` (path from `getCodexConfigPath()`).
- Called from `AcpAgentManager.resolveBuiltinBackendConfig` (every codex init) and `setMode` (every mode change).
- The resolvers defaulted to `workspace-write`, so the app silently granted write access the user never chose.

## Fix

Route the sandbox mode through a **Wayland-scoped `CODEX_HOME`** instead of the user's file, generalizing the existing flux-scoped-home pattern (`materializeFluxCodexHome`) so native (non-flux) codex spawns get the same treatment.

- **New `materializeNativeCodexHome(userDataDir, sandboxMode, userConfigPath, userAuthPath)`** in `codexConfig.ts`:
  - clones the user's real `config.toml` **verbatim** into `<userData>/codex-home/` (model, provider, `[mcp_servers]`, every custom setting preserved),
  - overrides **only** the top-level `sandbox_mode` with the value Wayland resolved for the session (surgical text-merge via `setSandboxModeInConfig`, comments/siblings byte-identical),
  - **mirrors the user's `auth.json`** into the scoped home so native ChatGPT / API-key login survives the `CODEX_HOME` redirect (codex reads its credential from `$CODEX_HOME/auth.json`).
  - The user's real `~/.codex` is **never written**.
- **Wired into `resolveAgentCliConfig`** for native (non-flux) codex spawns; flux-routed codex keeps its own scoped home (`materializeFluxCodexHome`, unchanged).
- **Removed `writeCodexSandboxMode` and both unconditional callers.** `initAgent` and `setMode` now persist the resolved mode on `data.sandboxMode` / `this.options.sandboxMode` so the next spawn's scoped home carries it (codex-acp has no live `set_mode`, so mode changes apply on the next spawn regardless -- no behavior change there).
- **Default is now `read-only`** (least privilege). `normalizeCodexSandboxMode` / `getCodexSandboxModeForSessionMode` return `read-only` for the no-explicit-mode path. An explicit escalated session mode still maps correctly: no-sandbox (yolo) -> `danger-full-access`, any other explicit mode -> `workspace-write`.

### Why scoped `CODEX_HOME` and not `--sandbox`

The `@zed-industries/codex-acp` bridge is spawned via npx and forwards no `--sandbox`/`-c` override; codex reads `sandbox_mode` only from `$CODEX_HOME/config.toml`. A scoped `CODEX_HOME` is the mechanism codex actually honors, and it is the pattern already proven for flux/claude/hermes in this file.

## Verification

- `bun run typecheck` -- passes clean.
- New `tests/unit/process/task/codexNativeSandbox.test.ts` proves: (a) the user's real `config.toml` is never written (byte-identical + mtime unchanged), only the scoped clone; (b) default sandbox mode is `read-only`; (c) explicit escalated modes (`workspace-write` / `danger-full-access`) reach the scoped home while the user's file stays untouched; (d) user config + `auth.json` are carried into the scoped home; (e) graceful degrade when the user has no config/auth.
- Relevant suites green: `codexNativeSandbox`, `codexConfigEffort`, `codexFluxMcp`, `connectors/codex`, `acpApplySessionMode`, `resolveAcpSessionModeId`, `acpAgentManagerCronGuard`, `acpConnectors` (all pass).
- `oxfmt --check` clean on all 4 changed files; `oxlint` 0 errors.

## Cross-audit notes

- **Auth.json is copied fresh on each native spawn** (not symlinked) so a token refresh in the user's real `~/.codex` is picked up on the next spawn. Codex may refresh the token inside the scoped home during a session; that refresh does not propagate back to the user's real file. Flag if you want write-back or a symlink instead.
- The scoped native home lives at `<userData>/codex-home` (distinct from flux's `<userData>/flux-codex-home`). Both are regenerated per spawn.
- `SupportedCodexSandboxMode` type was removed (its only consumers -- the flux materializer param and `writeCodexSandboxMode` -- are gone); flux materializer now takes `CodexSandboxMode` and defaults to `read-only`.
