### PR TITLE
fix(update): prefer electron-updater over manual DMG so quitAndInstall works on macOS (#286)

### DIFF
--- a/src/renderer/components/settings/UpdateModal.tsx
+++ b/src/renderer/components/settings/UpdateModal.tsx
@@ -148,9 +148,21 @@ const UpdateModal: React.FC = () => {
     if (!updateInfo && !autoUpdateAvailable) return;
     setStatus('downloading');
     try {
-      // Prefer the manual path so the URL is the CDN-rewritten asset.url.
-      // Fall back to electron-updater (GitHub) only when the GitHub API manual check failed
-      // but the yml-based auto-update check succeeded - a rare edge case.
+      // Prefer electron-updater whenever auto-update is available: it is the ONLY
+      // path that reaches quit + install + relaunch (via the 'downloaded' status
+      // event -> Install now -> quitAndInstall). The manual asset download only
+      // lands a file in the download folder with no in-place install/relaunch, so
+      // on macOS (where a .dmg recommendedAsset is always present) preferring the
+      // manual path left quitAndInstall as dead code (#286). Fall back to the
+      // manual CDN-rewritten asset ONLY when auto-update is unavailable.
+      if (autoUpdateAvailable) {
+        const res = await ipcBridge.autoUpdate.download.invoke();
+        if (!res?.success) {
+          throw new Error(res?.msg || t('update.downloadStartFailed'));
+        }
+        return;
+      }
+
       if (updateInfo?.recommendedAsset) {
         const asset = updateInfo.recommendedAsset;
         const res = await ipcBridge.update.download.invoke({
@@ -167,14 +179,6 @@ const UpdateModal: React.FC = () => {
         }
         setDownloadId(res.data.downloadId);
         setDownloadPath(res.data.filePath);
-        return;
-      }
-
-      if (autoUpdateAvailable) {
-        const res = await ipcBridge.autoUpdate.download.invoke();
-        if (!res?.success) {
-          throw new Error(res?.msg || t('update.downloadStartFailed'));
-        }
         return;
       }
 

--- a/tests/unit/UpdateModalDownloadPriority.dom.test.tsx
+++ b/tests/unit/UpdateModalDownloadPriority.dom.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Regression test for #286: on macOS a `.dmg` recommendedAsset is always
+ * present, so UpdateModal.startDownload() used to take the manual-download
+ * branch and `return` before ever reaching the electron-updater path. That made
+ * the quit + install + relaunch flow (autoUpdate.download -> 'downloaded' ->
+ * Install now -> quitAndInstall) dead code on macOS: the user only got a DMG
+ * dropped in ~/Downloads, never an in-place install/relaunch.
+ *
+ * After the fix, startDownload prefers autoUpdate.download whenever auto-update
+ * is available, and only falls back to the manual asset when it is not.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en-US' } }),
+}));
+
+// Keep the modal + markdown lightweight so the button always renders when visible.
+vi.mock('@/renderer/components/base/WaylandModal', () => ({
+  default: ({ visible, children }: { visible: boolean; children: React.ReactNode }) =>
+    visible ? <div data-testid='modal'>{children}</div> : null,
+}));
+vi.mock('@/renderer/components/Markdown', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const { autoUpdateDownload, manualDownload, autoUpdateCheck, manualCheck } = vi.hoisted(() => ({
+  autoUpdateDownload: vi.fn(),
+  manualDownload: vi.fn(),
+  autoUpdateCheck: vi.fn(),
+  manualCheck: vi.fn(),
+}));
+
+vi.mock('@/common/adapter/ipcBridge', () => {
+  const noop = () => () => {};
+  return {
+    conversation: {},
+    update: {
+      open: { on: noop },
+      check: { invoke: manualCheck },
+      download: { invoke: manualDownload },
+      downloadProgress: { on: noop },
+    },
+    autoUpdate: {
+      check: { invoke: autoUpdateCheck },
+      download: { invoke: autoUpdateDownload },
+      quitAndInstall: { invoke: vi.fn() },
+      status: { on: noop },
+    },
+    shell: {
+      openExternal: { invoke: vi.fn() },
+      openFile: { invoke: vi.fn() },
+      showItemInFolder: { invoke: vi.fn() },
+    },
+    ijfw: { triggerInstall: { invoke: vi.fn() } },
+  };
+});
+
+import UpdateModal from '@/renderer/components/settings/UpdateModal';
+
+const RECOMMENDED_ASSET = {
+  url: 'https://cdn.example.com/Wayland-0.11.12-arm64.dmg',
+  fallbackUrl: 'https://github.com/FerroxLabs/wayland/releases/download/v0.11.12/Wayland-0.11.12-arm64.dmg',
+  name: 'Wayland-0.11.12-arm64.dmg',
+};
+
+const LATEST = (withAsset: boolean) => ({
+  version: '0.11.12',
+  tagName: 'v0.11.12',
+  htmlUrl: 'https://github.com/FerroxLabs/wayland/releases/tag/v0.11.12',
+  name: 'Wayland 0.11.12',
+  body: 'notes',
+  recommendedAsset: withAsset ? RECOMMENDED_ASSET : undefined,
+});
+
+const openModal = async () => {
+  render(<UpdateModal />);
+  await act(async () => {
+    window.dispatchEvent(new Event('wayland-open-update-modal'));
+  });
+};
+
+describe('UpdateModal download priority (#286)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    autoUpdateDownload.mockResolvedValue({ success: true });
+    manualDownload.mockResolvedValue({ success: true, data: { downloadId: 'd1', filePath: '/tmp/x.dmg' } });
+  });
+
+  it('prefers electron-updater over the manual DMG when auto-update is available (mac case)', async () => {
+    // mac: BOTH auto-update available AND a .dmg recommendedAsset present.
+    autoUpdateCheck.mockResolvedValue({ success: true, data: { updateInfo: { version: '0.11.12' } } });
+    manualCheck.mockResolvedValue({
+      success: true,
+      data: { currentVersion: '0.11.11', latest: LATEST(true), updateAvailable: true },
+    });
+
+    await openModal();
+
+    const btn = await screen.findByText('update.downloadAndInstall');
+    fireEvent.click(btn);
+
+    await waitFor(() => expect(autoUpdateDownload).toHaveBeenCalledTimes(1));
+    expect(manualDownload).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the manual asset only when auto-update is unavailable', async () => {
+    // Auto-update check fails; manual check still finds a compatible .dmg asset.
+    autoUpdateCheck.mockResolvedValue({ success: false, msg: 'no yml' });
+    manualCheck.mockResolvedValue({
+      success: true,
+      data: { currentVersion: '0.11.11', latest: LATEST(true), updateAvailable: true },
+    });
+
+    await openModal();
+
+    const btn = await screen.findByText('update.downloadButton');
+    fireEvent.click(btn);
+
+    await waitFor(() => expect(manualDownload).toHaveBeenCalledTimes(1));
+    expect(autoUpdateDownload).not.toHaveBeenCalled();
+    // The manual path forwards the CDN-rewritten asset URL + release tag.
+    expect(manualDownload).toHaveBeenCalledWith(
+      expect.objectContaining({ url: RECOMMENDED_ASSET.url, tagName: 'v0.11.12' })
+    );
+  });
+});


