### PR TITLE
fix(model-selector): explain provider scoping in the Claude Code picker (#550)

### DIFF
--- a/src/renderer/components/agent/AcpModelSelector.tsx
+++ b/src/renderer/components/agent/AcpModelSelector.tsx
@@ -460,18 +460,25 @@ const AcpModelSelector: React.FC<{
   // still holds for a Flux selection.
   const onSelect = useCallback((modelId: string) => handleSelectModel(modelId), [handleSelectModel]);
   const onManage = useCallback(() => navigate('/settings/models'), [navigate]);
-  // #335 interim: in the Claude Code picker, clarify that the agent already runs
-  // on the user's Claude subscription, but picking Claude as direct chat models
-  // needs an Anthropic API key (subscription-as-chat-models isn't wired yet).
-  // Kills the "I signed in but can't see Claude under models — am I doing
-  // something wrong?" confusion until the engine OAuth provider lands (#367).
-  const notice =
+  // #550 / #335: a Claude Code chat runs the Claude Code CLI as its ACP agent, so
+  // it is Anthropic-native by construction — the picker only ever offers Claude
+  // models. A true mid-chat backend swap to ChatGPT/Gemini is not coherent (it
+  // would tear down the running agent = a new chat). Instead of leaving the picker
+  // looking broken when the user wants a different vendor, explain the scoping and
+  // point them at the honest path: start a new chat and pick that agent.
+  const claudeChatGuidance =
     backend === 'claude'
       ? t('conversation.modelSelector.claudeSubscriptionNotice', {
           defaultValue:
-            'Claude Code already runs on your Claude subscription — pick it from the agent selector. Choosing Claude models for direct chat here needs an Anthropic API key; using your subscription as chat models isn’t supported yet.',
+            'Claude Code runs on your Claude subscription (Anthropic), so this chat stays on Claude models. To use a different provider like ChatGPT or Gemini, start a new chat and pick that agent.',
         })
       : undefined;
+  // When Flux is connected the flyout surfaces Flux routing tiers as the
+  // keep-going path (they route cross-provider), so "this chat stays on Claude
+  // models / start a new chat" would contradict them — only show the notice when
+  // Flux is off. (State 2 below is only reachable with Flux off, so its read-only
+  // tooltip can carry the guidance unconditionally.)
+  const notice = claudeChatGuidance && !showFlux ? claudeChatGuidance : undefined;
   const flyoutDroplist = (
     <ModelSelectorFlyout
       vm={resolvedVm}
@@ -617,10 +624,16 @@ const AcpModelSelector: React.FC<{
     );
   }
 
-  // State 2: Has model info but cannot switch - read-only display
+  // State 2: Has model info but cannot switch - read-only display. This branch is
+  // reached only with Flux off (showFlux returns earlier), so a claude-code chat
+  // here has no in-picker path forward at all; fold the #550 guidance into the
+  // tooltip so the user still learns how to reach another provider.
   if (!modelInfo.canSwitch) {
+    const readOnlyTooltip = claudeChatGuidance
+      ? [tooltipContent, claudeChatGuidance].filter(Boolean).join('\n\n')
+      : tooltipContent;
     return (
-      <Tooltip content={tooltipContent} position='top'>
+      <Tooltip content={readOnlyTooltip} position='top'>
         <Button
           className='sendbox-model-btn header-model-btn agent-mode-compact-pill'
           shape='round'

--- a/src/renderer/services/i18n/locales/en-US/conversation.json
+++ b/src/renderer/services/i18n/locales/en-US/conversation.json
@@ -484,6 +484,6 @@
     "emptyFlux": "Tip: connect Flux Router for one-tap auto-routing across every model you add.",
     "connectProvider": "Connect a provider",
     "manageModels": "Manage models",
-    "claudeSubscriptionNotice": "Claude Code already runs on your Claude subscription — pick it from the agent selector. Choosing Claude models for direct chat here needs an Anthropic API key; using your subscription as chat models isn’t supported yet."
+    "claudeSubscriptionNotice": "Claude Code runs on your Claude subscription (Anthropic), so this chat stays on Claude models. To use a different provider like ChatGPT or Gemini, start a new chat and pick that agent."
   }
 }

--- a/tests/unit/AcpModelSelector.dom.test.tsx
+++ b/tests/unit/AcpModelSelector.dom.test.tsx
@@ -98,6 +98,10 @@ describe('AcpModelSelector', () => {
       return () => {};
     });
     ipcMock.getModelConfig.mockResolvedValue([]);
+    // Reset per-test: clearAllMocks() wipes calls but NOT implementations, so a
+    // test that connects Flux (registryList -> flux-router) would otherwise leak
+    // "Flux connected" into later tests. Default every test to Flux disconnected.
+    ipcMock.registryList.mockResolvedValue([]);
     ipcMock.setModel.mockResolvedValue({
       success: true,
       data: { modelInfo: null },
@@ -363,6 +367,67 @@ describe('AcpModelSelector', () => {
     await waitFor(() => {
       expect(screen.getByText('GPT-5.5 Codex')).toBeTruthy();
     });
+  });
+
+  // #550: a claude-code chat is Anthropic-native; the picker only offers Claude
+  // models, so a user who wants ChatGPT/Gemini sees no path and thinks it's broken.
+  // The picker must EXPLAIN the scoping and point to the honest path (start a new
+  // chat + pick that agent) rather than silently omit the option.
+  const CLAUDE_MODEL_INFO = {
+    currentModelId: 'claude-opus-4-8',
+    currentModelLabel: 'Opus 4.8',
+    availableModels: [
+      { id: 'claude-opus-4-8', label: 'Opus 4.8' },
+      { id: 'claude-sonnet-4-5', label: 'Sonnet 4.5' },
+    ],
+    canSwitch: true,
+    source: 'models',
+    sourceDetail: 'cc-switch',
+  };
+  const CLAUDE_CURATED = [
+    {
+      id: 'claude-opus-4-8',
+      providerId: 'anthropic',
+      displayName: 'Opus 4.8',
+      family: 'claude',
+      enabled: true,
+      recommended: true,
+      contextWindow: 200000,
+      costInPerM: 5,
+      costOutPerM: 15,
+    },
+  ];
+
+  it('explains how to reach other providers from an active Claude Code chat (#550, State 3)', async () => {
+    // Real #550 path: an ACTIVE claude chat with switchable models, Flux off.
+    ipcMock.getModelInfo.mockResolvedValue({ success: true, data: { modelInfo: CLAUDE_MODEL_INFO } });
+    configGetMock.mockResolvedValue(null);
+    ipcMock.curatedForAgent.mockResolvedValue(CLAUDE_CURATED);
+
+    render(<AcpModelSelector conversationId='conv-550' backend='claude' />);
+    await waitFor(() => expect(screen.getAllByText(/Opus 4.8/).length).toBeGreaterThan(0));
+
+    fireEvent.click(screen.getByRole('button'));
+    await waitFor(() => {
+      expect(screen.getByText(/start a new chat and pick that agent/i)).toBeTruthy();
+    });
+  });
+
+  it('suppresses the "start a new chat" notice when Flux is connected (Flux tiers ARE the keep-going path) (#550)', async () => {
+    // Flux connected → the flyout surfaces Flux routing tiers, so the
+    // "stays on Claude models / start a new chat" guidance would contradict them.
+    ipcMock.getModelInfo.mockResolvedValue({ success: true, data: { modelInfo: CLAUDE_MODEL_INFO } });
+    configGetMock.mockResolvedValue(null);
+    ipcMock.curatedForAgent.mockResolvedValue(CLAUDE_CURATED);
+    ipcMock.registryList.mockResolvedValue([{ providerId: 'flux-router' }]);
+
+    render(<AcpModelSelector conversationId='conv-550-flux' backend='claude' />);
+    await waitFor(() => expect(screen.getAllByText(/Opus 4.8/).length).toBeGreaterThan(0));
+
+    fireEvent.click(screen.getByRole('button'));
+    // Flux tier surfaces; the contradictory notice must NOT.
+    await waitFor(() => expect(screen.getAllByText(/Flux/).length).toBeGreaterThan(0));
+    expect(screen.queryByText(/start a new chat and pick that agent/i)).toBeNull();
   });
 
   it('renders the connected opencode-go catalog for the OpenCode agent instead of the first-connection tooltip (#407)', async () => {


### PR DESCRIPTION
Closes #550 (desktop half). Implements the **Overwatch Option-B ruling**.

## Problem

A claude-code chat runs the Claude Code CLI as its ACP agent, so it is **Anthropic-native by construction** — the picker only ever offers Claude models (plus Flux routing tiers when Flux is connected). A user who ran out of Claude credits and wanted ChatGPT/Gemini saw no option in the top-right selector and assumed it was **broken**.

Verified root cause: the in-chat picker is hard-scoped to the conversation's origin backend; `curatedForAgent('claude')` returns Anthropic-only (`CLI_UNDERLYING_PROVIDER.claude='anthropic'`, `CLI_OAUTH_PROVIDERS.claude=[]`). `wcore`/`gemini` union every connected provider — the asymmetry is the crux.

## Ruling (Option B) — what this builds

Overwatch ruled **against** a mid-chat backend swap (Option A): a claude-code chat *is* the Claude Code CLI, so swapping vendor mid-chat = tearing down the running agent = a new chat. It's deep, cross-cutting, and collides with #539. So instead:

1. **Explain the scoping + point to the honest path.** The picker notice now reads: *"Claude Code runs on your Claude subscription (Anthropic), so this chat stays on Claude models. To use a different provider like ChatGPT or Gemini, start a new chat and pick that agent."* (replaces the older #335-only subscription copy).
2. **Suppress that notice when Flux is connected** — the flyout then surfaces Flux routing tiers as the keep-going path, so "stays on Claude models / start a new chat" would contradict them.
3. **Surface the same guidance in the read-only (`canSwitch=false`) state**, which is only reachable with Flux off and otherwise offered no in-picker path forward.

**Ruling part 1 (only offer options that resolve through the Claude Code Anthropic endpoint) is already structurally satisfied:** a claude-code chat only ever lists the 4 Flux routing tiers + Anthropic models — no vendor-pinned Gemini/DeepSeek can leak (`FLUX_MODEL_IDS` is exactly the 4 tiers; the view model excludes `isFluxModelId` from `base`; `curatedForAgent('claude')` is Anthropic-only).

## Scope / ownership

- **Additive**, and does **not** touch the selector-resolution logic that **#539** owns (that lane keeps the wcore/registry legacy-picker desync). Per Overwatch, kept separate.

## Tests

`tests/unit/AcpModelSelector.dom.test.tsx`:
- Active claude chat (State 3, Flux off) → guidance renders in the flyout.
- Flux connected → guidance is **suppressed** (Flux tiers are the keep-going path). *Fails against the pre-fix ungated notice.*
- Fixed a mock-pollution leak (`registryList` implementation persisted across tests) by resetting it per-test.

i18n validated (`i18n:types` + `check-i18n`). Typecheck / oxlint / oxfmt clean; 25 picker tests green.

## Adversarial self-cross-audit

Independent adversarial subagent reviewed the full component. It caught two real gaps that are **fixed in this PR**: (1) the "stays on Claude models" claim contradicted the Flux tiers when Flux was connected → now suppressed; (2) the read-only `canSwitch=false` state showed no guidance → now folds it into the tooltip. It also flagged the original test exercised State 1b rather than the real State 3 → test rewritten.

## ⚠️ Not visually confirmed locally

DOM tests assert the rendered guidance across states, but I could not launch a build to eyeball the picker. Requesting a visual confirm (claude-code chat, Flux off → notice with the new-chat guidance; Flux on → suppressed). No self-merge.