### PR TITLE
fix(model-registry): register opencode-go + vultr for chat-start so the picker stops bouncing to Settings (#516, #556)

### DIFF
--- a/src/process/providers/ipc/modelRegistryIpc.ts
+++ b/src/process/providers/ipc/modelRegistryIpc.ts
@@ -1227,6 +1227,15 @@ const CHAT_START_PLATFORM: Partial<Record<ProviderId, string>> = {
   // and the picker bounced the user to Settings - the model could never be
   // selected and the #243 engine routing was never reached (live-E2E gap).
   'chatgpt-subscription': 'openai-compatible',
+  // OpenAI-compatible subscription/gateway providers from the bundled catalog
+  // ("100+ more"), connected via API key. Their endpoint is persisted into
+  // `creds.baseUrl` at connect time (catalog fallback, #63), so chat-start
+  // dispatches OpenAI-compatible against the right host. Without these entries
+  // buildChatStartPayload returned `unsupported`, resolveForChatStart failed, and
+  // the picker bounced the user to Settings -> Models with no error, so the model
+  // could never be selected. OpenCode Go = #516, Vultr = #556.
+  'opencode-go': 'openai-compatible',
+  vultr: 'openai-compatible',
   // Azure intentionally absent - the legacy dispatch has no Azure arm; a
   // future Azure chat-start will need its own dispatcher work.
 };

--- a/tests/unit/process/providers/modelRegistryIpc.test.ts
+++ b/tests/unit/process/providers/modelRegistryIpc.test.ts
@@ -324,6 +324,20 @@ describe('modelRegistry IPC - connect', () => {
     expect(call?.[2]).toBe('https://opencode.ai/zen/go/v1');
   });
 
+  it('threads the catalog baseUrl for Vultr on key-only connect (#556 - baseUrl the chat-start fix relies on)', async () => {
+    const { deps, test } = makeFakes();
+    const h = createModelRegistryHandlers(deps);
+
+    // vultr is likewise a bundled-catalog provider with no PROVIDER_ENDPOINTS
+    // entry; the #556 chat-start fix depends on this connect-time fallback
+    // persisting creds.baseUrl (CHAT_START_BASE_URL has no vultr entry).
+    await h.connect({ providerId: 'vultr' as ProviderId, creds: { key: 'sk-test' } });
+
+    const call = test.mock.calls.find((c) => c[0] === 'vultr');
+    expect(call).toBeDefined();
+    expect(call?.[2]).toBe('https://api.vultrinference.com/v1');
+  });
+
   it('returns the ConnectError and does not persist when the test fails', async () => {
     const { deps, repo } = makeFakes({ testResult: { ok: false, error: 'unauthorized' } });
     const h = createModelRegistryHandlers(deps);
@@ -2107,5 +2121,52 @@ describe('modelRegistry IPC - resolveForChatStart (#243 ChatGPT subscription)', 
 
     const result = await h.resolveForChatStart({ providerId: 'azure', modelId: 'gpt-4o' });
     expect(result).toEqual({ ok: false, error: 'unsupported' });
+  });
+});
+
+describe('modelRegistry IPC - resolveForChatStart (#516 OpenCode Go, #556 Vultr)', () => {
+  // Both are openai_compatible bundled-catalog providers connected via API key,
+  // whose endpoint is persisted into creds.baseUrl at connect time (#63). Before
+  // the fix they were absent from CHAT_START_PLATFORM, so resolveForChatStart
+  // returned `unsupported` and the Guid picker bounced the user to Settings.
+  it('resolves a connected OpenCode Go model to openai-compatible with its catalog baseUrl, no bounce (#516)', async () => {
+    const { deps, repo } = makeFakes();
+    repo.upsertRegistryProvider({
+      providerId: 'opencode-go',
+      connectedVia: 'apiKey',
+      state: 'connected',
+      creds: { key: 'sk-oc', baseUrl: 'https://opencode.ai/zen/go/v1' },
+    });
+    const h = createModelRegistryHandlers(deps);
+
+    const result = await h.resolveForChatStart({ providerId: 'opencode-go', modelId: 'glm-5.2' });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.provider.platform).toBe('openai-compatible');
+      expect(result.provider.providerId).toBe('opencode-go');
+      expect(result.provider.modelId).toBe('glm-5.2');
+      expect(result.provider.baseUrl).toBe('https://opencode.ai/zen/go/v1');
+    }
+  });
+
+  it('resolves a connected Vultr model to openai-compatible with its catalog baseUrl, no bounce (#556)', async () => {
+    const { deps, repo } = makeFakes();
+    repo.upsertRegistryProvider({
+      providerId: 'vultr',
+      connectedVia: 'apiKey',
+      state: 'connected',
+      creds: { key: 'sk-vultr', baseUrl: 'https://api.vultrinference.com/v1' },
+    });
+    const h = createModelRegistryHandlers(deps);
+
+    const result = await h.resolveForChatStart({ providerId: 'vultr', modelId: 'llama-3.3-70b' });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.provider.platform).toBe('openai-compatible');
+      expect(result.provider.providerId).toBe('vultr');
+      expect(result.provider.baseUrl).toBe('https://api.vultrinference.com/v1');
+    }
   });
 });


