### PR TITLE
fix(team): harden wcore-only subscription rebind + trim subscription-only ids from gemini team_list_models (#555)

### DIFF
--- a/src/common/utils/teamModelUtils.ts
+++ b/src/common/utils/teamModelUtils.ts
@@ -15,6 +15,19 @@ export type TeamAvailableModel = {
 };
 
 /**
+ * Registry-bridge tag stamped on the ChatGPT-subscription provider row
+ * (`v2:${CHATGPT_SUBSCRIPTION_PROVIDER_ID}` in envBuilder / legacyModelConfigBridge).
+ * Hardcoded here because this common-layer util must not import from @process.
+ */
+const CHATGPT_SUBSCRIPTION_BRIDGE_TAG = 'v2:chatgpt-subscription';
+
+function isChatGptSubscriptionProvider(provider: IProvider): boolean {
+  return (
+    (provider as unknown as Record<string, unknown>).__waylandModelRegistryBridge === CHATGPT_SUBSCRIPTION_BRIDGE_TAG
+  );
+}
+
+/**
  * Check whether a model passes the capability filter used by the frontend.
  * A model is included when:
  * - function_calling is true or undefined (unknown = allowed)
@@ -74,9 +87,16 @@ export function getTeamAvailableModels(
       }
     }
 
-    // ALL enabled providers' models with capability filtering
-    // Mirrors useModelProviderList(): every enabled provider is included
-    const enabledProviders = (providers || []).filter((p) => p.enabled !== false && p.model?.length);
+    // ALL enabled providers' models with capability filtering, EXCEPT the
+    // ChatGPT-subscription provider (#555): a Gemini-CLI teammate cannot use the
+    // ChatGPT OAuth route (it's keyless - only the wcore engine can auth it), so
+    // a subscription-ONLY model id (e.g. gpt-5.3-codex-spark) is unrunnable here
+    // and must not be offered. Ids the subscription shares with a metered
+    // provider (e.g. gpt-5.5 on the direct OpenAI provider) are still presented
+    // via that metered provider below, which a gemini teammate CAN bill on.
+    const enabledProviders = (providers || []).filter(
+      (p) => p.enabled !== false && p.model?.length && !isChatGptSubscriptionProvider(p)
+    );
     for (const p of enabledProviders) {
       for (const m of p.model || []) {
         if (p.modelEnabled?.[m] !== false && passesCapabilityFilter(p, m)) {

--- a/src/process/team/TeamSessionService.ts
+++ b/src/process/team/TeamSessionService.ts
@@ -262,8 +262,18 @@ export class TeamSessionService {
    * instead of the metered `--provider openai`. This is the choke point that
    * covers the default/fallback paths every shipped launcher hits (team_spawn_agent
    * is usually called with no explicit model), which bypass the pin resolver.
+   *
+   * WCORE-ONLY, self-enforced: only the wcore engine can auth the keyless
+   * subscription provider (OAuth via ~/.codex/auth.json). Re-binding a non-wcore
+   * (e.g. Gemini-CLI) teammate to that keyless row breaks bootstrap ("OpenAI API
+   * key is required"), so the guard lives HERE - the invariant holds no matter
+   * how the method is called, not just because a call site remembered to gate it.
    */
-  private async preferSubscriptionForOwnedModel(model: TProviderWithModel): Promise<TProviderWithModel> {
+  private async preferSubscriptionForOwnedModel(
+    model: TProviderWithModel,
+    conversationType?: string
+  ): Promise<TProviderWithModel> {
+    if (conversationType !== 'wcore') return model;
     const useModel = model?.useModel;
     if (!useModel) return model;
     const subTag = `v2:${CHATGPT_SUBSCRIPTION_PROVIDER_ID}`;
@@ -525,20 +535,13 @@ export class TeamSessionService {
       }
     }
 
-    // #555 teams choke point (WCORE ONLY): covers the wcore default
-    // (`providers[0]`) path that resolves a subscription model id onto the
-    // metered OpenAI provider (tag v2:openai) and would bill the API instead of
-    // the subscription. Scoped to wcore because ONLY the wcore engine can auth
-    // the keyless ChatGPT-subscription provider (OAuth via ~/.codex/auth.json,
-    // routed by envBuilder.mapProvider -> --provider openai-chatgpt). Re-binding a
-    // Gemini-CLI teammate to that keyless row would break bootstrap ("OpenAI API
-    // key is required"), so a gemini teammate on a subscription model id keeps the
-    // metered provider - the only route its backend can actually use. (Offering
-    // subscription-only ids to a gemini teammate at all is a separate concern in
-    // team_list_models/getTeamAvailableModels.)
-    if (conversationType === 'wcore') {
-      model = await this.preferSubscriptionForOwnedModel(model);
-    }
+    // #555 teams choke point: covers the wcore default (`providers[0]`) path that
+    // resolves a subscription model id onto the metered OpenAI provider (tag
+    // v2:openai) and would bill the API instead of the subscription. The method
+    // self-enforces the wcore-only invariant (a Gemini-CLI teammate cannot auth
+    // the keyless subscription provider, so it keeps the metered route), so we
+    // pass conversationType and let it decide rather than gating here.
+    model = await this.preferSubscriptionForOwnedModel(model, conversationType);
 
     return buildAgentConversationParams({
       backend,

--- a/tests/unit/process/team/team-resolveOwningProviderModelById.test.ts
+++ b/tests/unit/process/team/team-resolveOwningProviderModelById.test.ts
@@ -200,47 +200,65 @@ describe('TeamSessionService.preferSubscriptionForOwnedModel (#555 teams choke p
     mockProcessConfig.get.mockImplementation(async (key: string) => (key === 'model.config' ? SUB_AND_METERED : null));
   });
 
-  it('re-binds a subscription model resolved onto the metered provider back to the subscription', async () => {
-    const svc = makeService() as unknown as {
-      preferSubscriptionForOwnedModel: (m: Record<string, unknown>) => Promise<Record<string, unknown>>;
-    };
+  type ChokeFn = {
+    preferSubscriptionForOwnedModel: (
+      m: Record<string, unknown>,
+      conversationType?: string
+    ) => Promise<Record<string, unknown>>;
+  };
+
+  it('re-binds a subscription model resolved onto the metered provider back to the subscription (wcore)', async () => {
+    const svc = makeService() as unknown as ChokeFn;
     // Simulates the default/gemini-fallback outcome: metered provider + gpt-5.5.
     const metered = { id: '19cea7a9', __waylandModelRegistryBridge: 'v2:openai', useModel: 'gpt-5.5' };
-    const fixed = await svc.preferSubscriptionForOwnedModel(metered);
+    const fixed = await svc.preferSubscriptionForOwnedModel(metered, 'wcore');
     expect(fixed.id).toBe('5d2e7ed9');
     expect(fixed.__waylandModelRegistryBridge).toBe('v2:chatgpt-subscription');
     expect(fixed.useModel).toBe('gpt-5.5');
   });
 
-  it('leaves a model the subscription does NOT own untouched', async () => {
-    const svc = makeService() as unknown as {
-      preferSubscriptionForOwnedModel: (m: Record<string, unknown>) => Promise<Record<string, unknown>>;
-    };
+  it('does NOT re-bind a GEMINI teammate pinned to a subscription model id (self-enforced wcore-only guard)', async () => {
+    // A Gemini-CLI teammate cannot auth the keyless subscription provider, so
+    // re-binding it would break bootstrap. The guard lives IN the method, so even
+    // a subscription-owned gpt-5.5 stays on the metered provider for gemini.
+    const svc = makeService() as unknown as ChokeFn;
+    const metered = { id: '19cea7a9', __waylandModelRegistryBridge: 'v2:openai', useModel: 'gpt-5.5' };
+    const out = await svc.preferSubscriptionForOwnedModel(metered, 'gemini');
+    expect(out.id).toBe('19cea7a9');
+    expect(out.__waylandModelRegistryBridge).toBe('v2:openai');
+  });
+
+  it('is a no-op for any non-wcore conversationType (including undefined)', async () => {
+    const svc = makeService() as unknown as ChokeFn;
+    const metered = { id: '19cea7a9', __waylandModelRegistryBridge: 'v2:openai', useModel: 'gpt-5.5' };
+    expect((await svc.preferSubscriptionForOwnedModel(metered, undefined)).id).toBe('19cea7a9');
+    expect((await svc.preferSubscriptionForOwnedModel(metered, 'acp')).id).toBe('19cea7a9');
+    expect((await svc.preferSubscriptionForOwnedModel(metered, 'remote')).id).toBe('19cea7a9');
+  });
+
+  it('leaves a model the subscription does NOT own untouched (wcore)', async () => {
+    const svc = makeService() as unknown as ChokeFn;
     const metered = { id: '19cea7a9', __waylandModelRegistryBridge: 'v2:openai', useModel: 'text-embedding-3' };
-    const out = await svc.preferSubscriptionForOwnedModel(metered);
+    const out = await svc.preferSubscriptionForOwnedModel(metered, 'wcore');
     expect(out.id).toBe('19cea7a9'); // subscription doesn't list it -> unchanged
   });
 
-  it('is a no-op when the model is already the subscription', async () => {
-    const svc = makeService() as unknown as {
-      preferSubscriptionForOwnedModel: (m: Record<string, unknown>) => Promise<Record<string, unknown>>;
-    };
+  it('is a no-op when the model is already the subscription (wcore)', async () => {
+    const svc = makeService() as unknown as ChokeFn;
     const sub = { id: '5d2e7ed9', __waylandModelRegistryBridge: 'v2:chatgpt-subscription', useModel: 'gpt-5.5' };
-    const out = await svc.preferSubscriptionForOwnedModel(sub);
+    const out = await svc.preferSubscriptionForOwnedModel(sub, 'wcore');
     expect(out.id).toBe('5d2e7ed9');
   });
 
-  it('skips a subscription that has the model disabled', async () => {
+  it('skips a subscription that has the model disabled (wcore)', async () => {
     mockProcessConfig.get.mockImplementation(async (key: string) =>
       key === 'model.config'
         ? [SUB_AND_METERED[0], { ...SUB_AND_METERED[1], modelEnabled: { 'gpt-5.5': false } }]
         : null
     );
-    const svc = makeService() as unknown as {
-      preferSubscriptionForOwnedModel: (m: Record<string, unknown>) => Promise<Record<string, unknown>>;
-    };
+    const svc = makeService() as unknown as ChokeFn;
     const metered = { id: '19cea7a9', __waylandModelRegistryBridge: 'v2:openai', useModel: 'gpt-5.5' };
-    const out = await svc.preferSubscriptionForOwnedModel(metered);
+    const out = await svc.preferSubscriptionForOwnedModel(metered, 'wcore');
     expect(out.id).toBe('19cea7a9'); // subscription has gpt-5.5 disabled -> unchanged
   });
 });

--- a/tests/unit/teamModelUtils.test.ts
+++ b/tests/unit/teamModelUtils.test.ts
@@ -195,6 +195,44 @@ describe('getTeamAvailableModels', () => {
     ]);
   });
 
+  it('#555: Gemini backend TRIMS subscription-only model ids (gemini cannot use ChatGPT OAuth) but keeps ids a metered provider also offers', () => {
+    const providers: IProvider[] = [
+      // Direct OpenAI (metered) - a gemini teammate CAN bill on this via API key.
+      makeProvider({
+        id: 'openai-direct',
+        platform: 'openai',
+        model: ['gpt-5.5'],
+        __waylandModelRegistryBridge: 'v2:openai',
+      } as Partial<IProvider> & { platform: string; model: string[] }),
+      // ChatGPT subscription (keyless OAuth) - offers a SHARED id (gpt-5.5) and a
+      // subscription-ONLY id (gpt-5.3-codex-spark) that no metered provider lists.
+      makeProvider({
+        id: 'chatgpt-sub',
+        platform: 'openai-compatible',
+        model: ['gpt-5.5', 'gpt-5.3-codex-spark'],
+        __waylandModelRegistryBridge: 'v2:chatgpt-subscription',
+      } as Partial<IProvider> & { platform: string; model: string[] }),
+    ];
+    const result = getTeamAvailableModels('gemini', {}, providers, false);
+    const ids = result.map((m) => m.id);
+    expect(ids).toContain('gpt-5.5'); // still offered via the metered provider
+    expect(ids).not.toContain('gpt-5.3-codex-spark'); // subscription-only -> trimmed for gemini
+  });
+
+  it('#555: Wcore backend still includes subscription-only model ids (wcore CAN auth the subscription)', () => {
+    const providers: IProvider[] = [
+      makeProvider({
+        id: 'chatgpt-sub',
+        platform: 'openai-compatible',
+        model: ['gpt-5.5', 'gpt-5.3-codex-spark'],
+        __waylandModelRegistryBridge: 'v2:chatgpt-subscription',
+      } as Partial<IProvider> & { platform: string; model: string[] }),
+    ];
+    const ids = getTeamAvailableModels('wcore', {}, providers, false).map((m) => m.id);
+    expect(ids).toContain('gpt-5.5');
+    expect(ids).toContain('gpt-5.3-codex-spark'); // wcore keeps it (routes to --provider openai-chatgpt)
+  });
+
   it('UT-36: Gemini backend with Google Auth + multiple platform providers', () => {
     const providers: IProvider[] = [
       makeProvider({


### PR DESCRIPTION
Two follow-ups to the merged #570 team-spawn billing fix (Overwatch-requested).

## 1) HARDEN the wcore-only invariant (self-enforcing)
`preferSubscriptionForOwnedModel` now takes an explicit `conversationType` and **self-enforces** the wcore-only rule — it returns the model untouched unless `conversationType === 'wcore'` — instead of relying on the call site to gate it. Only the wcore engine can auth the keyless ChatGPT-subscription provider (OAuth via `~/.codex/auth.json`); re-binding a Gemini-CLI teammate to that keyless row breaks bootstrap (`OpenAI API key is required`). `buildConversationParams` now passes `conversationType` and calls unconditionally.

New negative tests: a **gemini** teammate pinned to a subscription model id is **not** rebound; a non-wcore call (`undefined`/`acp`/`remote`) is a no-op.

## 2) GEMINI TRIM in `getTeamAvailableModels`
A gemini teammate was still offered subscription-only model ids it can't run (Gemini CLI can't use the ChatGPT OAuth). `getTeamAvailableModels` now excludes the ChatGPT-subscription provider from the **gemini** backend's model list:
- **subscription-only** ids (e.g. `gpt-5.3-codex-spark`, listed by no other provider) → **trimmed** (a gemini teammate literally can't run them).
- ids the subscription **shares** with a metered provider (e.g. `gpt-5.5` on the direct OpenAI row) → **still offered** via that metered provider, which a gemini teammate can bill on.
- **wcore** backend is unchanged — it keeps subscription ids (routes to `--provider openai-chatgpt`).

This reaches `team_list_models` via `modelListHandler.ts`.

## Verification
- New tests: hardening negative cases (gemini pin not rebound, non-wcore no-op) + trim (gemini drops subscription-only, keeps shared; wcore keeps both). 350 team tests pass; typecheck + prek green.
- Layering: `teamModelUtils.ts` is common-layer and must not import `@process`, so the subscription bridge tag is defined locally with a comment pointing at `CHATGPT_SUBSCRIPTION_PROVIDER_ID`.
