### PR TITLE
chore: bump 0.11.12 + bundle wayland-core 0.12.21

### DIFF
--- a/installer/scripts/postinstall.mjs
+++ b/installer/scripts/postinstall.mjs
@@ -17,7 +17,7 @@ import { fileURLToPath } from 'node:url';
 
 // Kept in lockstep with scripts/prepareWaylandCore.js DEFAULT_WCORE_VERSION by
 // scripts/stage-wcore-bump.mjs. Do not hand-edit; run that tool so both move.
-const WCORE_VERSION = 'v0.12.20';
+const WCORE_VERSION = 'v0.12.21';
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PAYLOAD = resolve(HERE, '..', 'payload');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Wayland",
-  "version": "0.11.11",
+  "version": "0.11.12",
   "description": "The local-first desktop AI agent that drives every AI CLI on your machine - Claude Code, Codex, Gemini and more, on your keys.",
   "keywords": [],
   "license": "AGPL-3.0-or-later",

--- a/scripts/bundled-wcore-shasums.json
+++ b/scripts/bundled-wcore-shasums.json
@@ -1,5 +1,13 @@
 {
   "_comment": "Authoritative SHA-256 checksums for bundled wayland-core release archives (the downloaded .tar.gz / .zip assets), keyed by release tag then asset filename. Mirrors scripts/bundled-bun-shasums.json. Source of truth: the SHASUMS published alongside each signed FerroxLabs/wayland-core release. The downloaded archive is verified against this file BEFORE it is extracted, copied, or executed. Update this file in lockstep with DEFAULT_WCORE_VERSION in scripts/prepareWaylandCore.js and regenerate on every engine version bump.",
+  "v0.12.21": {
+    "wayland-core-v0.12.21-aarch64-apple-darwin.tar.gz": "sha256:13a6c4a8010673d3736bdee0b6e4d1e366f9b1c8b9556dc006a69aca80c0375b",
+    "wayland-core-v0.12.21-x86_64-apple-darwin.tar.gz": "sha256:6b10dbc2676ba017985e557c4494959d43e5d7363168fd8268bc2fc719c98626",
+    "wayland-core-v0.12.21-aarch64-unknown-linux-gnu.tar.gz": "sha256:fbda88e24cd02bf87a57e39556cd381329b17f1aeee9365b7103a8262f35aadb",
+    "wayland-core-v0.12.21-x86_64-unknown-linux-gnu.tar.gz": "sha256:ca72c300783ca587cb43fe2dd078bc211364056bbb34dab8f86b307d5d0128e6",
+    "wayland-core-v0.12.21-aarch64-pc-windows-msvc.zip": "sha256:ee781ad8bd4ff1662aae76f6c7588cdebc60f9a00a98422d9478d24c7b222a2f",
+    "wayland-core-v0.12.21-x86_64-pc-windows-msvc.zip": "sha256:b2dd5073c70dca4ee6aecde8a439b7f8b972812e31c140f405811197f771b5ca"
+  },
   "v0.12.20": {
     "wayland-core-v0.12.20-aarch64-apple-darwin.tar.gz": "sha256:326a98ae60b2b8e65fd3fb56e398fe42d3d851182d629c92a13106ac776ea77d",
     "wayland-core-v0.12.20-x86_64-apple-darwin.tar.gz": "sha256:20a2d52fea3088254e80b0a7275f9f6947e516fa93cb3671fd0c62c3d408dab3",

--- a/scripts/prepareWaylandCore.js
+++ b/scripts/prepareWaylandCore.js
@@ -184,7 +184,7 @@ function verifyArchiveChecksum(archivePath, expectedHex, assetName, tag) {
 // FerroxLabs/wayland-core; Desktop integrates against a specific tag rather
 // than tracking `latest` so version drift can't sneak in via a release made
 // while a CI build is mid-flight. Override with WCORE_VERSION=... when bumping.
-const DEFAULT_WCORE_VERSION = 'v0.12.20';
+const DEFAULT_WCORE_VERSION = 'v0.12.21';
 
 function getVersion() {
   return (process.env.WCORE_VERSION || DEFAULT_WCORE_VERSION).trim();


### PR DESCRIPTION
Release cut for **Desktop 0.11.12**, bundling **wayland-core v0.12.21**.

## Engine bump (verified)
- DEFAULT_WCORE_VERSION v0.12.20 -> v0.12.21; lockstep SHASUMS added for all 6 platform archives.
- SHASUMS verified against the real published `wayland-core-checksums.txt` AND by re-hashing the actual downloaded arm64-darwin archive (exact match).
- Engine 0.12.21: GHSA-8r7g closed end-to-end on ACP (#497 M1 + #568 M2), Windows P1 #520, #574 rate cap, json-stream hardening.

## Desktop 0.11.12 contents (already merged)
Ignition assistant + expert-skill arsenal; skill import + scan + verify security sweep (#582); macOS auto-install-on-quit relaunch-loop fix (#575/#586); team-spawn billing + token-cost fixes (#570/#576/#557); catalog + picker + cron fixes.

**Outward tag is held for Sean's go** — merge this on green CI, then push v0.11.12 (triggers 6-platform signed builds + npm).