### PR TITLE
fix(model-registry): default bundled-catalog providers to openai-compatible chat-start, retiring the allowlist drift (#578)

### DIFF
--- a/src/process/providers/ipc/modelRegistryIpc.ts
+++ b/src/process/providers/ipc/modelRegistryIpc.ts
@@ -1341,6 +1341,17 @@ type ChatStartBuildResult =
   | { kind: 'unsupported' }
   | { kind: 'undecryptable' };
 
+/**
+ * Every bundled-catalog provider id (the "100+ more" OpenAI-compatible long tail).
+ * The catalog generator (`isCatalogEligible`) EXCLUDES every `openai_compatible
+ * === false` (anthropic-wire) entry, so membership here is a guaranteed proxy for
+ * "the bundled catalog marks this provider openai_compatible". Native providers
+ * (anthropic / gemini / bedrock / vertex / azure) are never in the catalog - they
+ * carry explicit `CHAT_START_PLATFORM` entries instead. Computed once from the
+ * static bundled JSON (sync, network-free). Powers the #578 chat-start fallback.
+ */
+const CATALOG_OPENAI_COMPATIBLE_IDS: ReadonlySet<string> = new Set(loadBaselineProviderCatalog().map((e) => e.id));
+
 function buildChatStartPayload(
   providerId: ProviderId,
   modelId: string,
@@ -1350,7 +1361,19 @@ function buildChatStartPayload(
   // `gemini-with-google-auth` platform string (Fix 6). No api-key check.
   const isGoogleAuthGemini = providerId === 'google-gemini' && creds.useGoogleAuth === true;
 
-  const platform = isGoogleAuthGemini ? 'gemini-with-google-auth' : CHAT_START_PLATFORM[providerId];
+  let platform = isGoogleAuthGemini ? 'gemini-with-google-auth' : CHAT_START_PLATFORM[providerId];
+  if (!platform && CATALOG_OPENAI_COMPATIBLE_IDS.has(providerId)) {
+    // Durable fallback (#578): the provider has no hand-maintained
+    // CHAT_START_PLATFORM entry, but the bundled catalog marks it
+    // openai_compatible and its endpoint was persisted into `creds.baseUrl` at
+    // connect time (catalog fallback, #63). Dispatch it OpenAI-compatible against
+    // that stored baseUrl instead of returning `unsupported` (which bounces the
+    // picker to Settings - #516 / #556). A resolved baseUrl is REQUIRED: without
+    // a host there is nothing to dispatch against, so keep it unsupported below
+    // rather than silently defaulting to api.openai.com (the #36 401 trap).
+    const catalogBaseUrl = typeof creds.baseUrl === 'string' ? creds.baseUrl.trim() : '';
+    if (catalogBaseUrl.length > 0) platform = 'openai-compatible';
+  }
   if (!platform) return { kind: 'unsupported' };
 
   const payload: IModelRegistryChatStartPayload = {

--- a/tests/unit/process/providers/modelRegistryIpc.test.ts
+++ b/tests/unit/process/providers/modelRegistryIpc.test.ts
@@ -2170,3 +2170,101 @@ describe('modelRegistry IPC - resolveForChatStart (#516 OpenCode Go, #556 Vultr)
     }
   });
 });
