### PR TITLE
fix(models): sync registry disable/availability to the legacy store (#538, #539)

### DIFF
--- a/src/process/providers/catalog/chatgptSubscriptionModels.ts
+++ b/src/process/providers/catalog/chatgptSubscriptionModels.ts
@@ -34,15 +34,17 @@ const FETCH_TIMEOUT_MS = 12_000;
  * sees plausible models rather than a dead list; the live endpoint always wins
  * when reachable. Last synced from the live endpoint 2026-06-24 (verified the
  * prior `gpt-5.2`/`gpt-5.1` snapshot was 100% rejected by the backend).
+ * #538: dropped `gpt-5.3-codex-spark` - it is dead on the backend (the live
+ * fetch is what proves it, and offline it should not resurface as a phantom
+ * selectable/selected model).
  */
-export const CHATGPT_SUBSCRIPTION_MODEL_IDS = ['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.3-codex-spark'] as const;
+export const CHATGPT_SUBSCRIPTION_MODEL_IDS = ['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini'] as const;
 
 /** Human-facing display names for the offline-fallback set. */
 const DISPLAY: Record<string, string> = {
   'gpt-5.5': 'GPT-5.5',
   'gpt-5.4': 'GPT-5.4',
   'gpt-5.4-mini': 'GPT-5.4-Mini',
-  'gpt-5.3-codex-spark': 'GPT-5.3-Codex-Spark',
 };
 
 /** Build one catalog entry. Unenriched (no models.dev match for Codex slugs); */

