### PR TITLE
fix(team): stop wcore team-spawn billing a subscription model on a metered look-alike (#555)

### DIFF
--- a/src/process/team/TeamSessionService.ts
+++ b/src/process/team/TeamSessionService.ts
@@ -18,6 +18,7 @@ import type { AgentBackend } from '@/common/types/acpTypes';
 import type { IProvider, TChatConversation, TProviderWithModel } from '@/common/config/storage';
 import { ProcessConfig } from '@process/utils/initStorage';
 import { getAssistantsDir } from '@process/utils/initStorage';
+import { CHATGPT_SUBSCRIPTION_PROVIDER_ID } from '@process/providers/catalog/chatgptSubscriptionModels';
 import { EventLogger } from './EventLogger';
 import { TaskManager } from './TaskManager';
 import { Watchdog } from './Watchdog';
@@ -231,12 +232,54 @@ export class TeamSessionService {
       return geminiOwner ? ({ ...geminiOwner, useModel: modelId } as TProviderWithModel) : null;
     }
 
-    const owner = providers.find(owns);
+    // Prefer the ChatGPT-subscription provider (OAuth, no per-token cost) when it
+    // owns the pinned model id, so a subscription model is NOT hijacked by a
+    // metered look-alike that merely lists the same id first in model.config
+    // (direct OpenAI / OpenRouter). team_list_models hands the leader a BARE model
+    // id (e.g. 'gpt-5.4') with no provider identity, so first-match-by-config-order
+    // otherwise silently binds a subscription teammate to the metered API and
+    // bills it there instead of the subscription the user connected (#555 teams).
+    // Symmetric to the Gemini anti-hijack guard above (#207).
+    const isSubscriptionProvider = (p: IProvider): boolean =>
+      (p as unknown as Record<string, unknown>).__waylandModelRegistryBridge ===
+      `v2:${CHATGPT_SUBSCRIPTION_PROVIDER_ID}`;
+    const owner = providers.find((p) => owns(p) && isSubscriptionProvider(p)) ?? providers.find(owns);
     if (!owner) {
       return null;
     }
 
     return { ...owner, useModel: modelId } as TProviderWithModel;
+  }
+
+  /**
+   * #555 teams — final safety net against a teammate billing a ChatGPT-subscription
+   * model on a metered look-alike. Whatever path resolved the model (an explicit
+   * pin via resolveOwningProviderModelById, the wcore default `providers[0]`, or
+   * the gemini `fallbackProvider` first-match), if the resulting `useModel` is a
+   * model the ChatGPT-subscription provider OWNS (lists + enabled) but the
+   * resolved provider is NOT the subscription, re-bind to the subscription (OAuth,
+   * no per-token cost) provider so envBuilder routes `--provider openai-chatgpt`
+   * instead of the metered `--provider openai`. This is the choke point that
+   * covers the default/fallback paths every shipped launcher hits (team_spawn_agent
+   * is usually called with no explicit model), which bypass the pin resolver.
+   */
+  private async preferSubscriptionForOwnedModel(model: TProviderWithModel): Promise<TProviderWithModel> {
+    const useModel = model?.useModel;
+    if (!useModel) return model;
+    const subTag = `v2:${CHATGPT_SUBSCRIPTION_PROVIDER_ID}`;
+    const currentTag = (model as unknown as Record<string, unknown>).__waylandModelRegistryBridge;
+    if (currentTag === subTag) return model; // already the subscription - nothing to do
+
+    const configuredProviders = await ProcessConfig.get('model.config');
+    const providers = Array.isArray(configuredProviders) ? configuredProviders.filter((p) => p.enabled !== false) : [];
+    const subscription = providers.find(
+      (p) =>
+        (p as unknown as Record<string, unknown>).__waylandModelRegistryBridge === subTag &&
+        Array.isArray(p.model) &&
+        p.model.includes(useModel) &&
+        p.modelEnabled?.[useModel] !== false
+    );
+    return subscription ? ({ ...subscription, useModel } as TProviderWithModel) : model;
   }
 
   private async resolveConversationModel(params: {
@@ -296,12 +339,7 @@ export class TeamSessionService {
         : sourceLauncherId.startsWith('builtin-')
           ? sourceLauncherId.slice(8)
           : sourceLauncherId;
-      const candidates = new Set([
-        sourceLauncherId,
-        bare,
-        `ext-${bare}`,
-        `builtin-${bare}`,
-      ]);
+      const candidates = new Set([sourceLauncherId, bare, `ext-${bare}`, `builtin-${bare}`]);
       const matches = (record: { id?: string; standing?: boolean } | undefined): boolean => {
         const id = record?.id;
         return typeof id === 'string' && candidates.has(id) && record?.standing === true;
@@ -469,10 +507,11 @@ export class TeamSessionService {
       presetAgentType: isPreset ? backend : undefined,
     });
 
+    const conversationType = getConversationTypeForBackend(backend);
+
     // Override the working model when the agent pins one explicitly.
     if (agent.model) {
-      const type = getConversationTypeForBackend(backend);
-      if (type === 'wcore' || type === 'gemini') {
+      if (conversationType === 'wcore' || conversationType === 'gemini') {
         // Re-select the provider that OWNS this model id so the spawn hydrates
         // the right key/baseUrl (#87). Without this a pinned teammate keeps the
         // default-resolved provider and only swaps the model name, so a
@@ -481,9 +520,24 @@ export class TeamSessionService {
         // useModel-only override on the already-resolved provider when no
         // enabled provider claims it - e.g. a Google-auth Gemini model that
         // lives outside model.config.
-        const owned = await this.resolveOwningProviderModelById(agent.model, type);
+        const owned = await this.resolveOwningProviderModelById(agent.model, conversationType);
         model = owned ?? { ...model, useModel: agent.model };
       }
+    }
+
+    // #555 teams choke point (WCORE ONLY): covers the wcore default
+    // (`providers[0]`) path that resolves a subscription model id onto the
+    // metered OpenAI provider (tag v2:openai) and would bill the API instead of
+    // the subscription. Scoped to wcore because ONLY the wcore engine can auth
+    // the keyless ChatGPT-subscription provider (OAuth via ~/.codex/auth.json,
+    // routed by envBuilder.mapProvider -> --provider openai-chatgpt). Re-binding a
+    // Gemini-CLI teammate to that keyless row would break bootstrap ("OpenAI API
+    // key is required"), so a gemini teammate on a subscription model id keeps the
+    // metered provider - the only route its backend can actually use. (Offering
+    // subscription-only ids to a gemini teammate at all is a separate concern in
+    // team_list_models/getTeamAvailableModels.)
+    if (conversationType === 'wcore') {
+      model = await this.preferSubscriptionForOwnedModel(model);
     }
 
     return buildAgentConversationParams({

--- a/tests/unit/process/team/team-resolveOwningProviderModelById.test.ts
+++ b/tests/unit/process/team/team-resolveOwningProviderModelById.test.ts
@@ -83,6 +83,68 @@ describe('TeamSessionService.resolveOwningProviderModelById (#87)', () => {
     expect(await svc.resolveOwningProviderModelById('unknown-model')).toBeNull();
   });
 
+  it('#555 teams: prefers the ChatGPT-subscription provider over a metered look-alike that lists the same id first', async () => {
+    // A subscription model id (gpt-5.4) is offered by BOTH the direct OpenAI API
+    // provider (metered, tagged v2:openai, listed FIRST) and the ChatGPT
+    // subscription (OAuth, tagged v2:chatgpt-subscription). team_list_models hands
+    // the leader only the bare id, so first-match would bind the teammate to the
+    // metered provider and silently bill the API instead of the subscription.
+    mockProcessConfig.get.mockImplementation(async (key: string) =>
+      key === 'model.config'
+        ? [
+            {
+              id: '19cea7a9',
+              enabled: true,
+              apiKey: 'sk-proj-metered',
+              model: ['gpt-5.4', 'gpt-5.5'],
+              modelEnabled: {},
+              __waylandModelRegistryBridge: 'v2:openai',
+            },
+            {
+              id: '5d2e7ed9',
+              enabled: true,
+              apiKey: '',
+              model: ['gpt-5.4', 'gpt-5.4-mini', 'gpt-5.5'],
+              modelEnabled: {},
+              __waylandModelRegistryBridge: 'v2:chatgpt-subscription',
+            },
+          ]
+        : null
+    );
+    const svc = makeService() as unknown as {
+      resolveOwningProviderModelById: (
+        id: string,
+        type?: string
+      ) => Promise<{ id: string; __waylandModelRegistryBridge?: string; useModel: string } | null>;
+    };
+    const resolved = await svc.resolveOwningProviderModelById('gpt-5.4', 'wcore');
+    expect(resolved?.id).toBe('5d2e7ed9'); // subscription, NOT the metered 19cea7a9 listed first
+    expect(resolved?.__waylandModelRegistryBridge).toBe('v2:chatgpt-subscription');
+    expect(resolved?.useModel).toBe('gpt-5.4');
+  });
+
+  it('still resolves the metered provider when NO subscription provider owns the model', async () => {
+    mockProcessConfig.get.mockImplementation(async (key: string) =>
+      key === 'model.config'
+        ? [
+            {
+              id: '19cea7a9',
+              enabled: true,
+              apiKey: 'sk-proj-metered',
+              model: ['gpt-5.4'],
+              modelEnabled: {},
+              __waylandModelRegistryBridge: 'v2:openai',
+            },
+          ]
+        : null
+    );
+    const svc = makeService() as unknown as {
+      resolveOwningProviderModelById: (id: string, type?: string) => Promise<{ id: string } | null>;
+    };
+    const resolved = await svc.resolveOwningProviderModelById('gpt-5.4', 'wcore');
+    expect(resolved?.id).toBe('19cea7a9'); // no subscription owner -> first (only) owner
+  });
+
   it('skips a provider that has the model disabled', async () => {
     mockProcessConfig.get.mockImplementation(async (key: string) =>
       key === 'model.config'
@@ -101,5 +163,84 @@ describe('TeamSessionService.resolveOwningProviderModelById (#87)', () => {
       resolveOwningProviderModelById: (id: string) => Promise<unknown>;
     };
     expect(await svc.resolveOwningProviderModelById('claude-sonnet-4')).toBeNull();
+  });
+});
+
+// The choke point that covers the WCORE default path (resolveDefaultAionrsModel
+// providers[0]) which stamps a subscription model id onto the metered v2:openai
+// provider; it re-binds to the subscription so envBuilder bills --provider
+// openai-chatgpt. NB: buildConversationParams only INVOKES this for
+// conversationType === 'wcore' (the wcore engine is the only backend that can
+// auth the keyless subscription provider); these tests exercise the method's
+// resolution logic directly.
+describe('TeamSessionService.preferSubscriptionForOwnedModel (#555 teams choke point, wcore-only)', () => {
+  const SUB_AND_METERED = [
+    {
+      id: '19cea7a9',
+      enabled: true,
+      apiKey: 'sk-proj-metered',
+      platform: 'openai',
+      model: ['gpt-5.5', 'gpt-5.4'],
+      modelEnabled: {},
+      __waylandModelRegistryBridge: 'v2:openai',
+    },
+    {
+      id: '5d2e7ed9',
+      enabled: true,
+      apiKey: '',
+      platform: 'openai-compatible',
+      model: ['gpt-5.4', 'gpt-5.4-mini', 'gpt-5.5'],
+      modelEnabled: {},
+      __waylandModelRegistryBridge: 'v2:chatgpt-subscription',
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockProcessConfig.get.mockImplementation(async (key: string) => (key === 'model.config' ? SUB_AND_METERED : null));
+  });
+
+  it('re-binds a subscription model resolved onto the metered provider back to the subscription', async () => {
+    const svc = makeService() as unknown as {
+      preferSubscriptionForOwnedModel: (m: Record<string, unknown>) => Promise<Record<string, unknown>>;
+    };
+    // Simulates the default/gemini-fallback outcome: metered provider + gpt-5.5.
+    const metered = { id: '19cea7a9', __waylandModelRegistryBridge: 'v2:openai', useModel: 'gpt-5.5' };
+    const fixed = await svc.preferSubscriptionForOwnedModel(metered);
+    expect(fixed.id).toBe('5d2e7ed9');
+    expect(fixed.__waylandModelRegistryBridge).toBe('v2:chatgpt-subscription');
+    expect(fixed.useModel).toBe('gpt-5.5');
+  });
+
+  it('leaves a model the subscription does NOT own untouched', async () => {
+    const svc = makeService() as unknown as {
+      preferSubscriptionForOwnedModel: (m: Record<string, unknown>) => Promise<Record<string, unknown>>;
+    };
+    const metered = { id: '19cea7a9', __waylandModelRegistryBridge: 'v2:openai', useModel: 'text-embedding-3' };
+    const out = await svc.preferSubscriptionForOwnedModel(metered);
+    expect(out.id).toBe('19cea7a9'); // subscription doesn't list it -> unchanged
+  });
+
+  it('is a no-op when the model is already the subscription', async () => {
+    const svc = makeService() as unknown as {
+      preferSubscriptionForOwnedModel: (m: Record<string, unknown>) => Promise<Record<string, unknown>>;
+    };
+    const sub = { id: '5d2e7ed9', __waylandModelRegistryBridge: 'v2:chatgpt-subscription', useModel: 'gpt-5.5' };
+    const out = await svc.preferSubscriptionForOwnedModel(sub);
+    expect(out.id).toBe('5d2e7ed9');
+  });
+
+  it('skips a subscription that has the model disabled', async () => {
+    mockProcessConfig.get.mockImplementation(async (key: string) =>
+      key === 'model.config'
+        ? [SUB_AND_METERED[0], { ...SUB_AND_METERED[1], modelEnabled: { 'gpt-5.5': false } }]
+        : null
+    );
+    const svc = makeService() as unknown as {
+      preferSubscriptionForOwnedModel: (m: Record<string, unknown>) => Promise<Record<string, unknown>>;
+    };
+    const metered = { id: '19cea7a9', __waylandModelRegistryBridge: 'v2:openai', useModel: 'gpt-5.5' };
+    const out = await svc.preferSubscriptionForOwnedModel(metered);
+    expect(out.id).toBe('19cea7a9'); // subscription has gpt-5.5 disabled -> unchanged
   });
 });


### PR DESCRIPTION
Fixes the **real billing** half of #555 (the write side Overwatch asked me to confirm). Companion to PR #565 (which fixed only the picker *display*).

## The leak (DB-confirmed)
A team teammate's model is resolved to a provider by **bare model id** — `team_list_models` hands the leader only `gpt-5.4`, with no provider identity. Every resolution path first-matched by `model.config` order, and a ChatGPT-subscription model (`gpt-5.4/5.5`) is **also** listed by the direct OpenAI provider (metered), which sorts first. So the teammate's persisted `conversation.model` was stamped `{...openaiDirect}` with tag `v2:openai`, and `envBuilder.mapProvider` bills off that tag → `--provider openai` (metered) instead of `--provider openai-chatgpt` (OAuth subscription).

**Real DB evidence**: team "Dev Shop" teammates pinned to `gpt-5.5` → persisted tag `v2:openai`. Every shipped launcher spawns teammates with **no** explicit model, so the *unpinned default* path (`resolveDefaultAionrsModel` `providers[0]`, whose first enabled model can be a subscription id — the Openai row's list literally starts with `gpt-5.5`) is the actual trigger.

Unlike #565, this changes the **persisted tag that `envBuilder` reads**, so it actually stops the metered billing.

## Fix (wcore teammates)
- `resolveOwningProviderModelById`: prefer the subscription provider when it owns a **pinned** model id, before first-match (symmetric to the Gemini anti-hijack guard #207).
- `preferSubscriptionForOwnedModel`: a choke point on the **final** resolved model in `buildConversationParams` that re-binds a subscription-owned `useModel` off a metered tag onto `v2:chatgpt-subscription` — covering the **unpinned default** path.

**Scoped to `conversationType === 'wcore'`** (cross-audit finding): only the wcore engine can auth the *keyless* subscription provider (OAuth via `~/.codex/auth.json`). A Gemini-CLI teammate needs an API key, so re-binding it to the keyless subscription row would break bootstrap (`OpenAI API key is required`). Gemini teammates on a subscription model id therefore keep the metered provider — the only route their backend can use. (Trimming subscription-only ids from a gemini teammate's offered model list is a separate concern in `getTeamAvailableModels`.)

No subscription owner / non-owned / already-subscription / disabled / non-wcore → unchanged.

## Verification
- 12 tests: pinned prefers subscription over a metered look-alike listed first; metered still used when no subscription owns the model; choke point re-binds a subscription model resolved onto the metered provider, and leaves non-owned / already-subscription / disabled cases alone. `#87` (pinned ownership) + `#207` (gemini anti-hijack) unregressed. Typecheck + prek green.
- **Two cross-audits**: the first caught that v1 only covered the pinned path (unpinned default was the real trigger) → added the choke point; the second caught that applying it to gemini teammates broke bootstrap → scoped to wcore. Both folded.

## Forensics (Overwatch task 2)
Posted separately on #555: the leader token burn is dominated by the preset catalog (42%, via 7 re-sent copies) → #557 already fixes the biggest slice; teammate tool-results ~0%; the multiplier is `cache_read=0` × ~36 sub-calls → Core #559.
