### PR TITLE
chore: bump version to 0.11.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Wayland",
-  "version": "0.11.9",
+  "version": "0.11.10",
   "description": "The local-first desktop AI agent that drives every AI CLI on your machine - Claude Code, Codex, Gemini and more, on your keys.",
   "keywords": [],
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Bump version to 0.11.10 (patch). Bundled engine unchanged (wayland-core 0.12.19).

Release contents since v0.11.9 (all merged to main):
- fix(startup): surface real agent/session start-failure reasons + macOS fsevents startup-crash fix (#533 → #447/#484/#483/#369)
- fix(models): sync registry disable/availability to the legacy store — phantom/disabled models no longer default; local-model switching in existing chats (#541 → #538/#539)
- fix(chat): let the user scroll up while the AI streams (#532 → #479)
- fix(mcp): filesystem connector installs with its required directory arg (#534 → #448)
- fix(codex): stop rewriting the user's ~/.codex/config.toml for sandbox mode (#540 → #536, security)
- fix(mcp): enabled connectors reach every agent backend (#478)
- fix(wcore): render AskUserQuestion choices + return the picked answer (#517 → #504)
- plus #527, #526, #511, #513, #510, #431, #459
