### PR TITLE
feat(voice): wire local voice-model download progress (Whisper + Kokoro)

### DIFF
--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -49,7 +49,7 @@ import type {
 } from '../types/onboarding';
 import type { ProtocolDetectionRequest, ProtocolDetectionResponse } from '../utils/protocolDetector';
 import type { SpeechToTextRequest, SpeechToTextResult } from '../types/speech';
-import type { DownloadResult, VoiceAsset } from '../types/voiceAsset';
+import type { DownloadProgress, DownloadResult, VoiceAsset } from '../types/voiceAsset';
 import type { SkillSecurityReport, SkillIndexEntry, SkillSource, SkillVerdict } from '../types/skillTypes';
 import type { ImportResult } from '../../process/services/skills/SkillImport';
 import type { KickoffGridResult, KickoffResult, KickoffTelemetryEvent } from '../../process/services/kickoff/types';
@@ -594,6 +594,11 @@ export const imports = {
 export const voiceAsset = {
   download: buildProvider<DownloadResult, VoiceAsset>('voice-asset.download'),
   cancel: buildProvider<{ cancelled: boolean }, { assetId: string }>('voice-asset.cancel'),
+  // Streamed per-chunk download progress. voiceAssetBridge feeds this from the
+  // onProgress callback it hands to VoiceAssetManager.download; the renderer's
+  // download controls subscribe to drive <Progress/> (replaces the old
+  // hardcoded 0% + "progress reporting coming soon" stub).
+  downloadProgress: buildEmitter<DownloadProgress>('voice-asset.download-progress'),
   // Resolve the install state for a known asset. The renderer uses this to
   // suppress the Download button when the model is already on disk (no more
   // "Download Model" alongside an already-installed model).

--- a/src/process/bridge/voiceAssetBridge.ts
+++ b/src/process/bridge/voiceAssetBridge.ts
@@ -18,7 +18,12 @@ export function initVoiceAssetBridge(): void {
     // the inbound asset get filled from the registry; non-empty fields are
     // preserved (test overrides + future extension assets).
     const resolved = resolveVoiceAsset(asset);
-    return VoiceAssetManager.download(resolved);
+    // Stream per-chunk progress to the renderer so the download bar reflects
+    // real bytes instead of a hardcoded 0%. Cancel is already wired through
+    // the cancel provider + VoiceAssetManager's internal AbortController.
+    return VoiceAssetManager.download(resolved, (progress) => {
+      ipcBridge.voiceAsset.downloadProgress.emit(progress);
+    });
   });
   ipcBridge.voiceAsset.cancel.provider(async ({ assetId }) => ({
     cancelled: VoiceAssetManager.cancel(assetId),

--- a/src/renderer/components/settings/SettingsModal/contents/ToolsModalContent.tsx
+++ b/src/renderer/components/settings/SettingsModal/contents/ToolsModalContent.tsx
@@ -21,27 +21,14 @@ import {
   FLUX_RECOMMENDED_IMAGE_ID,
 } from '@/common/config/imageModels';
 import type { VoiceAsset } from '@/common/types/voiceAsset';
-import {
-  Divider,
-  Form,
-  Message,
-  Button,
-  Switch,
-  Input,
-  Slider,
-  Progress,
-} from '@arco-design/web-react';
+import { Divider, Form, Message, Button, Switch, Input, Slider, Progress } from '@arco-design/web-react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import useConfigModelListWithImage from '@/renderer/hooks/agent/useConfigModelListWithImage';
 import WaylandScrollArea from '@/renderer/components/base/WaylandScrollArea';
 import WaylandSelect from '@/renderer/components/base/WaylandSelect';
 import McpAgentStatusDisplay from '@/renderer/pages/settings/ToolsSettings/McpAgentStatusDisplay';
-import {
-  useMcpServers,
-  useMcpAgentStatus,
-  useMcpOperations,
-} from '@/renderer/hooks/mcp';
+import { useMcpServers, useMcpAgentStatus, useMcpOperations } from '@/renderer/hooks/mcp';
 import classNames from 'classnames';
 import { useNavigate } from 'react-router-dom';
 import { useSettingsViewMode } from '../settingsViewContext';
@@ -112,25 +99,28 @@ const WHISPER_MODEL_ASSETS: Record<string, VoiceAsset> = {
 
 type DownloadState = 'idle' | 'downloading' | 'success' | 'error';
 
-const WhisperLocalDownloadControl: React.FC<{
-  model: string;
-  onModelChange: (model: string) => void;
-}> = ({ model, onModelChange }) => {
-  const { t } = useTranslation();
+/**
+ * Shared download-with-progress controller for the local voice models (Whisper
+ * + Kokoro). Owns the download lifecycle, the on-disk install probe, and the
+ * live progress subscription so both controls render a real <Progress/> bar
+ * instead of the old hardcoded 0%. Pass `undefined` when no asset is selected
+ * (the hook stays inert until one is).
+ */
+const useVoiceAssetDownload = (asset: VoiceAsset | undefined) => {
   const [downloadState, setDownloadState] = useState<DownloadState>('idle');
   const [errorMsg, setErrorMsg] = useState('');
   const [installed, setInstalled] = useState<boolean | null>(null);
-  const cancelledRef = React.useRef(false);
+  const [percent, setPercent] = useState(0);
+  const cancelledRef = useRef(false);
+  const assetId = asset?.id;
 
-  // Probe install state on mount + every model switch so the UI shows
-  // "Installed" instead of a Download button when the file already exists
-  // on disk. Krug / Sutherland: don't make the user wonder.
+  // Probe install state on mount + every asset switch and after each download
+  // so the UI flips to "Installed" when the file already exists on disk.
   useEffect(() => {
+    if (!assetId) return;
     let cancelled = false;
-    const asset = WHISPER_MODEL_ASSETS[model];
-    if (!asset) return;
     void voiceAsset.exists
-      .invoke({ id: asset.id })
+      .invoke({ id: assetId })
       .then((r) => {
         if (!cancelled) setInstalled(Boolean(r?.installed));
       })
@@ -140,12 +130,26 @@ const WhisperLocalDownloadControl: React.FC<{
     return () => {
       cancelled = true;
     };
-  }, [model, downloadState]);
+  }, [assetId, downloadState]);
+
+  // Subscribe to streamed progress and translate bytes into a percentage.
+  // When the server omits Content-Length totalBytes is null and we stay at 0
+  // (indeterminate) rather than dividing by nothing.
+  useEffect(() => {
+    if (!assetId) return;
+    const removeListener = voiceAsset.downloadProgress.on((evt) => {
+      if (!evt || evt.assetId !== assetId) return;
+      setPercent(evt.totalBytes ? Math.min(100, Math.round((evt.bytesDownloaded / evt.totalBytes) * 100)) : 0);
+    });
+    return () => {
+      removeListener();
+    };
+  }, [assetId]);
 
   const handleDownload = useCallback(async () => {
-    const asset = WHISPER_MODEL_ASSETS[model];
     if (!asset) return;
     cancelledRef.current = false;
+    setPercent(0);
     setDownloadState('downloading');
     setErrorMsg('');
     try {
@@ -157,16 +161,28 @@ const WhisperLocalDownloadControl: React.FC<{
         setErrorMsg(err instanceof Error ? err.message : String(err));
       }
     }
-  }, [model]);
+  }, [asset]);
 
   const handleCancel = useCallback(async () => {
     cancelledRef.current = true;
-    const asset = WHISPER_MODEL_ASSETS[model];
-    if (asset) {
-      await voiceAsset.cancel.invoke({ assetId: asset.id }).catch(() => {});
+    if (assetId) {
+      await voiceAsset.cancel.invoke({ assetId }).catch(() => {});
     }
     setDownloadState('idle');
-  }, [model]);
+    setPercent(0);
+  }, [assetId]);
+
+  return { downloadState, errorMsg, installed, percent, handleDownload, handleCancel };
+};
+
+const WhisperLocalDownloadControl: React.FC<{
+  model: string;
+  onModelChange: (model: string) => void;
+}> = ({ model, onModelChange }) => {
+  const { t } = useTranslation();
+  const { downloadState, errorMsg, installed, percent, handleDownload, handleCancel } = useVoiceAssetDownload(
+    WHISPER_MODEL_ASSETS[model]
+  );
 
   return (
     <>
@@ -179,17 +195,12 @@ const WhisperLocalDownloadControl: React.FC<{
       <Form.Item label={t('settings.speechToTextDownloadModel')}>
         <div className='flex flex-col gap-8px'>
           {downloadState === 'downloading' ? (
-            <>
-              <div className='flex items-center gap-8px'>
-                <Progress percent={0} animation className='flex-1' />
-                <Button size='mini' onClick={handleCancel}>
-                  {t('settings.speechToTextCancelDownload')}
-                </Button>
-              </div>
-              <span className='text-12px text-t-tertiary'>
-                {t('settings.speechToTextDownloadProgressNotReported', 'Downloading… (progress reporting coming soon)')}
-              </span>
-            </>
+            <div className='flex items-center gap-8px'>
+              <Progress percent={percent} animation className='flex-1' />
+              <Button size='mini' onClick={handleCancel}>
+                {t('settings.speechToTextCancelDownload')}
+              </Button>
+            </div>
           ) : installed ? (
             <div className='flex items-center justify-between gap-8px h-32px px-12px rd-8px bg-[var(--color-fill-2)]'>
               <span className='flex items-center gap-8px text-12px text-[var(--success)]'>
@@ -240,48 +251,14 @@ export const TextToSpeechSettingsSection: React.FC<{
   onChange: (updater: (current: TextToSpeechConfig) => TextToSpeechConfig) => void;
 }> = ({ config, onChange }) => {
   const { t } = useTranslation();
-  const [downloadState, setDownloadState] = useState<DownloadState>('idle');
-  const [errorMsg, setErrorMsg] = useState('');
-  const [installed, setInstalled] = useState<boolean | null>(null);
-  const cancelledRef = React.useRef(false);
-
-  // Same install probe as Whisper - flip the UI from "Download Model" to
-  // "Installed" when the on-disk file already exists.
-  useEffect(() => {
-    let cancelled = false;
-    void voiceAsset.exists
-      .invoke({ id: KOKORO_ASSET.id })
-      .then((r) => {
-        if (!cancelled) setInstalled(Boolean(r?.installed));
-      })
-      .catch(() => {
-        if (!cancelled) setInstalled(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [downloadState]);
-
-  const handleDownloadKokoro = useCallback(async () => {
-    cancelledRef.current = false;
-    setDownloadState('downloading');
-    setErrorMsg('');
-    try {
-      await voiceAsset.download.invoke(KOKORO_ASSET);
-      if (!cancelledRef.current) setDownloadState('success');
-    } catch (err) {
-      if (!cancelledRef.current) {
-        setDownloadState('error');
-        setErrorMsg(err instanceof Error ? err.message : String(err));
-      }
-    }
-  }, []);
-
-  const handleCancelDownload = useCallback(async () => {
-    cancelledRef.current = true;
-    await voiceAsset.cancel.invoke({ assetId: KOKORO_ASSET.id }).catch(() => {});
-    setDownloadState('idle');
-  }, []);
+  const {
+    downloadState,
+    errorMsg,
+    installed,
+    percent,
+    handleDownload: handleDownloadKokoro,
+    handleCancel: handleCancelDownload,
+  } = useVoiceAssetDownload(KOKORO_ASSET);
 
   const handleProviderChange = useCallback(
     (value: string) => {
@@ -372,7 +349,7 @@ export const TextToSpeechSettingsSection: React.FC<{
             <div className='flex flex-col gap-8px'>
               {downloadState === 'downloading' ? (
                 <div className='flex items-center gap-8px'>
-                  <Progress percent={0} animation className='flex-1' />
+                  <Progress percent={percent} animation className='flex-1' />
                   <Button size='mini' onClick={handleCancelDownload}>
                     {t('settings.textToSpeechCancelDownload')}
                   </Button>
@@ -660,14 +637,9 @@ const ModalMcpLibraryLinkSection: React.FC = () => {
     <div className='flex flex-col gap-12px min-h-0'>
       <div className='flex items-center justify-between gap-12px'>
         <div className='flex flex-col gap-4px'>
-          <span className='text-14px text-t-primary'>
-            {t('settings.mcpSettings', { defaultValue: 'MCP Servers' })}
-          </span>
+          <span className='text-14px text-t-primary'>{t('settings.mcpSettings', { defaultValue: 'MCP Servers' })}</span>
           <span className='text-13px text-t-secondary'>
-            {t(
-              'settings.mcpModalDeprecatedBody',
-              'Browse, install, and manage MCP servers in the new MCP Library.'
-            )}
+            {t('settings.mcpModalDeprecatedBody', 'Browse, install, and manage MCP servers in the new MCP Library.')}
           </span>
         </div>
         <Button type='outline' shape='round' onClick={handleOpenLibrary}>

--- a/tests/unit/process/bridge/voiceAssetBridge.test.ts
+++ b/tests/unit/process/bridge/voiceAssetBridge.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * The local voice-model "Download Model" bar was hardcoded to 0% because the
+ * bridge never passed an onProgress callback into VoiceAssetManager.download,
+ * and no progress emitter existed. These tests pin the wiring: the download
+ * provider must feed an onProgress that re-emits each DownloadProgress over the
+ * `voiceAsset.downloadProgress` emitter so the renderer can drive <Progress/>.
+ */
+
+import type { DownloadProgress } from '@/common/types/voiceAsset';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    voiceAsset: {
+      download: { provider: vi.fn() },
+      cancel: { provider: vi.fn() },
+      exists: { provider: vi.fn() },
+      localModelBase: { provider: vi.fn() },
+      downloadProgress: { emit: vi.fn() },
+    },
+  },
+}));
+
+vi.mock('@process/services/voice/VoiceAssetManager', () => ({
+  VoiceAssetManager: {
+    download: vi.fn(async () => ({
+      assetId: 'kokoro-onnx-model',
+      destPath: '/p',
+      cached: false,
+      bytesWritten: 5,
+      sha256: 'abc',
+    })),
+    cancel: vi.fn(() => true),
+  },
+}));
+
+vi.mock('@process/services/voice/voiceAssetRegistry', () => ({
+  resolveVoiceAsset: vi.fn((asset: { id: string }) => ({ ...asset, destPath: '/resolved', sha256: 'deadbeef' })),
+}));
+
+vi.mock('@process/extensions/constants', () => ({ getVoiceModelsDir: () => '/models' }));
+vi.mock('@process/extensions/protocol/assetProtocol', () => ({ toAssetUrl: (p: string) => `wayland-asset://${p}` }));
+
+import { ipcBridge } from '@/common';
+import { initVoiceAssetBridge } from '@process/bridge/voiceAssetBridge';
+import { VoiceAssetManager } from '@process/services/voice/VoiceAssetManager';
+
+const downloadProviderFn = ipcBridge.voiceAsset.download.provider as unknown as ReturnType<typeof vi.fn>;
+const downloadFn = VoiceAssetManager.download as unknown as ReturnType<typeof vi.fn>;
+const emitFn = ipcBridge.voiceAsset.downloadProgress.emit as unknown as ReturnType<typeof vi.fn>;
+
+let downloadCallback:
+  | ((asset: { id: string; url: string; destPath: string; sha256: string }) => Promise<unknown>)
+  | null = null;
+
+describe('voiceAssetBridge - download progress wiring', () => {
+  beforeEach(() => {
+    downloadCallback = null;
+    downloadProviderFn.mockReset();
+    downloadFn.mockClear();
+    emitFn.mockReset();
+    downloadProviderFn.mockImplementation(
+      (cb: (asset: { id: string; url: string; destPath: string; sha256: string }) => Promise<unknown>) => {
+        downloadCallback = cb;
+      }
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes an onProgress callback into VoiceAssetManager.download', async () => {
+    initVoiceAssetBridge();
+    expect(downloadCallback).toBeTruthy();
+
+    await downloadCallback!({ id: 'kokoro-onnx-model', url: 'https://x.test/model.onnx', destPath: '', sha256: '' });
+
+    expect(downloadFn).toHaveBeenCalledTimes(1);
+    const onProgress = downloadFn.mock.calls[0][1];
+    expect(typeof onProgress).toBe('function');
+  });
+
+  it('re-emits each DownloadProgress over the downloadProgress emitter', async () => {
+    initVoiceAssetBridge();
+    await downloadCallback!({ id: 'kokoro-onnx-model', url: 'https://x.test/model.onnx', destPath: '', sha256: '' });
+
+    const onProgress = downloadFn.mock.calls[0][1] as (p: DownloadProgress) => void;
+    const progress: DownloadProgress = { assetId: 'kokoro-onnx-model', bytesDownloaded: 3, totalBytes: 10 };
+    onProgress(progress);
+
+    expect(emitFn).toHaveBeenCalledWith(progress);
+  });
+});


### PR DESCRIPTION
## What

The local voice-model **Download Model** bar (Settings → Tools → Speech-to-Text / Text-to-Speech) was hardcoded to `0%` with a "Downloading… (progress reporting coming soon)" caption. The download already streams to disk and works — only the progress UI was a stub. Whisper and Kokoro shared the identical bug.

This wires real download progress end-to-end for both.

## How

- **IPC bridge** (`src/common/adapter/ipcBridge.ts`): add a `voiceAsset.downloadProgress` emitter (mirrors the existing `update.downloadProgress` / `buildEmitter` pattern), typed `DownloadProgress`.
- **voiceAssetBridge** (`src/process/bridge/voiceAssetBridge.ts`): pass an `onProgress` callback into `VoiceAssetManager.download()` that re-emits each `{ assetId, bytesDownloaded, totalBytes }` over that channel. `VoiceAssetManager` already fired `onProgress` per chunk — it was just never passed. Cancel keeps working through the existing cancel provider + the manager's internal `AbortController`.
- **Renderer** (`ToolsModalContent.tsx`): hoist a shared `useVoiceAssetDownload` hook used by **both** `WhisperLocalDownloadControl` and `TextToSpeechSettingsSection` (no third copy). It subscribes to the emitter, filters by `assetId`, computes `percent = totalBytes ? min(100, round(bytes/total*100)) : 0`, feeds `<Progress percent={...}/>`, and deletes the coming-soon caption. When the server omits `Content-Length` (`totalBytes === null`) it stays indeterminate at 0 rather than dividing by nothing.

No new i18n keys (the removed caption was an inline default-value fallback, not a locale entry).

## Tests

- New `tests/unit/process/bridge/voiceAssetBridge.test.ts` (TDD): asserts the download provider passes an `onProgress` into `VoiceAssetManager.download` and that it re-emits each `DownloadProgress` over `voiceAsset.downloadProgress`.
- Existing `voiceAssetManager.test.ts` already covers per-chunk progress emission at the manager layer.
- Full gate green: `lint` (0 errors), `typecheck` (clean), `i18n:types` + `check-i18n` pass, and the full suite (`11882 passed / 0 failed`).

Note: no GitHub issue existed for this; titled descriptively.