### PR TITLE
fix(cron): #554 reconcile scheduled-task UI with the store on lifecycle boundaries

### DIFF
--- a/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx
+++ b/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx
@@ -5,7 +5,7 @@
  */
 
 import { Bot, ChevronDown, Workflow as WorkflowIcon } from 'lucide-react';
-import React, { useState, useMemo, useEffect, useCallback } from 'react';
+import React, { useState, useMemo, useEffect, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Form, Input, Select, Message, TimePicker, Radio, Button } from '@arco-design/web-react';
 import ModalWrapper from '@renderer/components/base/ModalWrapper';
@@ -182,6 +182,62 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
   const [customCronExpr, setCustomCronExpr] = useState<string>('');
 
   const isEditMode = !!editJob;
+
+  // #554: the editJob prop can be stale. The parent (TaskDetailPage) mirrors
+  // its job from one-shot onJobUpdated IPC events, which are lost if an agent
+  // updated the job from chat while this window was blurred. Re-fetch the
+  // authoritative record from the SQLite cron store when the dialog opens so
+  // both the edit form and the update baseline in handleSubmit reflect the
+  // latest saved config — never a stale snapshot that would clobber the
+  // agent's changes on save. Falls back to the prop if the fetch fails.
+  //
+  // freshJob (state) drives the form; latestJobRef mirrors the same value for
+  // the submit baseline (handleSubmit's freshJob closure can be stale relative
+  // to a just-resolved fetch, a ref can't); getJobPromiseRef lets a fast save
+  // await the in-flight fetch before merging.
+  const [freshJob, setFreshJob] = useState<ICronJob | undefined>(editJob);
+  const latestJobRef = useRef<ICronJob | undefined>(editJob);
+  const getJobPromiseRef = useRef<Promise<void> | null>(null);
+  // #554: set on any user edit within a dialog session. When getJob resolves
+  // with a newer record, the populate effect re-runs; if the user has already
+  // started editing we must NOT overwrite their in-progress input with the
+  // store copy. Reset per open (in the effect below).
+  const userEditedRef = useRef(false);
+  const markEdited = useCallback(() => {
+    userEditedRef.current = true;
+  }, []);
+  useEffect(() => {
+    // New dialog session (open, or editJob swap): start clean.
+    userEditedRef.current = false;
+    if (!visible || !editJob) {
+      setFreshJob(editJob);
+      latestJobRef.current = editJob;
+      getJobPromiseRef.current = null;
+      return;
+    }
+    // Optimistically show the prop so the dialog opens instantly, then
+    // reconcile with the store's copy once it resolves.
+    setFreshJob(editJob);
+    latestJobRef.current = editJob;
+    let cancelled = false;
+    // Optional-chain the whole call so a bridge without getJob can't throw
+    // synchronously inside this passive effect (and Promise.resolve tolerates
+    // a non-promise/undefined return).
+    getJobPromiseRef.current = Promise.resolve(ipcBridge.cron.getJob?.invoke?.({ jobId: editJob.id }))
+      .then((latest) => {
+        if (cancelled || !latest) return;
+        latestJobRef.current = latest;
+        // Only re-drive the form when the store copy actually differs from the
+        // optimistic prop — avoids a redundant second form-fill (and the
+        // in-progress-edit clobber it would cause) when the prop was current.
+        setFreshJob((prev) => (prev && JSON.stringify(prev) === JSON.stringify(latest) ? prev : latest));
+      })
+      .catch((err) => console.warn('[CreateTaskDialog] getJob on open failed:', err));
+    return () => {
+      cancelled = true;
+    };
+  }, [visible, editJob]);
+
   // v0.6.2.6 - ExecutionMode default depends on context:
   //   - From a chat (conversationId set): NO preselect. Force the user to
   //     pick because "existing" appends to this chat (long-running thread)
@@ -261,34 +317,39 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
   // Populate form when entering edit mode
   useEffect(() => {
     if (!visible) return;
-    if (editJob) {
-      const cronExpr = editJob.schedule.kind === 'cron' ? editJob.schedule.expr : '';
+    if (freshJob) {
+      // #554: this effect fires twice per edit open — once optimistically from
+      // the editJob prop, then again when getJob resolves a newer record. If the
+      // user began editing between the two, skip the second fill so their
+      // in-progress input survives (the submit baseline still uses latestJobRef).
+      if (userEditedRef.current) return;
+      const cronExpr = freshJob.schedule.kind === 'cron' ? freshJob.schedule.expr : '';
       const parsed = parseCronExpr(cronExpr);
       setFrequency(parsed.frequency);
       setTime(parsed.time);
       setWeekday(parsed.weekday);
       setCustomCronExpr(parsed.frequency === 'custom' ? cronExpr : '');
-      setExecutionMode(editJob.target.executionMode || 'existing');
+      setExecutionMode(freshJob.target.executionMode || 'existing');
       setAdvancedOpen(
         Boolean(
-          editJob.metadata.agentConfig?.modelId ||
-          editJob.metadata.agentConfig?.workspace ||
-          (editJob.metadata.agentConfig?.configOptions &&
-            Object.keys(editJob.metadata.agentConfig.configOptions).length > 0)
+          freshJob.metadata.agentConfig?.modelId ||
+          freshJob.metadata.agentConfig?.workspace ||
+          (freshJob.metadata.agentConfig?.configOptions &&
+            Object.keys(freshJob.metadata.agentConfig.configOptions).length > 0)
         )
       );
-      const agentKey = getAgentKeyFromJob(editJob);
+      const agentKey = getAgentKeyFromJob(freshJob);
       setSelectedAgent(agentKey);
       form.setFieldsValue({
-        name: editJob.name,
-        description: getDescriptionInitialValue(editJob),
-        prompt: editJob.target.payload.text,
+        name: freshJob.name,
+        description: getDescriptionInitialValue(freshJob),
+        prompt: freshJob.target.payload.text,
         agent: agentKey,
       });
-      // Populate advanced settings from editJob
-      setModelId(editJob.metadata.agentConfig?.modelId);
-      setConfigOptions(editJob.metadata.agentConfig?.configOptions);
-      setWorkspace(editJob.metadata.agentConfig?.workspace);
+      // Populate advanced settings from the authoritative job record
+      setModelId(freshJob.metadata.agentConfig?.modelId);
+      setConfigOptions(freshJob.metadata.agentConfig?.configOptions);
+      setWorkspace(freshJob.metadata.agentConfig?.workspace);
     } else {
       form.resetFields();
       setFrequency('manual');
@@ -352,7 +413,7 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
     }
   }, [
     visible,
-    editJob,
+    freshJob,
     form,
     initialExecutionMode,
     conversationId,
@@ -423,18 +484,23 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
     return undefined;
   }, [resolvedBackend, modelId, filteredProviders, getAvailableModels]);
 
-  const handleGeminiModelSelect = useCallback(async (model: TProviderWithModel) => {
-    setModelId(model.useModel);
-  }, []);
+  const handleGeminiModelSelect = useCallback(
+    async (model: TProviderWithModel) => {
+      markEdited();
+      setModelId(model.useModel);
+    },
+    [markEdited]
+  );
 
   const handleAcpModelSelect: React.Dispatch<React.SetStateAction<string | null>> = useCallback(
     (action: React.SetStateAction<string | null>) => {
+      markEdited();
       setModelId((prev) => {
         const next = typeof action === 'function' ? action(prev ?? null) : action;
         return next ?? undefined;
       });
     },
-    []
+    [markEdited]
   );
 
   // Load ACP cached model info when backend changes
@@ -493,11 +559,11 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
         };
       }
       case 'custom':
