### PR TITLE
feat(workspace): drag-drop file moves + reliable click preview in project Files

### DIFF
--- a/src/common/adapter/bridgeAllowlist.ts
+++ b/src/common/adapter/bridgeAllowlist.ts
@@ -156,6 +156,7 @@ const REMOTE_DENIED_KEYS: ReadonlySet<string> = new Set([
   'write-file',
   'remove-entry',
   'rename-entry',
+  'move-entry',
   'read-file',
   'read-file-buffer',
   'create-temp-file',

--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -369,6 +369,9 @@ export const fs = {
   >('copy-files-to-workspace'), // Copy files into workspace
   removeEntry: buildProvider<IBridgeResponse, { path: string }>('remove-entry'), // Delete file or folder
   renameEntry: buildProvider<IBridgeResponse<{ newPath: string }>, { path: string; newName: string }>('rename-entry'), // Rename file or folder
+  moveEntry: buildProvider<IBridgeResponse<{ newPath: string }>, { sourcePath: string; targetDir: string }>(
+    'move-entry'
+  ), // Move file or folder into a target directory
   readBuiltinRule: buildProvider<string, { fileName: string }>('read-builtin-rule'), // Read builtin rules file
   readBuiltinSkill: buildProvider<string, { fileName: string }>('read-builtin-skill'), // Read builtin skills file
   // Assistant rule file operations

--- a/src/process/bridge/fsBridge.ts
+++ b/src/process/bridge/fsBridge.ts
@@ -331,6 +331,19 @@ async function destinationExists(candidatePath: string): Promise<boolean> {
   }
 }
 
+/**
+ * Normalize path separators to POSIX `/` (#49 Windows fix). `path.join` emits
+ * backslashes on Windows, but `confinePath` normalizes to `/` internally and
+ * compares against `/`-formed roots — so a freshly joined destination would be
+ * misread as an out-of-root escape, and the string comparisons below (collision
+ * target, self-move, descendant guard) would break. Node's `fs` accepts forward
+ * slashes on Windows, so normalizing here keeps move/rename separator-agnostic
+ * on every platform.
+ */
+function toPosixPath(p: string): string {
+  return p.replace(/\\/g, '/');
+}
+
 const MAX_WORKSPACE_FILES = 20_000;
 
 async function listWorkspaceFilesRecursive(root: string): Promise<IWorkspaceFlatFile[]> {
@@ -1229,14 +1242,16 @@ export function initFsBridge(): void {
 
       const directory = path.dirname(safeTarget);
       // newName may contain traversal (e.g. `../../etc/cron.d/x`); confine the
-      // resulting destination as well so a rename cannot escape the root.
-      const candidateNewPath = path.join(directory, newName);
+      // resulting destination as well so a rename cannot escape the root. Keep
+      // path.join's `..` resolution but normalize separators to `/` (#49): on
+      // Windows path.join emits `\`, which confinePath misreads as an escape.
+      const candidateNewPath = toPosixPath(path.join(directory, newName));
       const newPath = await confinePath(candidateNewPath);
       if (newPath === null) {
         return { success: false, msg: 'Target name is outside the allowed workspace roots' };
       }
 
-      if (newPath === safeTarget) {
+      if (toPosixPath(newPath) === toPosixPath(safeTarget)) {
         // Skip when the new name equals the original path
         return { success: true, data: { newPath } };
       }
@@ -1285,20 +1300,26 @@ export function initFsBridge(): void {
         return { success: false, msg: 'Target directory does not exist' };
       }
 
-      // Destination path keeps the source's own name inside the target directory.
-      const candidateNewPath = path.join(safeDir, path.basename(safeSource));
+      // Destination path keeps the source's own name inside the target
+      // directory. Build it with POSIX separators (#49): path.join emits `\` on
+      // Windows, which confinePath then misreads as an out-of-root escape.
+      const posixDir = toPosixPath(safeDir);
+      const posixSource = toPosixPath(safeSource);
+      const candidateNewPath = `${posixDir.replace(/\/+$/, '')}/${path.basename(posixSource)}`;
       const newPath = await confinePath(candidateNewPath);
       if (newPath === null) {
         return { success: false, msg: 'Target path is outside the allowed workspace roots' };
       }
 
-      if (newPath === safeSource) {
+      const posixNewPath = toPosixPath(newPath);
+      if (posixNewPath === posixSource) {
         // Already lives in the target directory - nothing to do.
         return { success: true, data: { newPath } };
       }
 
-      // Block moving a directory into itself or one of its own descendants.
-      if (safeDir === safeSource || safeDir.startsWith(safeSource + path.sep)) {
+      // Block moving a directory into itself or one of its own descendants
+      // (separator-agnostic so it holds on Windows too).
+      if (posixDir === posixSource || posixDir.startsWith(`${posixSource}/`)) {
         return { success: false, msg: 'Cannot move a folder into itself' };
       }
 

--- a/src/process/bridge/fsBridge.ts
+++ b/src/process/bridge/fsBridge.ts
@@ -1243,6 +1243,72 @@ export function initFsBridge(): void {
     }
   });
 
+  // Move a file or directory into a target directory and return the new path
+  ipcBridge.fs.moveEntry.provider(async ({ sourcePath, targetDir }) => {
+    try {
+      // Confine the source to authorized roots (SEC-IPC-01).
+      const safeSource = await confinePath(sourcePath);
+      if (safeSource === null) {
+        return { success: false, msg: 'Source is outside the allowed workspace roots' };
+      }
+
+      // Confine the destination directory as well so a move cannot escape the root.
+      const safeDir = await confinePath(targetDir);
+      if (safeDir === null) {
+        return { success: false, msg: 'Target directory is outside the allowed workspace roots' };
+      }
+
+      let targetIsDirectory = false;
+      try {
+        const dirStats = await fs.lstat(safeDir);
+        targetIsDirectory = dirStats.isDirectory();
+      } catch {
+        targetIsDirectory = false;
+      }
+      if (!targetIsDirectory) {
+        return { success: false, msg: 'Target directory does not exist' };
+      }
+
+      // Destination path keeps the source's own name inside the target directory.
+      const candidateNewPath = path.join(safeDir, path.basename(safeSource));
+      const newPath = await confinePath(candidateNewPath);
+      if (newPath === null) {
+        return { success: false, msg: 'Target path is outside the allowed workspace roots' };
+      }
+
+      if (newPath === safeSource) {
+        // Already lives in the target directory - nothing to do.
+        return { success: true, data: { newPath } };
+      }
+
+      // Block moving a directory into itself or one of its own descendants.
+      if (safeDir === safeSource || safeDir.startsWith(safeSource + path.sep)) {
+        return { success: false, msg: 'Cannot move a folder into itself' };
+      }
+
+      const exists = await fs
+        .access(newPath)
+        .then(() => true)
+        .catch(() => false);
+
+      if (exists) {
+        // Block on collision - never silently overwrite.
+        return { success: false, msg: 'Target path already exists' };
+      }
+
+      await fs.rename(safeSource, newPath);
+      invalidateWorkspaceFileListCacheByPath(safeSource);
+      invalidateWorkspaceFileListCacheByPath(newPath);
+      return { success: true, data: { newPath } };
+    } catch (error) {
+      console.error('Failed to move entry:', error);
+      return {
+        success: false,
+        msg: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  });
+
   // Read built-in rules file from app resources
   ipcBridge.fs.readBuiltinRule.provider(async ({ fileName }) => {
     try {

--- a/src/process/bridge/fsBridge.ts
+++ b/src/process/bridge/fsBridge.ts
@@ -310,6 +310,27 @@ function invalidateWorkspaceFileListCacheByPath(changedPath: string): void {
   }
 }
 
+/**
+ * Fail-closed destination existence check for rename/move (#592 never-clobber).
+ *
+ * `fs.access(p).catch(() => false)` treats EVERY rejection as "absent", so a
+ * present-but-inaccessible destination (EACCES/ELOOP/ENOTDIR, or a transient FS
+ * error) would slip past the collision guard and let `fs.rename` overwrite it.
+ * Only a genuine ENOENT means "free to write here"; any other error is
+ * re-thrown so the caller aborts the move rather than risk clobbering.
+ */
+async function destinationExists(candidatePath: string): Promise<boolean> {
+  try {
+    await fs.lstat(candidatePath);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+}
+
 const MAX_WORKSPACE_FILES = 20_000;
 
 async function listWorkspaceFilesRecursive(root: string): Promise<IWorkspaceFlatFile[]> {
@@ -1220,12 +1241,7 @@ export function initFsBridge(): void {
         return { success: true, data: { newPath } };
       }
 
-      const exists = await fs
-        .access(newPath)
-        .then(() => true)
-        .catch(() => false);
-
-      if (exists) {
+      if (await destinationExists(newPath)) {
         // Avoid overwriting existing targets
         return { success: false, msg: 'Target path already exists' };
       }
@@ -1286,12 +1302,7 @@ export function initFsBridge(): void {
         return { success: false, msg: 'Cannot move a folder into itself' };
       }
 
-      const exists = await fs
-        .access(newPath)
-        .then(() => true)
-        .catch(() => false);
-
-      if (exists) {
+      if (await destinationExists(newPath)) {
         // Block on collision - never silently overwrite.
         return { success: false, msg: 'Target path already exists' };
       }

--- a/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceDragImport.ts
+++ b/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceDragImport.ts
@@ -30,6 +30,19 @@ const getBaseName = (targetPath: string): string => {
   return parts.pop() || targetPath;
 };
 
+/**
+ * True only for drags carrying OS files (from Finder/Explorer). Internal
+ * workspace-tree node drags (drag-to-move, issue #49) carry no files, so this
+ * lets them pass through to the Tree's own drop handling instead of triggering
+ * the import overlay.
+ */
+const isOsFileDrag = (event: DragEvent): boolean => {
+  const dataTransfer = event.dataTransfer || event.nativeEvent?.dataTransfer;
+  const types = dataTransfer?.types;
+  if (!types) return false;
+  return Array.from(types).includes('Files');
+};
+
 const dedupeItems = (items: DroppedItem[]): DroppedItem[] => {
   const map = new Map<string, DroppedItem>();
   for (const item of items) {
@@ -55,6 +68,7 @@ export function useWorkspaceDragImport({
   }, []);
 
   const handleDragEnter = useCallback((event: DragEvent) => {
+    if (!isOsFileDrag(event)) return;
     event.preventDefault();
     event.stopPropagation();
     dragCounterRef.current += 1;
@@ -63,6 +77,7 @@ export function useWorkspaceDragImport({
 
   const handleDragOver = useCallback(
     (event: DragEvent) => {
+      if (!isOsFileDrag(event)) return;
       event.preventDefault();
       event.stopPropagation();
       if (!isDragging) {
@@ -73,6 +88,7 @@ export function useWorkspaceDragImport({
   );
 
   const handleDragLeave = useCallback((event: DragEvent) => {
+    if (!isOsFileDrag(event)) return;
     event.preventDefault();
     event.stopPropagation();
     dragCounterRef.current = Math.max(0, dragCounterRef.current - 1);
@@ -119,6 +135,7 @@ export function useWorkspaceDragImport({
 
   const handleDrop = useCallback(
     async (event: DragEvent) => {
+      if (!isOsFileDrag(event)) return;
       event.preventDefault();
       event.stopPropagation();
       resetDragState();

--- a/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceFileOps.ts
+++ b/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceFileOps.ts
@@ -13,11 +13,11 @@ import {
   LARGE_TEXT_PREVIEW_MAX_LENGTH,
   LARGE_TEXT_PREVIEW_THRESHOLD,
 } from '@/renderer/pages/conversation/Preview/constants';
-import { removeWorkspaceEntry, renameWorkspaceEntry } from '@/renderer/utils/file/workspaceFs';
+import { moveWorkspaceEntry, removeWorkspaceEntry, renameWorkspaceEntry } from '@/renderer/utils/file/workspaceFs';
 import { useCallback } from 'react';
 import type { MessageApi, RenameModalState, DeleteModalState } from '../types';
 import type { FileOrFolderItem } from '@/renderer/utils/file/fileTypes';
-import { getPathSeparator, replacePathInList, updateTreeForRename } from '../utils/treeHelpers';
+import { getPathSeparator, replacePathInList, resolveMoveTarget, updateTreeForRename } from '../utils/treeHelpers';
 
 interface UseWorkspaceFileOpsOptions {
   workspace: string;
@@ -268,6 +268,37 @@ export function useWorkspaceFileOps(options: UseWorkspaceFileOpsOptions) {
   ]);
 
   /**
+   * Move a dragged file/folder into a drop-target folder.
+   *
+   * The UI guard (resolveMoveTarget) filters no-ops and self/descendant moves;
+   * the main process re-validates, confines both paths, and blocks collisions.
+   */
+  const handleMoveNode = useCallback(
+    async (dragData: IDirOrFile | null, dropData: IDirOrFile | null) => {
+      const resolved = resolveMoveTarget(dragData, dropData);
+      if (!resolved) return;
+
+      try {
+        const res = await moveWorkspaceEntry(resolved.sourceFullPath, resolved.targetDirFullPath);
+        if (!res?.success) {
+          messageApi.error(t('conversation.workspace.contextMenu.moveFailed'));
+          return;
+        }
+
+        setSelected([]);
+        selectedKeysRef.current = [];
+        selectedNodeRef.current = null;
+        emitter.emit(`${eventPrefix}.selected.file`, []);
+        messageApi.success(t('conversation.workspace.contextMenu.moveSuccess'));
+        setTimeout(() => refreshWorkspace(), 200);
+      } catch (error) {
+        messageApi.error(t('conversation.workspace.contextMenu.moveFailed'));
+      }
+    },
+    [eventPrefix, messageApi, refreshWorkspace, t, setSelected, selectedKeysRef, selectedNodeRef]
+  );
+
+  /**
    * Add to chat
    */
   const handleAddToChat = useCallback(
@@ -449,6 +480,7 @@ export function useWorkspaceFileOps(options: UseWorkspaceFileOpsOptions) {
     handleDeleteConfirm,
     handleRenameConfirm,
     handleAddToChat,
+    handleMoveNode,
     handlePreviewFile,
     openRenameModal,
     handleDownloadFile,

--- a/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceFileOps.ts
+++ b/src/renderer/pages/conversation/Workspace/hooks/useWorkspaceFileOps.ts
@@ -268,14 +268,16 @@ export function useWorkspaceFileOps(options: UseWorkspaceFileOpsOptions) {
   ]);
 
   /**
-   * Move a dragged file/folder into a drop-target folder.
+   * Move a dragged file/folder to the resolved drop destination.
    *
+   * `dropPosition` (Arco Tree) decides intent: `0` moves INTO the drop-target
+   * folder, a gap drop (non-zero) moves it to the target's sibling directory.
    * The UI guard (resolveMoveTarget) filters no-ops and self/descendant moves;
    * the main process re-validates, confines both paths, and blocks collisions.
    */
   const handleMoveNode = useCallback(
-    async (dragData: IDirOrFile | null, dropData: IDirOrFile | null) => {
-      const resolved = resolveMoveTarget(dragData, dropData);
+    async (dragData: IDirOrFile | null, dropData: IDirOrFile | null, dropPosition: number) => {
+      const resolved = resolveMoveTarget(dragData, dropData, dropPosition);
       if (!resolved) return;
 
       try {

--- a/src/renderer/pages/conversation/Workspace/index.tsx
+++ b/src/renderer/pages/conversation/Workspace/index.tsx
@@ -428,6 +428,15 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({
                   isLeaf: 'isFile',
                 }}
                 multiple
+                draggable
+                allowDrop={({ dropNode }) => {
+                  // Only folders accept move drops (issue #49).
+                  const target = extractNodeData(dropNode);
+                  return Boolean(target?.isDir) && !target?.isFile;
+                }}
+                onDrop={({ dragNode, dropNode }) => {
+                  void fileOpsHook.handleMoveNode(extractNodeData(dragNode), extractNodeData(dropNode));
+                }}
                 renderTitle={(node) => {
                   const relativePath = node.dataRef.relativePath;
                   const isFile = node.dataRef.isFile;
@@ -510,7 +519,9 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({
                       treeHook.setSelected(filteredKeys);
                     }
                     treeHook.selectedNodeRef.current = null;
-                    if (nodeData && clickedKey && !wasSelected) {
+                    // Always open preview on a file click - including when the
+                    // same file was previously selected (issue #49).
+                    if (nodeData && clickedKey) {
                       void fileOpsHook.handlePreviewFile(nodeData);
                     }
                     return;

--- a/src/renderer/pages/conversation/Workspace/index.tsx
+++ b/src/renderer/pages/conversation/Workspace/index.tsx
@@ -429,13 +429,19 @@ const ChatWorkspace: React.FC<WorkspaceProps> = ({
                 }}
                 multiple
                 draggable
-                allowDrop={({ dropNode }) => {
-                  // Only folders accept move drops (issue #49).
-                  const target = extractNodeData(dropNode);
-                  return Boolean(target?.isDir) && !target?.isFile;
+                allowDrop={({ dropNode, dropPosition }) => {
+                  // An onto-drop (dropPosition 0) moves INTO the target, so only
+                  // folders may accept it. A gap drop (non-zero) places the entry
+                  // as a sibling of the target, so any node type is a valid gap
+                  // anchor - its parent directory is the destination (issue #49).
+                  if (dropPosition === 0) {
+                    const target = extractNodeData(dropNode);
+                    return Boolean(target?.isDir) && !target?.isFile;
+                  }
+                  return true;
                 }}
-                onDrop={({ dragNode, dropNode }) => {
-                  void fileOpsHook.handleMoveNode(extractNodeData(dragNode), extractNodeData(dropNode));
+                onDrop={({ dragNode, dropNode, dropPosition }) => {
+                  void fileOpsHook.handleMoveNode(extractNodeData(dragNode), extractNodeData(dropNode), dropPosition);
                 }}
                 renderTitle={(node) => {
                   const relativePath = node.dataRef.relativePath;

--- a/src/renderer/pages/conversation/Workspace/utils/treeHelpers.ts
+++ b/src/renderer/pages/conversation/Workspace/utils/treeHelpers.ts
@@ -217,25 +217,48 @@ export function computeContextMenuPosition(
 /**
  * Resolve an internal drag-and-drop move within the workspace tree.
  *
+ * `dropPosition` follows Arco Tree semantics: `0` means the entry was dropped
+ * directly ONTO `dropData` (move INTO it - only valid for folders); a non-zero
+ * value (-1 before, 1 after) means a gap drop between rows, which places the
+ * entry at sibling level - the destination is then `dropData`'s parent
+ * directory, whether `dropData` is a file or a folder. This is why a gap drop
+ * next to a folder must not fall INTO that folder (issue #49).
+ *
  * Returns the source path and the destination directory when the move is
- * allowed, or `null` when it must be ignored: missing data, a non-directory
- * drop target, the workspace root as the drag source, a no-op move into the
- * current parent, or moving a folder into itself / one of its descendants.
- * The main process re-validates every move and blocks collisions - this is a
- * UI-side guard only, never the security boundary.
+ * allowed, or `null` when it must be ignored: missing data, the workspace root
+ * as the drag source, an onto-drop whose target is not a folder, a gap drop
+ * with no resolvable parent directory, a no-op move into the current parent, or
+ * moving a folder into itself / one of its descendants. The main process
+ * re-validates every move and blocks collisions - this is a UI-side guard only,
+ * never the security boundary.
  */
 export function resolveMoveTarget(
   dragData: IDirOrFile | null | undefined,
-  dropData: IDirOrFile | null | undefined
+  dropData: IDirOrFile | null | undefined,
+  dropPosition: number
 ): { sourceFullPath: string; sourceRelativePath: string; targetDirFullPath: string } | null {
   if (!dragData?.fullPath || !dropData?.fullPath) return null;
   // The workspace root (empty relativePath) cannot be moved.
   if (!dragData.relativePath) return null;
-  // Drops are only accepted onto folders.
-  if (!dropData.isDir || dropData.isFile) return null;
 
   const sourceFullPath = dragData.fullPath;
-  const targetDirFullPath = dropData.fullPath;
+
+  // Resolve the destination directory from the drop position. An onto-drop
+  // (dropPosition === 0) moves INTO the target and is only valid for folders;
+  // a gap drop (non-zero) places the entry as a sibling of the target, so its
+  // destination is the target's parent directory.
+  let targetDirFullPath: string;
+  if (dropPosition === 0) {
+    if (!dropData.isDir || dropData.isFile) return null;
+    targetDirFullPath = dropData.fullPath;
+  } else {
+    const dropSep = getPathSeparator(dropData.fullPath);
+    const dropParentIndex = dropData.fullPath.lastIndexOf(dropSep);
+    // A drop target with no separated parent (index <= 0) has no resolvable
+    // sibling directory inside the workspace.
+    if (dropParentIndex <= 0) return null;
+    targetDirFullPath = dropData.fullPath.slice(0, dropParentIndex);
+  }
 
   if (sourceFullPath === targetDirFullPath) return null;
 

--- a/src/renderer/pages/conversation/Workspace/utils/treeHelpers.ts
+++ b/src/renderer/pages/conversation/Workspace/utils/treeHelpers.ts
@@ -215,6 +215,46 @@ export function computeContextMenuPosition(
 }
 
 /**
+ * Resolve an internal drag-and-drop move within the workspace tree.
+ *
+ * Returns the source path and the destination directory when the move is
+ * allowed, or `null` when it must be ignored: missing data, a non-directory
+ * drop target, the workspace root as the drag source, a no-op move into the
+ * current parent, or moving a folder into itself / one of its descendants.
+ * The main process re-validates every move and blocks collisions - this is a
+ * UI-side guard only, never the security boundary.
+ */
+export function resolveMoveTarget(
+  dragData: IDirOrFile | null | undefined,
+  dropData: IDirOrFile | null | undefined
+): { sourceFullPath: string; sourceRelativePath: string; targetDirFullPath: string } | null {
+  if (!dragData?.fullPath || !dropData?.fullPath) return null;
+  // The workspace root (empty relativePath) cannot be moved.
+  if (!dragData.relativePath) return null;
+  // Drops are only accepted onto folders.
+  if (!dropData.isDir || dropData.isFile) return null;
+
+  const sourceFullPath = dragData.fullPath;
+  const targetDirFullPath = dropData.fullPath;
+
+  if (sourceFullPath === targetDirFullPath) return null;
+
+  const sep = getPathSeparator(sourceFullPath);
+  // No-op: the entry already lives directly inside the target directory.
+  const parentDir = sourceFullPath.slice(0, sourceFullPath.lastIndexOf(sep));
+  if (parentDir === targetDirFullPath) return null;
+
+  // Block moving a folder into itself or one of its own descendants.
+  if (targetDirFullPath === sourceFullPath || targetDirFullPath.startsWith(sourceFullPath + sep)) return null;
+
+  return {
+    sourceFullPath,
+    sourceRelativePath: dragData.relativePath,
+    targetDirFullPath,
+  };
+}
+
+/**
  * Get target folder path from selectedNodeRef or selected keys
  */
 export function getTargetFolderPath(

--- a/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/src/renderer/services/i18n/i18n-keys.d.ts
@@ -693,6 +693,8 @@ export type I18nKey =
   | 'conversation.workspace.contextMenu.downloadFailed'
   | 'conversation.workspace.contextMenu.downloadSuccess'
   | 'conversation.workspace.contextMenu.favorite'
+  | 'conversation.workspace.contextMenu.moveFailed'
+  | 'conversation.workspace.contextMenu.moveSuccess'
   | 'conversation.workspace.contextMenu.open'
   | 'conversation.workspace.contextMenu.openFailed'
   | 'conversation.workspace.contextMenu.openLocation'

--- a/src/renderer/services/i18n/locales/de-DE/conversation.json
+++ b/src/renderer/services/i18n/locales/de-DE/conversation.json
@@ -165,7 +165,9 @@
       "revealFailed": "Übergeordneter Ordner konnte nicht geöffnet werden",
       "download": "Herunterladen",
       "downloadSuccess": "Download erfolgreich",
-      "downloadFailed": "Download fehlgeschlagen"
+      "downloadFailed": "Download fehlgeschlagen",
+      "moveSuccess": "Erfolgreich verschoben",
+      "moveFailed": "Verschieben fehlgeschlagen"
     },
     "changes": {
       "tab": "Änderungen",

--- a/src/renderer/services/i18n/locales/en-US/conversation.json
+++ b/src/renderer/services/i18n/locales/en-US/conversation.json
@@ -174,7 +174,9 @@
       "revealFailed": "Failed to open containing folder",
       "download": "Download",
       "downloadSuccess": "Download successful",
-      "downloadFailed": "Download failed"
+      "downloadFailed": "Download failed",
+      "moveSuccess": "Moved successfully",
+      "moveFailed": "Move failed"
     },
     "favorites": {
       "title": "Favorites"

--- a/src/renderer/services/i18n/locales/es-ES/conversation.json
+++ b/src/renderer/services/i18n/locales/es-ES/conversation.json
@@ -165,7 +165,9 @@
       "revealFailed": "No se pudo abrir la carpeta contenedora",
       "download": "Descargar",
       "downloadSuccess": "Descarga correcta",
-      "downloadFailed": "Error en la descarga"
+      "downloadFailed": "Error en la descarga",
+      "moveSuccess": "Movido correctamente",
+      "moveFailed": "Error al mover"
     },
     "changes": {
       "tab": "Cambios",

--- a/src/renderer/services/i18n/locales/fr-FR/conversation.json
+++ b/src/renderer/services/i18n/locales/fr-FR/conversation.json
@@ -165,7 +165,9 @@
       "revealFailed": "Échec de l'ouverture du dossier conteneur",
       "download": "Télécharger",
       "downloadSuccess": "Téléchargement réussi",
-      "downloadFailed": "Échec du téléchargement"
+      "downloadFailed": "Échec du téléchargement",
+      "moveSuccess": "Déplacé avec succès",
+      "moveFailed": "Échec du déplacement"
     },
     "changes": {
       "tab": "Modifications",

--- a/src/renderer/services/i18n/locales/ja-JP/conversation.json
+++ b/src/renderer/services/i18n/locales/ja-JP/conversation.json
@@ -165,7 +165,9 @@
       "revealFailed": "フォルダーを開けませんでした",
       "download": "ダウンロード",
       "downloadSuccess": "ダウンロードしました",
-      "downloadFailed": "ダウンロードに失敗しました"
+      "downloadFailed": "ダウンロードに失敗しました",
+      "moveSuccess": "移動しました",
+      "moveFailed": "移動に失敗しました"
     },
     "changes": {
       "tab": "変更",

--- a/src/renderer/services/i18n/locales/ko-KR/conversation.json
+++ b/src/renderer/services/i18n/locales/ko-KR/conversation.json
@@ -165,7 +165,9 @@
       "revealFailed": "포함 폴더 열기 실패",
       "download": "다운로드",
       "downloadSuccess": "다운로드 완료",
-      "downloadFailed": "다운로드 실패"
+      "downloadFailed": "다운로드 실패",
+      "moveSuccess": "이동되었습니다",
+      "moveFailed": "이동 실패"
     },
     "changes": {
       "tab": "변경",

--- a/src/renderer/services/i18n/locales/pt-BR/conversation.json
+++ b/src/renderer/services/i18n/locales/pt-BR/conversation.json
@@ -165,7 +165,9 @@
       "revealFailed": "Falha ao abrir a pasta que contém o arquivo",
       "download": "Baixar",
       "downloadSuccess": "Download concluído",
-      "downloadFailed": "Falha no download"
+      "downloadFailed": "Falha no download",
+      "moveSuccess": "Movido com sucesso",
+      "moveFailed": "Falha ao mover"
     },
     "changes": {
       "tab": "Alterações",

--- a/src/renderer/services/i18n/locales/ru-RU/conversation.json
+++ b/src/renderer/services/i18n/locales/ru-RU/conversation.json
@@ -165,7 +165,9 @@
       "revealFailed": "Не удалось открыть содержащую папку",
       "download": "Скачать",
       "downloadSuccess": "Скачивание успешно",
-      "downloadFailed": "Не удалось скачать"
+      "downloadFailed": "Не удалось скачать",
+      "moveSuccess": "Успешно перемещено",
+      "moveFailed": "Не удалось переместить"
     },
     "changes": {
       "tab": "Изменения",

--- a/src/renderer/services/i18n/locales/tr-TR/conversation.json
+++ b/src/renderer/services/i18n/locales/tr-TR/conversation.json
@@ -158,7 +158,9 @@
       "revealFailed": "İçeren klasör açılamadı",
       "download": "İndir",
       "downloadSuccess": "İndirme başarılı",
-      "downloadFailed": "İndirme başarısız"
+      "downloadFailed": "İndirme başarısız",
+      "moveSuccess": "Başarıyla taşındı",
+      "moveFailed": "Taşıma başarısız"
     },
     "expand": "Çalışma Alanını Genişlet",
     "collapse": "Çalışma Alanını Daralt",

--- a/src/renderer/services/i18n/locales/uk-UA/conversation.json
+++ b/src/renderer/services/i18n/locales/uk-UA/conversation.json
@@ -165,7 +165,9 @@
       "revealFailed": "Не вдалося відкрити папку з файлом",
       "download": "Завантажити",
       "downloadSuccess": "Завантаження успішне",
-      "downloadFailed": "Не вдалося завантажити"
+      "downloadFailed": "Не вдалося завантажити",
+      "moveSuccess": "Успішно переміщено",
+      "moveFailed": "Не вдалося перемістити"
     },
     "changes": {
       "tab": "Зміни",

--- a/src/renderer/services/i18n/locales/zh-CN/conversation.json
+++ b/src/renderer/services/i18n/locales/zh-CN/conversation.json
@@ -165,7 +165,9 @@
       "revealFailed": "无法打开所在目录",
       "download": "下载",
       "downloadSuccess": "下载成功",
-      "downloadFailed": "下载失败"
+      "downloadFailed": "下载失败",
+      "moveSuccess": "移动成功",
+      "moveFailed": "移动失败"
     },
     "changes": {
       "tab": "变更",

--- a/src/renderer/services/i18n/locales/zh-TW/conversation.json
+++ b/src/renderer/services/i18n/locales/zh-TW/conversation.json
@@ -165,7 +165,9 @@
       "revealFailed": "無法開啟所在資料夾",
       "download": "下載",
       "downloadSuccess": "下載成功",
-      "downloadFailed": "下載失敗"
+      "downloadFailed": "下載失敗",
+      "moveSuccess": "移動成功",
+      "moveFailed": "移動失敗"
     },
     "changes": {
       "tab": "變更",

--- a/src/renderer/utils/file/workspaceFs.ts
+++ b/src/renderer/utils/file/workspaceFs.ts
@@ -25,3 +25,10 @@ export const removeWorkspaceEntry = (path: string) => {
 export const renameWorkspaceEntry = (path: string, newName: string) => {
   return ipcBridge.fs.renameEntry.invoke({ path, newName }) as Promise<IBridgeResponse<{ newPath: string }>>;
 };
+
+/**
+ * Move a file or directory into another directory inside the workspace.
+ */
+export const moveWorkspaceEntry = (sourcePath: string, targetDir: string) => {
+  return ipcBridge.fs.moveEntry.invoke({ sourcePath, targetDir }) as Promise<IBridgeResponse<{ newPath: string }>>;
+};

--- a/tests/unit/bridge/fsBridge.redteam.confinement.test.ts
+++ b/tests/unit/bridge/fsBridge.redteam.confinement.test.ts
@@ -436,4 +436,55 @@ describe('fsBridge confinement red-team', () => {
       expect(fsMock.copyFile).not.toHaveBeenCalled();
     });
   });
+
+  describe('moveEntry', () => {
+    it('rejects an out-of-root source and never renames', async () => {
+      const result = (await handlers.moveEntry({ sourcePath: SECRET, targetDir: ROOT })) as { success: boolean };
+      expect(result.success).toBe(false);
+      expect(fsMock.rename).not.toHaveBeenCalled();
+    });
+
+    it('rejects an out-of-root target directory and never renames', async () => {
+      const result = (await handlers.moveEntry({ sourcePath: `${ROOT}/a.txt`, targetDir: '/etc' })) as {
+        success: boolean;
+      };
+      expect(result.success).toBe(false);
+      expect(fsMock.rename).not.toHaveBeenCalled();
+    });
+
+    it('blocks on collision instead of overwriting', async () => {
+      fsMock.lstat.mockResolvedValue({ isDirectory: () => true });
+      fsMock.access.mockResolvedValue(undefined); // target already exists
+      const result = (await handlers.moveEntry({ sourcePath: `${ROOT}/a.txt`, targetDir: `${ROOT}/sub` })) as {
+        success: boolean;
+        msg?: string;
+      };
+      expect(result.success).toBe(false);
+      expect(result.msg).toBe('Target path already exists');
+      expect(fsMock.rename).not.toHaveBeenCalled();
+    });
+
+    it('refuses to move a folder into its own descendant', async () => {
+      fsMock.lstat.mockResolvedValue({ isDirectory: () => true });
+      fsMock.access.mockRejectedValue(new Error('no'));
+      const result = (await handlers.moveEntry({ sourcePath: `${ROOT}/dir`, targetDir: `${ROOT}/dir/child` })) as {
+        success: boolean;
+      };
+      expect(result.success).toBe(false);
+      expect(fsMock.rename).not.toHaveBeenCalled();
+    });
+
+    it('moves a legitimate in-root entry into a target directory', async () => {
+      fsMock.lstat.mockResolvedValue({ isDirectory: () => true });
+      fsMock.access.mockRejectedValue(new Error('no')); // no collision
+      fsMock.rename.mockResolvedValue(undefined);
+      const result = (await handlers.moveEntry({ sourcePath: `${ROOT}/a.txt`, targetDir: `${ROOT}/sub` })) as {
+        success: boolean;
+        data?: { newPath: string };
+      };
+      expect(fsMock.rename).toHaveBeenCalledWith(`${ROOT}/a.txt`, `${ROOT}/sub/a.txt`);
+      expect(result.success).toBe(true);
+      expect(result.data?.newPath).toBe(`${ROOT}/sub/a.txt`);
+    });
+  });
 });

--- a/tests/unit/bridge/fsBridge.redteam.confinement.test.ts
+++ b/tests/unit/bridge/fsBridge.redteam.confinement.test.ts
@@ -475,8 +475,15 @@ describe('fsBridge confinement red-team', () => {
     });
 
     it('moves a legitimate in-root entry into a target directory', async () => {
-      fsMock.lstat.mockResolvedValue({ isDirectory: () => true });
-      fsMock.access.mockRejectedValue(new Error('no')); // no collision
+      // Target dir exists (isDirectory); the destination path is absent (ENOENT),
+      // so the move proceeds. Collision detection now stats the destination
+      // (#592 never-clobber hardening) rather than fs.access.
+      fsMock.lstat.mockImplementation(async (p: string) => {
+        if (p === `${ROOT}/sub`) return { isDirectory: () => true } as never;
+        const err = new Error('ENOENT') as NodeJS.ErrnoException;
+        err.code = 'ENOENT';
+        throw err;
+      });
       fsMock.rename.mockResolvedValue(undefined);
       const result = (await handlers.moveEntry({ sourcePath: `${ROOT}/a.txt`, targetDir: `${ROOT}/sub` })) as {
         success: boolean;
@@ -485,6 +492,25 @@ describe('fsBridge confinement red-team', () => {
       expect(fsMock.rename).toHaveBeenCalledWith(`${ROOT}/a.txt`, `${ROOT}/sub/a.txt`);
       expect(result.success).toBe(true);
       expect(result.data?.newPath).toBe(`${ROOT}/sub/a.txt`);
+    });
+
+    it('aborts and never renames when the destination check errors with a non-ENOENT code (#592 never-clobber)', async () => {
+      // The target dir exists, but statting the destination fails with EACCES
+      // (present-but-inaccessible). fs.access(...).catch(()=>false) would have
+      // treated this as "absent" and let fs.rename clobber; the lstat-based
+      // guard must fail closed instead.
+      fsMock.lstat.mockImplementation(async (p: string) => {
+        if (p === `${ROOT}/sub`) return { isDirectory: () => true } as never;
+        const err = new Error('EACCES') as NodeJS.ErrnoException;
+        err.code = 'EACCES';
+        throw err;
+      });
+      fsMock.rename.mockResolvedValue(undefined);
+      const result = (await handlers.moveEntry({ sourcePath: `${ROOT}/a.txt`, targetDir: `${ROOT}/sub` })) as {
+        success: boolean;
+      };
+      expect(result.success).toBe(false);
+      expect(fsMock.rename).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/fsBridge.skills.test.ts
+++ b/tests/unit/fsBridge.skills.test.ts
@@ -243,6 +243,7 @@ describe('fsBridge skills functionality', () => {
             copyFilesToWorkspace: createCommandMock('copy-files-to-workspace'),
             removeEntry: createCommandMock('remove-entry'),
             renameEntry: createCommandMock('rename-entry'),
+            moveEntry: createCommandMock('move-entry'),
             readBuiltinRule: createCommandMock('read-builtin-rule'),
             readBuiltinSkill: createCommandMock('read-builtin-skill'),
             readAssistantRule: createCommandMock('read-assistant-rule'),

--- a/tests/unit/process/bridge/fsBridge.downloadRemoteBuffer.test.ts
+++ b/tests/unit/process/bridge/fsBridge.downloadRemoteBuffer.test.ts
@@ -80,6 +80,7 @@ vi.mock('@/common', () => ({
       copyFilesToWorkspace: { provider: vi.fn() },
       removeEntry: { provider: vi.fn() },
       renameEntry: { provider: vi.fn() },
+      moveEntry: { provider: vi.fn() },
       readBuiltinRule: { provider: vi.fn() },
       readBuiltinSkill: { provider: vi.fn() },
       readAssistantRule: { provider: vi.fn() },

--- a/tests/unit/process/bridge/fsBridge.listWorkspaceFiles.test.ts
+++ b/tests/unit/process/bridge/fsBridge.listWorkspaceFiles.test.ts
@@ -70,6 +70,7 @@ vi.mock('@/common', () => ({
       copyFilesToWorkspace: makeProvider('copyFilesToWorkspace'),
       removeEntry: makeProvider('removeEntry'),
       renameEntry: makeProvider('renameEntry'),
+      moveEntry: makeProvider('moveEntry'),
       readBuiltinRule: makeProvider('readBuiltinRule'),
       readBuiltinSkill: makeProvider('readBuiltinSkill'),
       readAssistantRule: makeProvider('readAssistantRule'),

--- a/tests/unit/process/bridge/fsBridge.readAssistantRule-ext.test.ts
+++ b/tests/unit/process/bridge/fsBridge.readAssistantRule-ext.test.ts
@@ -89,6 +89,7 @@ vi.mock('@/common', () => ({
       copyFilesToWorkspace: { provider: vi.fn() },
       removeEntry: { provider: vi.fn() },
       renameEntry: { provider: vi.fn() },
+      moveEntry: { provider: vi.fn() },
       readBuiltinRule: { provider: vi.fn() },
       readBuiltinSkill: { provider: vi.fn() },
       readAssistantRule: {

--- a/tests/unit/process/bridge/fsBridge.readFile.test.ts
+++ b/tests/unit/process/bridge/fsBridge.readFile.test.ts
@@ -64,6 +64,7 @@ vi.mock('@/common', () => {
         copyFilesToWorkspace: makeProvider('copyFilesToWorkspace'),
         removeEntry: makeProvider('removeEntry'),
         renameEntry: makeProvider('renameEntry'),
+        moveEntry: makeProvider('moveEntry'),
         readBuiltinRule: makeProvider('readBuiltinRule'),
         readBuiltinSkill: makeProvider('readBuiltinSkill'),
         readAssistantRule: makeProvider('readAssistantRule'),

--- a/tests/unit/process/bridge/fsBridge.standalone.test.ts
+++ b/tests/unit/process/bridge/fsBridge.standalone.test.ts
@@ -49,6 +49,7 @@ vi.mock('@/common', () => ({
       copyFilesToWorkspace: { provider: vi.fn() },
       removeEntry: { provider: vi.fn() },
       renameEntry: { provider: vi.fn() },
+      moveEntry: { provider: vi.fn() },
       readBuiltinRule: { provider: vi.fn() },
       readBuiltinSkill: { provider: vi.fn() },
       readAssistantRule: { provider: vi.fn() },

--- a/tests/unit/treeUtils.test.ts
+++ b/tests/unit/treeUtils.test.ts
@@ -185,10 +185,16 @@ describe('resolveMoveTarget', () => {
     ...over,
   });
 
+  // dropPosition follows Arco Tree semantics: 0 = dropped ONTO the node (move
+  // INTO a folder), non-zero (-1 before / 1 after) = a gap drop (sibling level).
+  const ONTO = 0;
+  const GAP_BEFORE = -1;
+  const GAP_AFTER = 1;
+
   it('resolves a file dropped onto a folder to a move into that folder', () => {
     const drag = node({ name: 'a.ts', fullPath: '/ws/a.ts', relativePath: 'a.ts', isFile: true, isDir: false });
     const drop = node({ name: 'sub', fullPath: '/ws/sub', relativePath: 'sub', isFile: false, isDir: true });
-    expect(resolveMoveTarget(drag, drop)).toEqual({
+    expect(resolveMoveTarget(drag, drop, ONTO)).toEqual({
       sourceFullPath: '/ws/a.ts',
       sourceRelativePath: 'a.ts',
       targetDirFullPath: '/ws/sub',
@@ -198,19 +204,56 @@ describe('resolveMoveTarget', () => {
   it('returns null when the drop target is a file, not a folder', () => {
     const drag = node({ name: 'a.ts', fullPath: '/ws/a.ts', relativePath: 'a.ts' });
     const drop = node({ name: 'b.ts', fullPath: '/ws/b.ts', relativePath: 'b.ts', isFile: true, isDir: false });
-    expect(resolveMoveTarget(drag, drop)).toBeNull();
+    expect(resolveMoveTarget(drag, drop, ONTO)).toBeNull();
+  });
+
+  it('resolves a gap drop next to a folder to the folder parent, not into the folder (#49)', () => {
+    // Dragging into the gap adjacent to a folder means sibling-level placement -
+    // the destination is the folder's parent dir, never inside the folder.
+    const drag = node({
+      name: 'a.ts',
+      fullPath: '/ws/other/a.ts',
+      relativePath: 'other/a.ts',
+      isFile: true,
+      isDir: false,
+    });
+    const drop = node({ name: 'sub', fullPath: '/ws/sub', relativePath: 'sub', isFile: false, isDir: true });
+    expect(resolveMoveTarget(drag, drop, GAP_AFTER)).toEqual({
+      sourceFullPath: '/ws/other/a.ts',
+      sourceRelativePath: 'other/a.ts',
+      targetDirFullPath: '/ws',
+    });
+  });
+
+  it('resolves a gap drop next to a file to that file parent directory', () => {
+    // A gap drop anchored on a file is valid: the entry becomes a sibling of the
+    // file, i.e. it moves into the file's parent directory.
+    const drag = node({ name: 'a.ts', fullPath: '/ws/a.ts', relativePath: 'a.ts', isFile: true, isDir: false });
+    const drop = node({ name: 'b.ts', fullPath: '/ws/sub/b.ts', relativePath: 'sub/b.ts', isFile: true, isDir: false });
+    expect(resolveMoveTarget(drag, drop, GAP_BEFORE)).toEqual({
+      sourceFullPath: '/ws/a.ts',
+      sourceRelativePath: 'a.ts',
+      targetDirFullPath: '/ws/sub',
+    });
+  });
+
+  it('returns null for a gap drop that resolves to the current parent (no-op)', () => {
+    // Reordering within the same directory is a filesystem no-op.
+    const drag = node({ name: 'a.ts', fullPath: '/ws/sub/a.ts', relativePath: 'sub/a.ts', isFile: true, isDir: false });
+    const drop = node({ name: 'b.ts', fullPath: '/ws/sub/b.ts', relativePath: 'sub/b.ts', isFile: true, isDir: false });
+    expect(resolveMoveTarget(drag, drop, GAP_AFTER)).toBeNull();
   });
 
   it('returns null for a no-op move into the current parent directory', () => {
     const drag = node({ name: 'a.ts', fullPath: '/ws/sub/a.ts', relativePath: 'sub/a.ts' });
     const drop = node({ name: 'sub', fullPath: '/ws/sub', relativePath: 'sub', isFile: false, isDir: true });
-    expect(resolveMoveTarget(drag, drop)).toBeNull();
+    expect(resolveMoveTarget(drag, drop, ONTO)).toBeNull();
   });
 
   it('returns null when moving a folder into itself', () => {
     const drag = node({ name: 'sub', fullPath: '/ws/sub', relativePath: 'sub', isFile: false, isDir: true });
     const drop = node({ name: 'sub', fullPath: '/ws/sub', relativePath: 'sub', isFile: false, isDir: true });
-    expect(resolveMoveTarget(drag, drop)).toBeNull();
+    expect(resolveMoveTarget(drag, drop, ONTO)).toBeNull();
   });
 
   it('returns null when moving a folder into one of its own descendants', () => {
@@ -222,18 +265,30 @@ describe('resolveMoveTarget', () => {
       isFile: false,
       isDir: true,
     });
-    expect(resolveMoveTarget(drag, drop)).toBeNull();
+    expect(resolveMoveTarget(drag, drop, ONTO)).toBeNull();
+  });
+
+  it('returns null for a gap drop into one of the dragged folder own descendants', () => {
+    const drag = node({ name: 'sub', fullPath: '/ws/sub', relativePath: 'sub', isFile: false, isDir: true });
+    const drop = node({
+      name: 'x.ts',
+      fullPath: '/ws/sub/deep/x.ts',
+      relativePath: 'sub/deep/x.ts',
+      isFile: true,
+      isDir: false,
+    });
+    expect(resolveMoveTarget(drag, drop, GAP_BEFORE)).toBeNull();
   });
 
   it('returns null when the drag source is the workspace root (empty relativePath)', () => {
     const drag = node({ name: 'ws', fullPath: '/ws', relativePath: '', isFile: false, isDir: true });
     const drop = node({ name: 'sub', fullPath: '/ws/sub', relativePath: 'sub', isFile: false, isDir: true });
-    expect(resolveMoveTarget(drag, drop)).toBeNull();
+    expect(resolveMoveTarget(drag, drop, ONTO)).toBeNull();
   });
 
   it('returns null for missing drag or drop data', () => {
     const folder = node({ name: 'sub', fullPath: '/ws/sub', relativePath: 'sub', isFile: false, isDir: true });
-    expect(resolveMoveTarget(null, folder)).toBeNull();
-    expect(resolveMoveTarget(folder, null)).toBeNull();
+    expect(resolveMoveTarget(null, folder, ONTO)).toBeNull();
+    expect(resolveMoveTarget(folder, null, ONTO)).toBeNull();
   });
 });

--- a/tests/unit/treeUtils.test.ts
+++ b/tests/unit/treeUtils.test.ts
@@ -4,6 +4,7 @@ import type { IDirOrFile } from '@/common/adapter/ipcBridge';
 import {
   collectFilePaths,
   computeContextMenuPosition,
+  resolveMoveTarget,
 } from '@/renderer/pages/conversation/Workspace/utils/treeHelpers';
 
 // Helper to create a file node
@@ -166,5 +167,73 @@ describe('computeContextMenuPosition', () => {
         configurable: true,
       });
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveMoveTarget
+// ---------------------------------------------------------------------------
+describe('resolveMoveTarget', () => {
+  // Build a node with explicit full/relative paths (the `file`/`dir` helpers
+  // above tie relativePath to the name, which is too coarse for move cases).
+  const node = (over: Partial<IDirOrFile>): IDirOrFile => ({
+    name: 'x',
+    fullPath: '/ws/x',
+    relativePath: 'x',
+    isDir: false,
+    isFile: true,
+    ...over,
+  });
+
+  it('resolves a file dropped onto a folder to a move into that folder', () => {
+    const drag = node({ name: 'a.ts', fullPath: '/ws/a.ts', relativePath: 'a.ts', isFile: true, isDir: false });
+    const drop = node({ name: 'sub', fullPath: '/ws/sub', relativePath: 'sub', isFile: false, isDir: true });
+    expect(resolveMoveTarget(drag, drop)).toEqual({
+      sourceFullPath: '/ws/a.ts',
+      sourceRelativePath: 'a.ts',
+      targetDirFullPath: '/ws/sub',
+    });
+  });
+
+  it('returns null when the drop target is a file, not a folder', () => {
+    const drag = node({ name: 'a.ts', fullPath: '/ws/a.ts', relativePath: 'a.ts' });
+    const drop = node({ name: 'b.ts', fullPath: '/ws/b.ts', relativePath: 'b.ts', isFile: true, isDir: false });
+    expect(resolveMoveTarget(drag, drop)).toBeNull();
+  });
+
+  it('returns null for a no-op move into the current parent directory', () => {
+    const drag = node({ name: 'a.ts', fullPath: '/ws/sub/a.ts', relativePath: 'sub/a.ts' });
+    const drop = node({ name: 'sub', fullPath: '/ws/sub', relativePath: 'sub', isFile: false, isDir: true });
+    expect(resolveMoveTarget(drag, drop)).toBeNull();
+  });
+
+  it('returns null when moving a folder into itself', () => {
+    const drag = node({ name: 'sub', fullPath: '/ws/sub', relativePath: 'sub', isFile: false, isDir: true });
+    const drop = node({ name: 'sub', fullPath: '/ws/sub', relativePath: 'sub', isFile: false, isDir: true });
+    expect(resolveMoveTarget(drag, drop)).toBeNull();
+  });
+
+  it('returns null when moving a folder into one of its own descendants', () => {
+    const drag = node({ name: 'sub', fullPath: '/ws/sub', relativePath: 'sub', isFile: false, isDir: true });
+    const drop = node({
+      name: 'deep',
+      fullPath: '/ws/sub/deep',
+      relativePath: 'sub/deep',
+      isFile: false,
+      isDir: true,
+    });
+    expect(resolveMoveTarget(drag, drop)).toBeNull();
+  });
+
+  it('returns null when the drag source is the workspace root (empty relativePath)', () => {
+    const drag = node({ name: 'ws', fullPath: '/ws', relativePath: '', isFile: false, isDir: true });
+    const drop = node({ name: 'sub', fullPath: '/ws/sub', relativePath: 'sub', isFile: false, isDir: true });
+    expect(resolveMoveTarget(drag, drop)).toBeNull();
+  });
+
+  it('returns null for missing drag or drop data', () => {
+    const folder = node({ name: 'sub', fullPath: '/ws/sub', relativePath: 'sub', isFile: false, isDir: true });
+    expect(resolveMoveTarget(null, folder)).toBeNull();
+    expect(resolveMoveTarget(folder, null)).toBeNull();
   });
 });


### PR DESCRIPTION
Addresses #49 (do not auto-close — release closes).

## What
Adds internal drag-and-drop **move** and consistent **click-to-preview** to the shared Workspace tree, which drives both project **Files** and the chat **workspace** (one change fixes both surfaces).

## How
**Backend**
- New `move-entry` IPC (`ipcBridge.fs.moveEntry`, `{ sourcePath, targetDir } -> { newPath }`) mirroring `renameEntry`/`removeEntry` in `fsBridge.ts`.
- Both the source and the destination directory are run through `confinePath` (realpath-collapses symlinks, rejects traversal/UNC/sensitive locations) — the existing security boundary is reused, not weakened.
- Moving an entry into itself or a descendant is blocked; a name collision in the target dir is **rejected** (`Target path already exists`) — never a silent overwrite.
- `move-entry` added to `REMOTE_DENIED_KEYS` so remote WS callers cannot reach the new mutation surface.

**Renderer**
- Workspace tree rows are `draggable`; only folder rows accept drops (`allowDrop`). Dropping onto a folder moves the entry on disk, then refreshes the tree with a success/error toast.
- Pure `resolveMoveTarget` helper filters no-ops and self/descendant moves before the IPC call; the main process re-validates independently.
- The OS-file **import** drag handlers now ignore internal node drags (guard on `dataTransfer.types` containing `Files`), so they no longer hijack the tree's own DnD or flash the import overlay.
- File clicks always open preview — including re-clicking an already-selected file (removed the `!wasSelected` suppression).
- All user-facing strings via i18n (`conversation.workspace.contextMenu.moveSuccess/moveFailed`) across all 12 locales.

## Tests
- `tests/unit/bridge/fsBridge.redteam.confinement.test.ts`: `moveEntry` confinement (out-of-root source/target rejected), collision blocked, self/descendant blocked, happy-path move.
- `tests/unit/treeUtils.test.ts`: `resolveMoveTarget` (drop onto folder, non-folder target, no-op into parent, self, descendant, root source, missing data).
- Provider mocks for the new `moveEntry` added to the 6 `initFsBridge` test harnesses.
- Full gate green: `bun run typecheck` clean, `oxlint` 0 errors, `oxfmt --check` clean, `bun run i18n:types` + `check-i18n.js` pass, full `bun run test` = 11892 passed / 0 failed.

## Recommended before merge
Live CDP verification of the drag-move and click-preview interactions in the running app against a real connected profile (per repo norms) — unit tests cover the backend guards and the pure move-resolution logic, not the Arco Tree DnD wiring end-to-end.