### PR TITLE
feat(wcore): #537 desktop half of the send_message host-transport hook [lane: BH2]

### DIFF
--- a/src/process/agent/wcore/envBuilder.ts
+++ b/src/process/agent/wcore/envBuilder.ts
@@ -688,5 +688,18 @@ export function buildEngineSpawnEnv(opts: {
   //     spawner (standalone CLI, third-party) from an untrusted wire peer.
   out.WAYLAND_ALLOW_WIRE_FORCE = '1';
 
+  // #537: opt the engine into host-delegated `send_message`. The desktop never
+  // writes channel `.toml` into WAYLAND_HOME/channels, so the engine's own
+  // channel table is empty and an agent `send_message` (e.g. to "email") fails
+  // with "unknown channel: email". With this set, the engine keeps the tool
+  // registered but routes the send back to the HOST (a `host_send_message_request`
+  // event), which fulfils it through the desktop's outbound channel plugins — the
+  // same path that already delivers replies — so there is ONE send path and the
+  // engine owns no channel credentials. Always set for the desktop's own trusted
+  // child: when no matching channel is configured the host replies with a clear
+  // error instead of the opaque "unknown channel". Standalone/CLI engines (which
+  // DO hand-author channel toml) never set this and are unaffected.
+  out.WAYLAND_SEND_MESSAGE_HOST_DELEGATE = '1';
+
   return out;
 }

--- a/src/process/agent/wcore/hostSendMessage.ts
+++ b/src/process/agent/wcore/hostSendMessage.ts
@@ -1,0 +1,158 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IChannelPluginStatus, IUnifiedOutgoingMessage } from '@process/channels/types';
+import type { WCoreEvent } from './protocol';
+
+/**
+ * Desktop half of the #537 host-send-transport hook.
+ *
+ * When the engine is host-delegated it emits `host_send_message_request` for
+ * every agent `send_message` call (its own channel table is empty under the
+ * desktop, so it would otherwise fail with "unknown channel: email"). The
+ * desktop fulfils the send through the SAME outbound channel plugin that already
+ * delivers replies — `PluginManager.sendMessage(pluginId, recipient, msg)` — so
+ * there is ONE send path and the engine owns no channel credentials.
+ *
+ * Note (deliberate): the outbound emitter is `PluginManager.sendMessage`
+ * (agent-INITIATED send TO a recipient), NOT `ChannelMessageService.sendMessage`
+ * — the latter feeds a message INTO the agent and streams a reply, which for an
+ * agent-initiated send would loop the message back into the conversation.
+ */
+
+export type HostSendMessageRequest = Extract<WCoreEvent, { type: 'host_send_message_request' }>;
+
+export type HostSendMessageResult = {
+  ok: boolean;
+  message_id?: string;
+  error?: string;
+};
+
+/**
+ * Injected seam so the handler is unit-testable without the live channels
+ * subsystem. The default binding (see {@link defaultHostSendDeps}) resolves the
+ * main-process `ChannelManager` singleton lazily.
+ */
+export interface HostSendDeps {
+  listPluginStatuses: () => Promise<IChannelPluginStatus[]>;
+  sendViaPlugin: (pluginId: string, recipient: string, message: IUnifiedOutgoingMessage) => Promise<string | null>;
+}
+
+/**
+ * Resolve a `send_message` platform token (e.g. "email") to a configured plugin
+ * instance id (e.g. "email-imap"). Mirrors the engine's channel-name family
+ * match (issue #116): exact token first, then the `<token>-<suffix>` family, so
+ * "email" resolves "email-imap"/"email-agentmail" but the `-` separator keeps
+ * "email" from matching an unrelated "emailfoo". Prefers live (enabled +
+ * connected) plugins; falls back to merely enabled so a transiently-down channel
+ * still routes (and returns its own send error) rather than reporting "no
+ * channel configured".
+ *
+ * When more than one plugin of the same family is configured (e.g. both
+ * email-imap AND email-agentmail), the FIRST configured (by the caller's status
+ * order, i.e. the DB order) wins — the agent asked for the "email" family, not a
+ * specific account. Single-channel-per-family is the common case; a
+ * default/primary tie-break can be layered later if multi-account demand appears.
+ */
+export function resolvePluginIdForPlatform(statuses: readonly IChannelPluginStatus[], platform: string): string | null {
+  const token = platform.trim();
+  if (token.length === 0) return null;
+
+  const matches = (s: IChannelPluginStatus): boolean =>
+    s.type === token || s.id === token || s.type.startsWith(`${token}-`) || s.id.startsWith(`${token}-`);
+
+  const live = statuses.filter((s) => s.enabled && s.connected && matches(s));
+  if (live.length > 0) return live[0].id;
+
+  const enabled = statuses.filter((s) => s.enabled && matches(s));
+  return enabled.length > 0 ? enabled[0].id : null;
+}
+
+/**
+ * Fulfil a host-delegated `send_message`. Pure w.r.t. its injected deps and
+ * never throws — every failure is returned as `{ ok: false, error }` so the
+ * caller can always reply with a `host_send_message_result` and the engine
+ * surfaces a real failure to the model instead of hanging.
+ */
+export async function handleHostSendMessageRequest(
+  req: HostSendMessageRequest,
+  deps: HostSendDeps
+): Promise<HostSendMessageResult> {
+  const platform = (req.platform ?? '').trim();
+  if (platform.length === 0) {
+    return { ok: false, error: 'send_message: missing platform' };
+  }
+
+  const recipient = (req.chat_id ?? '').trim();
+  if (recipient.length === 0) {
+    return {
+      ok: false,
+      error: `send_message: no recipient supplied for a "${platform}" send`,
+    };
+  }
+
+  // We only emit a text message; an empty body is a degenerate send (e.g. email
+  // rejects an empty envelope). Guard here for a clear error instead of a
+  // channel-specific throw surfaced as an opaque failure. (#537 cross-audit
+  // finding 2.)
+  const body = req.body ?? '';
+  if (body.trim().length === 0) {
+    return { ok: false, error: `send_message: empty message body for a "${platform}" send` };
+  }
+
+  const statuses = await deps.listPluginStatuses().catch((): IChannelPluginStatus[] => []);
+  const pluginId = resolvePluginIdForPlatform(statuses, platform);
+  if (!pluginId) {
+    return {
+      ok: false,
+      error: `send_message: no active "${platform}" channel is configured on this desktop`,
+    };
+  }
+
+  const outgoing: IUnifiedOutgoingMessage = {
+    type: 'text',
+    text: body,
+    ...(req.subject ? { subject: req.subject } : {}),
+    ...(req.thread_id ? { replyToMessageId: req.thread_id } : {}),
+  };
+
+  try {
+    const messageId = await deps.sendViaPlugin(pluginId, recipient, outgoing);
+    if (messageId) {
+      return { ok: true, message_id: messageId };
+    }
+    return { ok: false, error: `send_message: "${platform}" send failed (channel returned no message id)` };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+/**
+ * Default deps bound to the live main-process channels subsystem. `ChannelManager`
+ * is imported dynamically so importing this module (and `WCoreAgent`) never pulls
+ * the channels/plugin chain into module load.
+ */
+export function defaultHostSendDeps(): HostSendDeps {
+  return {
+    listPluginStatuses: async () => {
+      const { ChannelManager } = await import('@process/channels/core/ChannelManager');
+      const pm = ChannelManager.getInstance().getPluginManager();
+      return pm ? pm.getPluginStatuses() : [];
+    },
+    sendViaPlugin: async (pluginId, recipient, message) => {
+      const { ChannelManager } = await import('@process/channels/core/ChannelManager');
+      const plugin = ChannelManager.getInstance().getPluginManager()?.getPlugin(pluginId);
+      if (!plugin) return null;
+      // Call the plugin's sendMessage DIRECTLY, not PluginManager.sendMessage:
+      // the latter wraps the send in a try/catch that logs and returns `null`,
+      // which would collapse a real, actionable failure (SMTP 535 auth,
+      // connection refused, empty envelope) into an opaque "no message id". The
+      // plugin throws on failure, so the handler's catch surfaces the true
+      // reason to the model. (#537 cross-audit finding 1.)
+      return plugin.sendMessage(recipient, message);
+    },
+  };
+}

--- a/src/process/agent/wcore/index.ts
+++ b/src/process/agent/wcore/index.ts
@@ -18,6 +18,7 @@ import { hydrateModelForSpawn } from '@process/providers/ipc/modelRegistryIpc';
 import { killChild } from '@process/agent/acp/utils';
 import type { WCoreEvent, WCoreCommand, WCoreCapabilities } from './protocol';
 import { parseQuestionTool } from './questionTool';
+import { handleHostSendMessageRequest, defaultHostSendDeps } from './hostSendMessage';
 
 const WCORE_PROJECT_CONFIG = '.wcore.toml';
 
@@ -715,6 +716,15 @@ export class WCoreAgent {
         });
         break;
 
+      // ── #537 host-delegated send_message ──────────────────────────
+      // The engine (spawned with WAYLAND_SEND_MESSAGE_HOST_DELEGATE=1) routes an
+      // agent `send_message` here instead of failing on its empty channel table.
+      // We fulfil it through the desktop's own outbound channel plugins and reply
+      // with the result, correlated by call_id.
+      case 'host_send_message_request':
+        void this.handleHostSendMessage(event);
+        break;
+
       // ── Forward-compat default arm ────────────────────────────────
       // The W0 Host Decoder Contract (docs/json-stream-protocol.md
       // §"Host Decoder Contract") says hosts MUST drop unknown event
@@ -735,6 +745,23 @@ export class WCoreAgent {
         break;
       }
     }
