### PR TITLE
feat(workflow): merge double right-rail into one collapsible tabbed panel (#116)

### DIFF
--- a/src/renderer/hooks/workflow/useWorkflowNeedsInput.ts
+++ b/src/renderer/hooks/workflow/useWorkflowNeedsInput.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * useWorkflowNeedsInput - derives the "the run is waiting on the user" signal
+ * for a workflow session.
+ *
+ * "Is the agent currently producing output for this conversation?" is read from
+ * the shared generating-conversations store (fed by responseStream /
+ * turnCompleted). When it is NOT generating and the current step is not done,
+ * the run is waiting on the user. The idle edge is debounced so the brief gap
+ * between the user sending and the agent's first chunk does not flash the
+ * "Needs you" beat.
+ *
+ * Extracted from WorkflowSurface so the chat body (WorkflowSurface) and the
+ * merged Steps panel (WorkflowStepsTab, rendered in ChatLayout's right sider)
+ * compute the exact same value from the same inputs.
+ */
+
+import { useEffect, useState } from 'react';
+import type { WorkflowSession } from '@/common/types/workflowTypes';
+import { useConversationListSync } from '@/renderer/pages/conversation/GroupedHistory/hooks/useConversationListSync';
+
+export function useWorkflowNeedsInput(data: WorkflowSession | null | undefined): boolean {
+  const { isConversationGenerating } = useConversationListSync();
+  const responding = data ? isConversationGenerating(data.conversation_id) : false;
+
+  const [idleStable, setIdleStable] = useState(false);
+  useEffect(() => {
+    if (responding) {
+      setIdleStable(false);
+      return;
+    }
+    const id = window.setTimeout(() => setIdleStable(true), 600);
+    return () => window.clearTimeout(id);
+  }, [responding]);
+
+  const liveStep = data?.steps.find((s) => s.n === data.current_step);
+  const currentStepTerminal = liveStep
+    ? liveStep.status === 'done' || liveStep.status === 'skipped' || liveStep.status === 'errored'
+    : false;
+
+  return (
+    !!data &&
+    data.status === 'active' &&
+    data.begin_sent_at !== null &&
+    data.run_mode === 'running' &&
+    !currentStepTerminal &&
+    idleStable
+  );
+}

--- a/src/renderer/pages/conversation/components/ChatConversation.tsx
+++ b/src/renderer/pages/conversation/components/ChatConversation.tsx
@@ -13,6 +13,7 @@ import addChatIcon from '@/renderer/assets/icons/add-chat.svg';
 import { CronJobManager } from '@/renderer/pages/cron';
 import { usePresetAssistantInfo, resolveAssistantConfigId } from '@/renderer/hooks/agent/usePresetAssistantInfo';
 import { useWorkflowSession } from '@/renderer/hooks/workflow/useWorkflowSession';
+import { useWorkflowNeedsInput } from '@/renderer/hooks/workflow/useWorkflowNeedsInput';
 import { iconColors } from '@/renderer/styles/colors';
 import { Button, Dropdown, Menu, Tooltip, Typography } from '@arco-design/web-react';
 import React, { useCallback, useMemo, useRef } from 'react';
@@ -37,6 +38,7 @@ import { usePreviewContext } from '../Preview';
 import StarOfficeMonitorCard from '../platforms/openclaw/StarOfficeMonitorCard.tsx';
 import ConversationSkillsIndicator from './ConversationSkillsIndicator';
 import { WorkflowSurface } from '@/renderer/pages/guid/components/workflow/WorkflowSurface';
+import { WorkflowStepsTab } from '@/renderer/pages/guid/components/workflow/WorkflowStepsTab';
 // import SkillRuleGenerator from './components/SkillRuleGenerator'; // Temporarily hidden
 
 // Shared props for the wcore/gemini panels rendered inside WorkflowSurface.
@@ -47,7 +49,8 @@ type WorkflowPanelExtras = {
   initialWorkflowSession?: WorkflowSession;
   workflowTotalSteps: number | null;
   workflowApplyStepMarker: ReturnType<typeof useWorkflowSession>['applyStepMarker'];
-  onLaunchWorkflow: (workflowName: string) => void;
+  /** #116: the workflow "Steps" panel, rendered as a tab in ChatLayout's right sider. */
+  stepsPanel: React.ReactNode;
 };
 
 const _AssociatedConversation: React.FC<{ conversation_id: string }> = ({ conversation_id }) => {
@@ -281,7 +284,7 @@ const WCoreWorkflowPanel: React.FC<{ conversation: WCoreConversation } & Workflo
   initialWorkflowSession,
   workflowTotalSteps,
   workflowApplyStepMarker,
-  onLaunchWorkflow,
+  stepsPanel,
 }) => {
   const onSelectModel = useCallback(
     async (_provider: IProvider, modelName: string) => {
@@ -298,16 +301,13 @@ const WCoreWorkflowPanel: React.FC<{ conversation: WCoreConversation } & Workflo
       title={conversation.name}
       sider={<ChatSider conversation={conversation} />}
       siderTitle={sliderTitle}
+      stepsPanel={stepsPanel}
       workspaceEnabled={workspaceEnabled}
       workspacePath={conversation.extra.workspace}
       conversationId={conversation.id}
       hideHeader={true}
     >
-      <WorkflowSurface
-        sessionId={workflowSessionId}
-        initialSession={initialWorkflowSession}
-        onLaunchWorkflow={onLaunchWorkflow}
-      >
+      <WorkflowSurface sessionId={workflowSessionId} initialSession={initialWorkflowSession}>
         <WCoreChat
           key={conversation.id}
           conversation_id={conversation.id}
@@ -323,7 +323,9 @@ const WCoreWorkflowPanel: React.FC<{ conversation: WCoreConversation } & Workflo
   );
 };
 
-const GeminiWorkflowPanel: React.FC<{ conversation: GeminiConversation; hideSendBox?: boolean } & WorkflowPanelExtras> = ({
+const GeminiWorkflowPanel: React.FC<
+  { conversation: GeminiConversation; hideSendBox?: boolean } & WorkflowPanelExtras
+> = ({
   conversation,
   sliderTitle,
   workspaceEnabled,
@@ -331,7 +333,7 @@ const GeminiWorkflowPanel: React.FC<{ conversation: GeminiConversation; hideSend
   initialWorkflowSession,
   workflowTotalSteps,
   workflowApplyStepMarker,
-  onLaunchWorkflow,
+  stepsPanel,
   hideSendBox,
 }) => {
   const onSelectModel = useCallback(
@@ -348,16 +350,13 @@ const GeminiWorkflowPanel: React.FC<{ conversation: GeminiConversation; hideSend
       title={conversation.name}
       sider={<ChatSider conversation={conversation} />}
       siderTitle={sliderTitle}
+      stepsPanel={stepsPanel}
       workspaceEnabled={workspaceEnabled}
       workspacePath={conversation.extra.workspace}
       conversationId={conversation.id}
       hideHeader={true}
     >
-      <WorkflowSurface
-        sessionId={workflowSessionId}
-        initialSession={initialWorkflowSession}
-        onLaunchWorkflow={onLaunchWorkflow}
-      >
+      <WorkflowSurface sessionId={workflowSessionId} initialSession={initialWorkflowSession}>
         <GeminiChat
           key={conversation.id}
           conversation_id={conversation.id}
@@ -419,6 +418,22 @@ const ChatConversation: React.FC<{
   const hoistedWorkflowSession = useWorkflowSession(workflowSessionId, initialWorkflowSession);
   const workflowTotalSteps: number | null = hoistedWorkflowSession.data?.total_steps ?? null;
   const workflowApplyStepMarker = hoistedWorkflowSession.applyStepMarker;
+
+  // #116: the workflow "Steps" surface (step rail / Complete card) is rendered
+  // into ChatLayout's single right sider as a tab, instead of WorkflowSurface's
+  // own second rail. It reads the already-hoisted session (no extra
+  // subscription) and the shared needs-input signal, and routes jumps/launches
+  // through the same hook that owns the session state.
+  const workflowNeedsInput = useWorkflowNeedsInput(hoistedWorkflowSession.data);
+  const hoistedJumpToStep = hoistedWorkflowSession.jumpToStep;
+  const workflowStepsPanel = isWorkflow ? (
+    <WorkflowStepsTab
+      session={hoistedWorkflowSession.data}
+      needsInput={workflowNeedsInput}
+      onJumpToStep={hoistedJumpToStep}
+      onLaunchWorkflow={handleLaunchWorkflow}
+    />
+  ) : undefined;
 
   const isGeminiConversation = conversation?.type === 'gemini';
   const isWCoreConversation = conversation?.type === 'wcore';
@@ -577,7 +592,7 @@ const ChatConversation: React.FC<{
           initialWorkflowSession={initialWorkflowSession}
           workflowTotalSteps={workflowTotalSteps}
           workflowApplyStepMarker={workflowApplyStepMarker}
-          onLaunchWorkflow={handleLaunchWorkflow}
+          stepsPanel={workflowStepsPanel}
         />
       );
     }
@@ -593,7 +608,7 @@ const ChatConversation: React.FC<{
           initialWorkflowSession={initialWorkflowSession}
           workflowTotalSteps={workflowTotalSteps}
           workflowApplyStepMarker={workflowApplyStepMarker}
-          onLaunchWorkflow={handleLaunchWorkflow}
+          stepsPanel={workflowStepsPanel}
           hideSendBox={hideSendBox}
         />
       );
@@ -606,12 +621,13 @@ const ChatConversation: React.FC<{
         title={conversation?.name}
         sider={<ChatSider conversation={conversation} />}
         siderTitle={sliderTitle}
+        stepsPanel={workflowStepsPanel}
         workspaceEnabled={workspaceEnabled}
         workspacePath={conversation?.extra?.workspace}
         conversationId={conversation?.id}
         hideHeader={true}
       >
-        <WorkflowSurface sessionId={workflowSessionId} initialSession={initialWorkflowSession} onLaunchWorkflow={handleLaunchWorkflow}>
+        <WorkflowSurface sessionId={workflowSessionId} initialSession={initialWorkflowSession}>
           {conversationNode}
         </WorkflowSurface>
       </ChatLayout>

--- a/src/renderer/pages/conversation/components/ChatLayout/chat-layout.css
+++ b/src/renderer/pages/conversation/components/ChatLayout/chat-layout.css
@@ -71,6 +71,27 @@
   color: var(--text-primary) !important;
 }
 
+/* #116: workflow right-sider tabs ("Steps" | "Workspace"). Make the Arco Tabs
+   fill the sider's content height so each pane (the scrollable step rail / the
+   workspace file tree) gets the full column and manages its own scroll. */
+.workflow-sider-tabs.arco-tabs {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.workflow-sider-tabs > .arco-tabs-content {
+  flex: 1 1 auto;
+  min-height: 0;
+  height: 100%;
+  padding: 0;
+}
+
+.workflow-sider-tabs > .arco-tabs-content .arco-tabs-content-inner,
+.workflow-sider-tabs > .arco-tabs-content .arco-tabs-content-item {
+  height: 100%;
+}
+
 /* Workspace open button dropdown styles */
 .workspace-open-dropdown {
   background-color: var(--color-bg-2);

--- a/src/renderer/pages/conversation/components/ChatLayout/index.tsx
+++ b/src/renderer/pages/conversation/components/ChatLayout/index.tsx
@@ -30,7 +30,7 @@ import {
   WORKSPACE_HEADER_HEIGHT,
   calcLayoutMetrics,
 } from '@/renderer/pages/conversation/utils/layoutCalc';
-import { Layout as ArcoLayout } from '@arco-design/web-react';
+import { Layout as ArcoLayout, Tabs } from '@arco-design/web-react';
 import React from 'react';
 import useSWR from 'swr';
 import './chat-layout.css';
@@ -63,6 +63,14 @@ const ChatLayout: React.FC<{
    * workspace panel are unaffected.
    */
   hideHeader?: boolean;
+  /**
+   * Workflow "Steps" panel (issue #116). When provided, the right sider renders
+   * as two tabs - "Steps" (this node) and "Workspace" (`sider`) - inside the one
+   * collapsible panel, merging the workflow screen's former two right rails. The
+   * panel is shown (and stays collapsible) even when `workspaceEnabled` is false,
+   * so workspace-disabled workflows still surface their steps.
+   */
+  stepsPanel?: React.ReactNode;
 }> = (props) => {
   const { conversationId, workspacePath } = props;
   const { backend, presetAssistant, agentName } = props;
@@ -73,6 +81,13 @@ const ChatLayout: React.FC<{
   // only the tab bar is removed.
   const isPopout = useIsPopoutMode();
   const workspaceEnabled = props.workspaceEnabled ?? true;
+  // #116: a workflow's Steps panel lives in this same right sider. The panel
+  // (container + collapse control + layout width) must exist whenever there is
+  // EITHER a workspace OR a steps panel, so a workspace-disabled workflow still
+  // shows its steps. `workspaceEnabled` stays reserved for workspace-only bits
+  // (the Workspace tab + the "open in external tools" button).
+  const hasStepsPanel = Boolean(props.stepsPanel);
+  const panelEnabled = workspaceEnabled || hasStepsPanel;
   const layout = useLayoutContext();
   const isMacRuntime = isMacEnvironment();
   const isWindowsRuntime = isWindowsEnvironment();
@@ -84,7 +99,7 @@ const ChatLayout: React.FC<{
 
   // --- Hook A: workspace collapse ---
   const { rightSiderCollapsed, setRightSiderCollapsed } = useWorkspaceCollapse({
-    workspaceEnabled,
+    workspaceEnabled: panelEnabled,
     isMobile,
     conversationId,
   });
@@ -142,7 +157,7 @@ const ChatLayout: React.FC<{
     containerWidth,
     workspaceSplitRatio,
     chatSplitRatio: 60, // placeholder; only dynamicChatMinRatio/dynamicChatMaxRatio are used here
-    workspaceEnabled,
+    workspaceEnabled: panelEnabled,
     isDesktop,
     isPreviewOpen,
     rightSiderCollapsed,
@@ -166,7 +181,7 @@ const ChatLayout: React.FC<{
       containerWidth,
       workspaceSplitRatio,
       chatSplitRatio,
-      workspaceEnabled,
+      workspaceEnabled: panelEnabled,
       isDesktop,
       isPreviewOpen,
       rightSiderCollapsed,
@@ -177,7 +192,7 @@ const ChatLayout: React.FC<{
   usePreviewAutoCollapse({
     isPreviewOpen,
     isDesktop,
-    workspaceEnabled,
+    workspaceEnabled: panelEnabled,
     rightSiderCollapsed,
     setRightSiderCollapsed,
     siderCollapsed: layout?.siderCollapsed,
@@ -187,7 +202,7 @@ const ChatLayout: React.FC<{
   // --- Hook E: layout constraints ---
   useLayoutConstraints({
     containerWidth,
-    workspaceEnabled,
+    workspaceEnabled: panelEnabled,
     isDesktop,
     isPreviewOpen,
     rightSiderCollapsed,
@@ -259,7 +274,7 @@ const ChatLayout: React.FC<{
               assistantId={presetAssistant?.id}
             />
           )}
-          {isWindowsRuntime && workspaceEnabled && (
+          {isWindowsRuntime && panelEnabled && (
             <button
               type='button'
               className='workspace-header__toggle'
@@ -273,6 +288,27 @@ const ChatLayout: React.FC<{
       </ArcoLayout.Header>
       {resolvedTabsSlot}
     </>
+  );
+
+  // #116: right-sider inner content. With a workflow Steps panel present it
+  // becomes two tabs ("Steps" + "Workspace") in the one collapsible panel;
+  // a workspace-disabled workflow shows Steps alone (no tab bar); a plain
+  // conversation keeps the workspace `sider` exactly as before.
+  const siderInner = hasStepsPanel ? (
+    workspaceEnabled ? (
+      <Tabs defaultActiveTab='steps' className='workflow-sider-tabs' lazyload={false}>
+        <Tabs.TabPane key='steps' title={t('workflow.rail.title')}>
+          {props.stepsPanel}
+        </Tabs.TabPane>
+        <Tabs.TabPane key='workspace' title={t('conversation.workspace.title')}>
+          {props.sider}
+        </Tabs.TabPane>
+      </Tabs>
+    ) : (
+      props.stepsPanel
+    )
+  ) : (
+    props.sider
   );
 
   return (
@@ -376,7 +412,7 @@ const ChatLayout: React.FC<{
             )}
           </>
         )}
-        {workspaceEnabled && !layout?.isMobile && (
+        {panelEnabled && !layout?.isMobile && (
           <div
             className={classNames('!bg-1 relative chat-layout-right-sider layout-sider')}
             style={{
@@ -399,29 +435,30 @@ const ChatLayout: React.FC<{
               togglePlacement={layout?.isMobile ? 'left' : 'right'}
               workspacePath={workspacePath}
             >
-              {props.siderTitle}
+              {/* With the Steps/Workspace tabs the panel is self-labelling. */}
+              {hasStepsPanel ? null : props.siderTitle}
             </WorkspacePanelHeader>
             <ArcoLayout.Content style={{ height: `calc(100% - ${WORKSPACE_HEADER_HEIGHT}px)` }}>
-              {props.sider}
+              {siderInner}
             </ArcoLayout.Content>
           </div>
         )}
 
         {/* Mobile workspace overlay: backdrop + fixed panel + floating collapse handle */}
-        {workspaceEnabled && layout?.isMobile && (
+        {panelEnabled && layout?.isMobile && (
           <MobileWorkspaceOverlay
             rightSiderCollapsed={rightSiderCollapsed}
             setRightSiderCollapsed={setRightSiderCollapsed}
             workspaceWidthPx={workspaceWidthPx}
             mobileWorkspaceHandleRight={mobileWorkspaceHandleRight}
-            siderTitle={props.siderTitle}
-            sider={props.sider}
+            siderTitle={hasStepsPanel ? null : props.siderTitle}
+            sider={siderInner}
             workspacePath={workspacePath}
           />
         )}
 
-        {/* Desktop expand button when workspace is collapsed */}
-        {!isMacRuntime && !isWindowsRuntime && workspaceEnabled && rightSiderCollapsed && !layout?.isMobile && (
+        {/* Desktop expand button when the panel is collapsed */}
+        {!isMacRuntime && !isWindowsRuntime && panelEnabled && rightSiderCollapsed && !layout?.isMobile && (
           <DesktopWorkspaceToggle />
         )}
       </div>

--- a/src/renderer/pages/guid/components/workflow/WorkflowStepRail.tsx
+++ b/src/renderer/pages/guid/components/workflow/WorkflowStepRail.tsx
@@ -31,6 +31,12 @@ export type WorkflowStepRailProps = {
   onJumpToStep: (n: number) => void;
   /** True when the run is waiting on the user - the live step shows a blue "?" not a spinner. */
   needsInput?: boolean;
+  /**
+   * Embedded mode (issue #116): the rail lives inside ChatLayout's right sider
+   * tab rather than as its own fixed 280px column, so it fills the tab width and
+   * drops its own left border (the sider container supplies it).
+   */
+  embedded?: boolean;
   /** Bottom slot - `WorkflowStatusBar` is composed in by the parent (W3.J) via children prop. */
   children?: React.ReactNode;
 };
@@ -199,6 +205,7 @@ export const WorkflowStepRail: React.FC<WorkflowStepRailProps> = ({
   session,
   onJumpToStep,
   needsInput = false,
+  embedded = false,
   children,
 }) => {
   const { t } = useTranslation();
@@ -207,11 +214,12 @@ export const WorkflowStepRail: React.FC<WorkflowStepRailProps> = ({
     onJumpToStep(n);
   };
 
+  const layoutClass = embedded
+    ? 'w-full h-full flex flex-col overflow-y-auto bg-[color:var(--color-bg-2)] p-16px gap-6px'
+    : 'w-280px shrink-0 h-full flex flex-col overflow-y-auto border-l border-solid border-[color:var(--border-base)] bg-[color:var(--color-bg-2)] p-16px gap-6px';
+
   return (
-    <aside
-      data-testid='workflow-step-rail'
-      className={`${styles.rail} w-280px shrink-0 h-full flex flex-col overflow-y-auto border-l border-solid border-[color:var(--border-base)] bg-[color:var(--color-bg-2)] p-16px gap-6px`}
-    >
+    <aside data-testid='workflow-step-rail' className={`${styles.rail} ${layoutClass}`}>
       <div className={styles.titleStrip} data-testid='workflow-step-rail-title'>
         <span className={styles.modeDot} aria-hidden='true' />
         <span>{t('workflow.rail.title', { defaultValue: 'Steps' })}</span>

--- a/src/renderer/pages/guid/components/workflow/WorkflowStepsTab.tsx
+++ b/src/renderer/pages/guid/components/workflow/WorkflowStepsTab.tsx
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * WorkflowStepsTab - the workflow "Steps" surface, rendered inside ChatLayout's
+ * single collapsible right sider (as the "Steps" tab alongside "Workspace").
+ *
+ * This is the content that used to live in WorkflowSurface's own fixed 280px
+ * `.right` column. Merging it into ChatLayout's sider (issue #116) collapses
+ * the workflow screen's two right rails into one closeable, tabbed panel so the
+ * chat body is no longer squeezed.
+ *
+ * Purely presentational: session state + the needs-input signal + the
+ * jump/launch callbacks are owned by the caller (ChatConversation, off the
+ * hoisted `useWorkflowSession`).
+ */
+
+import React from 'react';
+
+import type { WorkflowSession } from '@/common/types/workflowTypes';
+import { WorkflowCompleteCard } from './WorkflowCompleteCard';
+import { WorkflowStatusBar } from './WorkflowStatusBar';
+import { WorkflowStepRail } from './WorkflowStepRail';
+
+export type WorkflowStepsTabProps = {
+  /** The live workflow session, or null while it resolves. */
+  session: WorkflowSession | null | undefined;
+  /** True when the run is waiting on the user - the live step shows a blue "?". */
+  needsInput: boolean;
+  /** Jump the workflow to a step (rail row click). */
+  onJumpToStep: (n: number) => void;
+  /** Launch a workflow by slug/name - backs the Complete card CTAs. */
+  onLaunchWorkflow: (workflowName: string) => void;
+  /** Suggested next workflows for the Complete card. */
+  suggestedNext?: Array<{ slug: string; display: string }>;
+};
+
+export const WorkflowStepsTab: React.FC<WorkflowStepsTabProps> = ({
+  session,
+  needsInput,
+  onJumpToStep,
+  onLaunchWorkflow,
+  suggestedNext,
+}) => {
+  if (!session) return null;
+
+  if (session.status === 'complete') {
+    return (
+      <WorkflowCompleteCard
+        session={session}
+        suggestedNext={suggestedNext}
+        onRunAgain={() => onLaunchWorkflow(session.workflow_name)}
+        onLaunchNext={(slug) => onLaunchWorkflow(slug)}
+      />
+    );
+  }
+
+  return (
+    <WorkflowStepRail session={session} needsInput={needsInput} onJumpToStep={onJumpToStep} embedded>
+      <WorkflowStatusBar session={session} />
+    </WorkflowStepRail>
+  );
+};
+
+export default WorkflowStepsTab;

--- a/src/renderer/pages/guid/components/workflow/WorkflowSurface.module.css
+++ b/src/renderer/pages/guid/components/workflow/WorkflowSurface.module.css
@@ -6,9 +6,9 @@
 
 /* WorkflowSurface - SPEC §5.8 composition root.
  *
- * Two-column layout: chat body (header + asks + caller's chat tape) on the
- * left, ~280px rail on the right. The right column is replaced by the
- * complete card when the session reaches terminal state. The root applies
+ * Single-column chat body (header + asks + StepReviewBeat + caller's chat
+ * tape). The step rail / Complete card moved out of this surface into
+ * ChatLayout's right sider as the "Steps" tab (issue #116). The root applies
  * a faint amber tint when status === 'errored' (SPEC §5.8 + §11).
  */
 
@@ -109,15 +109,6 @@
 .continueText span {
   font-size: 12px;
   color: var(--color-text-3);
-}
-
-.right {
-  display: flex;
-  flex-shrink: 0;
-  min-height: 0;
-  width: 280px;
-  border-left: 1px solid var(--border-base);
-  background-color: var(--color-bg-2);
 }
 
 .errored {

--- a/src/renderer/pages/guid/components/workflow/WorkflowSurface.tsx
+++ b/src/renderer/pages/guid/components/workflow/WorkflowSurface.tsx
@@ -11,21 +11,23 @@
  * mutations route through the `useWorkflowSession` hook so the hook stays
  * the single source of truth for session shape.
  *
- * Layout:
+ * Layout (issue #116 - the step rail no longer lives here):
  *
  *   [WorkflowLaunchOverlay - shown until its 1.6s sequence completes]
- *   ┌────────────────────────────────────────┬─────────────┐
- *   │ WorkflowHeader                                       │
- *   │ AskCard × N (pending asks only)                      │
+ *   ┌──────────────────────────────────────────────────────┐
+ *   │ WorkflowHeader                                        │
+ *   │ AskCard × N (pending asks only)                       │
+ *   │ StepReviewBeat (awaiting_input gate, inline)          │
  *   │ {children}  ← caller's chat tape + input             │
- *   │                                        │ StepRail    │
- *   │                                        │  └─ Status  │
- *   └────────────────────────────────────────┴─────────────┘
+ *   └──────────────────────────────────────────────────────┘
+ *
+ * The step rail / Complete card that used to sit in this surface's own fixed
+ * `.right` column now render as the "Steps" tab of ChatLayout's single
+ * collapsible right sider (see WorkflowStepsTab, fed from ChatConversation).
+ * That collapses the workflow screen's two right rails into one closeable panel.
  *
  * Status transitions:
- * - `complete`: header collapses (handled inside WorkflowHeader); rail
- *   slot renders `<WorkflowCompleteCard>` instead of `<WorkflowStepRail>`.
- * - `errored`:  root receives the `.errored` modifier class (amber tint).
+ * - `errored`: root receives the `.errored` modifier class (amber tint).
  *
  * Auto-send hidden begin (SPEC MUST 1 + §14): on first overlay-completion
  * for a *fresh* session (no asks, every step still `todo`), the surface
@@ -41,18 +43,18 @@ import { useTranslation } from 'react-i18next';
 import { ipcBridge } from '@/common';
 import type { WorkflowInteractivity, WorkflowSession } from '@/common/types/workflowTypes';
 import { useWorkflowSession } from '@/renderer/hooks/workflow/useWorkflowSession';
-import { useConversationListSync } from '@/renderer/pages/conversation/GroupedHistory/hooks/useConversationListSync';
+import { useWorkflowNeedsInput } from '@/renderer/hooks/workflow/useWorkflowNeedsInput';
 import { AskCard } from '@/renderer/pages/guid/components/workflow/AskCard';
 import { QueuedSteeringChip } from '@/renderer/pages/guid/components/workflow/QueuedSteeringChip';
 import { WorkflowNeedsInputCard } from '@/renderer/pages/guid/components/workflow/WorkflowNeedsInputCard';
 import { StepReviewBeat } from '@/renderer/pages/guid/components/workflow/StepReviewBeat';
 import { WorkflowClarifyCard } from '@/renderer/pages/guid/components/workflow/WorkflowClarifyCard';
-import { WorkflowCompleteCard } from '@/renderer/pages/guid/components/workflow/WorkflowCompleteCard';
 import { WorkflowHeader } from '@/renderer/pages/guid/components/workflow/WorkflowHeader';
 import { WorkflowLaunchOverlay } from '@/renderer/pages/guid/components/workflow/WorkflowLaunchOverlay';
-import { WorkflowStatusBar } from '@/renderer/pages/guid/components/workflow/WorkflowStatusBar';
-import { WorkflowStepRail } from '@/renderer/pages/guid/components/workflow/WorkflowStepRail';
-import { WorkflowViewModeProvider, useWorkflowViewModeState } from '@/renderer/pages/guid/components/workflow/workflowViewMode';
+import {
+  WorkflowViewModeProvider,
+  useWorkflowViewModeState,
+} from '@/renderer/pages/guid/components/workflow/workflowViewMode';
 
 import styles from './WorkflowSurface.module.css';
 
@@ -61,14 +63,6 @@ export type WorkflowSurfaceProps = {
   initialSession?: WorkflowSession;
   /** Slot for the existing chat tape + input (caller passes from GuidPage). */
   children: React.ReactNode;
-  /** Suggested next workflows for the Complete card. Optional - caller can derive from category. */
-  suggestedNext?: Array<{ slug: string; display: string }>;
-  /**
-   * Launch a workflow by its slug/name. Backs both Complete-card CTAs:
-   * "Run again" passes this session's own `workflow_name`, "Up next" passes
-   * the suggested slug. The caller (ChatConversation) routes to the launcher.
-   */
-  onLaunchWorkflow?: (workflowName: string) => void;
 };
 
 const isFreshLaunch = (session: WorkflowSession): boolean => {
@@ -91,13 +85,7 @@ const buildBeginMessageId = (sessionId: string): string => `workflow-begin-${ses
 const buildWorkflowAnswerEnvelope = (askId: string, stepN: number, answer: string): string =>
   `[workflow_answer ask_id="${askId}" step_n="${stepN}"]\n<answer>${answer}</answer>\n[/workflow_answer]`;
 
-export const WorkflowSurface: React.FC<WorkflowSurfaceProps> = ({
-  sessionId,
-  initialSession,
-  children,
-  suggestedNext,
-  onLaunchWorkflow,
-}) => {
+export const WorkflowSurface: React.FC<WorkflowSurfaceProps> = ({ sessionId, initialSession, children }) => {
   const { t } = useTranslation();
   const session = useWorkflowSession(sessionId, initialSession);
   const [launched, setLaunched] = useState(false);
@@ -109,41 +97,14 @@ export const WorkflowSurface: React.FC<WorkflowSurfaceProps> = ({
 
   const data = session.data;
 
-  // "Is the agent currently producing output for this conversation?" - read from
-  // the shared generating-conversations store (fed by responseStream /
-  // turnCompleted). When it is NOT generating and the step is not done, the run
-  // is waiting on the user. Debounce the idle edge so the brief gap between the
-  // user sending and the agent's first chunk does not flash the "Needs you"
-  // beat.
-  const { isConversationGenerating } = useConversationListSync();
-  const responding = data ? isConversationGenerating(data.conversation_id) : false;
-  const [idleStable, setIdleStable] = useState(false);
-  useEffect(() => {
-    if (responding) {
-      setIdleStable(false);
-      return;
-    }
-    const id = window.setTimeout(() => setIdleStable(true), 600);
-    return () => window.clearTimeout(id);
-  }, [responding]);
-
-  const liveStep = data?.steps.find((s) => s.n === data.current_step);
-  const currentStepTerminal = liveStep
-    ? liveStep.status === 'done' || liveStep.status === 'skipped' || liveStep.status === 'errored'
-    : false;
   // The "spinning forever" case: the run is nominally `running` but the agent
   // has gone idle without completing the step - it asked the user something in
   // prose (no structured marker), so the engine never flipped to awaiting_input.
   // Surface the blue "Needs you" beat. (A formal awaiting_input is handled by
   // the StepReviewBeat below - that's the step-complete Accept/Revise/Go-back
-  // gate, a different kind of "your move".)
-  const needsInput =
-    !!data &&
-    data.status === 'active' &&
-    data.begin_sent_at !== null &&
-    data.run_mode === 'running' &&
-    !currentStepTerminal &&
-    idleStable;
+  // gate, a different kind of "your move".) Shared with the merged Steps panel
+  // (WorkflowStepsTab) via this hook so both compute the identical value.
+  const needsInput = useWorkflowNeedsInput(data);
 
   // There is exactly ONE input - the conversation composer at the bottom. When
   // the run needs the user, jump them to it: scroll the end of the question
@@ -237,13 +198,6 @@ export const WorkflowSurface: React.FC<WorkflowSurfaceProps> = ({
       },
     });
   }, [session]);
-
-  const handleJumpToStep = useCallback(
-    (n: number) => {
-      void session.jumpToStep(n);
-    },
-    [session]
-  );
 
   const handleSetInteractivity = useCallback(
     (mode: WorkflowInteractivity) => {
@@ -406,7 +360,6 @@ export const WorkflowSurface: React.FC<WorkflowSurfaceProps> = ({
   }
 
   const showOverlay = !launched;
-  const isComplete = data.status === 'complete';
   const isErrored = data.status === 'errored';
   const rootClass = `${styles.root}${isErrored ? ` ${styles.errored}` : ''}`;
   const pendingAsks = data.asks.filter((ask) => ask.answer === null);
@@ -457,9 +410,11 @@ export const WorkflowSurface: React.FC<WorkflowSurfaceProps> = ({
               <WorkflowClarifyCard
                 workflowTitle={data.workflow_title}
                 mode={data.interactivity}
-                onSetMode={(m) => void session.setInteractivity(m).catch((err) => {
-                  console.warn('[WorkflowSurface] setInteractivity failed:', err);
-                })}
+                onSetMode={(m) =>
+                  void session.setInteractivity(m).catch((err) => {
+                    console.warn('[WorkflowSurface] setInteractivity failed:', err);
+                  })
+                }
                 onStart={handleClarifyStart}
               />
             ) : (
@@ -505,21 +460,6 @@ export const WorkflowSurface: React.FC<WorkflowSurfaceProps> = ({
                   {children}
                 </div>
               </>
-            )}
-          </div>
-
-          <div className={styles.right} data-testid='workflow-surface-right'>
-            {isComplete ? (
-              <WorkflowCompleteCard
-                session={data}
-                suggestedNext={suggestedNext}
-                onRunAgain={() => onLaunchWorkflow?.(data.workflow_name)}
-                onLaunchNext={(slug) => onLaunchWorkflow?.(slug)}
-              />
-            ) : (
-              <WorkflowStepRail session={data} needsInput={needsInput} onJumpToStep={handleJumpToStep}>
-                <WorkflowStatusBar session={data} />
-              </WorkflowStepRail>
             )}
           </div>
         </div>

--- a/tests/unit/WorkflowStepsTab.dom.test.tsx
+++ b/tests/unit/WorkflowStepsTab.dom.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { WorkflowSession } from '../../src/common/types/workflowTypes';
+import { WorkflowStepsTab } from '../../src/renderer/pages/guid/components/workflow/WorkflowStepsTab';
+
+// react-i18next isn't initialised in DOM tests - return the provided
+// defaultValue (or the key) so the rail/status/complete strings render.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: { defaultValue?: string } & Record<string, unknown>) => opts?.defaultValue ?? key,
+  }),
+}));
+
+// WorkflowCompleteCard pulls in the heavy Markdown renderer; stub it.
+vi.mock('@/renderer/components/Markdown', () => ({
+  default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const makeSession = (overrides: Partial<WorkflowSession> = {}): WorkflowSession => ({
+  id: 'sess-1',
+  workflow_name: 'demo',
+  workflow_title: 'Demo Workflow',
+  conversation_id: 'conv-1',
+  current_step: 1,
+  total_steps: 2,
+  steps: [
+    {
+      n: 1,
+      title: 'First step',
+      body_excerpt: '',
+      status: 'now',
+      started_at: null,
+      completed_at: null,
+      eta_seconds: null,
+      eta_source: null,
+      autonomous_run: null,
+    },
+    {
+      n: 2,
+      title: 'Second step',
+      body_excerpt: '',
+      status: 'todo',
+      started_at: null,
+      completed_at: null,
+      eta_seconds: null,
+      eta_source: null,
+      autonomous_run: null,
+    },
+  ],
+  skills: [],
+  asks: [],
+  status: 'active',
+  palette: null,
+  category: null,
+  created_at: Date.now(),
+  updated_at: Date.now(),
+  completed_at: null,
+  begin_sent_at: Date.now(),
+  run_mode: 'running',
+  interactivity: 'step',
+  ...overrides,
+});
+
+describe('WorkflowStepsTab', () => {
+  it('renders nothing when there is no session', () => {
+    const { container } = render(
+      <WorkflowStepsTab session={null} needsInput={false} onJumpToStep={vi.fn()} onLaunchWorkflow={vi.fn()} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the step rail and status bar for an active session', () => {
+    render(
+      <WorkflowStepsTab session={makeSession()} needsInput={false} onJumpToStep={vi.fn()} onLaunchWorkflow={vi.fn()} />
+    );
+    expect(screen.getByTestId('workflow-step-rail')).toBeInTheDocument();
+    expect(screen.getByTestId('workflow-status-bar')).toBeInTheDocument();
+    expect(screen.queryByTestId('workflow-complete-card')).not.toBeInTheDocument();
+  });
+
+  it('renders the complete card instead of the rail when the session is complete', () => {
+    render(
+      <WorkflowStepsTab
+        session={makeSession({ status: 'complete', completed_at: Date.now() })}
+        needsInput={false}
+        onJumpToStep={vi.fn()}
+        onLaunchWorkflow={vi.fn()}
+      />
+    );
+    expect(screen.getByTestId('workflow-complete-card')).toBeInTheDocument();
+    expect(screen.queryByTestId('workflow-step-rail')).not.toBeInTheDocument();
+  });
+
+  it('invokes onJumpToStep when a step row is clicked', () => {
+    const onJumpToStep = vi.fn();
+    render(
+      <WorkflowStepsTab
+        session={makeSession()}
+        needsInput={false}
+        onJumpToStep={onJumpToStep}
+        onLaunchWorkflow={vi.fn()}
+      />
+    );
+    const rows = screen.getAllByTestId('workflow-step-rail-row');
+    fireEvent.click(rows[1]);
+    expect(onJumpToStep).toHaveBeenCalledWith(2);
+  });
+
+  it('marks the current step as awaiting input when needsInput is true', () => {
+    render(<WorkflowStepsTab session={makeSession()} needsInput onJumpToStep={vi.fn()} onLaunchWorkflow={vi.fn()} />);
+    const rows = screen.getAllByTestId('workflow-step-rail-row');
+    expect(rows[0]).toHaveAttribute('data-needsinput', 'true');
+  });
+
+  it('runs onLaunchWorkflow with the session workflow_name from the complete card Run again CTA', () => {
+    const onLaunchWorkflow = vi.fn();
+    render(
+      <WorkflowStepsTab
+        session={makeSession({ status: 'complete', workflow_name: 'demo', completed_at: Date.now() })}
+        needsInput={false}
+        onJumpToStep={vi.fn()}
+        onLaunchWorkflow={onLaunchWorkflow}
+      />
+    );
+    // The complete card's primary CTA is a button; clicking it re-launches.
+    const buttons = screen.getAllByRole('button');
+    fireEvent.click(buttons[buttons.length - 1]);
+    expect(onLaunchWorkflow).toHaveBeenCalledWith('demo');
+  });
+});

--- a/tests/unit/renderer/pages/conversation/components/ChatConversation.dom.test.tsx
+++ b/tests/unit/renderer/pages/conversation/components/ChatConversation.dom.test.tsx
@@ -59,6 +59,18 @@ vi.mock('@/renderer/pages/conversation/components/ChatSider', () => ({
   default: () => <div data-testid='mock-chat-sider' />,
 }));
 
+// #116: ChatConversation now derives the workflow needs-input signal (via
+// useWorkflowNeedsInput) to feed the merged Steps sider panel. That reads the
+// shared generating-conversations store; stub it so the test never touches the
+// live ipcBridge / DB.
+vi.mock('@/renderer/pages/conversation/GroupedHistory/hooks/useConversationListSync', () => ({
+  useConversationListSync: () => ({ isConversationGenerating: () => false }),
+}));
+
+vi.mock('@/renderer/pages/guid/components/workflow/WorkflowStepsTab', () => ({
+  WorkflowStepsTab: () => <div data-testid='mock-workflow-steps-tab' />,
+}));
+
 // Platform chat mocks - each renders a distinctive testid and captures props
 // so W0.3 can assert that `workflowTotalSteps` is forwarded from the hoisted
 // `useWorkflowSession` call in ChatConversation.
@@ -140,7 +152,7 @@ vi.mock('@/renderer/hooks/agent/usePresetAssistantInfo', () => ({
 // W0.3: hoisted workflow-session subscription lives in ChatConversation.
 // Mocked so we can assert `workflowTotalSteps` is forwarded to the platform
 // chat without touching the IPC bridge.
-let mockWorkflowSessionData: { total_steps: number } | null = null;
+let mockWorkflowSessionData: { total_steps: number; steps: unknown[] } | null = null;
 vi.mock('@/renderer/hooks/workflow/useWorkflowSession', () => ({
   useWorkflowSession: () => ({
     data: mockWorkflowSessionData,
@@ -378,7 +390,7 @@ describe('ChatConversation - workflowSessionId from location.state', () => {
 
 describe('ChatConversation - W0.3 hoisted workflow total_steps', () => {
   it('threads workflowTotalSteps from the hoisted useWorkflowSession into AcpChat', () => {
-    mockWorkflowSessionData = { total_steps: 7 };
+    mockWorkflowSessionData = { total_steps: 7, steps: [] };
     render(<ChatConversation conversation={buildAcpConversation({ workflowSessionId: 'sess-totals' })} />);
 
     expect(acpChatCalls.length).toBeGreaterThan(0);
@@ -395,7 +407,7 @@ describe('ChatConversation - W0.3 hoisted workflow total_steps', () => {
   });
 
   it('forwards workflowApplyStepMarker from the hoisted session into AcpChat', () => {
-    mockWorkflowSessionData = { total_steps: 3 };
+    mockWorkflowSessionData = { total_steps: 3, steps: [] };
     render(<ChatConversation conversation={buildAcpConversation({ workflowSessionId: 'sess-marker' })} />);
 
     // The hoisted hook's applyStepMarker callback is forwarded as a sibling

--- a/tests/unit/renderer/pages/guid/components/workflow/WorkflowSurface.dom.test.tsx
+++ b/tests/unit/renderer/pages/guid/components/workflow/WorkflowSurface.dom.test.tsx
@@ -6,10 +6,13 @@
 
 /**
  * W3.J - DOM tests for WorkflowSurface. Covers the SPEC §5.8 composition
- * contract: launch overlay gate, header + rail + status bar layout, pending
- * AskCard rendering, status-driven swaps (complete → CompleteCard, errored
- * → root class), pause/end wiring, children slot preservation, and the
- * one-shot hidden begin send.
+ * contract: launch overlay gate, header + body layout, pending AskCard
+ * rendering, the errored root class, pause/end wiring, children slot
+ * preservation, and the one-shot hidden begin send.
+ *
+ * The step rail / Complete card no longer live in this surface (issue #116 -
+ * they moved to ChatLayout's right-sider "Steps" tab, see WorkflowStepsTab and
+ * its own spec). These tests assert the surface renders the chat body ONLY.
  */
 
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -47,9 +50,6 @@ vi.mock('@/renderer/pages/conversation/GroupedHistory/hooks/useConversationListS
 // internals (which have their own coverage in sibling spec files).
 type CapturedProps = Record<string, unknown>;
 const headerCalls: CapturedProps[] = [];
-const railCalls: CapturedProps[] = [];
-const statusBarCalls: CapturedProps[] = [];
-const completeCalls: CapturedProps[] = [];
 const overlayCalls: CapturedProps[] = [];
 const askCalls: CapturedProps[] = [];
 
@@ -59,23 +59,8 @@ vi.mock('@/renderer/pages/guid/components/workflow/WorkflowHeader', () => ({
     const paused = Boolean(props.paused);
     return (
       <div data-testid='mock-workflow-header' data-paused={paused ? 'true' : 'false'}>
-        <button onClick={props.onPauseToggle as () => void}>
-          {paused ? 'Resume' : 'Pause'}
-        </button>
+        <button onClick={props.onPauseToggle as () => void}>{paused ? 'Resume' : 'Pause'}</button>
         <button onClick={props.onEnd as () => void}>End workflow</button>
-      </div>
-    );
-  },
-  default: () => null,
-}));
-
-vi.mock('@/renderer/pages/guid/components/workflow/WorkflowStepRail', () => ({
-  WorkflowStepRail: (props: React.PropsWithChildren<CapturedProps>) => {
-    railCalls.push(props);
-    return (
-      <div data-testid='mock-workflow-rail'>
-        <button onClick={() => (props.onJumpToStep as (n: number) => void)(4)}>jump-4</button>
-        <div>{props.children}</div>
       </div>
     );
   },
@@ -85,9 +70,15 @@ vi.mock('@/renderer/pages/guid/components/workflow/WorkflowStepRail', () => ({
 vi.mock('@/renderer/pages/guid/components/workflow/StepReviewBeat', () => ({
   StepReviewBeat: (props: CapturedProps) => (
     <div data-testid='mock-step-review-beat'>
-      <button onClick={props.onAccept as () => void} data-testid='review-beat-accept'>Accept</button>
-      <button onClick={props.onRevise as () => void} data-testid='review-beat-revise'>Revise</button>
-      <button onClick={props.onGoBack as () => void} data-testid='review-beat-go-back'>Go back</button>
+      <button onClick={props.onAccept as () => void} data-testid='review-beat-accept'>
+        Accept
+      </button>
+      <button onClick={props.onRevise as () => void} data-testid='review-beat-revise'>
+        Revise
+      </button>
+      <button onClick={props.onGoBack as () => void} data-testid='review-beat-go-back'>
+        Go back
+      </button>
     </div>
   ),
   default: () => null,
@@ -95,27 +86,6 @@ vi.mock('@/renderer/pages/guid/components/workflow/StepReviewBeat', () => ({
 
 vi.mock('@/renderer/pages/guid/components/workflow/QueuedSteeringChip', () => ({
   QueuedSteeringChip: () => <div data-testid='mock-queued-chip' />,
-  default: () => null,
-}));
-
-vi.mock('@/renderer/pages/guid/components/workflow/WorkflowStatusBar', () => ({
-  WorkflowStatusBar: (props: CapturedProps) => {
-    statusBarCalls.push(props);
-    return <div data-testid='mock-workflow-status-bar' />;
-  },
-  default: () => null,
-}));
-
-vi.mock('@/renderer/pages/guid/components/workflow/WorkflowCompleteCard', () => ({
-  WorkflowCompleteCard: (props: CapturedProps) => {
-    completeCalls.push(props);
-    return (
-      <div data-testid='mock-workflow-complete'>
-        <button onClick={props.onRunAgain as () => void}>run-again</button>
-        <button onClick={() => (props.onLaunchNext as (s: string) => void)('next-wf')}>launch-next</button>
-      </div>
-    );
-  },
   default: () => null,
 }));
 
@@ -150,10 +120,7 @@ vi.mock('@/renderer/pages/guid/components/workflow/AskCard', () => ({
 vi.mock('@/renderer/pages/guid/components/workflow/WorkflowClarifyCard', () => ({
   WorkflowClarifyCard: (props: CapturedProps) => (
     <div data-testid='mock-workflow-clarify-card'>
-      <button
-        data-testid='mock-clarify-start'
-        onClick={() => (props.onStart as (note: string) => void)('')}
-      >
+      <button data-testid='mock-clarify-start' onClick={() => (props.onStart as (note: string) => void)('')}>
         Start
       </button>
       <button
@@ -177,22 +144,13 @@ vi.mock('@arco-design/web-react', () => ({
       {children}
     </button>
   ),
-  Radio: Object.assign(
-    ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
-    {
-      Group: ({
-        children,
-        value,
-      }: {
-        children?: React.ReactNode;
-        value?: string;
-      }) => (
-        <div data-testid='mock-radio-group' data-value={value}>
-          {children}
-        </div>
-      ),
-    }
-  ),
+  Radio: Object.assign(({ children }: { children?: React.ReactNode }) => <span>{children}</span>, {
+    Group: ({ children, value }: { children?: React.ReactNode; value?: string }) => (
+      <div data-testid='mock-radio-group' data-value={value}>
+        {children}
+      </div>
+    ),
+  }),
 }));
 
 // useWorkflowSession is the hook under composition. Stub it with a
@@ -332,9 +290,6 @@ const renderPostOverlay = (
 
 beforeEach(() => {
   headerCalls.length = 0;
-  railCalls.length = 0;
-  statusBarCalls.length = 0;
-  completeCalls.length = 0;
   overlayCalls.length = 0;
   askCalls.length = 0;
   hookOverrides = {};
@@ -359,7 +314,7 @@ describe('WorkflowSurface', () => {
 
     expect(screen.getByTestId('mock-workflow-launch-overlay')).toBeTruthy();
     expect(screen.queryByTestId('mock-workflow-header')).toBeNull();
-    expect(screen.queryByTestId('mock-workflow-rail')).toBeNull();
+    expect(screen.queryByTestId('workflow-step-rail')).toBeNull();
     expect(screen.queryByTestId('caller-children')).toBeNull();
     expect(overlayCalls[0].workflowName).toBe('Automate Business Workflows');
     expect(overlayCalls[0].totalSteps).toBe(4);
@@ -402,15 +357,15 @@ describe('WorkflowSurface', () => {
     expect(screen.getByTestId('caller-children')).toBeTruthy();
   });
 
-  it('after overlay onComplete, renders header + rail + status bar + children slot', () => {
+  it('after overlay onComplete, renders header + children slot (the rail moved to the sider tab, #116)', () => {
     renderPostOverlay(buildSession());
 
     expect(screen.getByTestId('mock-workflow-header')).toBeTruthy();
-    expect(screen.getByTestId('mock-workflow-rail')).toBeTruthy();
-    expect(screen.getByTestId('mock-workflow-status-bar')).toBeTruthy();
     expect(screen.getByTestId('caller-children')).toBeTruthy();
-    // StatusBar must be wired as the rail's children (per SPEC §5.8).
-    expect(railCalls.length).toBeGreaterThan(0);
+    // #116: the step rail / status bar are no longer part of this surface -
+    // they render in ChatLayout's right-sider "Steps" tab (WorkflowStepsTab).
+    expect(screen.queryByTestId('workflow-step-rail')).toBeNull();
+    expect(screen.queryByTestId('workflow-status-bar')).toBeNull();
   });
 
   it('shows the StepReviewBeat only when run_mode === "awaiting_input"', () => {
@@ -436,25 +391,14 @@ describe('WorkflowSurface', () => {
     expect(resumeRun).not.toHaveBeenCalled();
   });
 
-  it('renders WorkflowCompleteCard instead of the rail when status === "complete"', () => {
-    const onLaunchWorkflow = vi.fn();
-    renderPostOverlay(buildSession({ status: 'complete', completed_at: NOW }), {
-      onLaunchWorkflow,
-      suggestedNext: [{ slug: 'next-wf', display: 'Next Workflow' }],
-    });
+  it('does not render the Complete card in the surface when status === "complete" (#116: it lives in the sider tab)', () => {
+    renderPostOverlay(buildSession({ status: 'complete', completed_at: NOW }));
 
-    expect(screen.getByTestId('mock-workflow-complete')).toBeTruthy();
-    expect(screen.queryByTestId('mock-workflow-rail')).toBeNull();
-
-    // "Run again" relaunches THIS session's own workflow by name (#82).
-    fireEvent.click(screen.getByText('run-again'));
-    expect(onLaunchWorkflow).toHaveBeenCalledWith('automate-business-workflows');
-
-    // "Up next" relaunches the suggested slug.
-    fireEvent.click(screen.getByText('launch-next'));
-    expect(onLaunchWorkflow).toHaveBeenCalledWith('next-wf');
-
-    expect(completeCalls[0].suggestedNext).toEqual([{ slug: 'next-wf', display: 'Next Workflow' }]);
+    // The surface still shows its chat body; the Complete card / rail are the
+    // sider "Steps" tab's job now (WorkflowStepsTab), not this surface's.
+    expect(screen.getByTestId('caller-children')).toBeTruthy();
+    expect(screen.queryByTestId('workflow-complete-card')).toBeNull();
+    expect(screen.queryByTestId('workflow-step-rail')).toBeNull();
   });
 
   it('applies the errored class on the root when status === "errored"', () => {
@@ -576,15 +520,6 @@ describe('WorkflowSurface', () => {
       config.onOk();
     });
     expect(end).toHaveBeenCalledTimes(1);
-  });
-
-  it('wires rail callback: onJumpToStep -> session.jumpToStep', () => {
-    const jumpToStep = vi.fn().mockResolvedValue(undefined);
-    hookOverrides.jumpToStep = jumpToStep;
-    renderPostOverlay(buildSession());
-
-    fireEvent.click(screen.getByText('jump-4'));
-    expect(jumpToStep).toHaveBeenCalledWith(4);
   });
 
   it('fresh launch (begin_sent_at null, all steps todo): calls markBeginSent then sendMessage', async () => {


### PR DESCRIPTION
Addresses #116 (do not auto-close - release closes).

## Problem
The workflow screen rendered **two** right rails side by side: ChatLayout's collapsible workspace sider AND WorkflowSurface's own fixed 280px, non-collapsible `StepRail`. Together they squeezed the chat, and neither the steps rail nor the "revise this step" gate could be closed (per the reporter's screenshot).

## What + how
Merge both into ChatLayout's **single** collapsible right sider, rendered as two Arco tabs — **Steps** (the step rail / Complete card) and **Workspace** (the file tree). One panel, one collapse control, one resize handle. `StepReviewBeat` stays inline in the chat body (already folded in; no dialog work).

- **New `WorkflowStepsTab`** — presentational step rail / Complete card, fed from ChatConversation's already-hoisted `useWorkflowSession` (no extra subscription).
- **New `useWorkflowNeedsInput`** — extracts the needs-input signal so the chat body (`WorkflowSurface`) and the Steps tab compute the identical value.
- **`WorkflowSurface`** drops its `.right` column and keeps only the chat body (header, asks, StepReviewBeat, transcript, composer).
- **`ChatLayout`** gains a `stepsPanel` prop; the right sider renders (and stays collapsible) when there is **either** a workspace **or** a steps panel — so workspace-disabled workflows still show Steps.
- **`WorkflowStepRail`** gains an `embedded` mode (fills the tab width, drops its own left border).

## Tests
- New `WorkflowStepsTab.dom.test.tsx`: rail vs Complete card, step-jump callback, needs-input bullet, Run-again CTA.
- `WorkflowSurface` + `ChatConversation` specs updated to the merged contract (surface renders the chat body only).
- Full suite green (1128 files); typecheck + oxlint clean; i18n in sync (reuses existing `workflow.rail.title` / `conversation.workspace.title` keys — no new strings).

## Note
User-facing UI change — **needs a live-verify pass** in the running app (tab switching, collapse/resize, and the workspace-disabled-workflow case) before merge.