### PR TITLE
chore: bump version to 0.11.11 (bundle wayland-core 0.12.20)

### DIFF
--- a/installer/scripts/postinstall.mjs
+++ b/installer/scripts/postinstall.mjs
@@ -17,7 +17,7 @@ import { fileURLToPath } from 'node:url';
 
 // Kept in lockstep with scripts/prepareWaylandCore.js DEFAULT_WCORE_VERSION by
 // scripts/stage-wcore-bump.mjs. Do not hand-edit; run that tool so both move.
-const WCORE_VERSION = 'v0.12.19';
+const WCORE_VERSION = 'v0.12.20';
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PAYLOAD = resolve(HERE, '..', 'payload');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Wayland",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "description": "The local-first desktop AI agent that drives every AI CLI on your machine - Claude Code, Codex, Gemini and more, on your keys.",
   "keywords": [],
   "license": "AGPL-3.0-or-later",

--- a/scripts/bundled-wcore-shasums.json
+++ b/scripts/bundled-wcore-shasums.json
@@ -1,5 +1,13 @@
 {
   "_comment": "Authoritative SHA-256 checksums for bundled wayland-core release archives (the downloaded .tar.gz / .zip assets), keyed by release tag then asset filename. Mirrors scripts/bundled-bun-shasums.json. Source of truth: the SHASUMS published alongside each signed FerroxLabs/wayland-core release. The downloaded archive is verified against this file BEFORE it is extracted, copied, or executed. Update this file in lockstep with DEFAULT_WCORE_VERSION in scripts/prepareWaylandCore.js and regenerate on every engine version bump.",
+  "v0.12.20": {
+    "wayland-core-v0.12.20-aarch64-apple-darwin.tar.gz": "sha256:326a98ae60b2b8e65fd3fb56e398fe42d3d851182d629c92a13106ac776ea77d",
+    "wayland-core-v0.12.20-x86_64-apple-darwin.tar.gz": "sha256:20a2d52fea3088254e80b0a7275f9f6947e516fa93cb3671fd0c62c3d408dab3",
+    "wayland-core-v0.12.20-aarch64-unknown-linux-gnu.tar.gz": "sha256:53e374f1a46f61bc48afb7116533ce47e88b417397fb9c0fc47057ee51d13618",
+    "wayland-core-v0.12.20-x86_64-unknown-linux-gnu.tar.gz": "sha256:f0f2c8a9fdad599cde04ce4306a8fec2a666c5d5a996b280c5789effa657c1c3",
+    "wayland-core-v0.12.20-aarch64-pc-windows-msvc.zip": "sha256:e3d5ebbba0ca02127c70d6853acdc6ab0178b5f9c5eaf347e4ff29f63c492d4b",
+    "wayland-core-v0.12.20-x86_64-pc-windows-msvc.zip": "sha256:62ca1cfcd303c6cfcf7c68c90fa8f5347007775f3c1f8e9f9f70e3d757e4ddf8"
+  },
   "v0.12.19": {
     "wayland-core-v0.12.19-aarch64-apple-darwin.tar.gz": "sha256:a05b102abe834888451a1d1289e5b703a69617e190630c1a6b7654e2e99cc35d",
     "wayland-core-v0.12.19-x86_64-apple-darwin.tar.gz": "sha256:ddea7129b86d7c68c783b1ff452ed49b252ebbb824e671dc50e46d5cbe68003f",

--- a/scripts/prepareWaylandCore.js
+++ b/scripts/prepareWaylandCore.js
@@ -184,7 +184,7 @@ function verifyArchiveChecksum(archivePath, expectedHex, assetName, tag) {
 // FerroxLabs/wayland-core; Desktop integrates against a specific tag rather
 // than tracking `latest` so version drift can't sneak in via a release made
 // while a CI build is mid-flight. Override with WCORE_VERSION=... when bumping.
-const DEFAULT_WCORE_VERSION = 'v0.12.19';
+const DEFAULT_WCORE_VERSION = 'v0.12.20';
 
 function getVersion() {
   return (process.env.WCORE_VERSION || DEFAULT_WCORE_VERSION).trim();


### PR DESCRIPTION
Complete cut. Bundles engine wayland-core 0.12.20 and ships the desktop send_message host-transport (#537) plus all fixes merged since 0.11.9.

Engine: wayland-core v0.12.19 -> v0.12.20 (DEFAULT_WCORE_VERSION + 6-platform SHA-256 archive checksums added to bundled-wcore-shasums.json; darwin-arm64 download re-verified locally).

Headline in this cut:
- #537 agent send_message host-transport: builtin send_message now routes to the desktop outbound channel plugins (host-delegated). Live-verified end-to-end on 0.12.20 + #543 — real email delivered via IMAP/SMTP. Autonomous send in Autopilot is intended.
- Everything already merged for the cancelled 0.11.10: #532 scroll-while-streaming, #533 startup surfacing + #447 fsevents, #534 filesystem MCP install, #535 shutdown-reap, #540 Codex sandbox-config security (#536), #541 model picker desync (#538/#539).

Follow-ups filed (non-blocking): #547 inbound-reply loop guard, #548 channels settings display/rehydrate.

0.11.10 was cancelled (partial); this is the single complete cut. Tagging v0.11.11 after merge triggers the 6-platform signed build + npm publish.