### PR DESCRIPTION
Closes #516, closes #556 (same root cause).

## Problem

Selecting a **connected + enabled** OpenCode Go model (glm-5.2, #516) or **any Vultr** model (#556) from the model picker navigates to **Settings → Models** instead of activating it — with no error. The provider is connected, the model is catalogued and enabled, yet it can never be selected, so the subscription is unusable.

## Root cause (one bug, two providers)

`GuidModelSelector.handlePickCurated` resolves the pick via `modelRegistry.resolveForChatStart`; on `!result.ok` it `navigate('/settings/models')`. `resolveForChatStart` → `buildChatStartPayload` returns `{kind:'unsupported'}` when `CHAT_START_PLATFORM[providerId]` is `undefined`:

```ts
const platform = CHAT_START_PLATFORM[providerId];
if (!platform) return { kind: 'unsupported' };   // → resolveForChatStart !ok → picker bounces
```

`opencode-go` and `vultr` are `openai_compatible` bundled-catalog providers but were **missing from `CHAT_START_PLATFORM`**. This is the *exact* bounce documented in the map for `chatgpt-subscription` (#243) and `ollama-cloud` (#36).

## Fix

Add both entries:
```ts
'opencode-go': 'openai-compatible',   // #516
vultr: 'openai-compatible',            // #556
```

**BaseUrl resolves correctly** (the #36 401-trap does *not* apply): neither provider is in `PROVIDER_ENDPOINTS`, so the connect-time **#63 catalog fallback** persists the catalog endpoint (`opencode.ai/zen/go/v1`, `api.vultrinference.com/v1`) into `creds.baseUrl`; `buildChatStartPayload` reads it via `customBaseUrl`. This is purely the **wcore chat-start** path and does **not** affect the OpenCode ACP agent path (which never calls `buildChatStartPayload`).

## Tests

`modelRegistryIpc.test.ts`:
- `resolveForChatStart` returns `ok` + `platform: 'openai-compatible'` + the catalog `baseUrl` for both providers. *Verified these fail pre-fix (returned `unsupported`).*
- Vultr connect-time baseUrl fallback test (mirrors the existing #63 opencode-go test) — pins the mechanism the fix relies on.

Typecheck / oxlint / oxfmt clean; 97 modelRegistryIpc tests green.

## Adversarial self-cross-audit

Independent adversarial subagent: **SHIP, no blocker/major.** It confirmed (1) baseUrl resolves via the #63 fallback (not the #36 trap), and (2) no ACP-vs-wcore dispatch conflict — `CHAT_START_PLATFORM` is only read by the wcore chat-start path; `opencode → opencode-go` mapping only *surfaces* the catalog, it doesn't route dispatch. Its one minor coverage nit (vultr connect-time baseUrl untested) is **fixed** in this PR.

## Live-verify

App boots cleanly with the fix on CDP :9334 (healthy UI confirmed). The definitive **select-model → no-bounce** repro is **credential-gated**: it needs a *connected* Vultr/OpenCode Go subscription (real API key), and `resolveForChatStart` is a returns-secret channel denied from the generic test bridge, so it's only reachable via the real UI flow. Routing that packaged/credentialed live-verify to Overwatch. Unit tests prove the exact `resolveForChatStart` contract change.

## ⚠️ Systemic follow-up (flagged to Overwatch)

This is whack-a-mole: **~97 of 104** `openai_compatible` catalog providers are still absent from `CHAT_START_PLATFORM` (vivgrid, wafer.ai, wandb, digitalocean, baseten, github-models, …) and carry the identical bounce bug. The durable fix is a catalog-driven default in `buildChatStartPayload` (any connected `openai_compatible` provider with a resolved `creds.baseUrl` → default `'openai-compatible'`). Out of scope here; raised for a ruling. No self-merge.