### PR TITLE
fix(model-selector): stop rendering the provider three times per picker row (triple-label)

### DIFF
--- a/src/renderer/components/model/modelSelector/ModelSelectorFlyout.module.css
+++ b/src/renderer/components/model/modelSelector/ModelSelectorFlyout.module.css
@@ -195,14 +195,6 @@
   align-items: center;
   gap: 7px;
 }
-.srcTag {
-  font-family: var(--mono, ui-monospace, Menlo, monospace);
-  font-size: 9.5px;
-  color: var(--color-text-3);
-  background: var(--color-border-2);
-  padding: 1px 5px;
-  border-radius: 5px;
-}
 .desc {
   font-size: 11.5px;
   color: var(--color-text-3);

--- a/src/renderer/components/model/modelSelector/ModelSelectorFlyout.tsx
+++ b/src/renderer/components/model/modelSelector/ModelSelectorFlyout.tsx
@@ -107,11 +107,8 @@ const ModelSelectorFlyout: React.FC<ModelSelectorProps> = ({
         <div className={`${styles.row} ${styles.unavail}`} key={row.key}>
           <Tile label={row.label} />
           <div className={styles.meta}>
-            <div className={styles.name}>
-              {row.label}
-              <span className={styles.srcTag}>{row.providerId}</span>
-            </div>
-            <div className={styles.desc}>{row.descriptor}</div>
+            <div className={styles.name}>{row.label}</div>
+            {row.descriptor && <div className={styles.desc}>{row.descriptor}</div>}
           </div>
           <span className={styles.unavailNote}>
             {t('conversation.modelSelector.unavailable', { defaultValue: 'Currently unavailable' })}
@@ -134,11 +131,8 @@ const ModelSelectorFlyout: React.FC<ModelSelectorProps> = ({
       >
         <Tile label={row.label} />
         <div className={styles.meta}>
-          <div className={styles.name}>
-            {row.label}
-            <span className={styles.srcTag}>{row.providerId}</span>
-          </div>
-          <div className={styles.desc}>{row.descriptor}</div>
+          <div className={styles.name}>{row.label}</div>
+          {row.descriptor && <div className={styles.desc}>{row.descriptor}</div>}
         </div>
         {row.price && <span className={tierClass(row.price)}>{row.price}</span>}
         {active && (

--- a/src/renderer/components/model/modelSelector/modelRowHelpers.ts
+++ b/src/renderer/components/model/modelSelector/modelRowHelpers.ts
@@ -12,13 +12,23 @@ export const modelKey = (m: Pick<CatalogModel, 'providerId' | 'id'>): string => 
 
 /**
  * One-line descriptor for a model row: "<context> context · <provider>".
- * The context segment is dropped when `contextWindow` is unknown, leaving just
- * the human provider name (e.g. "OpenAI").
+ * The context segment is dropped when `contextWindow` is unknown.
+ *
+ * Set `includeProvider = false` for rows that already sit under a provider-named
+ * zone header (e.g. "Recommended for OpenAI"), so the provider isn't repeated a
+ * second time in the descriptor. Those rows collapse to "<context> context", or
+ * an empty string when the context window is unknown. Mixed zones (Pinned /
+ * Recently used) keep the provider since they have no provider header.
  */
-export const describeModel = (m: Pick<CatalogModel, 'providerId' | 'contextWindow'>): string => {
+export const describeModel = (
+  m: Pick<CatalogModel, 'providerId' | 'contextWindow'>,
+  includeProvider = true
+): string => {
+  const hasCtx = typeof m.contextWindow === 'number' && m.contextWindow > 0;
+  const ctx = hasCtx ? `${Math.round(m.contextWindow / 1000)}K context` : '';
+  if (!includeProvider) return ctx;
   const provider = providerLabel(m.providerId);
-  if (typeof m.contextWindow !== 'number' || m.contextWindow <= 0) return provider;
-  const ctx = `${Math.round(m.contextWindow / 1000)}K context`;
+  if (!hasCtx) return provider;
   return `${ctx} · ${provider}`;
 };
 

--- a/src/renderer/components/model/modelSelector/useModelSelectorViewModel.ts
+++ b/src/renderer/components/model/modelSelector/useModelSelectorViewModel.ts
@@ -6,7 +6,13 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import type { CuratedModel, ProviderId } from '@process/providers/types';
-import { FLUX_AUTO_MODEL, FLUX_MODEL_DISPLAY, FLUX_MODEL_IDS, isFluxModelId, type FluxModelId } from '@/common/config/flux';
+import {
+  FLUX_AUTO_MODEL,
+  FLUX_MODEL_DISPLAY,
+  FLUX_MODEL_IDS,
+  isFluxModelId,
+  type FluxModelId,
+} from '@/common/config/flux';
 import { useModelRegistry } from '@renderer/hooks/useModelRegistry';
 import { useFluxConnected } from '@renderer/hooks/useFluxConnected';
 import { usePinnedModels } from '@renderer/hooks/usage/usePinnedModels';
@@ -22,15 +28,20 @@ const EFFORT_BACKENDS = new Set(['codex', 'wcore', 'claude']);
 /** Cap on the recently-used zone (Claude-style short list). */
 const RECENT_LIMIT = 4;
 
-/** Build a row for a real curated model. */
-function curatedRow(m: CuratedModel, pinned: Set<string>): ModelRow {
+/**
+ * Build a row for a real curated model. `includeProvider` controls whether the
+ * descriptor repeats the provider name: pass `false` for rows that live under a
+ * provider-named zone header (Recommended / More) so the provider isn't shown
+ * twice; leave it `true` for the mixed Pinned / Recently used zones.
+ */
+function curatedRow(m: CuratedModel, pinned: Set<string>, includeProvider = true): ModelRow {
   const key = modelKey(m);
   return {
     key,
     id: m.id,
     providerId: m.providerId,
     label: m.displayName,
-    descriptor: describeModel(m),
+    descriptor: describeModel(m, includeProvider),
     price: priceTier(m),
     pinned: pinned.has(key),
     available: m.enabled,
@@ -157,7 +168,7 @@ export function useModelSelectorViewModel(backend: string, activeModelKey?: stri
     const recentKeys = new Set(recentRows.map((r) => r.key));
     const recommendedRows = base
       .filter((m) => m.recommended && !recentKeys.has(modelKey(m)))
-      .map((m) => curatedRow(m, pinned));
+      .map((m) => curatedRow(m, pinned, false));
     const recommendedZones = groupByProvider(recommendedRows, 'recommended');
 
     const zones: ModelZone[] = [];
@@ -175,7 +186,7 @@ export function useModelSelectorViewModel(backend: string, activeModelKey?: stri
     // More-models: the long tail not surfaced in any zone above, grouped by
     // provider (pinned ∪ recent ∪ recommended are excluded).
     const surfaced = new Set<string>([...pinnedKeys, ...recentKeys, ...recommendedRows.map((r) => r.key)]);
-    const moreRows = base.filter((m) => !surfaced.has(modelKey(m))).map((m) => curatedRow(m, pinned));
+    const moreRows = base.filter((m) => !surfaced.has(modelKey(m))).map((m) => curatedRow(m, pinned, false));
     const moreZones = groupByProvider(moreRows, 'more');
 
     return {

--- a/tests/unit/renderer/modelSelector/ModelSelectorFlyout.dom.test.tsx
+++ b/tests/unit/renderer/modelSelector/ModelSelectorFlyout.dom.test.tsx
@@ -77,6 +77,16 @@ describe('ModelSelectorFlyout', () => {
     expect(screen.getByText('GPT-5.2')).toBeInTheDocument();
   });
 
+  it('does not leak the raw providerId as a label pill (triple-label fix)', () => {
+    render(<ModelSelectorFlyout vm={baseVm} onSelect={noop} onTogglePin={noop} onManage={noop} />);
+    // The human labels/headers still show; the raw internal ids must not.
+    expect(screen.getByText('GPT-5.2')).toBeInTheDocument();
+    expect(screen.getByText('Recommended for OpenAI')).toBeInTheDocument();
+    expect(screen.queryByText('openai')).not.toBeInTheDocument();
+    expect(screen.queryByText('anthropic')).not.toBeInTheDocument();
+    expect(screen.queryByText('flux-router')).not.toBeInTheDocument();
+  });
+
   it('fires onSelect with (id, providerId) when a row is clicked', () => {
     const onSelect = vi.fn();
     render(<ModelSelectorFlyout vm={baseVm} onSelect={onSelect} onTogglePin={noop} onManage={noop} />);

--- a/tests/unit/renderer/modelSelector/modelRowHelpers.test.ts
+++ b/tests/unit/renderer/modelSelector/modelRowHelpers.test.ts
@@ -31,12 +31,25 @@ describe('modelRowHelpers', () => {
   it('describeModel renders "<context> context · <provider>"', () => {
     expect(
       describeModel(
-        model({ id: 'claude-opus-4-8', providerId: 'anthropic', displayName: 'Opus 4.8', family: 'claude', contextWindow: 200000 })
+        model({
+          id: 'claude-opus-4-8',
+          providerId: 'anthropic',
+          displayName: 'Opus 4.8',
+          family: 'claude',
+          contextWindow: 200000,
+        })
       )
     ).toBe('200K context · Anthropic');
   });
   it('describeModel omits context when unknown', () => {
     expect(describeModel(model({ id: 'x', providerId: 'openai', displayName: 'X', family: 'gpt' }))).toBe('OpenAI');
+  });
+  it('describeModel drops the provider when includeProvider=false (provider-grouped zone)', () => {
+    // Rows under a "Recommended for OpenAI" header must not repeat the provider.
+    expect(describeModel(model({ providerId: 'anthropic', contextWindow: 200000 }), false)).toBe('200K context');
+  });
+  it('describeModel returns an empty descriptor when includeProvider=false and context is unknown', () => {
+    expect(describeModel(model({ providerId: 'openai' }), false)).toBe('');
   });
   it('priceTier buckets by output cost per M', () => {
     expect(priceTier(model({ costOutPerM: 2 }))).toBe('$');

--- a/tests/unit/renderer/modelSelector/useModelSelectorViewModel.dom.test.ts
+++ b/tests/unit/renderer/modelSelector/useModelSelectorViewModel.dom.test.ts
@@ -82,6 +82,27 @@ describe('useModelSelectorViewModel', () => {
     expect(result.current.empty).toBe(false);
   });
 
+  it('drops the provider from grouped-zone descriptors but keeps it in mixed zones (triple-label fix)', async () => {
+    // opus is pinned (mixed zone) AND recommended (provider-grouped zone).
+    mockCuratedForAgent.mockResolvedValue([opus, sonnet]);
+    mockUseFluxConnected.mockReturnValue(false);
+    mockUsePinnedModels.mockReturnValue({ pinned: new Set(['anthropic:claude-opus-4-8']), toggle: vi.fn() });
+
+    const { result } = renderHook(() => useModelSelectorViewModel('wcore'));
+    await waitFor(() => expect(result.current.zones.some((z) => z.id === 'pinned')).toBe(true));
+
+    // Pinned zone has no provider header -> descriptor keeps the provider.
+    const pinnedRow = result.current.zones.find((z) => z.id === 'pinned')?.rows.find((r) => r.id === 'claude-opus-4-8');
+    expect(pinnedRow?.descriptor).toBe('200K context · Anthropic');
+
+    // Recommended zone IS grouped under "Anthropic" -> descriptor drops it.
+    const recRow = result.current.zones
+      .find((z) => z.id.startsWith('recommended'))
+      ?.rows.find((r) => r.id === 'claude-opus-4-8');
+    expect(recRow?.descriptor).toBe('200K context');
+    expect(recRow?.descriptor).not.toContain('Anthropic');
+  });
+
   it('surfaces the non-auto Flux routing tiers as a top zone when connected', async () => {
     mockCuratedForAgent.mockResolvedValue([opus]);
     mockUseFluxConnected.mockReturnValue(true);


### PR DESCRIPTION
## Problem — "triple-label"

In the chat model picker, a model's **provider** rendered up to **three times** per row:

1. the provider-named **zone header** — e.g. *"Recommended for OpenAI"*
2. a raw-**`providerId` pill** next to the model name — literally `openai` / `flux-router` (an internal id leaked into the UI)
3. the **descriptor** tail from `describeModel` — *"128K context · OpenAI"*

Worst on Flux rows, which read `Flux Standard` + a `flux-router` pill + the tier descriptor.

## Fix

- **Remove the raw-`providerId` pill** from both render branches in `ModelSelectorFlyout.tsx` and delete the now-dead `.srcTag` CSS.
- **Provider-aware descriptor:** `describeModel` / `curatedRow` take an `includeProvider` flag (default `true`). Provider-**grouped** zones (Recommended / More) already show the provider in their header, so their rows render **context-only**; the **mixed** Pinned / Recently-used zones (no provider header) **keep** the provider. Flux tier rows are untouched (they set their own descriptor).
- **Guard the descriptor div** so a context-less grouped row doesn't emit an empty node (prevents ragged row heights — from the audit).

Net: provider shows **exactly once** per row. `providerId` is still carried on the row for `onSelect` / grouping / keys / **search** (find-by-provider still matches the `providerId` field, independent of the removed pill).

## Tests

Extends the existing suite (all green, 23 modelSelector tests):
- `ModelSelectorFlyout.dom.test.tsx` — the raw ids (`openai` / `anthropic` / `flux-router`) no longer render as pills. *Verified this fails pre-fix.*
- `useModelSelectorViewModel.dom.test.ts` — a model in both Pinned and Recommended keeps the provider in Pinned but drops it under the provider header in Recommended. *Verified this fails pre-fix.*
- `modelRowHelpers.test.ts` — `describeModel(m, false)` → context-only / empty.

Typecheck clean · oxlint clean on changed files.

## Adversarial self-cross-audit

Independent adversarial subagent reviewed the full component set. **No blocker/major.** It confirmed: search find-by-provider survives (matches `providerId` field), Flux rows unaffected, `.srcTag` deletion complete (the only other `.srcTag` is an unrelated CSS module), `providerId` still populated/used. One minor (empty-descriptor ragged rows) — **fixed** in this PR via the descriptor guard. One by-design note (same model shows provider in Pinned but not Recommended — intended).

## ⚠️ Not visually confirmed locally

This is a pure presentational change; DOM tests assert the exact rendered strings (pill absent, grouped-zone descriptor de-duped). I could **not** launch the app to eyeball it (fresh worktree needs a full build, and the picker needs connected providers/Flux to populate). Requesting a quick visual confirm of the picker rows on a running build. No self-merge.