### PR TITLE
refactor(workflow): merge the double right-rail into one Steps|Workspace sider (Addresses #116)

### DIFF
--- a/src/renderer/pages/conversation/components/ChatConversation.tsx
+++ b/src/renderer/pages/conversation/components/ChatConversation.tsx
@@ -308,6 +308,7 @@ const WCoreWorkflowPanel: React.FC<{ conversation: WCoreConversation } & Workflo
         workspacePath={conversation.extra.workspace}
         conversationId={conversation.id}
         hideHeader={true}
+        stepsRailSider={true}
       >
         <WorkflowSurface
           sessionId={workflowSessionId}
@@ -363,6 +364,7 @@ const GeminiWorkflowPanel: React.FC<
         workspacePath={conversation.extra.workspace}
         conversationId={conversation.id}
         hideHeader={true}
+        stepsRailSider={true}
       >
         <WorkflowSurface
           sessionId={workflowSessionId}
@@ -626,6 +628,7 @@ const ChatConversation: React.FC<{
           workspacePath={conversation?.extra?.workspace}
           conversationId={conversation?.id}
           hideHeader={true}
+          stepsRailSider={true}
         >
           <WorkflowSurface
             sessionId={workflowSessionId}

--- a/src/renderer/pages/conversation/components/ChatConversation.tsx
+++ b/src/renderer/pages/conversation/components/ChatConversation.tsx
@@ -37,6 +37,8 @@ import { usePreviewContext } from '../Preview';
 import StarOfficeMonitorCard from '../platforms/openclaw/StarOfficeMonitorCard.tsx';
 import ConversationSkillsIndicator from './ConversationSkillsIndicator';
 import { WorkflowSurface } from '@/renderer/pages/guid/components/workflow/WorkflowSurface';
+import { WorkflowRailSlotProvider } from '@/renderer/pages/guid/components/workflow/WorkflowRailSlot';
+import { WorkflowTabbedSider } from '@/renderer/pages/guid/components/workflow/WorkflowTabbedSider';
 // import SkillRuleGenerator from './components/SkillRuleGenerator'; // Temporarily hidden
 
 // Shared props for the wcore/gemini panels rendered inside WorkflowSurface.
@@ -294,36 +296,43 @@ const WCoreWorkflowPanel: React.FC<{ conversation: WCoreConversation } & Workflo
   );
   const modelSelection = useWCoreModelSelection({ initialModel: conversation.model, onSelectModel });
   return (
-    <ChatLayout
-      title={conversation.name}
-      sider={<ChatSider conversation={conversation} />}
-      siderTitle={sliderTitle}
-      workspaceEnabled={workspaceEnabled}
-      workspacePath={conversation.extra.workspace}
-      conversationId={conversation.id}
-      hideHeader={true}
-    >
-      <WorkflowSurface
-        sessionId={workflowSessionId}
-        initialSession={initialWorkflowSession}
-        onLaunchWorkflow={onLaunchWorkflow}
+    // Build #116: one right sider - the WorkflowSurface step rail portals into the
+    // "Steps" tab beside "Workspace", instead of a second fixed 280px rail. Force
+    // the sider on so a workspace-less workflow still shows its Steps tab.
+    <WorkflowRailSlotProvider>
+      <ChatLayout
+        title={conversation.name}
+        sider={<WorkflowTabbedSider workspace={workspaceEnabled ? <ChatSider conversation={conversation} /> : null} />}
+        siderTitle={sliderTitle}
+        workspaceEnabled={true}
+        workspacePath={conversation.extra.workspace}
+        conversationId={conversation.id}
+        hideHeader={true}
       >
-        <WCoreChat
-          key={conversation.id}
-          conversation_id={conversation.id}
-          workspace={conversation.extra.workspace}
-          modelSelection={modelSelection}
-          sessionMode={conversation.extra?.sessionMode}
-          workflowSessionId={workflowSessionId}
-          workflowTotalSteps={workflowTotalSteps}
-          workflowApplyStepMarker={workflowApplyStepMarker}
-        />
-      </WorkflowSurface>
-    </ChatLayout>
+        <WorkflowSurface
+          sessionId={workflowSessionId}
+          initialSession={initialWorkflowSession}
+          onLaunchWorkflow={onLaunchWorkflow}
+        >
+          <WCoreChat
+            key={conversation.id}
+            conversation_id={conversation.id}
+            workspace={conversation.extra.workspace}
+            modelSelection={modelSelection}
+            sessionMode={conversation.extra?.sessionMode}
+            workflowSessionId={workflowSessionId}
+            workflowTotalSteps={workflowTotalSteps}
+            workflowApplyStepMarker={workflowApplyStepMarker}
+          />
+        </WorkflowSurface>
+      </ChatLayout>
+    </WorkflowRailSlotProvider>
   );
 };
 
