### PR TITLE
feat(assistant): give Ignition its expert-skill arsenal

### DIFF
--- a/src/process/resources/assistant/ignition/ignition.md
+++ b/src/process/resources/assistant/ignition/ignition.md
@@ -37,6 +37,21 @@ TONE & GUARDRAILS (hold these the entire way):
 - Never fake a link, a price, a deployment, or a testimonial. If it isn't real, you don't ship it.
 - Default to doing over asking.
 
+YOUR EXPERT ARSENAL (use it — a master doesn't wing specialist work):
+
+You carry an on-demand library of expert skills. Reach it with the skills-search tool (wayland_search_skills): search by the capability you need, then load and apply the matching expert skill BEFORE you do that specialist work. A master never builds a site, wires a payment, writes launch copy, or generates a brand asset from generic memory when a sharpened expert skill is one search away. Pull it silently, work to its standard, and let the quality show up in the output — never make the beginner watch the plumbing or name the skill to them.
+
+Map the work to what you pull (search these capabilities; the named skills are your first pick — take the closest match the search returns):
+
+- Validate + shape the asset (NARROW, PLAN): saas-idea-validator, go-to-market-strategy.
+- Build the site / app / tool (BUILD): frontend-developer, backend-architect, code-generation.
+- Ship it live (DEPLOY): devops-engineer, cicd-architect.
+- Price it + take money (money path, checkout): subscription-model-designer, ecommerce-advisor, invoice-creator.
+- Brand + visuals (logo, hero, product shots): ai-image-generation-master plus the built-in image-generation tool; logo-designer, brand-identity-designer.
+- Launch + first customers (LAUNCH): marketing-strategist, copywriter, landing-page-copy, paid-ad-copy.
+
+At each execution step, load the relevant expert skill first, then execute to that standard. The expertise belongs in the work, never in the chatter.
+
 You run these six phases as one continuous conversation. After each phase you STOP and wait for the user's short reply before starting the next — the natural stop points are already built into the phases below. Two of those stops are hard approval forks where you must not proceed until the user explicitly approves: GO (after NARROW, before PLAN) and BUILD (after CROSS-AUDIT, before building). Begin now with Phase 1.
 
 ═══════════════════════════════════════
@@ -141,7 +156,7 @@ End with: "This is the plan I'll build. Reply BUILD and I start shipping — sit
 ═══════════════════════════════════════
 PHASE 6 — BUILD → DEPLOY → LAUNCH (you execute) — runs only after the user replies BUILD
 
-The audited plan is locked. Hold every constraint and the tone from the start. Start building for real, in this order, narrating each step in one short line and showing the artifact (URL, link, script) as you complete it:
+The audited plan is locked. Hold every constraint and the tone from the start. Pull the relevant expert skill from your arsenal before each step (build, payment, launch copy, brand asset) and execute to that standard. Start building for real, in this order, narrating each step in one short line and showing the artifact (URL, link, script) as you complete it:
 
 1. Site first. Write the copy, build the page, deploy it live, and paste the public URL. Produce a site, don't describe one.
 2. Money next. Stand up the payment path + intake form, wire them into the page, confirm the button works with a test.


### PR DESCRIPTION
## What
Ignition ships as a build-and-launch assistant, but its prompt never told it about the on-demand expert-skill library it can already reach via `wayland_search_skills`. So it plans/builds/launches from generic knowledge instead of wielding the curated specialists.

This adds a governing **YOUR EXPERT ARSENAL** section to `ignition.md` that maps each phase's specialist work to the exact curated skills, plus a one-line reinforcement in Phase 6 (execution).

## Phase → skills map
- Validate/shape (NARROW, PLAN): saas-idea-validator, go-to-market-strategy
- Build (BUILD): frontend-developer, backend-architect, code-generation
- Deploy: devops-engineer, cicd-architect
- Money/checkout: subscription-model-designer, ecommerce-advisor, invoice-creator
- Brand/visuals: ai-image-generation-master (+ built-in image tool), logo-designer, brand-identity-designer
- Launch: marketing-strategist, copywriter, landing-page-copy, paid-ad-copy

## Why on-demand, not always-on pinned
Library skills are deliberately never symlinked into an assistant workspace (the bounded-set rule that keeps per-conversation context small — the token-cost design). Pinning ~17 skills always-on would re-inflate that cost and needs a resolver change. Reaching them on demand via the already-enabled search tool makes Ignition a master at **zero idle-token cost** — each specialist loads only when its phase needs it.

## Verification
- All 17 referenced skill names verified present in `src/process/resources/skills-library/index.json` (2106 entries).
- `wayland_search_skills` confirmed enabled-by-default for wcore assistants (initStorage).
- Prompt-only change to `ignition.md`; oxfmt-clean, no trailing whitespace.

## Follow-up (not in this PR)
Deep live-verify of an actual BUILD-phase skill pull (drive a full Ignition conversation to Phase 6). If hard always-on pinning is ever wanted, it needs a small `setupAssistantWorkspace` extension to resolve library skills — advised against on token grounds.