### PR DESCRIPTION
## Problem (#286)

On macOS, auto-update `0.11.x → 0.11.y` **never restarts** and silently re-offers. Root cause is in the renderer, not the ShipIt/Squirrel layer:

`UpdateModal.startDownload()` fired the **manual asset-download** branch first:

```ts
if (updateInfo?.recommendedAsset) { …manual DMG download…; return; }
if (autoUpdateAvailable)          { …electron-updater…;    return; }
```

On macOS a `.dmg` `recommendedAsset` is **always** present (and scores above `.zip`), so `startDownload` always took the manual branch and `return`ed. The electron-updater path — the **only** one that reaches `quit + install + relaunch` (`autoUpdate.download` → `'downloaded'` status event → **Install now** → `quitAndInstall`) — was therefore **dead code on macOS**. The user just got a DMG dropped in `~/Downloads`; the app never installed/relaunched, and the update re-offered on next check.

## Fix

Invert the priority in `startDownload()`:

- **Prefer** `ipcBridge.autoUpdate.download.invoke()` whenever `autoUpdateAvailable` is true → reaches the existing Install-now / `quitAndInstall` flow (~539–558, unchanged).
- Fall back to the manual CDN-rewritten asset **only** when auto-update is unavailable.

The button label logic already renders **“Download and Install”** when `autoUpdateAvailable`, so no UI copy change is needed. The manual `error` view keeps its **“Go to Release”** CTA as a manual escape hatch if an auto-download fails.

## Tests

Adds `tests/unit/UpdateModalDownloadPriority.dom.test.tsx` (jsdom):
- **mac case** (auto-update *and* `.dmg` both present) → routes to `autoUpdate.download`, **never** the manual path. *Verified this test FAILS against pre-fix code and PASSES after.*
- **auto-update unavailable** → manual fallback still fires, forwarding the CDN `url` + release `tagName`.

Typecheck clean; 69 update/auto-update tests green; oxlint clean on changed files (pre-existing scope warnings only).

## Adversarial self-cross-audit

An independent adversarial subagent reviewed the full component (not just the diff). No blocker/major bugs. Two notes, both accepted:
1. There is now **no automatic** fallback from a *failed* auto-download to the manual asset — this is the intended #286 tradeoff (auto-first); the mac error view’s “Go to Release” CTA keeps users unstuck.
2. Auto-path progress UI depends on the main process emitting `autoUpdate.status` `'downloading'` events (pre-existing; not introduced here) — folded into the live-verify ask below.

## ⚠️ Overwatch: needs a PACKAGED Apple-Silicon install/relaunch test

electron-updater is **hard-disabled in dev**, so this cannot be verified locally. Please run on a **packaged arm64 build**: trigger an update, confirm **Download and Install → Install now → the app quits, installs, and relaunches on the new version** (not a DMG in Downloads), and confirm the progress bar advances (finding #2 above). No self-merge.