+  }
+
+  /**
+   * #537: fulfil a host-delegated `send_message` via the desktop's outbound
+   * channel plugins and reply with `host_send_message_result`. Always replies
+   * (even on failure) so the engine's tool call never hangs; the handler itself
+   * never throws.
+   */
+  private async handleHostSendMessage(event: WCoreEvent & { type: 'host_send_message_request' }): Promise<void> {
+    const result = await handleHostSendMessageRequest(event, defaultHostSendDeps());
+    this.sendCommand({
+      type: 'host_send_message_result',
+      call_id: event.call_id,
+      ok: result.ok,
+      ...(result.message_id ? { message_id: result.message_id } : {}),
+      ...(result.error ? { error: result.error } : {}),
+    });
   }
 
   /**

--- a/src/process/agent/wcore/protocol.ts
+++ b/src/process/agent/wcore/protocol.ts
@@ -281,6 +281,23 @@ export type WCoreEvent =
       op: string;
       app?: string;
       reason: string;
+    }
+  // #537 host-send-transport hook. When the engine is host-delegated
+  // (WAYLAND_SEND_MESSAGE_HOST_DELEGATE=1 at spawn) its `send_message` tool
+  // routes the send to the HOST instead of the engine's channel table (which is
+  // empty under the desktop → "unknown channel: email"). The engine emits this
+  // request; the host fulfils it through its own outbound channel plugins and
+  // replies with `host_send_message_result` (correlated by `call_id`).
+  // `platform`/`chat_id`/`thread_id` mirror the engine's ParsedTarget.
+  | {
+      type: 'host_send_message_request';
+      call_id: string;
+      platform: string;
+      chat_id?: string;
+      thread_id?: string;
+      body: string;
+      subject?: string;
+      conversation_id?: string;
     };
 
 // ============================================
@@ -318,5 +335,16 @@ export type WCoreCommand =
       env?: Record<string, string>;
       url?: string;
       headers?: Record<string, string>;
+    }
+  // #537 reply to `host_send_message_request`. `ok=true` → the engine resolves
+  // the tool call as sent (optional `message_id` receipt); `ok=false`/`error`
+  // → the engine surfaces a real send failure to the model (never a false
+  // success). Correlated to the request by `call_id`.
+  | {
+      type: 'host_send_message_result';
+      call_id: string;
+      ok: boolean;
+      message_id?: string;
+      error?: string;
     }
   | { type: 'ping' };

--- a/tests/unit/hostSendMessage.test.ts
+++ b/tests/unit/hostSendMessage.test.ts
@@ -1,0 +1,165 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { IChannelPluginStatus, IUnifiedOutgoingMessage } from '@process/channels/types';
+import {
+  handleHostSendMessageRequest,
+  resolvePluginIdForPlatform,
+  type HostSendDeps,
+  type HostSendMessageRequest,
+} from '@process/agent/wcore/hostSendMessage';
+
+function status(partial: Partial<IChannelPluginStatus> & { id: string; type: string }): IChannelPluginStatus {
+  return {
+    name: partial.id,
+    enabled: true,
+    connected: true,
+    status: 'running',
+    activeUsers: 0,
+    ...partial,
+  } as IChannelPluginStatus;
+}
+
+function req(partial: Partial<HostSendMessageRequest>): HostSendMessageRequest {
+  return {
+    type: 'host_send_message_request',
+    call_id: 'c1',
+    platform: 'email',
+    chat_id: 'someone@example.com',
+    body: 'hello',
+    ...partial,
+  } as HostSendMessageRequest;
+}
+
+describe('resolvePluginIdForPlatform', () => {
+  const emailImap = status({ id: 'email-imap', type: 'email-imap' });
+
+  it('family-matches a platform token to its instance plugin (email -> email-imap)', () => {
+    expect(resolvePluginIdForPlatform([emailImap], 'email')).toBe('email-imap');
+  });
+
+  it('exact-matches a default-named channel', () => {
+    expect(resolvePluginIdForPlatform([status({ id: 'telegram', type: 'telegram' })], 'telegram')).toBe('telegram');
+  });
+
+  it('does not cross platforms on a bare prefix (email must not match emailfoo)', () => {
+    expect(resolvePluginIdForPlatform([status({ id: 'emailfoo', type: 'emailfoo' })], 'email')).toBeNull();
+  });
+
+  it('prefers a live (connected) plugin over a merely-enabled one', () => {
+    const down = status({ id: 'email-imap', type: 'email-imap', connected: false, status: 'error' });
+    const up = status({ id: 'email-agentmail', type: 'email-agentmail', connected: true });
+    expect(resolvePluginIdForPlatform([down, up], 'email')).toBe('email-agentmail');
+  });
+
+  it('falls back to an enabled-but-disconnected plugin when none are live', () => {
+    const down = status({ id: 'email-imap', type: 'email-imap', connected: false, status: 'error' });
+    expect(resolvePluginIdForPlatform([down], 'email')).toBe('email-imap');
+  });
+
+  it('with two live same-family accounts, returns the first configured (documented order-dependent)', () => {
+    const imap = status({ id: 'email-imap', type: 'email-imap' });
+    const agentmail = status({ id: 'email-agentmail', type: 'email-agentmail' });
+    expect(resolvePluginIdForPlatform([agentmail, imap], 'email')).toBe('email-agentmail');
+    expect(resolvePluginIdForPlatform([imap, agentmail], 'email')).toBe('email-imap');
+  });
+
+  it('ignores disabled plugins and returns null when nothing matches', () => {
+    expect(
+      resolvePluginIdForPlatform([status({ id: 'email-imap', type: 'email-imap', enabled: false })], 'email')
+    ).toBeNull();
+    expect(resolvePluginIdForPlatform([emailImap], 'discord')).toBeNull();
+    expect(resolvePluginIdForPlatform([emailImap], '  ')).toBeNull();
+  });
+});
+
+describe('handleHostSendMessageRequest', () => {
+  function deps(over: Partial<HostSendDeps> = {}): HostSendDeps {
+    return {
+      listPluginStatuses: async () => [status({ id: 'email-imap', type: 'email-imap' })],
+      sendViaPlugin: async () => 'msg-123',
+      ...over,
+    };
+  }
+
+  it('sends via the resolved plugin and returns the receipt', async () => {
+    const sendViaPlugin = vi.fn(async () => 'msg-123');
+    const out = await handleHostSendMessageRequest(req({}), deps({ sendViaPlugin }));
+    expect(out).toEqual({ ok: true, message_id: 'msg-123' });
+    expect(sendViaPlugin).toHaveBeenCalledWith('email-imap', 'someone@example.com', {
+      type: 'text',
+      text: 'hello',
+    });
+  });
+
+  it('threads subject + thread_id into the outgoing message', async () => {
+    let captured: IUnifiedOutgoingMessage | undefined;
+    const sendViaPlugin = vi.fn(async (_id: string, _to: string, m: IUnifiedOutgoingMessage) => {
+      captured = m;
+      return 'id';
+    });
+    await handleHostSendMessageRequest(req({ subject: 'Re: hi', thread_id: 't-9' }), deps({ sendViaPlugin }));
+    expect(captured).toEqual({ type: 'text', text: 'hello', subject: 'Re: hi', replyToMessageId: 't-9' });
+  });
+
+  it('fails cleanly when no recipient is supplied', async () => {
+    const out = await handleHostSendMessageRequest(req({ chat_id: '' }), deps());
+    expect(out.ok).toBe(false);
+    expect(out.error).toMatch(/no recipient/i);
+  });
+
+  it('fails cleanly on an empty message body', async () => {
+    for (const b of ['', '   ']) {
+      const out = await handleHostSendMessageRequest(req({ body: b }), deps());
+      expect(out.ok).toBe(false);
+      expect(out.error).toMatch(/empty message body/i);
+    }
+  });
+
+  it('fails cleanly when the platform is missing', async () => {
+    const out = await handleHostSendMessageRequest(req({ platform: '   ' }), deps());
+    expect(out.ok).toBe(false);
+    expect(out.error).toMatch(/missing platform/i);
+  });
+
+  it('fails cleanly when no matching channel is configured', async () => {
+    const out = await handleHostSendMessageRequest(req({ platform: 'discord' }), deps());
+    expect(out.ok).toBe(false);
+    expect(out.error).toMatch(/no active "discord" channel/i);
+  });
+
+  it('reports a send failure when the plugin returns no id', async () => {
+    const out = await handleHostSendMessageRequest(req({}), deps({ sendViaPlugin: async () => null }));
+    expect(out.ok).toBe(false);
+    expect(out.error).toMatch(/send failed/i);
+  });
+
+  it('never throws — a plugin error becomes { ok:false, error }', async () => {
+    const out = await handleHostSendMessageRequest(
+      req({}),
+      deps({
+        sendViaPlugin: async () => {
+          throw new Error('SMTP 535 auth failed');
+        },
+      })
+    );
+    expect(out).toEqual({ ok: false, error: 'SMTP 535 auth failed' });
+  });
+
+  it('treats a status-lookup failure as no channels (clean error, no throw)', async () => {
+    const out = await handleHostSendMessageRequest(
+      req({}),
+      deps({
+        listPluginStatuses: async () => {
+          throw new Error('db down');
+        },
+      })
+    );
+    expect(out.ok).toBe(false);
+    expect(out.error).toMatch(/no active "email" channel/i);
+  });
+});


### PR DESCRIPTION
## What & why (desktop half of #537)

An agent that calls the wayland-core engine's built-in `send_message` tool for email fails with **"unknown channel: email"**: under the desktop the engine's channel table is empty (the desktop writes no channel `.toml` into `$WAYLAND_HOME/channels`). Per Overwatch's decision (Option 1, **host-send-transport-hook** variant), the engine keeps `send_message` registered but, when spawned host-delegated, routes the send back to the **host**; the desktop fulfils it through its own outbound channel plugins — the same path that already delivers email replies. One SMTP path; the engine owns no channel credentials.

**This is the DESKTOP half only.** The engine hook is a separate Core change (spec posted on #537); **merge order is engine-first**. This code is **dormant** until the engine emits `host_send_message_request` (the current bundled engine never does; the extra env var is inert).

## Changes
- **`protocol.ts`** — `host_send_message_request` (engine→host) + `host_send_message_result` (host→engine), correlated by `call_id`; `platform`/`chat_id`/`thread_id` mirror the engine's `ParsedTarget`.
- **`hostSendMessage.ts`** (new) — pure, injectable handler. Resolves a platform token → configured plugin via family match (`email`→`email-imap`/`email-agentmail`, mirroring #116; the `-` separator stops `email` matching `emailfoo`), prefers live channels, and sends via the plugin's outbound emitter. **Never throws** — every failure → `{ok:false, error}` so the engine surfaces a real send failure and the tool call can't hang.
- **`index.ts`** — handles the event, always replies exactly once.
- **`envBuilder.ts`** — sets `WAYLAND_SEND_MESSAGE_HOST_DELEGATE=1` for the desktop's own engine child (standalone/CLI engines that hand-author channel toml are unaffected).

**Deliberate:** the outbound emitter is `PluginManager`/plugin `sendMessage` (agent-*initiated* send TO a recipient), **not** `ChannelMessageService.sendMessage` (inbound-to-agent → would loop). Verified in cross-audit (`chat_id` is the recipient address for email: `EmailImapAdapter` `to: chatId`).

## Verification
- 16 unit tests (family match incl. `emailfoo` guard + two-account tie-break, never-throws, empty-body + missing-recipient guards, subject/thread threading, status-lookup failure). `typecheck` + `prek` green; 278 existing wcore/agent tests pass.
- **Independent cross-audit: SAFE TO SHIP (dormant half), no blockers.** Folded its findings: (1) call the plugin directly so a real SMTP error surfaces instead of PluginManager's null-swallow; (2) empty-body guard; (3) documented + tested the multi-account first-configured-wins tie-break.
- **Live-verify (agent `send_message(email)` → real email delivered) is gated on the Core engine hook landing** — deferred per the engine-first merge order.

## ⚠️ Flag for Core / Overwatch (finding 4, Core-owned)
`host_send_message_request` bypasses the `tool_request` confirmation card — the desktop performs the actual send trusting the engine already gated `send_message`. **Confirm the engine enforces `send_message` approval BEFORE emitting the request** (esp. that Info-category `send_message` isn't silently auto-approved), so an agent turn can't send email to arbitrary recipients with no confirmation. The desktop can't re-gate what the engine approved without a protocol addition; consider a "sent via email" activity/audit surface.

Ref #537. Do not self-merge — Overwatch sequences after the Core hook.
