### PR TITLE
feat(projects): show chat creation date/time on Chats rows

### DIFF
--- a/src/renderer/pages/projects/ProjectWorkspacePage.tsx
+++ b/src/renderer/pages/projects/ProjectWorkspacePage.tsx
@@ -26,6 +26,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import { isConversationPinned } from '@/renderer/pages/conversation/GroupedHistory/utils/groupingHelpers';
+import { formatConversationDate } from '@/renderer/utils/chat/timeline';
 import ProjectFilesPanel from './components/ProjectFilesPanel';
 import ProjectSettingsDrawer, { type SettingsSection } from './components/ProjectSettingsDrawer';
 import ProjectReferencePanel from './components/ProjectReferencePanel';
@@ -126,7 +127,9 @@ const ProjectWorkspacePage: React.FC = () => {
         await ipcBridge.conversation.update.invoke({
           id: c.id,
           updates: {
-            extra: { pinned: !pinned, pinnedAt: pinned ? undefined : Date.now() } as Partial<TChatConversation['extra']>,
+            extra: { pinned: !pinned, pinnedAt: pinned ? undefined : Date.now() } as Partial<
+              TChatConversation['extra']
+            >,
           } as Partial<TChatConversation>,
           mergeExtra: true,
         });
@@ -167,7 +170,12 @@ const ProjectWorkspacePage: React.FC = () => {
   const color = project?.iconColor || '#FF6A00';
 
   const TABS: Array<{ key: ProjectTab; label: string; icon: React.ReactNode; count?: number }> = [
-    { key: 'chats', label: t('projects.workspace.tabChats'), icon: <MessageSquare size={15} />, count: conversations.length },
+    {
+      key: 'chats',
+      label: t('projects.workspace.tabChats'),
+      icon: <MessageSquare size={15} />,
+      count: conversations.length,
+    },
     { key: 'files', label: t('projects.workspace.tabFiles'), icon: <FolderOpen size={15} /> },
     { key: 'reference', label: t('projects.workspace.tabReference'), icon: <Paperclip size={15} /> },
     { key: 'memory', label: t('projects.workspace.tabMemory'), icon: <NotebookPen size={15} /> },
@@ -285,77 +293,88 @@ const ProjectWorkspacePage: React.FC = () => {
                     return pb - pa;
                   })
                   .map((c) => {
-                  const backend = (c.extra as { backend?: string } | undefined)?.backend || c.type;
-                  return (
-                    <div
-                      key={c.id}
-                      role='button'
-                      tabIndex={0}
-                      onClick={() => navigate(`/conversation/${c.id}`)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') navigate(`/conversation/${c.id}`);
-                      }}
-                      className={`group flex items-center gap-12px px-14px py-12px cursor-pointer ${styles.card}`}
-                    >
-                      <div className='flex flex-col gap-2px min-w-0 flex-1'>
-                        <div className='flex items-center gap-6px min-w-0'>
-                          {isConversationPinned(c) && <Pin size={12} className='text-t-tertiary shrink-0' />}
-                          <div className='text-14px font-500 text-t-primary truncate'>
-                            {c.name || t('projects.workspace.untitledChat')}
+                    const backend = (c.extra as { backend?: string } | undefined)?.backend || c.type;
+                    const created = formatConversationDate(c.createTime);
+                    return (
+                      <div
+                        key={c.id}
+                        role='button'
+                        tabIndex={0}
+                        onClick={() => navigate(`/conversation/${c.id}`)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') navigate(`/conversation/${c.id}`);
+                        }}
+                        className={`group flex items-center gap-12px px-14px py-12px cursor-pointer ${styles.card}`}
+                      >
+                        <div className='flex flex-col gap-2px min-w-0 flex-1'>
+                          <div className='flex items-center gap-6px min-w-0'>
+                            {isConversationPinned(c) && <Pin size={12} className='text-t-tertiary shrink-0' />}
+                            <div className='text-14px font-500 text-t-primary truncate'>
+                              {c.name || t('projects.workspace.untitledChat')}
+                            </div>
+                          </div>
+                          <div className='flex items-center gap-6px text-11px text-t-tertiary'>
+                            <span className='uppercase tracking-wide'>{backend}</span>
+                            {created && (
+                              <>
+                                <span aria-hidden='true'>·</span>
+                                <span className='normal-case'>
+                                  {t('projects.workspace.created', { date: created })}
+                                </span>
+                              </>
+                            )}
                           </div>
                         </div>
-                        <div className='text-11px text-t-tertiary uppercase tracking-wide'>{backend}</div>
-                      </div>
-                      {/* stopPropagation on the wrapper (not the trigger button) so the
+                        {/* stopPropagation on the wrapper (not the trigger button) so the
                           row click doesn't navigate, while Arco's click-to-open still fires. */}
-                      <div onClick={(e) => e.stopPropagation()}>
-                        <Dropdown
-                          trigger='click'
-                          position='br'
-                          droplist={
-                            <Menu
-                              onClickMenuItem={(key) => {
-                                if (key === 'pin') void togglePin(c);
-                                else if (key === 'rename') openRename(c);
-                                else if (key === 'remove') removeFromProject(c.id);
-                              }}
-                            >
-                              <Menu.Item key='pin'>
-                                <div className='flex items-center gap-8px'>
-                                  {isConversationPinned(c) ? <PinOff size={15} /> : <Pin size={15} />}
-                                  <span>
-                                    {isConversationPinned(c)
-                                      ? t('conversation.history.unpin')
-                                      : t('conversation.history.pin')}
-                                  </span>
-                                </div>
-                              </Menu.Item>
-                              <Menu.Item key='rename'>
-                                <div className='flex items-center gap-8px'>
-                                  <Pencil size={15} />
-                                  <span>{t('conversation.history.rename')}</span>
-                                </div>
-                              </Menu.Item>
-                              <Menu.Item key='remove'>
-                                <div className='flex items-center gap-8px text-[rgb(var(--warning-6))]'>
-                                  <FolderMinus size={15} />
-                                  <span>{t('projects.workspace.removeChat')}</span>
-                                </div>
-                              </Menu.Item>
-                            </Menu>
-                          }
-                        >
-                          <Button
-                            type='text'
-                            size='mini'
-                            className='opacity-0 group-hover:opacity-100 transition-opacity'
-                            icon={<MoreHorizontal size={16} />}
-                          />
-                        </Dropdown>
+                        <div onClick={(e) => e.stopPropagation()}>
+                          <Dropdown
+                            trigger='click'
+                            position='br'
+                            droplist={
+                              <Menu
+                                onClickMenuItem={(key) => {
+                                  if (key === 'pin') void togglePin(c);
+                                  else if (key === 'rename') openRename(c);
+                                  else if (key === 'remove') removeFromProject(c.id);
+                                }}
+                              >
+                                <Menu.Item key='pin'>
+                                  <div className='flex items-center gap-8px'>
+                                    {isConversationPinned(c) ? <PinOff size={15} /> : <Pin size={15} />}
+                                    <span>
+                                      {isConversationPinned(c)
+                                        ? t('conversation.history.unpin')
+                                        : t('conversation.history.pin')}
+                                    </span>
+                                  </div>
+                                </Menu.Item>
+                                <Menu.Item key='rename'>
+                                  <div className='flex items-center gap-8px'>
+                                    <Pencil size={15} />
+                                    <span>{t('conversation.history.rename')}</span>
+                                  </div>
+                                </Menu.Item>
+                                <Menu.Item key='remove'>
+                                  <div className='flex items-center gap-8px text-[rgb(var(--warning-6))]'>
+                                    <FolderMinus size={15} />
+                                    <span>{t('projects.workspace.removeChat')}</span>
+                                  </div>
+                                </Menu.Item>
+                              </Menu>
+                            }
+                          >
+                            <Button
+                              type='text'
+                              size='mini'
+                              className='opacity-0 group-hover:opacity-100 transition-opacity'
+                              icon={<MoreHorizontal size={16} />}
+                            />
+                          </Dropdown>
+                        </div>
                       </div>
-                    </div>
-                  );
-                })}
+                    );
+                  })}
               </div>
             )}
           </div>