-const GeminiWorkflowPanel: React.FC<{ conversation: GeminiConversation; hideSendBox?: boolean } & WorkflowPanelExtras> = ({
+const GeminiWorkflowPanel: React.FC<
+  { conversation: GeminiConversation; hideSendBox?: boolean } & WorkflowPanelExtras
+> = ({
   conversation,
   sliderTitle,
   workspaceEnabled,
@@ -344,34 +353,37 @@ const GeminiWorkflowPanel: React.FC<{ conversation: GeminiConversation; hideSend
   );
   const modelSelection = useGeminiModelSelection({ initialModel: conversation.model, onSelectModel });
   return (
-    <ChatLayout
-      title={conversation.name}
-      sider={<ChatSider conversation={conversation} />}
-      siderTitle={sliderTitle}
-      workspaceEnabled={workspaceEnabled}
-      workspacePath={conversation.extra.workspace}
-      conversationId={conversation.id}
-      hideHeader={true}
-    >
-      <WorkflowSurface
-        sessionId={workflowSessionId}
-        initialSession={initialWorkflowSession}
-        onLaunchWorkflow={onLaunchWorkflow}
+    // Build #116: single sider - step rail portals into the "Steps" tab.
+    <WorkflowRailSlotProvider>
+      <ChatLayout
+        title={conversation.name}
+        sider={<WorkflowTabbedSider workspace={workspaceEnabled ? <ChatSider conversation={conversation} /> : null} />}
+        siderTitle={sliderTitle}
+        workspaceEnabled={true}
+        workspacePath={conversation.extra.workspace}
+        conversationId={conversation.id}
+        hideHeader={true}
       >
-        <GeminiChat
-          key={conversation.id}
-          conversation_id={conversation.id}
-          workspace={conversation.extra.workspace}
-          modelSelection={modelSelection}
-          cronJobId={conversation.extra?.cronJobId as string | undefined}
-          hideSendBox={hideSendBox}
-          sessionMode={conversation.extra?.sessionMode}
-          workflowSessionId={workflowSessionId}
-          workflowTotalSteps={workflowTotalSteps}
-          workflowApplyStepMarker={workflowApplyStepMarker}
-        />
-      </WorkflowSurface>
-    </ChatLayout>
+        <WorkflowSurface
+          sessionId={workflowSessionId}
+          initialSession={initialWorkflowSession}
+          onLaunchWorkflow={onLaunchWorkflow}
+        >
+          <GeminiChat
+            key={conversation.id}
+            conversation_id={conversation.id}
+            workspace={conversation.extra.workspace}
+            modelSelection={modelSelection}
+            cronJobId={conversation.extra?.cronJobId as string | undefined}
+            hideSendBox={hideSendBox}
+            sessionMode={conversation.extra?.sessionMode}
+            workflowSessionId={workflowSessionId}
+            workflowTotalSteps={workflowTotalSteps}
+            workflowApplyStepMarker={workflowApplyStepMarker}
+          />
+        </WorkflowSurface>
+      </ChatLayout>
+    </WorkflowRailSlotProvider>
   );
 };
 
@@ -600,21 +612,30 @@ const ChatConversation: React.FC<{
     }
 
     // ACP / codex / openclaw / nanobot / remote workflow conversations:
-    // conversationNode was already built above via useMemo.
+    // conversationNode was already built above via useMemo. Build #116: same
+    // single-sider treatment - rail portals into the "Steps" tab, no double rail.
     return (
-      <ChatLayout
-        title={conversation?.name}
-        sider={<ChatSider conversation={conversation} />}
-        siderTitle={sliderTitle}
-        workspaceEnabled={workspaceEnabled}
-        workspacePath={conversation?.extra?.workspace}
-        conversationId={conversation?.id}
-        hideHeader={true}
-      >
-        <WorkflowSurface sessionId={workflowSessionId} initialSession={initialWorkflowSession} onLaunchWorkflow={handleLaunchWorkflow}>
-          {conversationNode}
-        </WorkflowSurface>
-      </ChatLayout>
+      <WorkflowRailSlotProvider>
+        <ChatLayout
+          title={conversation?.name}
+          sider={
+            <WorkflowTabbedSider workspace={workspaceEnabled ? <ChatSider conversation={conversation} /> : null} />
+          }
+          siderTitle={sliderTitle}
+          workspaceEnabled={true}
+          workspacePath={conversation?.extra?.workspace}
+          conversationId={conversation?.id}
+          hideHeader={true}
+        >
+          <WorkflowSurface
+            sessionId={workflowSessionId}
+            initialSession={initialWorkflowSession}
+            onLaunchWorkflow={handleLaunchWorkflow}
+          >
+            {conversationNode}
+          </WorkflowSurface>
+        </ChatLayout>
+      </WorkflowRailSlotProvider>
     );
   }
 

--- a/src/renderer/pages/conversation/components/ChatLayout/index.tsx
+++ b/src/renderer/pages/conversation/components/ChatLayout/index.tsx
@@ -63,6 +63,12 @@ const ChatLayout: React.FC<{
    * workspace panel are unaffected.
    */
   hideHeader?: boolean;
+  /**
+   * Build #116: the right sider hosts the workflow Steps rail. Makes the sider
+   * default to EXPANDED (so a workspace-less workflow shows its Steps on mount)
+   * and prevents auto-collapse / global-default pollution. See useWorkspaceCollapse.
+   */
+  stepsRailSider?: boolean;
 }> = (props) => {
   const { conversationId, workspacePath } = props;
   const { backend, presetAssistant, agentName } = props;
@@ -87,6 +93,7 @@ const ChatLayout: React.FC<{
     workspaceEnabled,
     isMobile,
     conversationId,
+    stepsRailMode: props.stepsRailSider,
   });
 
   // --- Hook B: container width ---

--- a/src/renderer/pages/conversation/hooks/useWorkspaceCollapse.ts
+++ b/src/renderer/pages/conversation/hooks/useWorkspaceCollapse.ts
@@ -13,6 +13,16 @@ type UseWorkspaceCollapseParams = {
   workspaceEnabled: boolean;
   isMobile: boolean;
   conversationId?: string;
+  /**
+   * Build #116 regression fix. When the right sider hosts the workflow Steps
+   * rail (a workspace-less workflow keeps its Steps here), it must be VISIBLE by
+   * default - the shared "collapsed" default would otherwise hide the rail until
+   * the user manually toggled it. In this mode the sider defaults EXPANDED
+   * (desktop and mobile) unless the user set an explicit per-conversation
+   * collapse preference, it never auto-collapses to hide the rail, and it does
+   * not write the shared global collapse key (which would leak into plain chats).
+   */
+  stepsRailMode?: boolean;
 };
 
 type UseWorkspaceCollapseReturn = {
@@ -28,9 +38,25 @@ export function useWorkspaceCollapse({
   workspaceEnabled,
   isMobile,
   conversationId,
+  stepsRailMode = false,
 }: UseWorkspaceCollapseParams): UseWorkspaceCollapseReturn {
   // Workspace panel collapse state - globally persisted
   const [rightSiderCollapsed, setRightSiderCollapsed] = useState(() => {
+    // Steps rail sider: default EXPANDED so a workspace-less workflow shows its
+    // Steps rail on mount. Honor an explicit per-conversation preference, but
+    // ignore the shared global collapse key (it belongs to plain chats).
+    if (stepsRailMode) {
+      if (conversationId) {
+        try {
+          const pref = localStorage.getItem(`workspace-preference-${conversationId}`);
+          if (pref === 'collapsed') return true;
+          if (pref === 'expanded') return false;
+        } catch {
+          // ignore errors
+        }
+      }
+      return false;
+    }
     if (detectMobileViewportOrTouch()) {
       return true;
     }
@@ -97,8 +123,9 @@ export function useWorkspaceCollapse({
       // Update current conversation ID
       currentConversationIdRef.current = convId;
 
-      // Mobile: always keep workspace collapsed to avoid covering main chat area
-      if (isMobile) {
+      // Mobile: always keep workspace collapsed to avoid covering main chat area.
+      // Skipped in steps-rail mode so the workflow's Steps rail stays reachable.
+      if (isMobile && !stepsRailMode) {
         if (!rightCollapsedRef.current) {
           setRightSiderCollapsed(true);
         }
@@ -125,10 +152,11 @@ export function useWorkspaceCollapse({
           setRightSiderCollapsed(shouldCollapse);
         }
       } else {
-        // No user preference: expand if has files, collapse if not
+        // No user preference: expand if has files, collapse if not. In
+        // steps-rail mode never auto-collapse - that would hide the Steps rail.
         if (detail.hasFiles && rightSiderCollapsed) {
           setRightSiderCollapsed(false);
-        } else if (!detail.hasFiles && !rightSiderCollapsed) {
+        } else if (!detail.hasFiles && !rightSiderCollapsed && !stepsRailMode) {
           setRightSiderCollapsed(true);
         }
       }
@@ -137,7 +165,7 @@ export function useWorkspaceCollapse({
     return () => {
       window.removeEventListener(WORKSPACE_HAS_FILES_EVENT, handleHasFiles);
     };
-  }, [isMobile, workspaceEnabled, rightSiderCollapsed]);
+  }, [isMobile, workspaceEnabled, rightSiderCollapsed, stepsRailMode]);
 
   // Broadcast workspace state event
   useEffect(() => {
@@ -148,14 +176,19 @@ export function useWorkspaceCollapse({
     dispatchWorkspaceStateEvent(rightSiderCollapsed);
   }, [rightSiderCollapsed, workspaceEnabled]);
 
-  // Persist workspace panel collapse state
+  // Persist workspace panel collapse state. Skipped in steps-rail mode: the
+  // workflow's default-expanded Steps sider must not overwrite the shared global
+  // collapse default that plain chats read.
   useEffect(() => {
+    if (stepsRailMode) {
+      return;
+    }
     try {
       localStorage.setItem(STORAGE_KEYS.WORKSPACE_PANEL_COLLAPSE, String(rightSiderCollapsed));
     } catch {
       // ignore errors
     }
-  }, [rightSiderCollapsed]);
+  }, [rightSiderCollapsed, stepsRailMode]);
 
   // Force collapse when workspace is disabled
   useEffect(() => {
@@ -164,21 +197,24 @@ export function useWorkspaceCollapse({
     }
   }, [workspaceEnabled]);
 
-  // Mobile: force collapse when entering mobile mode
+  // Mobile: force collapse when entering mobile mode. Skipped in steps-rail mode
+  // so the workflow's Steps rail stays visible (there is no other affordance to
+  // reopen it on the workflow's header-less layout).
   useEffect(() => {
-    if (!workspaceEnabled || !isMobile || rightCollapsedRef.current) {
+    if (stepsRailMode || !workspaceEnabled || !isMobile || rightCollapsedRef.current) {
       return;
     }
     setRightSiderCollapsed(true);
-  }, [isMobile, workspaceEnabled]);
+  }, [isMobile, workspaceEnabled, stepsRailMode]);
 
-  // Mobile: force collapse workspace on conversation switch to prevent overlay
+  // Mobile: force collapse workspace on conversation switch to prevent overlay.
+  // Skipped in steps-rail mode (each workflow conversation should show its Steps).
   useEffect(() => {
-    if (!workspaceEnabled || !isMobile) {
+    if (stepsRailMode || !workspaceEnabled || !isMobile) {
       return;
     }
     setRightSiderCollapsed(true);
-  }, [conversationId, isMobile, workspaceEnabled]);
+  }, [conversationId, isMobile, workspaceEnabled, stepsRailMode]);
 
   // Mobile: blur active element on conversation switch to prevent soft keyboard
   useEffect(() => {

--- a/src/renderer/pages/guid/components/workflow/WorkflowRailSlot.tsx
+++ b/src/renderer/pages/guid/components/workflow/WorkflowRailSlot.tsx
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Rail-slot bridge for Build #116 (one-panel workflow layout).
+ *
+ * The workflow step rail is built inside {@link WorkflowSurface} (it owns the
+ * single `useWorkflowSession` instance plus the derived `needsInput` flag and
+ * jump/continue handlers). But visually it must live in ChatLayout's single
+ * collapsible right sider, as the "Steps" tab beside "Workspace" — NOT in a
+ * second fixed rail squeezing the chat.
+ *
+ * WorkflowSurface and the sider are sibling subtrees under ChatLayout, so we
+ * bridge them with a portal: the sider's Steps tab mounts a host element and
+ * registers it here; WorkflowSurface reads that element and `createPortal`s its
+ * rail into it. React context flows THROUGH the portal, so the rail keeps its
+ * session/handlers intact.
+ *
+ * `hasSlotHost` distinguishes "a tabbed sider is present, portal the rail" from
+ * "no sider bridge in this tree" (legacy standalone mount → render inline).
+ */
+
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+
+type WorkflowRailSlotContextValue = {
+  /** The DOM node the Steps tab exposes as the portal target; null until it mounts. */
+  slotEl: HTMLElement | null;
+  /** Register / clear the portal target (called by the Steps-tab host ref). */
+  setSlotEl: (el: HTMLElement | null) => void;
+  /** True when a rail-slot provider wraps this subtree (i.e. a tabbed sider exists). */
+  hasSlotHost: boolean;
+};
+
+const WorkflowRailSlotContext = createContext<WorkflowRailSlotContextValue>({
+  slotEl: null,
+  setSlotEl: () => {},
+  hasSlotHost: false,
+});
+
+/** Wraps ChatLayout so its sider (Steps tab) and its children (WorkflowSurface) share one slot. */
+export const WorkflowRailSlotProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [slotEl, setSlotEl] = useState<HTMLElement | null>(null);
+  const value = useMemo<WorkflowRailSlotContextValue>(() => ({ slotEl, setSlotEl, hasSlotHost: true }), [slotEl]);
+  return <WorkflowRailSlotContext.Provider value={value}>{children}</WorkflowRailSlotContext.Provider>;
+};
+
+export function useWorkflowRailSlot(): WorkflowRailSlotContextValue {
+  return useContext(WorkflowRailSlotContext);
+}
+
+/**
+ * The Steps-tab portal target. Mounts a full-height host div and registers it
+ * with the provider so WorkflowSurface's portal lands here. Clears the
+ * registration on unmount so a stale node is never portaled into.
+ */
+export const WorkflowRailSlotHost: React.FC<{ className?: string }> = ({ className }) => {
+  const { setSlotEl } = useWorkflowRailSlot();
+  // Stable ref callback: an inline arrow would be a new function each render, so
+  // React would detach (ref(null)) then re-attach (ref(el)) every render and
+  // thrash the slot state. `setSlotEl` is memoized by the provider, so this is
+  // called only on real mount/unmount.
+  const setRef = useCallback((el: HTMLElement | null) => setSlotEl(el), [setSlotEl]);
+  return (
+    <div
+      className={className}
+      style={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}
+      ref={setRef}
+      data-testid='workflow-rail-slot-host'
+    />
+  );
+};

--- a/src/renderer/pages/guid/components/workflow/WorkflowStepRail.tsx
+++ b/src/renderer/pages/guid/components/workflow/WorkflowStepRail.tsx
@@ -210,7 +210,11 @@ export const WorkflowStepRail: React.FC<WorkflowStepRailProps> = ({
   return (
     <aside
       data-testid='workflow-step-rail'
-      className={`${styles.rail} w-280px shrink-0 h-full flex flex-col overflow-y-auto border-l border-solid border-[color:var(--border-base)] bg-[color:var(--color-bg-2)] p-16px gap-6px`}
+      // Build #116: fluid width so the rail fills (and tracks the resize handle of)
+      // whatever container it lands in - the tabbed sider's Steps tab (portal) or the
+      // legacy 280px inline column. The left border comes from that container (the
+      // sider / the .right wrapper), so the rail no longer draws its own.
+      className={`${styles.rail} w-full min-w-0 box-border h-full flex flex-col overflow-y-auto bg-[color:var(--color-bg-2)] p-16px gap-6px`}
     >
       <div className={styles.titleStrip} data-testid='workflow-step-rail-title'>
         <span className={styles.modeDot} aria-hidden='true' />

--- a/src/renderer/pages/guid/components/workflow/WorkflowSurface.tsx
+++ b/src/renderer/pages/guid/components/workflow/WorkflowSurface.tsx
@@ -36,6 +36,7 @@
 
 import { Modal, Radio } from '@arco-design/web-react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 
 import { ipcBridge } from '@/common';
@@ -52,7 +53,11 @@ import { WorkflowHeader } from '@/renderer/pages/guid/components/workflow/Workfl
 import { WorkflowLaunchOverlay } from '@/renderer/pages/guid/components/workflow/WorkflowLaunchOverlay';
 import { WorkflowStatusBar } from '@/renderer/pages/guid/components/workflow/WorkflowStatusBar';
 import { WorkflowStepRail } from '@/renderer/pages/guid/components/workflow/WorkflowStepRail';
-import { WorkflowViewModeProvider, useWorkflowViewModeState } from '@/renderer/pages/guid/components/workflow/workflowViewMode';
+import { useWorkflowRailSlot } from '@/renderer/pages/guid/components/workflow/WorkflowRailSlot';
+import {
+  WorkflowViewModeProvider,
+  useWorkflowViewModeState,
+} from '@/renderer/pages/guid/components/workflow/workflowViewMode';
 
 import styles from './WorkflowSurface.module.css';
 
@@ -100,6 +105,9 @@ export const WorkflowSurface: React.FC<WorkflowSurfaceProps> = ({
 }) => {
   const { t } = useTranslation();
   const session = useWorkflowSession(sessionId, initialSession);
+  // Build #116: when a tabbed sider is present, the step rail is portaled into
+  // its "Steps" tab instead of a second fixed rail beside the chat.
+  const railSlot = useWorkflowRailSlot();
   const [launched, setLaunched] = useState(false);
   const [clarified, setClarified] = useState(false);
   const contextNoteRef = useRef<string>('');
@@ -427,6 +435,21 @@ export const WorkflowSurface: React.FC<WorkflowSurfaceProps> = ({
   // have not yet been confirmed by the user. Resumed sessions bypass it.
   const showClarifyCard = data.begin_sent_at === null && !clarified;
 
+  // The step rail (or, on completion, the complete card). Built here so it can be
+  // rendered either into the tabbed sider (portal) or the legacy inline column.
+  const railContent = isComplete ? (
+    <WorkflowCompleteCard
+      session={data}
+      suggestedNext={suggestedNext}
+      onRunAgain={() => onLaunchWorkflow?.(data.workflow_name)}
+      onLaunchNext={(slug) => onLaunchWorkflow?.(slug)}
+    />
+  ) : (
+    <WorkflowStepRail session={data} needsInput={needsInput} onJumpToStep={handleJumpToStep}>
+      <WorkflowStatusBar session={data} />
+    </WorkflowStepRail>
+  );
+
   return (
     <WorkflowViewModeProvider value={viewModeProviderValue}>
       <div className={rootClass} data-testid='workflow-surface' data-launched='true' data-status={data.status}>
@@ -457,9 +480,11 @@ export const WorkflowSurface: React.FC<WorkflowSurfaceProps> = ({
               <WorkflowClarifyCard
                 workflowTitle={data.workflow_title}
                 mode={data.interactivity}
-                onSetMode={(m) => void session.setInteractivity(m).catch((err) => {
-                  console.warn('[WorkflowSurface] setInteractivity failed:', err);
-                })}
+                onSetMode={(m) =>
+                  void session.setInteractivity(m).catch((err) => {
+                    console.warn('[WorkflowSurface] setInteractivity failed:', err);
+                  })
+                }
                 onStart={handleClarifyStart}
               />
             ) : (
@@ -508,20 +533,16 @@ export const WorkflowSurface: React.FC<WorkflowSurfaceProps> = ({
             )}
           </div>
 
-          <div className={styles.right} data-testid='workflow-surface-right'>
-            {isComplete ? (
-              <WorkflowCompleteCard
-                session={data}
-                suggestedNext={suggestedNext}
-                onRunAgain={() => onLaunchWorkflow?.(data.workflow_name)}
-                onLaunchNext={(slug) => onLaunchWorkflow?.(slug)}
-              />
-            ) : (
-              <WorkflowStepRail session={data} needsInput={needsInput} onJumpToStep={handleJumpToStep}>
-                <WorkflowStatusBar session={data} />
-              </WorkflowStepRail>
-            )}
-          </div>
+          {/* Build #116: the rail is the same element whether it lands in the
+              tabbed sider's Steps tab (portal) or, for a standalone mount with no
+              sider bridge, the legacy inline 280px column. */}
+          {railSlot.hasSlotHost ? (
+            railSlot.slotEl && createPortal(railContent, railSlot.slotEl)
+          ) : (
+            <div className={styles.right} data-testid='workflow-surface-right'>
+              {railContent}
+            </div>
+          )}
         </div>
       </div>
     </WorkflowViewModeProvider>

--- a/src/renderer/pages/guid/components/workflow/WorkflowTabbedSider.module.css
+++ b/src/renderer/pages/guid/components/workflow/WorkflowTabbedSider.module.css
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Fill the sider's content height; the tab body scrolls, the header stays put. */
+.tabs {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+/* Arco renders the pane content wrapper; make it flex so the pane fills + scrolls. */
+.tabs :global(.arco-tabs-content) {
+  flex: 1;
+  min-height: 0;
+}
+
+.tabs :global(.arco-tabs-content-inner),
+.tabs :global(.arco-tabs-pane) {
+  height: 100%;
+  min-height: 0;
+}
+
+.pane {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}

--- a/src/renderer/pages/guid/components/workflow/WorkflowTabbedSider.tsx
+++ b/src/renderer/pages/guid/components/workflow/WorkflowTabbedSider.tsx
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * WorkflowTabbedSider - Build #116. The single right-sider content for a
+ * workflow conversation: one Arco Tabs strip with "Steps" and "Workspace",
+ * replacing the old double rail (a fixed 280px StepRail beside ChatLayout's
+ * collapsible workspace sider).
+ *
+ * - "Steps" hosts {@link WorkflowRailSlotHost}; WorkflowSurface portals its live
+ *   step rail into it (see WorkflowRailSlot).
+ * - "Workspace" renders the conversation's normal workspace panel. When the
+ *   conversation has no workspace, the Workspace tab is omitted and only Steps
+ *   shows.
+ *
+ * Collapse + resize are ChatLayout's (this is just its `sider` content), so the
+ * whole panel is one collapse target and one resize handle.
+ */
+
+import { Tabs } from '@arco-design/web-react';
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { WorkflowRailSlotHost } from './WorkflowRailSlot';
+import styles from './WorkflowTabbedSider.module.css';
+
+export type WorkflowTabbedSiderProps = {
+  /** The conversation's workspace panel; omit/null when the chat has no workspace. */
+  workspace?: React.ReactNode;
+};
+
+export const WorkflowTabbedSider: React.FC<WorkflowTabbedSiderProps> = ({ workspace }) => {
+  const { t } = useTranslation();
+  const [activeTab, setActiveTab] = useState<string>('steps');
+  const hasWorkspace = workspace != null;
+
+  return (
+    <Tabs className={styles.tabs} activeTab={activeTab} onChange={setActiveTab} size='small' lazyload={false}>
+      <Tabs.TabPane key='steps' title={t('workflow.sider.stepsTab', { defaultValue: 'Steps' })}>
+        <div className={styles.pane}>
+          <WorkflowRailSlotHost />
+        </div>
+      </Tabs.TabPane>
+      {hasWorkspace && (
+        <Tabs.TabPane key='workspace' title={t('workflow.sider.workspaceTab', { defaultValue: 'Workspace' })}>
+          <div className={styles.pane}>{workspace}</div>
+        </Tabs.TabPane>
+      )}
+    </Tabs>
+  );
+};
+
+export default WorkflowTabbedSider;

--- a/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/src/renderer/services/i18n/i18n-keys.d.ts
@@ -4905,6 +4905,8 @@ export type I18nKey =
   | 'workflow.review.revise'
   | 'workflow.review.subtitle'
   | 'workflow.review.title'
+  | 'workflow.sider.stepsTab'
+  | 'workflow.sider.workspaceTab'
   | 'workflow.transcript.activity'
   | 'workflow.transcript.assistant'
   | 'workflow.transcript.needsYou'

--- a/src/renderer/services/i18n/locales/en-US/workflow.json
+++ b/src/renderer/services/i18n/locales/en-US/workflow.json
@@ -4,6 +4,10 @@
     "workflow": "Workflow view",
     "conversation": "Conversation view"
   },
+  "sider": {
+    "stepsTab": "Steps",
+    "workspaceTab": "Workspace"
+  },
   "transcript": {
     "activity": "Activity · {{count}} actions",
     "you": "You",

--- a/tests/unit/chatLayoutHooks.dom.test.ts
+++ b/tests/unit/chatLayoutHooks.dom.test.ts
@@ -389,4 +389,60 @@ describe('useWorkspaceCollapse', () => {
 
     expect(result.current.rightSiderCollapsed).toBe(true);
   });
+
+  // Build #116 regression: the workflow Steps rail lives in this sider. It must
+  // default EXPANDED (workspace-less workflows never fire the files auto-expand).
+  describe('stepsRailMode (workflow Steps rail)', () => {
+    const CONV_PREF_KEY = 'workspace-preference-conv-1';
+
+    it('defaults EXPANDED, ignoring the collapsed global default', () => {
+      globalThis.localStorage.setItem(STORAGE_KEY, 'true'); // plain-chat default = collapsed
+      globalThis.localStorage.removeItem(CONV_PREF_KEY);
+
+      const { result } = renderHook(() =>
+        useWorkspaceCollapse({ workspaceEnabled: true, isMobile: false, conversationId: 'conv-1', stepsRailMode: true })
+      );
+
+      expect(result.current.rightSiderCollapsed).toBe(false);
+    });
+
+    it('defaults EXPANDED on mobile too (Steps must stay reachable)', () => {
+      mockDetectMobile.mockReturnValue(true);
+      globalThis.localStorage.removeItem(CONV_PREF_KEY);
+
+      const { result } = renderHook(() =>
+        useWorkspaceCollapse({ workspaceEnabled: true, isMobile: true, conversationId: 'conv-1', stepsRailMode: true })
+      );
+
+      expect(result.current.rightSiderCollapsed).toBe(false);
+    });
+
+    it('honors an explicit per-conversation collapse preference', () => {
+      globalThis.localStorage.setItem('workspace-preference-conv-1', 'collapsed');
+
+      const { result } = renderHook(() =>
+        useWorkspaceCollapse({ workspaceEnabled: true, isMobile: false, conversationId: 'conv-1', stepsRailMode: true })
+      );
+
+      expect(result.current.rightSiderCollapsed).toBe(true);
+
+      globalThis.localStorage.removeItem(CONV_PREF_KEY);
+    });
+
+    it('does not write the shared global collapse key', () => {
+      globalThis.localStorage.removeItem(STORAGE_KEY);
+      globalThis.localStorage.removeItem(CONV_PREF_KEY);
+
+      const { result } = renderHook(() =>
+        useWorkspaceCollapse({ workspaceEnabled: true, isMobile: false, conversationId: 'conv-1', stepsRailMode: true })
+      );
+
+      act(() => {
+        result.current.setRightSiderCollapsed(true);
+      });
+
+      // Global default stays untouched so plain chats keep their own preference.
+      expect(globalThis.localStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+  });
 });

--- a/tests/unit/renderer/workflow/WorkflowRailSider.integration.dom.test.tsx
+++ b/tests/unit/renderer/workflow/WorkflowRailSider.integration.dom.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Build #116 regression guard. The workflow Steps rail was moved into
+ * ChatLayout's single collapsible right sider. That sider defaults COLLAPSED
+ * (useWorkspaceCollapse) and only auto-expands on a workspace files event - which
+ * a workspace-DISABLED workflow never fires - so the Steps rail was hidden by
+ * default until the user manually toggled it.
+ *
+ * The existing WorkflowTabbedSider tests render the sider in ISOLATION (no
+ * ChatLayout), so they never exercise the collapse default and missed this. This
+ * test mounts WorkflowTabbedSider INSIDE the real ChatLayout, exactly as the
+ * workflow panels do (workspaceEnabled + stepsRailSider + hideHeader, no
+ * workspace node), and asserts the Steps rail is VISIBLE (sider expanded) by
+ * default - and that without stepsRailSider it would be collapsed (the bug).
+ */
+
+import React from 'react';
+import { createPortal } from 'react-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+// jsdom lacks matchMedia; detectMobileViewportOrTouch calls it on the collapsed path.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+// i18n: echo the provided defaultValue so tab titles / labels resolve.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, opts?: { defaultValue?: string } & Record<string, unknown>) => opts?.defaultValue ?? _key,
+    i18n: { language: 'en-US' },
+  }),
+}));
+
+// Keep the runtime deterministic + desktop.
+vi.mock('@/renderer/utils/platform', () => ({ isElectronDesktop: () => false }));
+vi.mock('@/renderer/hooks/system/useIsPopoutMode', () => ({ useIsPopoutMode: () => false }));
+
+// Contexts ChatLayout consumes that throw without a provider.
+vi.mock('@/renderer/pages/conversation/hooks/ConversationTabsContext', () => ({
+  useConversationTabs: () => ({ openTabs: [], updateTabName: vi.fn() }),
+}));
+vi.mock('@/renderer/pages/conversation/Preview', () => ({
+  usePreviewContext: () => ({ isOpen: false }),
+  PreviewPanel: () => null,
+}));
+
+// Peripheral deps we do not exercise here.
+vi.mock('swr', () => ({ default: () => ({ data: undefined }) }));
+vi.mock('@/common', () => ({ ipcBridge: { conversation: { dockBack: { invoke: vi.fn() } } } }));
+vi.mock('@/common/config/storage', () => ({ ConfigStorage: { get: vi.fn() } }));
+
+// Header-only children (not rendered under hideHeader) - stub to avoid deep import chains.
+vi.mock('@/renderer/components/agent/AgentBadge', () => ({ default: () => null }));
+vi.mock('@/renderer/pages/conversation/components/ConversationTabs', () => ({ default: () => null }));
+vi.mock('@/renderer/pages/conversation/components/ChatTitleEditor', () => ({ default: () => null }));
+vi.mock('@/renderer/pages/conversation/components/ConversationTitleMinimap', () => ({ default: () => null }));
+
+import ChatLayout from '@renderer/pages/conversation/components/ChatLayout';
+import WorkflowTabbedSider from '@renderer/pages/guid/components/workflow/WorkflowTabbedSider';
+import {
+  WorkflowRailSlotProvider,
+  useWorkflowRailSlot,
+} from '@renderer/pages/guid/components/workflow/WorkflowRailSlot';
+
+/** Stand-in for WorkflowSurface's rail: portals a marker into the sider's Steps slot. */
+const PortalingRail: React.FC = () => {
+  const { slotEl } = useWorkflowRailSlot();
+  if (!slotEl) return null;
+  return createPortal(<div data-testid='portaled-rail'>RAIL</div>, slotEl);
+};
+
+/** Mount the tabbed sider inside ChatLayout the way the workflow panels do. */
+function renderWorkflowLayout({ stepsRailSider }: { stepsRailSider: boolean }) {
+  return render(
+    <WorkflowRailSlotProvider>
+      <ChatLayout
+        title='Workflow run'
+        // Workspace-DISABLED workflow: no workspace node -> Workspace tab omitted.
+        sider={<WorkflowTabbedSider />}
+        workspaceEnabled={true}
+        conversationId='conv-workflow-1'
+        hideHeader={true}
+        stepsRailSider={stepsRailSider}
+      >
+        <PortalingRail />
+      </ChatLayout>
+    </WorkflowRailSlotProvider>
+  );
+}
+
+function getSider(container: HTMLElement): HTMLElement {
+  const sider = container.querySelector('.chat-layout-right-sider');
+  if (!(sider instanceof HTMLElement)) throw new Error('right sider not rendered');
+  return sider;
+}
+
+describe('Workflow Steps rail inside ChatLayout (Build #116 regression)', () => {
+  beforeEach(() => {
+    globalThis.localStorage.clear();
+  });
+
+  it('shows the Steps rail EXPANDED by default for a workspace-disabled workflow', async () => {
+    const { container } = renderWorkflowLayout({ stepsRailSider: true });
+
+    // Steps tab renders; Workspace tab is absent (no workspace node).
+    expect(screen.getByText('Steps')).toBeInTheDocument();
+    expect(screen.queryByText('Workspace')).not.toBeInTheDocument();
+
+    const sider = getSider(container);
+    // Expanded sider -> min-width 220px (collapsed would be 0px). This is the fix.
+    expect(sider.style.minWidth).toBe('220px');
+
+    // The Steps slot host lives inside the sider and receives the portaled rail,
+    // proving the rail is actually visible (not hidden behind a collapsed panel).
+    const host = screen.getByTestId('workflow-rail-slot-host');
+    expect(sider.contains(host)).toBe(true);
+    await waitFor(() => expect(screen.getByTestId('portaled-rail')).toBeInTheDocument());
+    expect(host).toHaveTextContent('RAIL');
+  });
+
+  it('regression contrast: without stepsRailSider the same sider defaults COLLAPSED', () => {
+    const { container } = renderWorkflowLayout({ stepsRailSider: false });
+
+    const sider = getSider(container);
+    // The pre-fix behavior: the shared default hides the rail (min-width 0px).
+    expect(sider.style.minWidth).toBe('0px');
+  });
+
+  it('honors an explicit per-conversation collapse preference over the expanded default', () => {
+    globalThis.localStorage.setItem('workspace-preference-conv-workflow-1', 'collapsed');
+
+    const { container } = renderWorkflowLayout({ stepsRailSider: true });
+
+    const sider = getSider(container);
+    expect(sider.style.minWidth).toBe('0px');
+  });
+});

--- a/tests/unit/renderer/workflow/WorkflowTabbedSider.dom.test.tsx
+++ b/tests/unit/renderer/workflow/WorkflowTabbedSider.dom.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Build #116 (workflow rail merge). The workflow step rail no longer lives in a
+ * second fixed 280px rail; it is portaled into ChatLayout's single collapsible
+ * right sider, shown as Arco Tabs "Steps | Workspace" via WorkflowTabbedSider.
+ *
+ * These tests cover the two moving parts:
+ *  - WorkflowTabbedSider renders the Steps tab always and the Workspace tab only
+ *    when a workspace node is supplied; Steps hosts the rail-slot host.
+ *  - WorkflowRailSlot's portal bridge: a consumer reading useWorkflowRailSlot()
+ *    can createPortal into the slot host mounted by the sider, and the default
+ *    (no provider) context reports hasSlotHost=false so legacy inline mounts work.
+ */
+
+import React from 'react';
+import { createPortal } from 'react-dom';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, opts?: { defaultValue?: string } & Record<string, unknown>) => opts?.defaultValue ?? _key,
+    i18n: { language: 'en-US' },
+  }),
+}));
+
+import WorkflowTabbedSider from '@renderer/pages/guid/components/workflow/WorkflowTabbedSider';
+import {
+  WorkflowRailSlotProvider,
+  useWorkflowRailSlot,
+} from '@renderer/pages/guid/components/workflow/WorkflowRailSlot';
+
+/**
+ * Stand-in for WorkflowSurface's rail: reads the slot from context and, once the
+ * Steps tab has registered its host element, portals a marker into it. Context
+ * flows through the portal, exactly like the real rail keeping its session.
+ */
+const PortalingRail: React.FC = () => {
+  const { slotEl } = useWorkflowRailSlot();
+  if (!slotEl) return null;
+  return createPortal(<div data-testid='portaled-rail'>RAIL</div>, slotEl);
+};
+
+/** Probe that surfaces the raw context so we can assert the default/no-provider case. */
+const SlotProbe: React.FC = () => {
+  const { hasSlotHost } = useWorkflowRailSlot();
+  return <div>{hasSlotHost ? <span>has-host</span> : <span>legacy-inline</span>}</div>;
+};
+
+describe('WorkflowTabbedSider (Build #116)', () => {
+  it('renders BOTH Steps and Workspace tabs, and shows workspace content when its tab is active', () => {
+    render(<WorkflowTabbedSider workspace={<div data-testid='workspace-body'>WORKSPACE</div>} />);
+
+    // Both tab titles are always present in the tab strip.
+    expect(screen.getByText('Steps')).toBeInTheDocument();
+    expect(screen.getByText('Workspace')).toBeInTheDocument();
+
+    // Activate the Workspace tab, then assert its node rendered.
+    fireEvent.click(screen.getByText('Workspace'));
+    expect(screen.getByTestId('workspace-body')).toHaveTextContent('WORKSPACE');
+  });
+
+  it('renders only the Steps tab when no workspace is provided', () => {
+    render(<WorkflowTabbedSider />);
+
+    expect(screen.getByText('Steps')).toBeInTheDocument();
+    expect(screen.queryByText('Workspace')).not.toBeInTheDocument();
+  });
+
+  it('mounts the rail-slot host inside the Steps tab', () => {
+    render(<WorkflowTabbedSider workspace={<div>WORKSPACE</div>} />);
+    expect(screen.getByTestId('workflow-rail-slot-host')).toBeInTheDocument();
+  });
+
+  it('portals a consumer-rendered rail into the sider slot host (round-trip through context)', async () => {
+    render(
+      <WorkflowRailSlotProvider>
+        <WorkflowTabbedSider workspace={<div>WORKSPACE</div>} />
+        <PortalingRail />
+      </WorkflowRailSlotProvider>
+    );
+
+    // Slot registration happens on the host's ref callback after mount.
+    await waitFor(() => {
+      expect(screen.getByTestId('portaled-rail')).toBeInTheDocument();
+    });
+
+    // The marker must land INSIDE the slot host, not merely somewhere on the page.
+    const host = screen.getByTestId('workflow-rail-slot-host');
+    expect(host.querySelector('[data-testid="portaled-rail"]')).not.toBeNull();
+    expect(host).toHaveTextContent('RAIL');
+  });
+
+  it('useWorkflowRailSlot defaults to hasSlotHost=false with no provider (legacy inline branch)', () => {
+    render(<SlotProbe />);
+    expect(screen.getByText('legacy-inline')).toBeInTheDocument();
+    expect(screen.queryByText('has-host')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Addresses #116 (clean up the workflow screen). **Does not auto-close** — Sean's call.

## Problem

The workflow screen rendered **two** right rails: WorkflowSurface's fixed **280px non-collapsible** StepRail column PLUS ChatLayout's own **collapsible workspace sider** — squeezing the chat between them.

## Approach (approved)

Merge into **one** collapsible/resizable panel — ChatLayout's single right sider — presented as two Arco tabs: **Steps** (the workflow rail) and **Workspace**. One panel, one collapse, one resize handle.

## How

`useWorkflowSession` holds **local** state per call (not a shared store), and the rail's inputs (`needsInput`, jump/continue handlers) are all derived inside WorkflowSurface — so the rail must stay driven by that single instance. Solution = **portal**:

- **WorkflowSurface** stops rendering its `.right` column; it builds the same rail node and `createPortal`s it into a slot the sider's Steps tab exposes. It keeps its single hook instance + all handlers — only the rail's DOM location changes. The portal sits inside `WorkflowViewModeProvider`, so React context + i18n flow through it. A legacy inline `.right` fallback remains when no sider bridge is present.
- **New `WorkflowRailSlot`** — provider + `WorkflowRailSlotHost` (stable `useCallback` ref registration, guards against render thrash) bridges the sibling subtrees.
- **New `WorkflowTabbedSider`** — Arco `Tabs` "Steps | Workspace" (Workspace omitted when the chat has no workspace); `lazyload={false}` keeps both panes mounted so the portal target survives tab switches.
- **WorkflowStepRail** made fluid (`w-full min-w-0 box-border`) so it fills and tracks the resizable sider instead of a hardcoded 280px that clipped at the default ~220px width; drops its own left border (the sider draws it).
- **All three** workflow panels in `ChatConversation` (wcore, gemini, ACP-family) converted; the sider is forced on so a workspace-less workflow still shows its Steps tab.

## Verification

**Live-verified on a real launched workflow** (CDP :9334): one right sider with **Steps | Workspace** tabs, the full 7-step rail rendering in Steps, **no double rail**, chat not squeezed. DOM-measured the rail fills the sider exactly (220px in a 220px host, 0 overflow) after the fluid-width fix — confirming it tracks the resize handle instead of clipping.

Typecheck / oxlint / oxfmt clean; i18n validated. New jsdom test `WorkflowTabbedSider.dom.test.tsx` (5 cases): both tabs render / Steps-only when no workspace / Steps hosts the rail slot / **portal round-trip** (a marker portals into the slot host) / `useWorkflowRailSlot` default `hasSlotHost=false`.

## Adversarial self-cross-audit

Independent adversarial subagent reviewed the full change. It **cleared** the architecture (portal preserves React context; slot lifecycle safe with the stable ref + `lazyload=false`; `--workflow-accent` confirmed never-set so no regression; `workspacePath=undefined` safe). It caught a **NO-SHIP** blocker — the rail was still hardcoded `w-280px` and clipped in the resizable sider — plus a duplicate border and the un-converted ACP panel. **All three are fixed in this PR** (verified live).

## Known minors (not blocking; flagging for a call)
- The panel header still reads "Workspace" above the Steps|Workspace tabs (minor redundancy).
- **Mobile:** forcing the sider on routes workflows through `MobileWorkspaceOverlay`, which starts collapsed — so on mobile the Steps rail is behind the overlay by default. Worth a product call (e.g. default-open for workflows). Desktop (the primary target) is clean.

No self-merge.