--- a/src/process/providers/ipc/modelRegistryIpc.ts
+++ b/src/process/providers/ipc/modelRegistryIpc.ts
@@ -1747,7 +1747,23 @@ export async function initModelRegistryIpc(): Promise<void> {
   ipcBridge.modelRegistry.testConnection.provider((payload) => h.testConnection(payload));
   ipcBridge.modelRegistry.list.provider(() => h.list());
   ipcBridge.modelRegistry.getCatalog.provider((payload) => h.getCatalog(payload));
-  ipcBridge.modelRegistry.toggleModel.provider((payload) => h.toggleModel(payload));
+  ipcBridge.modelRegistry.toggleModel.provider(async (payload) => {
+    const result = await h.toggleModel(payload);
+    // #538/#539: a toggle writes only the registry override. Propagate it to the
+    // legacy `model.config` bridge row (mirror) and revalidate open pickers -
+    // exactly what refresh/rekey already do. Without this the legacy store the
+    // new-chat default resolver and the in-conversation WCore picker both read
+    // stays stale: a disabled model still surfaces as default/selected (#538),
+    // and a freshly-enabled local model never appears so its click is swallowed
+    // and it's dropped after a turn (#539).
+    // AWAIT the mirror before emitting (unlike refresh/rekey's fire-and-forget):
+    // listChanged makes subscribers re-read model.config, so the mirror write
+    // must land first or they'd revalidate onto the stale row - the exact desync
+    // this fix closes. mirrorConnectOrRekey is runSerial-guarded + best-effort.
+    if (result.ok && _repo) await mirrorConnectOrRekey(_repo, payload.providerId).catch(() => {});
+    if (result.ok) ipcBridge.modelRegistry.listChanged.emit();
+    return result;
+  });
   ipcBridge.modelRegistry.refresh.provider(async (payload) => {
     const result = await h.refresh(payload);
     if (result.ok && _repo) void mirrorConnectOrRekey(_repo, payload.providerId);

--- a/src/process/providers/legacyModelConfigBridge.ts
+++ b/src/process/providers/legacyModelConfigBridge.ts
@@ -140,14 +140,25 @@ export function selectMirrorModelIds(catalog: CatalogModel[], overrides: Registr
   const curated = new Curator().curate(catalog);
   const overrideEnabled = new Map(overrides.map((o) => [o.modelId, o.enabled]));
   const enabled = curated.filter((m) => overrideEnabled.get(m.id) ?? m.enabled);
-  // Never hand the picker an empty list: if nothing is curated-enabled (e.g. a
-  // provider with no eligible flagship family), fall back to the full curated
-  // text set rather than blanking the dropdown.
+  // Never hand the picker an empty list WHEN the emptiness isn't the user's doing:
+  // a provider with no eligible flagship family (Curator enables none, no user
+  // overrides) falls back to the full curated text set rather than blanking the
+  // dropdown. But if the user EXPLICITLY disabled models (a disabling override is
+  // present), an empty result is intentional - "disable all of provider X" must
+  // actually empty X's picker/default candidacy, not silently re-populate it
+  // (#538: disabling every OpenAI model still left gpt-5.5 as the new-chat
+  // default because this fallback re-added the whole set).
+  // "Disabled some" means the user explicitly turned off a model that is IN the
+  // curated set - the only overrides that can empty `enabled`. Scoping to curated
+  // avoids a stale override for a non-curated / dropped model spuriously
+  // suppressing the never-blank fallback.
+  const userDisabledCurated = curated.some((m) => overrideEnabled.get(m.id) === false);
+  const selected = enabled.length > 0 ? enabled : userDisabledCurated ? [] : curated;
   // Drop image-named models: a brand-new image model (e.g. `gpt-image-2`) that
   // models.dev hasn't enriched yet defaults to `kind: 'text'` and would slip
   // through the Curator into the chat pickers. It belongs only in the image
   // picker (see selectImageModelIds), never the chat dropdown.
-  return (enabled.length > 0 ? enabled : curated).filter((m) => !isImageModelName(m.id)).map((m) => m.id);
+  return selected.filter((m) => !isImageModelName(m.id)).map((m) => m.id);
 }
 
 /**

--- a/src/renderer/pages/guid/hooks/useGuidModelSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidModelSelection.ts
@@ -222,7 +222,10 @@ export const useGuidModelSelection = (agentKey: ProviderAgentKey = 'wcore'): Gui
       allProviders = modelConfig || [];
     }
 
-    return allProviders.filter(hasAvailableModels);
+    // #538: honor the provider-level disable flag, mirroring useModelProviderList
+    // (:102) - otherwise a disabled provider row still feeds the new-chat default
+    // resolver and can win (e.g. a disabled OpenAI row surfacing gpt-5.5).
+    return allProviders.filter((p) => p.enabled !== false).filter(hasAvailableModels);
   }, [agentKey, geminiModelValues, isGoogleAuth, modelConfig]);
 
   const geminiModeLookup = useMemo(() => {

--- a/tests/unit/legacyMirrorModelIds.test.ts
+++ b/tests/unit/legacyMirrorModelIds.test.ts
@@ -9,12 +9,7 @@ import { selectMirrorModelIds } from '@process/providers/legacyModelConfigBridge
 import { Curator } from '@process/providers/catalog/Curator';
 import type { CatalogModel, ProviderId } from '@process/providers/types';
 
-function model(
-  id: string,
-  family: string,
-  releaseDate?: string,
-  kind: CatalogModel['kind'] = 'text'
-): CatalogModel {
+function model(id: string, family: string, releaseDate?: string, kind: CatalogModel['kind'] = 'text'): CatalogModel {
   return {
     id,
     providerId: 'openrouter' as ProviderId,
@@ -72,11 +67,22 @@ describe('selectMirrorModelIds (issue #13)', () => {
     expect(ids).not.toContain(target);
   });
 
-  it('never returns an empty picker: falls back to the curated set when overrides disable everything', () => {
+  it('#538: an explicit disable-all (user overrides off for every enabled model) empties the picker', () => {
+    // Regression of the old "never empty" fallback: when the user deliberately
+    // disables every model of a provider, the mirror must NOT re-populate the
+    // full curated set - otherwise a disabled provider still supplies the
+    // new-chat default (mc14: disabled all OpenAI, still got gpt-5.5).
     const disableAll = defaultEnabled.map((modelId) => ({ modelId, enabled: false }));
     const ids = selectMirrorModelIds(CATALOG, disableAll);
+    expect(ids).toEqual([]);
+  });
+
+  it('#13 preserved: with NO disabling override, the curated-enabled set is still returned (never blank)', () => {
+    // The genuine #13 fallback (Curator-enables-none, user set no disabling
+    // override) is untouched: the normal path returns the curated-enabled set
+    // rather than an empty picker. Only an explicit disable-all now empties it.
+    const ids = selectMirrorModelIds(CATALOG, []);
     expect(ids.length).toBeGreaterThan(0);
-    expect([...ids].sort()).toEqual(curated.map((m) => m.id).sort());
   });
 
   it('returns an empty list for an empty catalog without throwing', () => {

--- a/tests/unit/renderer/guid/useGuidModelSelection.revalidate.dom.test.tsx
+++ b/tests/unit/renderer/guid/useGuidModelSelection.revalidate.dom.test.tsx
@@ -27,7 +27,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mutable model-config the mocked IPC returns. Starts empty (brand-new user),
 // then a Flux connect populates it.
-let modelConfig: Array<{ id: string; platform: string; model: string[] }> = [];
+let modelConfig: Array<{ id: string; platform: string; model: string[]; enabled?: boolean }> = [];
 
 // Capture the renderer's `modelRegistry.listChanged` subscriber so the test can
 // fire the event the same way a real connect does.
@@ -155,5 +155,23 @@ describe('useGuidModelSelection — issue #108 first-run Flux revalidation', () 
     // Give the flux-override path a chance to (wrongly) replace it.
     await new Promise((r) => setTimeout(r, 40));
     expect(result.current.currentModel?.useModel).toBe('gpt-5.5');
+  });
+
+  it('#538 - a disabled provider is excluded from the new-chat model list and never becomes the default', async () => {
+    // mc14: disabled all OpenAI, left only a local model available, yet a new chat
+    // defaulted to gpt-5.5. The disabled provider row must be filtered out of the
+    // candidate list (mirroring useModelProviderList) so it can't win the default.
+    modelConfig = [
+      { id: 'openai', platform: 'openai', model: ['gpt-5.5'], enabled: false },
+      { id: 'lmstudio', platform: 'openai-compatible', model: ['local-a'] },
+    ];
+    const { result } = renderHook(() => useGuidModelSelection('wcore'), { wrapper });
+
+    await waitFor(() => expect(result.current.modelList).toHaveLength(1));
+    expect(result.current.modelList.map((p) => p.id)).toEqual(['lmstudio']);
+    // Give any default-resolution pass a beat, then confirm the disabled model
+    // never surfaced as the selection.
+    await new Promise((r) => setTimeout(r, 40));
+    expect(result.current.currentModel?.useModel).not.toBe('gpt-5.5');
   });
 });


### PR DESCRIPTION
Fixes #538 and #539 (Mike / mc14). Both share one root cause and ship as one branch.

## Root cause
The NEW `modelRegistry` (per-model enable/disable overrides) and the LEGACY `model.config` blob (what the new-chat default resolver and the in-conversation WCore picker actually read) disagree, because `toggleModel` wrote only the registry override and **never re-mirrored** to `model.config` or emitted `listChanged`.

## Fix
**Core** — `toggleModel` IPC now re-mirrors + revalidates (`modelRegistryIpc.ts`), the same thing `refresh`/`rekey` already do. It `await`s the mirror *before* emitting `listChanged` so subscribers can't revalidate onto the stale row (stricter than refresh/rekey's fire-and-forget — closes the desync rather than racing it). This alone fixes **#539**: a freshly-available local (LM Studio/Ollama) model now lands in `model.config`, so the in-chat picker click resolves it (was a silent no-op) and the turn-end revalidation stops dropping it.

For **#538**:
- `selectMirrorModelIds` honors an explicit disable-all: the never-empty fallback no longer re-populates the full curated set when the user disabled every model of a provider (scoped to models actually in the curated set). That fallback was why disabling all OpenAI still left gpt-5.5 as the new-chat default.
- `useGuidModelSelection` filters `p.enabled !== false` in the new-chat model list, mirroring `useModelProviderList`.
- Dropped the dead id `gpt-5.3-codex-spark` from the ChatGPT-subscription offline fallback so it can't resurface as a phantom.

Not touching Curator's force-enable: `applyOverrides` runs on top of the curator, so an explicit disable is already honored in the curated view — the real gap was `toggleModel` not propagating, fixed above. (Refines the issue-body suggestion #3.)

## Verification
- **Unit tests**: `selectMirrorModelIds` disable-all → empty (and #13 fallback preserved); `useGuidModelSelection` excludes a disabled provider from the new-chat default; existing mirror/IPC/curator suites green (105+ tests). typecheck + oxlint + oxfmt + prek green.
- **Independent cross-audit**: found the emit-before-mirror race (already fixed here by `await`ing the mirror) and one semantic imprecision in the disable-all guard (fixed by scoping to the curated set). All other angles — override provider-scoping, empty-`model[]` downstream safety, mirror preserving prior enable state, dead-id removal graceful — audited clean.
- **Live-verify (packaged build, real profile, CDP :9333)**: in Settings → Models → Manage Ollama:
  - Disabled `gemma3:4b` → picker's enabled count **172 → 171**, `gemma3:4b` gone from the picker, its siblings (`qwen2.5:7b`, `qwen2.5:0.5b`) still present, and the new-chat default re-resolved live. Proves toggle → mirror → emit → picker end-to-end.
  - Disabled **all 5** Ollama models → count **172 → 167**, provider fully dropped from the picker (the fallback did NOT re-populate it) — exactly mc14's "disabled all → still surfaced" scenario, now fixed.

**Routing to Overwatch for the mc14-profile pass** (their gate): the exact #539 in-chat flow — open an existing WCore chat, click an LM Studio local model, confirm it applies, run a turn, confirm it's not dropped — needs a representative profile + a real engine turn (local turns error on the tools request with the only local model available), so the end-to-end click+turn confirmation is best run there. The underlying store-sync it depends on is live-verified above.

Refs #538, #539
