### PR TITLE
fix(email-imap): guard against inbound self-reply loop

### DIFF
--- a/src/process/channels/plugins/tier1/email-imap/EmailImapConnection.ts
+++ b/src/process/channels/plugins/tier1/email-imap/EmailImapConnection.ts
@@ -284,6 +284,7 @@ export class EmailImapConnection {
         // Suppress the agent's own outbound echoing back into INBOX (#547) - mark
         // it seen so it is not re-fetched, but never hand it to onMessage.
         if (this.isOwnEcho(unified)) {
+          console.debug(`[emailWorker] suppressing own echo uid=${raw.uid}`);
           if (raw.uid > this.lastSeenUid) this.lastSeenUid = raw.uid;
           seenUids.push(raw.uid);
           continue;

--- a/src/process/channels/plugins/tier1/email-imap/EmailImapConnection.ts
+++ b/src/process/channels/plugins/tier1/email-imap/EmailImapConnection.ts
@@ -27,6 +27,17 @@ import {
 const POLL_INTERVAL_MS = 30_000;
 const RECONNECT_BACKOFF_START_MS = 5_000;
 const RECONNECT_BACKOFF_MAX_MS = 60_000;
+/**
+ * Cap on remembered outbound Message-IDs. Bounds memory on a long-lived
+ * connection while comfortably covering the window between a send and IMAP
+ * polling that same message back into INBOX.
+ */
+const MAX_TRACKED_SENT_IDS = 500;
+
+/** Lower-case + trim an address/Message-ID for case-insensitive comparison. */
+function normalizeKey(value: string | undefined): string {
+  return (value ?? '').trim().toLowerCase();
+}
 
 export type TestResult = { success: boolean; botUsername?: string; error?: string };
 
@@ -41,12 +52,26 @@ export class EmailImapConnection {
   private reconnectTimer: NodeJS.Timeout | null = null;
   private reconnectBackoffMs = RECONNECT_BACKOFF_START_MS;
   private stopped = false;
+  /**
+   * Inbound self-reply loop guard (#547). The agent sends from its own inbox
+   * over SMTP; IMAP later polls that same mail back into INBOX as UNSEEN. Without
+   * a guard, fetchUnseen() would hand the agent its own message, trigger another
+   * reply, and loop unbounded. We suppress those echoes two ways:
+   *   - selfAddresses: any inbound whose From equals our own inbox address.
+   *   - sentMessageIds: any inbound carrying a Message-ID we just sent (covers
+   *     alias/relay rewrites where the From no longer matches the inbox).
+   * This is inbound-only - the send path is never gated.
+   */
+  private readonly selfAddresses = new Set<string>();
+  private readonly sentMessageIds = new Set<string>();
 
   constructor(private readonly onMessage: (message: IUnifiedIncomingMessage) => void) {}
 
   async connect(creds: ResolvedCredentials): Promise<void> {
     this.creds = creds;
     this.stopped = false;
+    this.rememberSelfAddress(creds.imap.user);
+    this.rememberSelfAddress(creds.smtp.user);
 
     // Build outbound SMTP transport eagerly so send-failures surface here
     // rather than on the first agent reply.
@@ -63,6 +88,9 @@ export class EmailImapConnection {
 
   async send(chatId: string, message: IUnifiedOutgoingMessage, fromUser: string): Promise<string> {
     if (!this.smtp) throw new Error('Email-IMAP worker not connected');
+    // The From we are about to send is one of our own addresses; record it so
+    // the echo it produces is recognised even before its Message-ID is known.
+    this.rememberSelfAddress(fromUser);
     const envelope = buildSmtpEnvelope(message, chatId, fromUser, message.replyToMessageId);
     const info = await this.smtp.sendMail({
       from: envelope.from,
@@ -74,6 +102,7 @@ export class EmailImapConnection {
     });
     const id = typeof info.messageId === 'string' ? info.messageId : '';
     if (!id) throw new Error('SMTP send returned no Message-ID');
+    this.rememberSentMessageId(id);
     return id;
   }
 
@@ -103,6 +132,8 @@ export class EmailImapConnection {
     this.creds = null;
     this.lastSeenUid = 0;
     this.reconnectBackoffMs = RECONNECT_BACKOFF_START_MS;
+    this.selfAddresses.clear();
+    this.sentMessageIds.clear();
   }
 
   /**
@@ -156,9 +187,7 @@ export class EmailImapConnection {
     this.idleActive = true;
     const client = this.client;
     client.on('exists', () => {
-      void this.fetchUnseen().catch((err) =>
-        console.error('[emailWorker] fetch on exists failed:', err)
-      );
+      void this.fetchUnseen().catch((err) => console.error('[emailWorker] fetch on exists failed:', err));
     });
     void (async () => {
       while (this.idleActive && this.client === client && !this.stopped) {
@@ -218,9 +247,7 @@ export class EmailImapConnection {
     if (this.pollTimer) return;
     this.pollTimer = setInterval(() => {
       if (this.pollInFlight) return;
-      void this.fetchUnseen().catch((err) =>
-        console.error('[emailWorker] poll fetch failed:', err)
-      );
+      void this.fetchUnseen().catch((err) => console.error('[emailWorker] poll fetch failed:', err));
     }, POLL_INTERVAL_MS);
   }
 
@@ -254,6 +281,13 @@ export class EmailImapConnection {
           console.warn('[emailWorker] dropping message with missing uid/from/messageId');
           continue;
         }
+        // Suppress the agent's own outbound echoing back into INBOX (#547) - mark
+        // it seen so it is not re-fetched, but never hand it to onMessage.
+        if (this.isOwnEcho(unified)) {
+          if (raw.uid > this.lastSeenUid) this.lastSeenUid = raw.uid;
+          seenUids.push(raw.uid);
+          continue;
+        }
         try {
           this.onMessage(unified);
         } catch (err) {
@@ -275,6 +309,35 @@ export class EmailImapConnection {
       }
     } finally {
       this.pollInFlight = false;
+    }
+  }
+
+  /**
+   * True when an inbound message is the agent's own outbound mail echoing back
+   * into INBOX - either its From is one of our own addresses, or it carries a
+   * Message-ID we recently sent. See the selfAddresses/sentMessageIds fields.
+   */
+  private isOwnEcho(message: IUnifiedIncomingMessage): boolean {
+    const from = normalizeKey(message.email?.from ?? message.chatId);
+    if (from && this.selfAddresses.has(from)) return true;
+    const messageId = normalizeKey(message.email?.messageId ?? message.id);
+    if (messageId && this.sentMessageIds.has(messageId)) return true;
+    return false;
+  }
+
+  private rememberSelfAddress(address: string | undefined): void {
+    const key = normalizeKey(address);
+    if (key) this.selfAddresses.add(key);
+  }
+
+  private rememberSentMessageId(messageId: string): void {
+    const key = normalizeKey(messageId);
+    if (!key) return;
+    this.sentMessageIds.add(key);
+    // Evict oldest (insertion-ordered Set) once over the cap.
+    if (this.sentMessageIds.size > MAX_TRACKED_SENT_IDS) {
+      const oldest = this.sentMessageIds.values().next().value;
+      if (oldest !== undefined) this.sentMessageIds.delete(oldest);
     }
   }
 }

--- a/tests/unit/process/channels/plugins/tier1/email-imap/EmailImapConnection.fetch.test.ts
+++ b/tests/unit/process/channels/plugins/tier1/email-imap/EmailImapConnection.fetch.test.ts
@@ -8,17 +8,24 @@
  * for-await. Calling another command mid-fetch deadlocks the connection (fetch
  * holds the lock the command waits for), which previously hung connect() right
  * after the first message.
+ *
+ * Also covers the inbound self-reply loop guard (#547): the agent's own
+ * outbound, polled back into INBOX, must not be re-emitted to onMessage.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ResolvedCredentials } from '@process/channels/plugins/tier1/email-imap/EmailImapShared';
 
-const { ImapFlowStub, fetchMessages, flagsAddCalls, fetchActive } = vi.hoisted(() => {
+const { ImapFlowStub, fetchMessages, flagsAddCalls, fetchActive, sentMail, lastClient } = vi.hoisted(() => {
   type Raw = { uid: number; envelope: unknown; source: Buffer };
   const fetchMessages: Raw[] = [];
   const flagsAddCalls: Array<{ uids: string; duringFetch: boolean }> = [];
   const fetchActive = { value: false };
+  const sentMail = { messageId: '<sent-default>' };
+  const lastClient: { emit: (event: string, ...args: unknown[]) => void } = {
+    emit: () => undefined,
+  };
 
   function makeEmitter() {
     const listeners: Record<string, Array<(...a: unknown[]) => void>> = {};
@@ -30,8 +37,9 @@ const { ImapFlowStub, fetchMessages, flagsAddCalls, fetchActive } = vi.hoisted((
       off() {
         return this;
       },
-      emit() {
-        return false;
+      emit(event: string, ...args: unknown[]) {
+        for (const cb of listeners[event] ?? []) cb(...args);
+        return true;
       },
     };
   }
@@ -57,16 +65,22 @@ const { ImapFlowStub, fetchMessages, flagsAddCalls, fetchActive } = vi.hoisted((
           flagsAddCalls.push({ uids, duringFetch: fetchActive.value });
         }),
       });
+      lastClient.emit = (event: string, ...args: unknown[]) => fake.emit(event, ...args);
       return fake as unknown as ImapFlowStub;
     }
   }
 
-  return { ImapFlowStub, fetchMessages, flagsAddCalls, fetchActive };
+  return { ImapFlowStub, fetchMessages, flagsAddCalls, fetchActive, sentMail, lastClient };
 });
 
 vi.mock('imapflow', () => ({ ImapFlow: ImapFlowStub }));
 vi.mock('nodemailer', () => ({
-  default: { createTransport: vi.fn(() => ({ sendMail: vi.fn(), close: vi.fn() })) },
+  default: {
+    createTransport: vi.fn(() => ({
+      sendMail: vi.fn(async () => ({ messageId: sentMail.messageId })),
+      close: vi.fn(),
+    })),
+  },
 }));
 
 import { EmailImapConnection } from '@process/channels/plugins/tier1/email-imap/EmailImapConnection';
@@ -118,6 +132,74 @@ describe('EmailImapConnection - fetch drain marks seen after iteration', () => {
     const conn = new EmailImapConnection(() => undefined);
     // The bug made this hang forever; a passing test proves connect() returns.
     await expect(conn.connect(makeCreds())).resolves.toBeUndefined();
+    await conn.stop();
+  });
+});
+
+describe('EmailImapConnection - inbound self-reply loop guard (#547)', () => {
+  beforeEach(() => {
+    fetchMessages.length = 0;
+    flagsAddCalls.length = 0;
+    fetchActive.value = false;
+    sentMail.messageId = '<sent-default>';
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('does NOT re-emit the agent own mail (from == inbox address) but still marks it seen', async () => {
+    // makeCreds() logs in as a@b, so a message FROM a@b is the agent echoing
+    // its own just-sent mail back into INBOX. A genuine reply from z@y.com must
+    // still be delivered.
+    fetchMessages.push(makeRaw(1, 'a@b'), makeRaw(2, 'z@y.com'));
+
+    const seen: string[] = [];
+    const conn = new EmailImapConnection((m) => seen.push(m.chatId));
+    await conn.connect(makeCreds());
+
+    // Only the genuine inbound reply reaches onMessage.
+    expect(seen).toEqual(['z@y.com']);
+    // Both UIDs are still marked seen so the echo is not re-fetched forever.
+    expect(flagsAddCalls).toHaveLength(1);
+    expect(flagsAddCalls[0]!.uids).toBe('1,2');
+
+    await conn.stop();
+  });
+
+  it('does NOT re-emit a message whose Message-ID matches one we just sent', async () => {
+    // The agent sends a reply; SMTP returns <m5>. When IMAP polls that exact
+    // message back (even if the From header does not equal the inbox address,
+    // e.g. an alias/relay rewrite), the Message-ID dedup must still suppress it.
+    sentMail.messageId = '<m5>';
+
+    const seen: string[] = [];
+    const conn = new EmailImapConnection((m) => seen.push(m.id));
+    await conn.connect(makeCreds());
+    await conn.send('to@x.com', { text: 'hi' } as never, 'alias@b');
+
+    // From is NOT the inbox address - isolates the Message-ID dedup path.
+    fetchMessages.push(
+      {
+        uid: 5,
+        envelope: { messageId: '<m5>', from: [{ address: 'noreply@relay.example' }], subject: 's' },
+        source: Buffer.from('body'),
+      },
+      makeRaw(6, 'stranger@y.com')
+    );
+    // Drive a second poll the way IMAP IDLE does - via the 'exists' event.
+    lastClient.emit('exists');
+    await vi.waitFor(() => expect(seen).toEqual(['<m6>']));
+
+    await conn.stop();
+  });
+
+  it('delivers a genuine inbound reply from a third party unchanged', async () => {
+    fetchMessages.push(makeRaw(9, 'customer@acme.com'));
+
+    const seen: string[] = [];
+    const conn = new EmailImapConnection((m) => seen.push(m.chatId));
+    await conn.connect(makeCreds());
+
+    expect(seen).toEqual(['customer@acme.com']);
+
     await conn.stop();
   });
 });


### PR DESCRIPTION
Addresses #547 (do not auto-close - release closes).

## Problem
The autopilot email channel could get stuck in an unbounded self-reply loop. `EmailImapConnection.send()` SMTP-sends the agent's reply and returns the Message-ID but records nothing. `fetchUnseen()` FETCHes every UNSEEN message and calls `onMessage()` for all of them — including the agent's OWN just-sent mail once IMAP polls it back into INBOX. That echo drives another agent turn → another send → loop.

## Fix (inbound-only)
Desktop mirror of the already-merged wayland-core self-echo guard.

- Track own outbound in `EmailImapConnection`:
  - `selfAddresses` — the inbox address (IMAP/SMTP user, plus each `fromUser` we send as).
  - `sentMessageIds` — a bounded (cap 500, oldest-evicted) set of Message-IDs we returned from `send()`.
- In `fetchUnseen()`, before emitting, `isOwnEcho()` checks the parsed message's From against `selfAddresses` and its Message-ID against `sentMessageIds`. A match is skipped — but still marked `\Seen` so it is not re-fetched forever.
- The send path is **never** gated. Both tracking sets are cleared on `stop()`.

The Message-ID dedup covers alias/relay rewrites where the echoed From no longer equals the inbox address.

## Test
`tests/unit/process/channels/plugins/tier1/email-imap/EmailImapConnection.fetch.test.ts` — new cases assert:
- the agent's own mail (From == inbox) is NOT re-emitted but IS marked seen,
- a message whose Message-ID matches one we just sent is suppressed even from a non-inbox From,
- a genuine third-party inbound reply is delivered unchanged.

## Gate
- Targeted + full suite: 11883 passed, 0 failed.
- Typecheck clean, oxfmt clean, oxlint 0 errors on changed files.