+
+describe('modelRegistry IPC - resolveForChatStart durable catalog fallback (#578)', () => {
+  // The hand-maintained CHAT_START_PLATFORM allowlist drifted from the bundled
+  // catalog: ~97 openai_compatible catalog providers were missing and each bounced
+  // the picker to Settings. buildChatStartPayload now defaults ANY bundled-catalog
+  // provider (guaranteed openai_compatible - anthropic-wire is excluded at generation)
+  // with a resolved creds.baseUrl to 'openai-compatible', retiring the allowlist drift.
+
+  it('resolves a catalog openai_compatible provider NOT in CHAT_START_PLATFORM to openai-compatible', async () => {
+    const { deps, repo } = makeFakes();
+    // baseten is in the bundled catalog but has NO explicit CHAT_START_PLATFORM entry.
+    repo.upsertRegistryProvider({
+      providerId: 'baseten',
+      connectedVia: 'apiKey',
+      state: 'connected',
+      creds: { key: 'sk-baseten', baseUrl: 'https://inference.baseten.co/v1' },
+    });
+    const h = createModelRegistryHandlers(deps);
+
+    const result = await h.resolveForChatStart({ providerId: 'baseten', modelId: 'llama-3.3-70b' });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.provider.platform).toBe('openai-compatible');
+      expect(result.provider.providerId).toBe('baseten');
+      expect(result.provider.baseUrl).toBe('https://inference.baseten.co/v1');
+    }
+  });
+
+  it('still returns unsupported for a catalog provider with NO resolved baseUrl (no host to dispatch to)', async () => {
+    const { deps, repo } = makeFakes();
+    // Connected catalog provider but creds carry no baseUrl - the fallback must NOT
+    // fire (defaulting to api.openai.com would be the #36 401 trap).
+    repo.upsertRegistryProvider({
+      providerId: 'baseten',
+      connectedVia: 'apiKey',
+      state: 'connected',
+      creds: { key: 'sk-baseten' },
+    });
+    const h = createModelRegistryHandlers(deps);
+
+    const result = await h.resolveForChatStart({ providerId: 'baseten', modelId: 'llama-3.3-70b' });
+    expect(result).toEqual({ ok: false, error: 'unsupported' });
+  });
+
+  it('still returns unsupported for a non-catalog provider even with a baseUrl (not openai_compatible)', async () => {
+    const { deps, repo } = makeFakes();
+    // A provider id that is NOT in the bundled catalog and NOT in CHAT_START_PLATFORM
+    // must never be defaulted to openai-compatible, even with a baseUrl.
+    repo.upsertRegistryProvider({
+      providerId: 'totally-unknown-provider' as ProviderId,
+      connectedVia: 'apiKey',
+      state: 'connected',
+      creds: { key: 'sk-x', baseUrl: 'https://example.com/v1' },
+    });
+    const h = createModelRegistryHandlers(deps);
+
+    const result = await h.resolveForChatStart({
+      providerId: 'totally-unknown-provider' as ProviderId,
+      modelId: 'm',
+    });
+    expect(result).toEqual({ ok: false, error: 'unsupported' });
+  });
+
+  it('does NOT default a native anthropic-wire provider to openai-compatible (over-fire guard)', async () => {
+    const { deps, repo } = makeFakes();
+    // azure is a native, NOT in the bundled catalog (native-collision excluded at
+    // generation) and intentionally absent from CHAT_START_PLATFORM. The fallback
+    // must not fire even though creds carry a baseUrl.
+    repo.upsertRegistryProvider({
+      providerId: 'azure',
+      connectedVia: 'apiKey',
+      state: 'connected',
+      creds: { key: 'sk-azure', baseUrl: 'https://my-azure.openai.azure.com' },
+    });
+    const h = createModelRegistryHandlers(deps);
+
+    const result = await h.resolveForChatStart({ providerId: 'azure', modelId: 'gpt-4o' });
+    expect(result).toEqual({ ok: false, error: 'unsupported' });
+  });
+
+  it('routes an empty-key catalog provider (fallback fires) to undecryptable, not unsupported', async () => {
+    const { deps, repo } = makeFakes();
+    // Fallback fires (baseten in catalog + baseUrl present) -> platform set ->
+    // standard API-key block sees an empty key on a non-local host -> undecryptable
+    // (a re-key prompt), NOT unsupported and NOT a silent openai.com dispatch.
+    repo.upsertRegistryProvider({
+      providerId: 'baseten',
+      connectedVia: 'apiKey',
+      state: 'connected',
+      creds: { key: '', baseUrl: 'https://inference.baseten.co/v1' },
+    });
+    const h = createModelRegistryHandlers(deps);
+
+    const result = await h.resolveForChatStart({ providerId: 'baseten', modelId: 'llama-3.3-70b' });
+    expect(result).toEqual({ ok: false, error: 'undecryptable' });
+  });
+});