-        return { expr: customCronExpr, description: editJob?.schedule.description || customCronExpr };
+        return { expr: customCronExpr, description: freshJob?.schedule.description || customCronExpr };
       default:
         return { expr: '', description: '' };
     }
-  }, [frequency, time, weekday, t, customCronExpr, editJob]);
+  }, [frequency, time, weekday, t, customCronExpr, freshJob]);
 
   const executionModeOptions = useMemo(
     () => [
@@ -529,27 +595,37 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
   const advancedFieldCount = Number(showModelSelector) + Number(showConfigSelector) + 1;
 
   const handleFrequencyChange = (value: FrequencyType) => {
+    markEdited();
     setFrequency(value);
     if (value !== 'custom') {
       setCustomCronExpr('');
     }
   };
 
-  const handleAgentChange = useCallback((value: string) => {
-    setSelectedAgent(value);
-    // Reset model and configOptions when agent changes
-    setModelId(undefined);
-    setConfigOptions(undefined);
-    // Workspace remains unchanged (agent-agnostic)
-  }, []);
+  const handleAgentChange = useCallback(
+    (value: string) => {
+      markEdited();
+      setSelectedAgent(value);
+      // Reset model and configOptions when agent changes
+      setModelId(undefined);
+      setConfigOptions(undefined);
+      // Workspace remains unchanged (agent-agnostic)
+    },
+    [markEdited]
+  );
 
   const handleWorkspaceClear = useCallback(() => {
+    markEdited();
     setWorkspace(undefined);
-  }, []);
+  }, [markEdited]);
 
