### PR TITLE
fix(updater): stop the macOS auto-install-on-quit relaunch loop (#575)

### DIFF
--- a/src/process/services/autoUpdaterService.ts
+++ b/src/process/services/autoUpdaterService.ts
@@ -191,6 +191,11 @@ class AutoUpdaterService extends EventEmitter {
 
     // Disable auto-download for manual control
     autoUpdater.autoDownload = false;
+    // autoInstallOnAppQuit starts enabled (normal auto-update: a staged update
+    // installs on quit) but is DISABLED the moment a macOS block/apply-failure is
+    // detected — see setInstallOnQuit(). A bundle ShipIt can't apply in place must
+    // never auto-install on quit, or ShipIt relaunches the old version → re-stages
+    // → endless respawn loop (#575). The manual-download path stays available.
     autoUpdater.autoInstallOnAppQuit = true;
 
     // Set the correct update channel based on platform and architecture before
@@ -323,6 +328,9 @@ class AutoUpdaterService extends EventEmitter {
         log.warn(
           `[autoUpdater] Update ${info.version} cannot be applied in place (${blockReason}); surfacing guidance.`
         );
+        // Never let checkForUpdatesAndNotify's staged download auto-install on
+        // quit when we know the apply can't succeed — that's the #575 loop.
+        this.disableInstallOnQuit(`macOS block: ${blockReason}`);
         this.broadcastInstallFailed(blockReason, info.version);
         return;
       }
@@ -331,6 +339,7 @@ class AutoUpdaterService extends EventEmitter {
       // same doomed update (the loop in #286) — surface the failure + manual path.
       if (this._failedInstallVersion && info.version === this._failedInstallVersion) {
         log.warn(`[autoUpdater] Suppressing re-offer of ${info.version}: prior install silently failed (#286).`);
+        this.disableInstallOnQuit(`silent-noop re-offer of ${info.version}`);
         this.broadcastInstallFailed('silent-noop', info.version);
         return;
       }
@@ -540,6 +549,10 @@ class AutoUpdaterService extends EventEmitter {
 
     // Downloaded + install attempted, but the version never advanced.
     this._failedInstallVersion = expected;
+    // The staged update ShipIt keeps trying to apply is the #575 loop engine.
+    // Kill auto-install-on-quit now, at startup, before the next check re-stages —
+    // so this quit (and every quit after) stops handing the doomed bundle to ShipIt.
+    this.disableInstallOnQuit(`silent apply failure of ${expected}`);
     log.error(
       `[autoUpdater] Update to ${expected} was downloaded and install was attempted, but the app is ` +
         `still on ${current}. The post-quit Squirrel/ShipIt apply step silently failed (#286).`
@@ -643,6 +656,24 @@ class AutoUpdaterService extends EventEmitter {
       log.warn('[autoUpdater] isInApplicationsFolder check failed:', error);
     }
     return null;
+  }
+
+  /**
+   * Break the #575 respawn loop: when a macOS update block or a silent
+   * apply-failure is detected, disable autoInstallOnAppQuit so a bundle ShipIt
+   * can't apply in place is NEVER handed to ShipIt on quit. Without this, a
+   * staged-but-unappliable update makes every quit relaunch the old version →
+   * re-stage → loop (Dock spam + focus theft). Idempotent; the manual-download
+   * path (broadcastInstallFailed) still lets the user update deliberately.
+   *
+   * On the happy path (no block) autoInstallOnAppQuit is left at its enabled
+   * default, so normal auto-update on quit is preserved.
+   */
+  private disableInstallOnQuit(context: string): void {
+    if (autoUpdater.autoInstallOnAppQuit) {
+      log.warn(`[autoUpdater] Disabling autoInstallOnAppQuit (${context}) to prevent the #575 relaunch loop.`);
+      autoUpdater.autoInstallOnAppQuit = false;
+    }
   }
 
   /**

--- a/tests/unit/autoUpdaterServiceInstallGuard.test.ts
+++ b/tests/unit/autoUpdaterServiceInstallGuard.test.ts
@@ -187,4 +187,72 @@ describe('autoUpdaterService install guard (#286)', () => {
     expect(lastStatus().status).toBe('available');
     expect(app.isInApplicationsFolder).not.toHaveBeenCalled();
   });
+
+  // #575: a bundle ShipIt can't apply in place must never auto-install on quit,
+  // or ShipIt relaunches the old version → re-stages → endless respawn loop
+  // (Dock spam + focus theft). The loop-breaker is autoInstallOnAppQuit=false
+  // the moment any block/apply-failure is detected.
+  describe('autoInstallOnAppQuit loop-breaker (#575)', () => {
+    it('constructor leaves autoInstallOnAppQuit enabled (normal auto-update default)', () => {
+      // freshService() re-ran the constructor in beforeEach.
+      expect(autoUpdater.autoInstallOnAppQuit).toBe(true);
+    });
+
+    it('macOS block (outside /Applications) → autoInstallOnAppQuit disabled', () => {
+      setPlatform('darwin');
+      (app.isInApplicationsFolder as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+      service.triggerEventForTest('update-available', { version: '2.0.0' });
+
+      expect(autoUpdater.autoInstallOnAppQuit).toBe(false);
+    });
+
+    it('happy path (macOS inside /Applications, no block) → autoInstallOnAppQuit stays true', () => {
+      setPlatform('darwin');
+      (app.isInApplicationsFolder as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+      service.triggerEventForTest('update-available', { version: '2.0.0' });
+
+      expect(lastStatus().status).toBe('available');
+      expect(autoUpdater.autoInstallOnAppQuit).toBe(true);
+    });
+
+    it('non-macOS offer → autoInstallOnAppQuit stays true (loop is macOS-only)', () => {
+      setPlatform('win32');
+      service.triggerEventForTest('update-available', { version: '2.0.0' });
+
+      expect(lastStatus().status).toBe('available');
+      expect(autoUpdater.autoInstallOnAppQuit).toBe(true);
+    });
+
+    it('silent apply failure on reconcile → autoInstallOnAppQuit disabled at startup', () => {
+      fs.writeFileSync(markerPath(), JSON.stringify({ version: '2.0.0', attemptedAt: 1 }));
+      (app.getVersion as ReturnType<typeof vi.fn>).mockReturnValue('1.0.0');
+
+      service.reconcilePendingInstall();
+
+      expect(autoUpdater.autoInstallOnAppQuit).toBe(false);
+    });
+
+    it('successful reconcile (version advanced) → autoInstallOnAppQuit stays true', () => {
+      fs.writeFileSync(markerPath(), JSON.stringify({ version: '1.0.0', attemptedAt: 1 }));
+      (app.getVersion as ReturnType<typeof vi.fn>).mockReturnValue('1.0.0');
+
+      service.reconcilePendingInstall();
+
+      expect(autoUpdater.autoInstallOnAppQuit).toBe(true);
+    });
+
+    it('re-offer of a silently-failed version → autoInstallOnAppQuit disabled', () => {
+      fs.writeFileSync(markerPath(), JSON.stringify({ version: '2.0.0', attemptedAt: 1 }));
+      service.reconcilePendingInstall();
+      // reconcile already disabled it; re-enable to prove the re-offer path also disables.
+      autoUpdater.autoInstallOnAppQuit = true;
+
+      service.triggerEventForTest('update-available', { version: '2.0.0' });
+
+      expect(lastStatus().status).toBe('install-failed');
+      expect(autoUpdater.autoInstallOnAppQuit).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
Addresses #575 and the loop half of #286 (do not auto-close — release closes). Disables autoInstallOnAppQuit whenever a macOS update block/apply-failure is detected, so a bundle ShipIt can't apply in place never auto-installs on quit and never triggers the ShipIt relaunch storm. Manual-download path preserved. NOTE: the ROOT apply-failure (translocation vs signature/staple) remains #286's open packaging question and needs a signed-artifact repro; this PR breaks the user-facing spawn loop only.