### PR DESCRIPTION
Closes #578. Implements the **Overwatch-ruled durable fix** for the `CHAT_START_PLATFORM` allowlist drift (the class behind #516 / #556, which are separately fixed via explicit entries in the merged #577).

## Problem

`CHAT_START_PLATFORM` is a hand-maintained allowlist mapping `providerId → chat-start platform`. `buildChatStartPayload` returned `{kind:'unsupported'}` for any provider absent from it → `resolveForChatStart` fails → the model picker navigates to **Settings → Models** instead of activating the model. **~97 of 104** `openai_compatible` bundled-catalog providers were missing, each carrying the identical bounce bug.

## Fix (per the ruling)

In `buildChatStartPayload`, when `CHAT_START_PLATFORM` has no entry, **default `platform` to `'openai-compatible'`** for any provider the **bundled catalog** marks `openai_compatible` **AND** that has a **resolved `creds.baseUrl`**; else keep `unsupported`.

```ts
let platform = ... CHAT_START_PLATFORM[providerId];
if (!platform && CATALOG_OPENAI_COMPATIBLE_IDS.has(providerId)) {
  const catalogBaseUrl = typeof creds.baseUrl === 'string' ? creds.baseUrl.trim() : '';
  if (catalogBaseUrl.length > 0) platform = 'openai-compatible';
}
if (!platform) return { kind: 'unsupported' };
```

**Why catalog membership is a guaranteed proxy for `openai_compatible`:** the catalog generator (`isCatalogEligible`, `catalogCuration.ts:135-137`) **excludes** every `openai_compatible === false` (anthropic-wire) entry, plus native-collision / templated / local-only. Natives (anthropic / gemini / bedrock / vertex / azure) are **never** in the catalog — they keep explicit `CHAT_START_PLATFORM` entries. The id set is built once from the static bundled JSON (`loadBaselineProviderCatalog()` — sync, network-free).

**BaseUrl resolves** (not the #36 401-trap): connected catalog providers get their endpoint persisted into `creds.baseUrl` at connect time (`#63` fallback); a missing baseUrl keeps it `unsupported` rather than silently hitting `api.openai.com`.

## Tests

`modelRegistryIpc.test.ts` (uses the **real** bundled catalog — only electron/fetch mocked):
- `baseten` (in catalog, **not** in map) → `openai-compatible` + its catalog baseUrl. *Fails pre-fix.*
- catalog provider with **no baseUrl** → `unsupported`.
- **non-catalog** provider even with a baseUrl → `unsupported`.
- **native** (`azure`) never defaulted → `unsupported` (over-fire guard).
- empty-key catalog provider → `undecryptable` (re-key prompt), not unsupported.

Typecheck / oxlint / oxfmt clean; 102 modelRegistryIpc tests green. Boots clean on CDP :9334 (module-level id-set builds at import with no crash).

## Adversarial self-cross-audit

Independent adversarial subagent: **SHIP, no blocker/major.** It empirically verified the current 100-row catalog has zero native-collision / templated / local-only / non-https entries, confirmed natives are absent (azure stays `unsupported`), no over-fire, no import cycle, and downstream payload correctness. Its two minor test-coverage nits (native over-fire guard + empty-key transition) are **added** in this PR.

## Known by-design note (raised for awareness, not a regression)

`github-copilot` is `openai_compatible = true` in the catalog with `env_var = GITHUB_TOKEN`, so it now resolves to `openai-compatible` and would dispatch a plain bearer against `api.githubcopilot.com` — which typically needs special token exchange, so it may 401/403 at *inference*. This is **not a regression** (pre-fix it was a silent Settings-bounce; now it's selectable but may error at inference) and is inherent to the ruled "trust the catalog's `openai_compatible` flag" design. If Copilot is a supported chat target, it may warrant a dedicated dispatch arm or a catalog exclusion — flagging for a call. No self-merge.