### PR TITLE
fix(model): bind persisted wcore selection to its bridge-tag owner in the picker (#555)

### DIFF
--- a/src/renderer/components/model/modelSelector/resolveSelectedProvider.ts
+++ b/src/renderer/components/model/modelSelector/resolveSelectedProvider.ts
@@ -9,8 +9,8 @@ import { FLUX_PROVIDER_ID, isFluxModelId } from '@/common/config/flux';
 import { modelKey } from './modelRowHelpers';
 
 /** The tag the registry bridge stamps on each mirrored row: `v2:<registryProviderId>`. */
-const BRIDGE_TAG_KEY = '__waylandModelRegistryBridge';
-const V2_TAG_PREFIX = 'v2:';
+export const BRIDGE_TAG_KEY = '__waylandModelRegistryBridge';
+export const V2_TAG_PREFIX = 'v2:';
 
 /**
  * Resolve the legacy `IProvider` that owns a model the unified flyout emitted.

--- a/src/renderer/pages/conversation/platforms/wcore/useWCoreModelSelection.ts
+++ b/src/renderer/pages/conversation/platforms/wcore/useWCoreModelSelection.ts
@@ -8,6 +8,7 @@ import type { IProvider, TProviderWithModel } from '@/common/config/storage';
 import { useModelProviderList } from '@/renderer/hooks/agent/useModelProviderList';
 import { useModelDisplayName } from '@/renderer/hooks/agent/useModelDisplayName';
 import { isFluxModelId } from '@/common/config/flux';
+import { BRIDGE_TAG_KEY, V2_TAG_PREFIX } from '@/renderer/components/model/modelSelector/resolveSelectedProvider';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 export type WCoreModelSelection = {
@@ -85,8 +86,34 @@ export const useWCoreModelSelection = ({
     // race). Once loaded, a genuinely-disconnected provider still clears (#64).
     if (providerListLoading) return;
     const useModel = currentModel.useModel ?? '';
+    // #555 - the selection's registry-bridge tag (`v2:<registryProviderId>`), if
+    // it carries one. A persisted wcore chat/team model can store `id` as the
+    // registry ProviderId (e.g. 'chatgpt-subscription') rather than the opaque
+    // mirrored legacy id, so the id-only match below misses. Without a
+    // tag-aware step the bare-model-id fallback then binds the picker to
+    // whatever provider lists the same bare id FIRST - e.g. a metered
+    // direct-API/OpenRouter provider that shares 'gpt-5.4' - mislabeling the
+    // selection as a provider the user never chose. (Real spend is routed
+    // engine-side from the persisted conversation.model tag, not this local
+    // state, so this is a picker/header/health display fix, not a billing fix.)
+    // Resolve the owner by tag before the bare-id fallback, mirroring
+    // resolveSelectedProvider's priority.
+    const currentTag = (currentModel as unknown as Record<string, unknown>)[BRIDGE_TAG_KEY];
+    const tagOf = (p: IProvider): unknown => (p as unknown as Record<string, unknown>)[BRIDGE_TAG_KEY];
     const owner =
+      // 1. exact legacy id (cheap, correct when registry and storage ids align)
       providers.find((p) => p.id === currentModel.id && getAvailableModels(p).includes(useModel)) ??
+      // 2. the selection's OWN bridge tag - deterministic registry owner. Match
+      //    by tag ALONE (no getAvailableModels gate), exactly like
+      //    resolveSelectedProvider.bridgeTagMatch: a ChatGPT-subscription row can
+      //    be curated out of the function-calling set (#168/#158) yet still be
+      //    the true owner - gating on availability would fall through to the
+      //    bare-id metered look-alike again.
+      (typeof currentTag === 'string' ? providers.find((p) => tagOf(p) === currentTag) : undefined) ??
+      // 3. persisted id IS the registry ProviderId (untagged model): match the
+      //    provider tagged `v2:<id>` (tag alone, same rationale as step 2)
+      providers.find((p) => tagOf(p) === `${V2_TAG_PREFIX}${currentModel.id}`) ??
+      // 4. bare-model-id membership fallback (untagged providers only in practice)
       providers.find((p) => getAvailableModels(p).includes(useModel));
     if (!owner) {
       // The model isn't in any provider's *curated* available list. Before

--- a/tests/unit/renderer/wcoreModelSelection.dom.test.tsx
+++ b/tests/unit/renderer/wcoreModelSelection.dom.test.tsx
@@ -40,12 +40,7 @@ const openai = { id: 'openai', platform: 'openai', model: ['gpt-5.5'] } as unkno
 const fluxModel = { id: 'flux', useModel: 'flux-auto' } as unknown as TProviderWithModel;
 const onSelectModel = vi.fn().mockResolvedValue(true);
 
-function setList(
-  providers: IProvider[],
-  avail: Record<string, string[]>,
-  connected?: IProvider[],
-  isLoading = false
-) {
+function setList(providers: IProvider[], avail: Record<string, string[]>, connected?: IProvider[], isLoading = false) {
   providerListState.providers = providers;
   // The unfiltered connected list defaults to the picker list; pass it
   // explicitly to model the "connected but no available models" case.
@@ -130,5 +125,81 @@ describe('useWCoreModelSelection revalidation (#64)', () => {
     const { result } = renderHook(() => useWCoreModelSelection({ initialModel: initial, onSelectModel }));
     await waitFor(() => expect(result.current.currentModel?.id).toBe('prov_a1b2'));
     expect(result.current.currentModel?.useModel).toBe('gpt-5.5');
+  });
+
+  it('#555 rebinds a ChatGPT-subscription selection to its OWN provider, not a metered provider that shares the model id', async () => {
+    // Money bug: a wcore chat/team persists model.id as the registry ProviderId
+    // ('chatgpt-subscription') plus the bridge tag. On remount the id-only match
+    // fails (the mirrored legacy provider's id is opaque, e.g. '5d2e7ed9'), so
+    // the bare-model-id fallback picks the FIRST provider offering 'gpt-5.4' -
+    // the direct OpenAI API provider (metered, real sk-proj key), which is
+    // listed before the subscription. That silently moves billing off the
+    // subscription. The revalidation must disambiguate by the bridge tag first,
+    // exactly like resolveSelectedProvider, and re-bind to the subscription row.
+    const BRIDGE = '__waylandModelRegistryBridge';
+    const openaiDirect = {
+      id: '19cea7a9',
+      platform: 'openai',
+      model: ['gpt-5.4', 'gpt-5.5'],
+      [BRIDGE]: 'v2:openai',
+    } as unknown as IProvider;
+    const subscription = {
+      id: '5d2e7ed9',
+      platform: 'openai-compatible',
+      model: ['gpt-5.4', 'gpt-5.4-mini', 'gpt-5.5'],
+      [BRIDGE]: 'v2:chatgpt-subscription',
+    } as unknown as IProvider;
+    // Direct-API provider listed FIRST (as in the real model.config order).
+    setList([openaiDirect, subscription], {
+      '19cea7a9': ['gpt-5.4', 'gpt-5.5'],
+      '5d2e7ed9': ['gpt-5.4', 'gpt-5.4-mini', 'gpt-5.5'],
+    });
+    const initial = {
+      id: 'chatgpt-subscription',
+      platform: 'openai-compatible',
+      useModel: 'gpt-5.4',
+      [BRIDGE]: 'v2:chatgpt-subscription',
+    } as unknown as TProviderWithModel;
+    const { result } = renderHook(() => useWCoreModelSelection({ initialModel: initial, onSelectModel }));
+    // It must bind to the subscription provider (5d2e7ed9), NEVER the metered
+    // direct-API provider (19cea7a9).
+    await waitFor(() => expect(result.current.currentModel?.id).toBe('5d2e7ed9'));
+    expect(result.current.currentModel?.id).not.toBe('19cea7a9');
+    expect(result.current.currentModel?.useModel).toBe('gpt-5.4');
+  });
+
+  it('#555 binds by bridge tag even when the subscription row is curated out of getAvailableModels (#168/#158)', async () => {
+    // The bridge-tag match must NOT gate on getAvailableModels: a ChatGPT-
+    // subscription row can be filtered out of the function-calling set yet still
+    // be the true owner. Here getAvailableModels(subscription) does NOT include
+    // 'gpt-5.4' (curated out), but the subscription is still connected (it offers
+    // another model), while the metered direct-API provider DOES list 'gpt-5.4'.
+    // Tag resolution must still bind to the subscription, not the look-alike.
+    const BRIDGE = '__waylandModelRegistryBridge';
+    const openaiDirect = {
+      id: '19cea7a9',
+      platform: 'openai',
+      model: ['gpt-5.4', 'gpt-5.5'],
+      [BRIDGE]: 'v2:openai',
+    } as unknown as IProvider;
+    const subscription = {
+      id: '5d2e7ed9',
+      platform: 'openai-compatible',
+      model: ['gpt-5.4', 'gpt-5.4-mini'],
+      [BRIDGE]: 'v2:chatgpt-subscription',
+    } as unknown as IProvider;
+    setList([openaiDirect, subscription], {
+      '19cea7a9': ['gpt-5.4', 'gpt-5.5'],
+      '5d2e7ed9': ['gpt-5.4-mini'], // 'gpt-5.4' curated out of the available set
+    });
+    const initial = {
+      id: 'chatgpt-subscription',
+      platform: 'openai-compatible',
+      useModel: 'gpt-5.4',
+      [BRIDGE]: 'v2:chatgpt-subscription',
+    } as unknown as TProviderWithModel;
+    const { result } = renderHook(() => useWCoreModelSelection({ initialModel: initial, onSelectModel }));
+    await waitFor(() => expect(result.current.currentModel?.id).toBe('5d2e7ed9'));
+    expect(result.current.currentModel?.id).not.toBe('19cea7a9');
   });
 });


### PR DESCRIPTION
Fixes the picker half of #555.

## What repro'd (and what didn't)
A wcore chat/team can persist `conversation.model.id` as the **registry ProviderId** (`"chatgpt-subscription"`) plus the bridge tag, not the opaque mirrored legacy id. On remount, `useWCoreModelSelection`'s revalidation matched by `id` (miss), then fell back to the **first provider offering the bare model id** — the direct **OpenAI API** provider (metered), which lists bare `gpt-5.4` before the subscription — and `setCurrentModel` rebound the **picker** to it. Reproduced from real on-disk state (Dev DB conv `45fcf7c2`) + a failing test.

**Verified it is a DISPLAY bug, not a billing leak.** Real spend is routed engine-side: `WCoreManager` is built from `conversation.model` (DB), and `hydrateModelForSpawn`/`mapProvider` (`envBuilder`) resolve the backend **from the persisted bridge tag** (`v2:chatgpt-subscription` → `--provider openai-chatgpt`, OAuth), never from the legacy id or renderer state. The revalidation rebind is local `setCurrentModel` and **never persists**, so billing stays on the subscription. (Confirmed independently by cross-audit.) So per "don't fix a ghost": the money leak does **not** reproduce via this path — this PR fixes the picker/header/health mislabeling (and the indirect risk of a user re-picking the wrongly-shown metered provider), not spend.

## Fix
Resolve the owner by the registry **bridge tag** before the bare-id fallback — mirroring `resolveSelectedProvider`'s priority (exact id → tag → membership). The tag steps match by **tag alone** (no `getAvailableModels` gate), exactly like `resolveSelectedProvider.bridgeTagMatch`, so a subscription row curated out of the function-calling set (#168/#158) is still resolved to its true owner instead of the metered look-alike.

Exported `BRIDGE_TAG_KEY`/`V2_TAG_PREFIX` from `resolveSelectedProvider.ts` (single-sourced).

## Tests
- New `#555` test: old code bound to the metered id (`19cea7a9`); new code binds to the subscription (`5d2e7ed9`).
- New `#555` curated-out test: subscription's `gpt-5.4` filtered out of `getAvailableModels` but the tag still wins (covers the cross-audit's flagged gap).
- Existing `#124` rebind, `#64` disconnect, OpenRouter-transient-filter, loading-race, flux-exempt tests all unregressed (8/8).
- prek green (TypeScript / Oxlint / Oxfmt).

## Not in this PR
No billing-path change (none needed — it's already tag-first). If a real spend leak was observed, it would have to be a separate write path that persists a wrong tag onto `conversation.model`; flagged for separate investigation in `modelRegistryIpc.ts`/`envBuilder.ts`.