--- a/src/renderer/pages/projects/ProjectWorkspacePage.tsx
+++ b/src/renderer/pages/projects/ProjectWorkspacePage.tsx
@@ -54,7 +54,7 @@ const hasContent = (raw: string): boolean =>
  * execution lock: many chats can run at once, so nothing here disables.
  */
 const ProjectWorkspacePage: React.FC = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const navigate = useNavigate();
   const { projectId } = useParams<{ projectId: string }>();
 
@@ -294,7 +294,7 @@ const ProjectWorkspacePage: React.FC = () => {
                   })
                   .map((c) => {
                     const backend = (c.extra as { backend?: string } | undefined)?.backend || c.type;
-                    const created = formatConversationDate(c.createTime);
+                    const created = formatConversationDate(c.createTime, i18n.language || 'en-US');
                     return (
                       <div
                         key={c.id}

--- a/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/src/renderer/services/i18n/i18n-keys.d.ts
@@ -2173,6 +2173,7 @@ export type I18nKey =
   | 'projects.wizard.titleInstructions'
   | 'projects.wizard.titleRules'
   | 'projects.wizard.useDraft'
+  | 'projects.workspace.created'
   | 'projects.workspace.edit'
   | 'projects.workspace.emptyBody'
   | 'projects.workspace.emptyTitle'

--- a/src/renderer/services/i18n/locales/de-DE/projects.json
+++ b/src/renderer/services/i18n/locales/de-DE/projects.json
@@ -43,6 +43,7 @@
     "emptyTitle": "Noch keine Chats in diesem Projekt",
     "emptyBody": "Starte einen Chat mit einem beliebigen Backend, Modell oder Assistenten. Er gehört zu diesem Projekt, und du kannst so viele gleichzeitig laufen lassen, wie du möchtest.",
     "untitledChat": "Unbenannter Chat",
+    "created": "Erstellt {{date}}",
     "removeChat": "Entfernen",
     "tabReference": "Referenz",
     "tabMemory": "Gedächtnis",

--- a/src/renderer/services/i18n/locales/en-US/projects.json
+++ b/src/renderer/services/i18n/locales/en-US/projects.json
@@ -43,6 +43,7 @@
     "emptyTitle": "No chats in this project yet",
     "emptyBody": "Start a chat with any backend, model or assistant. It will live under this project, and you can run as many as you like at once.",
     "untitledChat": "Untitled chat",
+    "created": "Created {{date}}",
     "removeChat": "Remove",
     "tabReference": "Reference",
     "tabMemory": "Memory",

--- a/src/renderer/services/i18n/locales/es-ES/projects.json
+++ b/src/renderer/services/i18n/locales/es-ES/projects.json
@@ -43,6 +43,7 @@
     "emptyTitle": "Aún no hay chats en este proyecto",
     "emptyBody": "Inicia un chat con cualquier backend, modelo o asistente. Vivirá dentro de este proyecto, y puedes ejecutar tantos como quieras a la vez.",
     "untitledChat": "Chat sin título",
+    "created": "Creado {{date}}",
     "removeChat": "Quitar",
     "tabReference": "Referencia",
     "tabMemory": "Memoria",

--- a/src/renderer/services/i18n/locales/fr-FR/projects.json
+++ b/src/renderer/services/i18n/locales/fr-FR/projects.json
@@ -43,6 +43,7 @@
     "emptyTitle": "Aucune conversation dans ce projet pour l'instant",
     "emptyBody": "Démarrez une conversation avec n'importe quel backend, modèle ou assistant. Elle sera rattachée à ce projet, et vous pouvez en lancer autant que vous le souhaitez en même temps.",
     "untitledChat": "Conversation sans titre",
+    "created": "Créé {{date}}",
     "removeChat": "Retirer",
     "tabReference": "Référence",
     "tabMemory": "Mémoire",

--- a/src/renderer/services/i18n/locales/ja-JP/projects.json
+++ b/src/renderer/services/i18n/locales/ja-JP/projects.json
@@ -40,6 +40,7 @@
     "emptyTitle": "No chats in this project yet",
     "emptyBody": "Start a chat with any backend, model or assistant. It will live under this project, and you can run as many as you like at once.",
     "untitledChat": "Untitled chat",
+    "created": "作成 {{date}}",
     "removeChat": "Remove",
     "tabChats": "Chats",
     "tabFiles": "Files",

--- a/src/renderer/services/i18n/locales/ko-KR/projects.json
+++ b/src/renderer/services/i18n/locales/ko-KR/projects.json
@@ -40,6 +40,7 @@
     "emptyTitle": "No chats in this project yet",
     "emptyBody": "Start a chat with any backend, model or assistant. It will live under this project, and you can run as many as you like at once.",
     "untitledChat": "Untitled chat",
+    "created": "생성 {{date}}",
     "removeChat": "Remove",
     "tabChats": "Chats",
     "tabFiles": "Files",

--- a/src/renderer/services/i18n/locales/pt-BR/projects.json
+++ b/src/renderer/services/i18n/locales/pt-BR/projects.json
@@ -43,6 +43,7 @@
     "emptyTitle": "Nenhuma conversa neste projeto ainda",
     "emptyBody": "Inicie uma conversa com qualquer backend, modelo ou assistente. Ela ficará dentro deste projeto, e você pode rodar quantas quiser ao mesmo tempo.",
     "untitledChat": "Conversa sem título",
+    "created": "Criado {{date}}",
     "removeChat": "Remover",
     "tabReference": "Referência",
     "tabMemory": "Memória",

--- a/src/renderer/services/i18n/locales/ru-RU/projects.json
+++ b/src/renderer/services/i18n/locales/ru-RU/projects.json
@@ -40,6 +40,7 @@
     "emptyTitle": "No chats in this project yet",
     "emptyBody": "Start a chat with any backend, model or assistant. It will live under this project, and you can run as many as you like at once.",
     "untitledChat": "Untitled chat",
+    "created": "Создано {{date}}",
     "removeChat": "Remove",
     "tabChats": "Chats",
     "tabFiles": "Files",

--- a/src/renderer/services/i18n/locales/tr-TR/projects.json
+++ b/src/renderer/services/i18n/locales/tr-TR/projects.json
@@ -40,6 +40,7 @@
     "emptyTitle": "No chats in this project yet",
     "emptyBody": "Start a chat with any backend, model or assistant. It will live under this project, and you can run as many as you like at once.",
     "untitledChat": "Untitled chat",
+    "created": "Oluşturuldu {{date}}",
     "removeChat": "Remove",
     "tabChats": "Chats",
     "tabFiles": "Files",

--- a/src/renderer/services/i18n/locales/uk-UA/projects.json
+++ b/src/renderer/services/i18n/locales/uk-UA/projects.json
@@ -40,6 +40,7 @@
     "emptyTitle": "No chats in this project yet",
     "emptyBody": "Start a chat with any backend, model or assistant. It will live under this project, and you can run as many as you like at once.",
     "untitledChat": "Untitled chat",
+    "created": "Створено {{date}}",
     "removeChat": "Remove",
     "tabChats": "Chats",
     "tabFiles": "Files",

--- a/src/renderer/services/i18n/locales/zh-CN/projects.json
+++ b/src/renderer/services/i18n/locales/zh-CN/projects.json
@@ -40,6 +40,7 @@
     "emptyTitle": "No chats in this project yet",
     "emptyBody": "Start a chat with any backend, model or assistant. It will live under this project, and you can run as many as you like at once.",
     "untitledChat": "Untitled chat",
+    "created": "创建于 {{date}}",
     "removeChat": "Remove",
     "tabChats": "Chats",
     "tabFiles": "Files",

--- a/src/renderer/services/i18n/locales/zh-TW/projects.json
+++ b/src/renderer/services/i18n/locales/zh-TW/projects.json
@@ -40,6 +40,7 @@
     "emptyTitle": "No chats in this project yet",
     "emptyBody": "Start a chat with any backend, model or assistant. It will live under this project, and you can run as many as you like at once.",
     "untitledChat": "Untitled chat",
+    "created": "建立於 {{date}}",
     "removeChat": "Remove",
     "tabChats": "Chats",
     "tabFiles": "Files",

--- a/src/renderer/utils/chat/timeline.ts
+++ b/src/renderer/utils/chat/timeline.ts
@@ -23,6 +23,20 @@ export const diffDay = (time1: number, time2: number): number => {
 };
 
 /**
+ * Format a conversation timestamp as a short, locale-aware absolute date + time.
+ *
+ * Absolute (with year) rather than relative so the oldest chat stays identifiable
+ * when pruning duplicates. Returns '' for a missing/zero/NaN timestamp.
+ *
+ * @param timestamp - Milliseconds since epoch (e.g. conversation.createTime)
+ * @param locale - Optional BCP 47 locale; defaults to the runtime locale
+ */
+export const formatConversationDate = (timestamp: number, locale?: string): string => {
+  if (!timestamp || Number.isNaN(timestamp)) return '';
+  return new Intl.DateTimeFormat(locale, { dateStyle: 'medium', timeStyle: 'short' }).format(timestamp);
+};
+
+/**
  * Get the activity time (most recent) from a conversation
  */
 export const getActivityTime = (conversation: TChatConversation): number => {

--- a/tests/unit/formatConversationDate.test.ts
+++ b/tests/unit/formatConversationDate.test.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { formatConversationDate } from '@renderer/utils/chat/timeline';
+
+describe('formatConversationDate', () => {
+  // Noon UTC so the calendar date is identical in every timezone (UTC-12..+14).
+  const NOON_UTC_2024 = Date.UTC(2024, 0, 15, 12, 0, 0);
+
+  it('returns an empty string for a missing/zero timestamp', () => {
+    expect(formatConversationDate(0)).toBe('');
+    expect(formatConversationDate(Number.NaN)).toBe('');
+  });
+
+  it('formats a valid timestamp as a non-empty absolute date', () => {
+    expect(formatConversationDate(NOON_UTC_2024, 'en-US')).not.toBe('');
+  });
+
+  it('includes the year so the oldest chat is identifiable across years', () => {
+    expect(formatConversationDate(NOON_UTC_2024, 'en-US')).toContain('2024');
+  });
+
+  it('is deterministic for the same input', () => {
+    expect(formatConversationDate(NOON_UTC_2024, 'en-US')).toBe(formatConversationDate(NOON_UTC_2024, 'en-US'));
+  });
+});


### PR DESCRIPTION
Addresses #571 (do not auto-close - release closes).

## What
Each chat row in the Projects workspace **Chats** tab now shows its creation date/time next to the backend label. This makes it easy to identify the oldest of several near-duplicate chats when pruning.

## How
- Added a small, locale-aware `formatConversationDate(timestamp, locale?)` helper to the existing chat time utils (`src/renderer/utils/chat/timeline.ts`). It returns a short absolute date+time (`Intl.DateTimeFormat` with `dateStyle: 'medium'`, `timeStyle: 'short'`) and `''` for a missing/zero timestamp. Absolute *with year* (not relative) so the oldest chat stays identifiable across months/years.
- Wired it into the Chats row metadata line in `ProjectWorkspacePage.tsx`, rendering `createTime` behind an i18n label `projects.workspace.created` ("Created {{date}}"), added to all 12 locales.
- The surrounding row block was reflowed by oxfmt (the file was not oxfmt-canonical on `main`, so touching it triggers a full format pass); the only semantic change is the new timestamp element.

## Test
- New TDD unit test `tests/unit/formatConversationDate.test.ts` (empty/NaN -> '', valid -> non-empty, includes year, deterministic).
- Full gate green: lint (0 errors), oxfmt (changed files clean), typecheck, `bun run i18n:types` + `node scripts/check-i18n.js`, and full `bun run test` (11884 passed, 0 failed).