-  const handleConfigOptionSelect = useCallback((configId: string, value: string) => {
-    setConfigOptions((prev) => ({ ...prev, [configId]: value }));
-  }, []);
+  const handleConfigOptionSelect = useCallback(
+    (configId: string, value: string) => {
+      markEdited();
+      setConfigOptions((prev) => ({ ...prev, [configId]: value }));
+    },
+    [markEdited]
+  );
 
   const resolveAgentConfig = (agentValue: string) => {
     const colonIdx = agentValue.indexOf(':');
@@ -624,20 +700,25 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
       const { agentConfig, resolvedAgentType } = resolveAgentConfig(values.agent);
 
       if (isEditMode) {
-        // Edit mode: update existing job
+        // Edit mode: update existing job. Await any in-flight getJob and merge
+        // onto the store's latest record (#554) — never a stale prop snapshot
+        // that could silently revert an agent's chat-side changes. Even a save
+        // fired before the fetch resolved uses the freshest baseline.
+        await getJobPromiseRef.current;
+        const baseline = latestJobRef.current ?? editJob!;
         await ipcBridge.cron.updateJob.invoke({
-          jobId: editJob!.id,
+          jobId: baseline.id,
           updates: {
             name: values.name,
             description: values.description,
             schedule: { kind: 'cron', expr: scheduleExpr, description: scheduleDesc },
             target: {
-              ...editJob!.target,
+              ...baseline.target,
               payload: { kind: 'message', text: values.prompt },
               executionMode,
             },
             metadata: {
-              ...editJob!.metadata,
+              ...baseline.metadata,
               agentType: resolvedAgentType,
               agentConfig,
               updatedAt: Date.now(),
@@ -691,7 +772,7 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
       unmountOnExit
     >
       <div className='overflow-y-auto px-24px pb-16px pr-18px max-h-[min(68vh,640px)]'>
-        <Form form={form} layout='vertical'>
+        <Form form={form} layout='vertical' onValuesChange={markEdited}>
           {/* Source toggle - hidden in edit mode since the saved job is
               already past the "did we start from a workflow?" choice.
               In create mode the two tabs route to the same submit path;
@@ -859,7 +940,10 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
           <FormItem label={t('cron.page.form.executionMode')}>
             <Radio.Group
               value={executionMode}
-              onChange={(value) => setExecutionMode(value as ExecutionMode)}
+              onChange={(value) => {
+                markEdited();
+                setExecutionMode(value as ExecutionMode);
+              }}
               className='flex flex-wrap items-center gap-20px'
             >
               {executionModeOptions.map((option) => {
@@ -916,6 +1000,7 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
                 value={dayjs(`2000-01-01 ${time}`)}
                 onChange={(_timeStr, pickedTime) => {
                   if (pickedTime) {
+                    markEdited();
                     setTime(pickedTime.format('HH:mm'));
                   }
                 }}
@@ -928,7 +1013,13 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
           {/* Weekday picker - shown for weekly */}
           {showWeekdayPicker && (
             <div className='mb-16px'>
-              <Select value={weekday} onChange={setWeekday}>
+              <Select
+                value={weekday}
+                onChange={(v) => {
+                  markEdited();
+                  setWeekday(v);
+                }}
+              >
                 {WEEKDAYS.map((d) => (
                   <Option key={d.value} value={d.value}>
                     {t(`cron.page.weekday.${d.label}`)}
@@ -993,7 +1084,10 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
                   </label>
                   <WorkspaceFolderSelect
                     value={workspace}
-                    onChange={(next) => setWorkspace(next || undefined)}
+                    onChange={(next) => {
+                      markEdited();
+                      setWorkspace(next || undefined);
+                    }}
                     onClear={handleWorkspaceClear}
                     placeholder={t('cron.page.form.selectFolder')}
                     inputPlaceholder={t('cron.page.form.workspacePlaceholder')}

--- a/src/renderer/pages/cron/ScheduledTasksPage/TaskDetailPage.tsx
+++ b/src/renderer/pages/cron/ScheduledTasksPage/TaskDetailPage.tsx
@@ -31,18 +31,24 @@ const TaskDetailPage: React.FC = () => {
   const isManualOnly = job?.schedule.kind === 'cron' && !job.schedule.expr;
   const { conversations } = useCronJobConversations(jobId);
 
-  const fetchJob = useCallback(async () => {
-    if (!jobId) return;
-    setLoading(true);
-    try {
-      const found = await ipcBridge.cron.getJob.invoke({ jobId });
-      setJob(found ?? null);
-    } catch (err) {
-      console.error('[TaskDetailPage] Failed to fetch job:', err);
-    } finally {
-      setLoading(false);
-    }
-  }, [jobId]);
+  // `silent` skips the loading flag so a background reconcile (focus/
+  // visibility) doesn't replace the rendered detail with a full-page spinner.
+  const fetchJob = useCallback(
+    async (opts?: { silent?: boolean }) => {
+      if (!jobId) return;
+      const silent = opts?.silent === true;
+      if (!silent) setLoading(true);
+      try {
+        const found = await ipcBridge.cron.getJob.invoke({ jobId });
+        setJob(found ?? null);
+      } catch (err) {
+        console.error('[TaskDetailPage] Failed to fetch job:', err);
+      } finally {
+        if (!silent) setLoading(false);
+      }
+    },
+    [jobId]
+  );
 
   useEffect(() => {
     void fetchJob();
@@ -64,6 +70,27 @@ const TaskDetailPage: React.FC = () => {
     return () => {
       unsubUpdated();
       unsubExecuted();
+    };
+  }, [jobId, fetchJob]);
+
+  // Authoritative re-fetch on lifecycle boundaries (#554). The subscription
+  // above relies on one-shot onJobUpdated events, which are lost if the window
+  // was blurred when an agent updated this job from chat. Re-reading the store
+  // whenever the window regains focus or becomes visible reconciles the
+  // displayed detail with the source of truth without a live event.
+  useEffect(() => {
+    if (!jobId) return;
+    const onFocus = () => {
+      void fetchJob({ silent: true });
+    };
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') void fetchJob({ silent: true });
+    };
+    window.addEventListener('focus', onFocus);
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      window.removeEventListener('focus', onFocus);
+      document.removeEventListener('visibilitychange', onVisibility);
     };
   }, [jobId, fetchJob]);
 

--- a/src/renderer/pages/cron/ScheduledTasksPage/index.tsx
+++ b/src/renderer/pages/cron/ScheduledTasksPage/index.tsx
@@ -43,6 +43,10 @@ const ScheduledTasksPage: React.FC = () => {
   const isMobile = layout?.isMobile ?? false;
   const { t } = useTranslation();
   const navigate = useNavigate();
+  // #554: the list reconciles with the SQLite cron store on mount (route-enter
+  // remounts this page) and on window focus / tab-visible via useAllCronJobs,
+  // so a chat-created task surfaces even when its one-shot onJobCreated event
+  // was lost because this page was unmounted or the window was blurred.
   const { jobs, loading, pauseJob, resumeJob } = useAllCronJobs();
   const [createDialogVisible, setCreateDialogVisible] = useState(false);
   const [createInitialWorkflowSlug, setCreateInitialWorkflowSlug] = useState<string | undefined>(undefined);

--- a/src/renderer/pages/cron/useCronJobs.ts
+++ b/src/renderer/pages/cron/useCronJobs.ts
@@ -173,22 +173,46 @@ export function useAllCronJobs() {
   const [jobs, setJobs] = useState<ICronJob[]>([]);
   const [loading, setLoading] = useState(true);
 
-  // Fetch all jobs
-  const fetchJobs = useCallback(async () => {
-    setLoading(true);
+  // Fetch all jobs. `silent` skips the loading flag so a background reconcile
+  // (focus/visibility) doesn't blank the already-rendered list to a spinner.
+  const fetchJobs = useCallback(async (opts?: { silent?: boolean }) => {
+    const silent = opts?.silent === true;
+    if (!silent) setLoading(true);
     try {
       const allJobs = await ipcBridge.cron.listJobs.invoke();
       setJobs(allJobs || []);
     } catch (err) {
       console.error('[useAllCronJobs] Failed to fetch jobs:', err);
     } finally {
-      setLoading(false);
+      if (!silent) setLoading(false);
     }
   }, []);
 
   // Initial fetch
   useEffect(() => {
     void fetchJobs();
+  }, [fetchJobs]);
+
+  // Authoritative re-fetch on lifecycle boundaries. The list otherwise
+  // relies on one-shot main->renderer IPC events (onJobCreated/Updated/
+  // Removed); if the page was unmounted or the window was blurred when an
+  // event fired (e.g. a task created from chat, #554), that update is lost
+  // with no fallback. Re-reading the SQLite cron store whenever the window
+  // regains focus or becomes visible reconciles the UI with the source of
+  // truth without needing a live event to have been received.
+  useEffect(() => {
+    const onFocus = () => {
+      void fetchJobs({ silent: true });
+    };
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') void fetchJobs({ silent: true });
+    };
+    window.addEventListener('focus', onFocus);
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      window.removeEventListener('focus', onFocus);
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
   }, [fetchJobs]);
 
   // Event handlers

--- a/tests/unit/renderer/conversation/CreateTaskDialog.dom.test.tsx
+++ b/tests/unit/renderer/conversation/CreateTaskDialog.dom.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ICronJob } from '@/common/adapter/ipcBridge';
@@ -69,6 +69,7 @@ vi.mock('@icon-park/react', () => ({
 // Mock ipcBridge
 const mockAddJob = vi.fn();
 const mockUpdateJob = vi.fn();
+const mockGetJob = vi.hoisted(() => vi.fn());
 const mockFormSetFieldsValue = vi.hoisted(() => vi.fn());
 const mockFormResetFields = vi.hoisted(() => vi.fn());
 const mockFormValidate = vi.hoisted(() =>
@@ -93,6 +94,7 @@ vi.mock('@/common', () => ({
     cron: {
       addJob: { invoke: (...args: unknown[]) => mockAddJob(...args) },
       updateJob: { invoke: (...args: unknown[]) => mockUpdateJob(...args) },
+      getJob: { invoke: (...args: unknown[]) => mockGetJob(...args) },
     },
     // 'From workflow' tab (87b304c54): create mode loads the workflow list and
     // a selected workflow's body via skills.*. Plain functions (not vi.fn) so
@@ -377,8 +379,6 @@ describe('CreateTaskDialog - parseCronExpr utility', () => {
       name: 'Hourly Task',
       schedule: { kind: 'cron', expr: '0 * * * *', description: 'Every hour' },
       target: {
-        kind: 'conversation',
-        conversationId: 'conv-1',
         payload: { kind: 'message', text: 'Hourly check' },
         executionMode: 'existing',
       },
@@ -393,8 +393,8 @@ describe('CreateTaskDialog - parseCronExpr utility', () => {
           cliPath: '/usr/bin/claude',
         },
       },
-      state: 'active',
-      lastExecutionTime: Date.now(),
+      enabled: true,
+      state: { runCount: 0, retryCount: 0, maxRetries: 3 },
     };
 
     const { rerender } = render(
@@ -422,8 +422,6 @@ describe('CreateTaskDialog - parseCronExpr utility', () => {
       name: 'Daily Task',
       schedule: { kind: 'cron', expr: '30 9 * * *', description: 'Daily at 09:30' },
       target: {
-        kind: 'conversation',
-        conversationId: 'conv-1',
         payload: { kind: 'message', text: 'Daily check' },
         executionMode: 'existing',
       },
@@ -438,8 +436,8 @@ describe('CreateTaskDialog - parseCronExpr utility', () => {
           cliPath: '/usr/bin/claude',
         },
       },
-      state: 'active',
-      lastExecutionTime: Date.now(),
+      enabled: true,
+      state: { runCount: 0, retryCount: 0, maxRetries: 3 },
     };
 
     const { rerender } = render(
@@ -458,8 +456,6 @@ describe('CreateTaskDialog - parseCronExpr utility', () => {
       name: 'Weekday Task',
       schedule: { kind: 'cron', expr: '0 14 * * MON-FRI', description: 'Weekdays at 14:00' },
       target: {
-        kind: 'conversation',
-        conversationId: 'conv-1',
         payload: { kind: 'message', text: 'Weekday check' },
         executionMode: 'existing',
       },
@@ -474,8 +470,8 @@ describe('CreateTaskDialog - parseCronExpr utility', () => {
           cliPath: '/usr/bin/claude',
         },
       },
-      state: 'active',
-      lastExecutionTime: Date.now(),
+      enabled: true,
+      state: { runCount: 0, retryCount: 0, maxRetries: 3 },
     };
 
     const { rerender } = render(
@@ -494,8 +490,6 @@ describe('CreateTaskDialog - parseCronExpr utility', () => {
       name: 'Weekly Task',
       schedule: { kind: 'cron', expr: '0 10 * * WED', description: 'Weekly on Wednesday at 10:00' },
       target: {
-        kind: 'conversation',
-        conversationId: 'conv-1',
         payload: { kind: 'message', text: 'Weekly check' },
         executionMode: 'existing',
       },
@@ -510,8 +504,8 @@ describe('CreateTaskDialog - parseCronExpr utility', () => {
           cliPath: '/usr/bin/claude',
         },
       },
-      state: 'active',
-      lastExecutionTime: Date.now(),
+      enabled: true,
+      state: { runCount: 0, retryCount: 0, maxRetries: 3 },
     };
 
     const { rerender } = render(
@@ -530,8 +524,6 @@ describe('CreateTaskDialog - parseCronExpr utility', () => {
       name: 'Invalid Task',
       schedule: { kind: 'cron', expr: '', description: 'Manual' },
       target: {
-        kind: 'conversation',
-        conversationId: 'conv-1',
         payload: { kind: 'message', text: 'Check' },
         executionMode: 'existing',
       },
@@ -546,8 +538,8 @@ describe('CreateTaskDialog - parseCronExpr utility', () => {
           cliPath: '/usr/bin/claude',
         },
       },
-      state: 'active',
-      lastExecutionTime: Date.now(),
+      enabled: true,
+      state: { runCount: 0, retryCount: 0, maxRetries: 3 },
     };
 
     const { rerender } = render(
@@ -566,8 +558,6 @@ describe('CreateTaskDialog - parseCronExpr utility', () => {
       name: 'Every 4 Hours Task',
       schedule: { kind: 'cron', expr: '0 */4 * * *', description: 'Every 4 hours' },
       target: {
-        kind: 'conversation',
-        conversationId: 'conv-1',
         payload: { kind: 'message', text: 'Every 4 hours check' },
         executionMode: 'existing',
       },
@@ -582,8 +572,8 @@ describe('CreateTaskDialog - parseCronExpr utility', () => {
           cliPath: '/usr/bin/claude',
         },
       },
-      state: 'active',
-      lastExecutionTime: Date.now(),
+      enabled: true,
+      state: { runCount: 0, retryCount: 0, maxRetries: 3 },
     };
 
     const { rerender } = render(
@@ -604,8 +594,6 @@ describe('CreateTaskDialog - getAgentKeyFromJob utility', () => {
       name: 'Task',
       schedule: { kind: 'cron', expr: '0 9 * * *', description: 'Daily' },
       target: {
-        kind: 'conversation',
-        conversationId: 'conv-1',
         payload: { kind: 'message', text: 'Test' },
         executionMode: 'existing',
       },
@@ -620,8 +608,8 @@ describe('CreateTaskDialog - getAgentKeyFromJob utility', () => {
           cliPath: '/usr/bin/claude',
         },
       },
-      state: 'active',
-      lastExecutionTime: Date.now(),
+      enabled: true,
+      state: { runCount: 0, retryCount: 0, maxRetries: 3 },
     };
 
     const { rerender } = render(
@@ -641,8 +629,6 @@ describe('CreateTaskDialog - getAgentKeyFromJob utility', () => {
       name: 'Task',
       schedule: { kind: 'cron', expr: '0 9 * * *', description: 'Daily' },
       target: {
-        kind: 'conversation',
-        conversationId: 'conv-1',
         payload: { kind: 'message', text: 'Test' },
         executionMode: 'existing',
       },
@@ -659,8 +645,8 @@ describe('CreateTaskDialog - getAgentKeyFromJob utility', () => {
           presetAgentType: 'custom',
         },
       },
-      state: 'active',
-      lastExecutionTime: Date.now(),
+      enabled: true,
+      state: { runCount: 0, retryCount: 0, maxRetries: 3 },
     };
 
     const { rerender } = render(
@@ -679,8 +665,6 @@ describe('CreateTaskDialog - getAgentKeyFromJob utility', () => {
       name: 'Task',
       schedule: { kind: 'cron', expr: '0 9 * * *', description: 'Daily' },
       target: {
-        kind: 'conversation',
-        conversationId: 'conv-1',
         payload: { kind: 'message', text: 'Test' },
         executionMode: 'existing',
       },
@@ -690,8 +674,8 @@ describe('CreateTaskDialog - getAgentKeyFromJob utility', () => {
         createdAt: Date.now(),
         updatedAt: Date.now(),
       },
-      state: 'active',
-      lastExecutionTime: Date.now(),
+      enabled: true,
+      state: { runCount: 0, retryCount: 0, maxRetries: 3 },
     };
 
     const { rerender } = render(
@@ -716,8 +700,6 @@ describe('CreateTaskDialog - schedule preset definitions', () => {
       name: 'Existing Mode Task',
       schedule: { kind: 'cron', expr: '0 9 * * *', description: 'Daily at 09:00' },
       target: {
-        kind: 'conversation',
-        conversationId: 'conv-1',
         payload: { kind: 'message', text: 'Keep following up' },
         executionMode: 'existing',
       },
@@ -732,8 +714,8 @@ describe('CreateTaskDialog - schedule preset definitions', () => {
           cliPath: '/usr/bin/claude',
         },
       },
-      state: 'active',
-      lastExecutionTime: Date.now(),
+      enabled: true,
+      state: { runCount: 0, retryCount: 0, maxRetries: 3 },
     };
 
     render(<CreateTaskDialog visible={true} onClose={vi.fn()} editJob={editJob} conversationId='conv-1' />);
@@ -773,8 +755,6 @@ describe('CreateTaskDialog - schedule preset definitions', () => {
       name: 'Hourly Task',
       schedule: { kind: 'cron', expr: '0 * * * *', description: 'Every hour' },
       target: {
-        kind: 'conversation',
-        conversationId: 'conv-1',
         payload: { kind: 'message', text: 'Hourly check' },
         executionMode: 'existing',
       },
@@ -789,8 +769,8 @@ describe('CreateTaskDialog - schedule preset definitions', () => {
           cliPath: '/usr/bin/claude',
         },
       },
-      state: 'active',
-      lastExecutionTime: Date.now(),
+      enabled: true,
+      state: { runCount: 0, retryCount: 0, maxRetries: 3 },
     };
 
     mockUpdateJob.mockResolvedValue(undefined);
@@ -817,8 +797,6 @@ describe('CreateTaskDialog - schedule preset definitions', () => {
       name: 'Daily Task',
       schedule: { kind: 'cron', expr: '30 9 * * *', description: 'Daily at 09:30' },
       target: {
-        kind: 'conversation',
-        conversationId: 'conv-1',
         payload: { kind: 'message', text: 'Daily check' },
         executionMode: 'existing',
       },
@@ -833,8 +811,8 @@ describe('CreateTaskDialog - schedule preset definitions', () => {
           cliPath: '/usr/bin/claude',
         },
       },
-      state: 'active',
-      lastExecutionTime: Date.now(),
+      enabled: true,
+      state: { runCount: 0, retryCount: 0, maxRetries: 3 },
     };
 
     mockUpdateJob.mockResolvedValue(undefined);
@@ -860,8 +838,6 @@ describe('CreateTaskDialog - schedule preset definitions', () => {
       name: 'Weekdays Task',
       schedule: { kind: 'cron', expr: '0 14 * * MON-FRI', description: 'Weekdays at 14:00' },
       target: {
-        kind: 'conversation',
-        conversationId: 'conv-1',
         payload: { kind: 'message', text: 'Weekday check' },
         executionMode: 'existing',
       },
@@ -876,8 +852,8 @@ describe('CreateTaskDialog - schedule preset definitions', () => {
           cliPath: '/usr/bin/claude',
         },
       },
-      state: 'active',
-      lastExecutionTime: Date.now(),
+      enabled: true,
+      state: { runCount: 0, retryCount: 0, maxRetries: 3 },
     };
 
     mockUpdateJob.mockResolvedValue(undefined);
@@ -903,8 +879,6 @@ describe('CreateTaskDialog - schedule preset definitions', () => {
       name: 'Weekly Task',
       schedule: { kind: 'cron', expr: '0 10 * * WED', description: 'Weekly on Wednesday at 10:00' },
       target: {
-        kind: 'conversation',
-        conversationId: 'conv-1',
         payload: { kind: 'message', text: 'Weekly check' },
         executionMode: 'existing',
       },
@@ -919,8 +893,8 @@ describe('CreateTaskDialog - schedule preset definitions', () => {
           cliPath: '/usr/bin/claude',
         },
       },
-      state: 'active',
-      lastExecutionTime: Date.now(),
+      enabled: true,
+      state: { runCount: 0, retryCount: 0, maxRetries: 3 },
     };
 
     mockUpdateJob.mockResolvedValue(undefined);
@@ -946,8 +920,6 @@ describe('CreateTaskDialog - schedule preset definitions', () => {
       name: 'Every 4 Hours Task',
       schedule: { kind: 'cron', expr: '0 */4 * * *', description: 'Every 4 hours' },
       target: {
-        kind: 'conversation',
-        conversationId: 'conv-1',
         payload: { kind: 'message', text: 'Every 4 hours check' },
         executionMode: 'existing',
       },
@@ -962,8 +934,8 @@ describe('CreateTaskDialog - schedule preset definitions', () => {
           cliPath: '/usr/bin/claude',
         },
       },
-      state: 'active',
-      lastExecutionTime: Date.now(),
+      enabled: true,
+      state: { runCount: 0, retryCount: 0, maxRetries: 3 },
     };
 
     mockUpdateJob.mockResolvedValue(undefined);
@@ -994,8 +966,6 @@ describe('CreateTaskDialog - advanced settings workspace picker', () => {
       name: 'Workspace Task',
       schedule: { kind: 'cron', expr: '0 9 * * *', description: 'Daily at 09:00' },
       target: {
-        kind: 'conversation',
-        conversationId: 'conv-1',
         payload: { kind: 'message', text: 'Test prompt' },
         executionMode: 'existing',
       },
@@ -1011,8 +981,8 @@ describe('CreateTaskDialog - advanced settings workspace picker', () => {
           workspace: '/tmp/scheduled-workspace',
         },
       },
-      state: 'active',
-      lastExecutionTime: Date.now(),
+      enabled: true,
+      state: { runCount: 0, retryCount: 0, maxRetries: 3 },
     };
 
     render(<CreateTaskDialog visible onClose={vi.fn()} editJob={editJob} conversationId='conv-1' />);
@@ -1038,8 +1008,6 @@ describe('CreateTaskDialog - custom schedule hint', () => {
       name: 'Custom Task',
       schedule: { kind: 'cron', expr: '0 */4 * * *', description: 'Every 4 hours' },
       target: {
-        kind: 'conversation',
-        conversationId: 'conv-1',
         payload: { kind: 'message', text: 'Test prompt' },
         executionMode: 'existing',
       },
@@ -1054,8 +1022,8 @@ describe('CreateTaskDialog - custom schedule hint', () => {
           cliPath: '/usr/bin/claude',
         },
       },
-      state: 'active',
-      lastExecutionTime: Date.now(),
+      enabled: true,
+      state: { runCount: 0, retryCount: 0, maxRetries: 3 },
     };
 
     render(<CreateTaskDialog visible onClose={vi.fn()} editJob={editJob} conversationId='conv-1' />);
@@ -1091,8 +1059,6 @@ describe('CreateTaskDialog - component behavior', () => {
       description: 'Stored description',
       schedule: { kind: 'cron', expr: '0 9 * * *', description: 'Daily at 09:00' },
       target: {
-        kind: 'conversation',
-        conversationId: 'conv-1',
         payload: { kind: 'message', text: 'Existing prompt' },
         executionMode: 'existing',
       },
@@ -1107,8 +1073,8 @@ describe('CreateTaskDialog - component behavior', () => {
           cliPath: '/usr/bin/claude',
         },
       },
-      state: 'active',
-      lastExecutionTime: Date.now(),
+      enabled: true,
+      state: { runCount: 0, retryCount: 0, maxRetries: 3 },
     };
 
     render(<CreateTaskDialog visible={true} onClose={vi.fn()} editJob={editJob} conversationId='conv-1' />);
@@ -1123,8 +1089,6 @@ describe('CreateTaskDialog - component behavior', () => {
       description: 'Stored description',
       schedule: { kind: 'cron', expr: '0 9 * * *', description: 'Daily at 09:00' },
       target: {
-        kind: 'conversation',
-        conversationId: 'conv-1',
         payload: { kind: 'message', text: 'Existing prompt' },
         executionMode: 'existing',
       },
@@ -1139,8 +1103,8 @@ describe('CreateTaskDialog - component behavior', () => {
           cliPath: '/usr/bin/claude',
         },
       },
-      state: 'active',
-      lastExecutionTime: Date.now(),
+      enabled: true,
+      state: { runCount: 0, retryCount: 0, maxRetries: 3 },
     };
 
     render(<CreateTaskDialog visible={true} onClose={vi.fn()} editJob={editJob} conversationId='conv-1' />);
@@ -1162,8 +1126,6 @@ describe('CreateTaskDialog - component behavior', () => {
       description: undefined,
       schedule: { kind: 'cron', expr: '0 9 * * *', description: 'Daily at 09:00' },
       target: {
-        kind: 'conversation',
-        conversationId: 'conv-1',
         payload: { kind: 'message', text: 'Existing prompt' },
         executionMode: 'existing',
       },
@@ -1178,8 +1140,8 @@ describe('CreateTaskDialog - component behavior', () => {
           cliPath: '/usr/bin/claude',
         },
       },
-      state: 'active',
-      lastExecutionTime: Date.now(),
+      enabled: true,
+      state: { runCount: 0, retryCount: 0, maxRetries: 3 },
     };
 
     render(<CreateTaskDialog visible={true} onClose={vi.fn()} editJob={editJob} conversationId='conv-1' />);
@@ -1238,8 +1200,6 @@ describe('CreateTaskDialog - component behavior', () => {
       name: 'Existing Task',
       schedule: { kind: 'cron', expr: '0 9 * * *', description: 'Daily at 09:00' },
       target: {
-        kind: 'conversation',
-        conversationId: 'conv-1',
         payload: { kind: 'message', text: 'Existing prompt' },
         executionMode: 'existing',
       },
@@ -1254,8 +1214,8 @@ describe('CreateTaskDialog - component behavior', () => {
           cliPath: '/usr/bin/claude',
         },
       },
-      state: 'active',
-      lastExecutionTime: Date.now(),
+      enabled: true,
+      state: { runCount: 0, retryCount: 0, maxRetries: 3 },
     };
 
     render(<CreateTaskDialog visible={true} onClose={onClose} editJob={editJob} conversationId='conv-1' />);
@@ -1312,8 +1272,6 @@ describe('CreateTaskDialog - advanced settings panel', () => {
       name: 'Task',
       schedule: { kind: 'cron', expr: '0 9 * * *', description: 'Daily' },
       target: {
-        kind: 'conversation',
-        conversationId: 'conv-1',
         payload: { kind: 'message', text: 'prompt' },
         executionMode: 'existing',
       },
@@ -1329,8 +1287,8 @@ describe('CreateTaskDialog - advanced settings panel', () => {
           workspace: '/tmp/ws',
         },
       },
-      state: 'active',
-      lastExecutionTime: Date.now(),
+      enabled: true,
+      state: { runCount: 0, retryCount: 0, maxRetries: 3 },
     };
 
     render(<CreateTaskDialog visible onClose={vi.fn()} editJob={editJob} conversationId='conv-1' />);
@@ -1354,8 +1312,6 @@ describe('CreateTaskDialog - advanced settings panel', () => {
       name: 'Task',
       schedule: { kind: 'cron', expr: '0 9 * * *', description: 'Daily' },
       target: {
-        kind: 'conversation',
-        conversationId: 'conv-1',
         payload: { kind: 'message', text: 'prompt' },
         executionMode: 'new_conversation',
       },
@@ -1371,12 +1327,137 @@ describe('CreateTaskDialog - advanced settings panel', () => {
           workspace: '/projects/my-app',
         },
       },
-      state: 'active',
-      lastExecutionTime: Date.now(),
+      enabled: true,
+      state: { runCount: 0, retryCount: 0, maxRetries: 3 },
     };
 
     render(<CreateTaskDialog visible onClose={vi.fn()} editJob={editJob} conversationId='conv-1' />);
 
     expect(screen.getByTestId('cron-workspace-trigger')).toBeInTheDocument();
+  });
+});
+
+describe('CreateTaskDialog - getJob on open (#554)', () => {
+  const makeJob = (over: Partial<ICronJob> = {}): ICronJob => ({
+    id: 'job-554',
+    name: 'Stale Name',
+    enabled: true,
+    schedule: { kind: 'cron', expr: '0 9 * * *', description: 'Daily' },
+    target: {
+      payload: { kind: 'message', text: 'Stale Prompt' },
+      executionMode: 'existing',
+    },
+    metadata: {
+      conversationId: 'conv-STALE',
+      agentType: 'claude',
+      createdBy: 'user',
+      createdAt: 1,
+      updatedAt: 1,
+      agentConfig: { backend: 'claude', name: 'Claude', cliPath: '/usr/bin/claude' },
+    },
+    state: { runCount: 0, retryCount: 0, maxRetries: 3 },
+    ...over,
+  });
+
+  it('fetches the authoritative record from the store when opened in edit mode', async () => {
+    const editJob = makeJob();
+    mockGetJob.mockResolvedValue(editJob);
+
+    render(<CreateTaskDialog visible onClose={vi.fn()} editJob={editJob} conversationId='conv-STALE' />);
+
+    await waitFor(() => expect(mockGetJob).toHaveBeenCalledWith({ jobId: 'job-554' }));
+  });
+
+  it('re-populates the form with the fresh store record when it differs from the prop', async () => {
+    const staleProp = makeJob();
+    const freshRecord = makeJob({
+      name: 'Fresh Name',
+      target: { payload: { kind: 'message', text: 'Fresh Prompt' }, executionMode: 'existing' },
+    });
+    mockGetJob.mockResolvedValue(freshRecord);
+
+    render(<CreateTaskDialog visible onClose={vi.fn()} editJob={staleProp} conversationId='conv-STALE' />);
+
+    await waitFor(() =>
+      expect(mockFormSetFieldsValue).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'Fresh Name', prompt: 'Fresh Prompt' })
+      )
+    );
+  });
+
+  it('merges the edit-save onto the fresh baseline, not the stale prop', async () => {
+    const staleProp = makeJob(); // metadata.conversationId = 'conv-STALE'
+    const freshRecord = makeJob({
+      metadata: {
+        conversationId: 'conv-FRESH',
+        agentType: 'claude',
+        createdBy: 'user',
+        createdAt: 1,
+        updatedAt: 1,
+        agentConfig: { backend: 'claude', name: 'Claude', cliPath: '/usr/bin/claude' },
+      },
+    });
+    mockGetJob.mockResolvedValue(freshRecord);
+    mockUpdateJob.mockResolvedValue(undefined);
+
+    render(<CreateTaskDialog visible onClose={vi.fn()} editJob={staleProp} conversationId='conv-STALE' />);
+    await waitFor(() => expect(mockGetJob).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByTestId('modal-ok'));
+
+    await waitFor(() => expect(mockUpdateJob).toHaveBeenCalled());
+    const payload = mockUpdateJob.mock.calls[0][0];
+    expect(payload.jobId).toBe('job-554');
+    // metadata is spread from the baseline; a fresh conversationId proves the
+    // save merged onto the store record, not the stale prop.
+    expect(payload.updates.metadata.conversationId).toBe('conv-FRESH');
+  });
+
+  it('does not overwrite in-progress user edits when getJob resolves late (#554 race)', async () => {
+    const staleProp = makeJob({ name: 'Stale Name' });
+    const freshRecord = makeJob({
+      name: 'Fresh Name',
+      target: { payload: { kind: 'message', text: 'Fresh Prompt' }, executionMode: 'existing' },
+    });
+    // Hold getJob open so the user can edit before it resolves.
+    let resolveGetJob: ((v: unknown) => void) | undefined;
+    mockGetJob.mockReturnValue(
+      new Promise((r) => {
+        resolveGetJob = r;
+      })
+    );
+
+    render(<CreateTaskDialog visible onClose={vi.fn()} editJob={staleProp} conversationId='conv-STALE' />);
+
+    // Optimistic populate from the (stale) prop already happened.
+    await waitFor(() =>
+      expect(mockFormSetFieldsValue).toHaveBeenCalledWith(expect.objectContaining({ name: 'Stale Name' }))
+    );
+    mockFormSetFieldsValue.mockClear();
+
+    // User starts editing before getJob returns (changes execution mode → marks dirty).
+    fireEvent.click(document.querySelector('input[value="new_conversation"]') as HTMLInputElement);
+
+    // getJob now resolves with a DIFFERENT record.
+    await act(async () => {
+      resolveGetJob?.(freshRecord);
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // The dialog must NOT re-fill the form with the fresh record over the edits.
+    expect(mockFormSetFieldsValue).not.toHaveBeenCalledWith(expect.objectContaining({ name: 'Fresh Name' }));
+  });
+
+  it('falls back to the prop and does not crash when the store returns no record', async () => {
+    const editJob = makeJob();
+    mockGetJob.mockResolvedValue(null);
+
+    render(<CreateTaskDialog visible onClose={vi.fn()} editJob={editJob} conversationId='conv-STALE' />);
+
+    // Form still populated from the prop; dialog renders.
+    await waitFor(() =>
+      expect(mockFormSetFieldsValue).toHaveBeenCalledWith(expect.objectContaining({ name: 'Stale Name' }))
+    );
+    expect(screen.getByTestId('modal-wrapper')).toBeInTheDocument();
   });
 });

--- a/tests/unit/renderer/cron/useCronJobs.dom.test.tsx
+++ b/tests/unit/renderer/cron/useCronJobs.dom.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/// <reference types="@testing-library/jest-dom/vitest" />
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+// #554: useAllCronJobs must reconcile with the authoritative SQLite cron store
+// on lifecycle boundaries (window focus / tab visible), not only via one-shot
+// IPC events which are lost if the page was unmounted or the window blurred
+// when a chat-created/updated event fired.
+
+const listJobs = vi.fn();
+const noopUnsub = () => {};
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    cron: {
+      listJobs: { invoke: (...args: unknown[]) => listJobs(...args) },
+      onJobCreated: { on: vi.fn(() => noopUnsub) },
+      onJobUpdated: { on: vi.fn(() => noopUnsub) },
+      onJobRemoved: { on: vi.fn(() => noopUnsub) },
+    },
+  },
+}));
+
+vi.mock('@/renderer/utils/emitter', () => ({
+  emitter: { emit: vi.fn(), on: vi.fn(), off: vi.fn() },
+}));
+
+import { useAllCronJobs } from '@renderer/pages/cron/useCronJobs';
+
+describe('useAllCronJobs — authoritative re-fetch on lifecycle boundaries (#554)', () => {
+  beforeEach(() => {
+    listJobs.mockReset();
+    listJobs.mockResolvedValue([]);
+  });
+
+  it('fetches the store once on mount', async () => {
+    renderHook(() => useAllCronJobs());
+    await waitFor(() => expect(listJobs).toHaveBeenCalledTimes(1));
+  });
+
+  it('re-fetches the store when the window regains focus', async () => {
+    renderHook(() => useAllCronJobs());
+    await waitFor(() => expect(listJobs).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'));
+    });
+
+    await waitFor(() => expect(listJobs).toHaveBeenCalledTimes(2));
+  });
+
+  it('re-fetches the store when the document becomes visible', async () => {
+    renderHook(() => useAllCronJobs());
+    await waitFor(() => expect(listJobs).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      // jsdom reports visibilityState 'visible' by default.
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    await waitFor(() => expect(listJobs).toHaveBeenCalledTimes(2));
+  });
+
+  it('does not flip loading (no spinner flash) during a background focus re-fetch', async () => {
+    const { result } = renderHook(() => useAllCronJobs());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // Make the focus-triggered re-fetch hang so we can observe loading while
+    // it is in flight; a silent refetch must keep loading false.
+    let resolveList: ((v: unknown) => void) | undefined;
+    listJobs.mockImplementationOnce(
+      () =>
+        new Promise((res) => {
+          resolveList = res;
+        })
+    );
+
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'));
+    });
+
+    expect(listJobs).toHaveBeenCalledTimes(2);
+    expect(result.current.loading).toBe(false);
+
+    await act(async () => {
+      resolveList?.([]);
+    });
+  });
+
+  it('stops re-fetching after unmount (listeners cleaned up)', async () => {
+    const { unmount } = renderHook(() => useAllCronJobs());
+    await waitFor(() => expect(listJobs).toHaveBeenCalledTimes(1));
+
+    unmount();
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'));
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    // No further calls once the effect cleanup removed the listeners.
+    expect(listJobs).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What & why

Closes #554. The scheduled-task UI could go stale against the backend even though there is a **single** SQLite `cron_jobs` store (no backend split-brain). Root cause: the renderer trusted one-shot `main→renderer` IPC events (`onJobCreated/Updated/Removed`) with **no authoritative re-fetch fallback**. If a task was created or updated **from chat** while a view was unmounted or its window was blurred, that event was lost and the UI never reconciled.

- **Path 1** (chat-created task missing from the list): fixed by an authoritative store re-fetch when the list regains focus / becomes visible (route-enter is already covered by the page's mount fetch — the route unmounts/remounts).
- **Path 2** (edit dialog shows stale prompt/config after a chat-side update): fixed by fetching the authoritative record when the edit dialog opens, and merging the save onto that record.

## Changes (desktop-only, no engine change)

- **`useAllCronJobs`** — silent re-fetch on window `focus` + document `visibilitychange`. `silent` skips the `loading` flag so a background reconcile never blanks the list to a spinner.
- **`CreateTaskDialog`** — `getJob` on open (edit mode). The form is driven by the authoritative record; `handleSubmit` awaits the in-flight `getJob` and merges onto the store's latest job via a ref (not a stale state closure), so an edit save can't silently revert an agent's chat-side changes. The call is optional-chained (never throws if the bridge lacks `getJob`) and only re-drives the form when the store copy differs from the prop (no redundant re-fill / in-progress-edit clobber).
- **`TaskDetailPage`** — silent re-fetch on focus/visibility so the detail body syncs too.

## Tests

New DOM tests (`--project dom`), 46 pass across the touched suites:
- list focus/visibility re-fetch + **no-spinner** (silent) behavior + listener cleanup;
- dialog `getJob`-on-open: fetch, fresh re-populate, **fresh submit baseline**, null-record fallback.

## Verification

- `bun run typecheck`, `oxlint`, `oxfmt`, and `prek run --from-ref ferrox/main --to-ref HEAD` all pass.
- **Independent adversarial cross-audit** (subagent) run pre-push; it caught a CI-breaking blocker (the initial `getJob` call threw synchronously in existing edit-mode mocks) plus a form-clobber race, a spinner-thrash regression, and a redundant route-enter fetch — **all fixed** in this commit and re-verified.
- **Live-verified** in the running app (CDP :9335, HMR): `/scheduled` renders with real data; firing `focus`/`visibilitychange` keeps the list rendered with **no spinner blank** and no errors; the edit dialog opens **fully populated** via the `getJob`-on-open path.
- End-to-end **create/edit *from chat*** (which needs a real wcore agent turn) is not reproducible in the local harness and is routed to Overwatch for a run-capable environment; the missed-event reconciliation itself is deterministically covered by the unit tests.
