### PR TITLE
fix(wcore): surface the actual shell command in the tool timeline (Addresses #520)

### DIFF
--- a/src/common/chat/activity/activityLabels.ts
+++ b/src/common/chat/activity/activityLabels.ts
@@ -53,6 +53,24 @@ const firstPath = (s: string): string => {
   return m ? m[0] : '';
 };
 
+/**
+ * #520 - a one-line, capped rendering of a raw command for the timeline label.
+ * Collapses whitespace/newlines (a heredoc must not blow up the row) and caps
+ * length so a long command stays a legible single line; the full text remains
+ * available in the expandable detail.
+ */
+const CMD_LABEL_CAP = 64;
+export const formatCommandLabel = (command: string): string => {
+  // Drop a leading "Execute: " the wcore mapper prefixes onto the description
+  // fallback, so we show the bare command either way.
+  const bare = command
+    .replace(/^execute:\s*/i, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const capped = bare.length > CMD_LABEL_CAP ? `${bare.slice(0, CMD_LABEL_CAP - 1)}…` : bare;
+  return `Running ${capped}`;
+};
+
 type LabelRule = {
   /** matches against the lowercased "name + ' ' + detail" haystack. */
   test: RegExp;
@@ -125,7 +143,7 @@ const RULES: LabelRule[] = [
  * falling back to a cleaned tool name so a label is ALWAYS produced (never blank).
  */
 export const deriveStep = (
-  node: Pick<ActivityNode, 'kind' | 'name' | 'detail'>
+  node: Pick<ActivityNode, 'kind' | 'name' | 'detail' | 'command'>
 ): { label: string; glyph: GlyphKind } => {
   if (node.kind === 'thinking') return { label: 'Reasoning', glyph: 'reasoning' };
   if (node.kind === 'sub_agent') return { label: node.name || 'Sub-agent working', glyph: 'sub_agent' };
@@ -137,8 +155,16 @@ export const deriveStep = (
 
   const hay = `${node.name || ''} ${node.detail || ''}`;
   const lower = hay.toLowerCase();
+  const command = node.command?.trim();
   for (const rule of RULES) {
-    if (rule.test.test(lower)) return { label: rule.build(hay), glyph: rule.glyph };
+    if (rule.test.test(lower)) {
+      // #520: for a shell/command tool, show the ACTUAL command instead of the
+      // generic "Running a command" - that visibility is the whole point of the
+      // fix. Non-command glyphs (file/web/search) keep their richer humanized
+      // labels, which already name the file/host/query.
+      if (rule.glyph === 'command' && command) return { label: formatCommandLabel(command), glyph: 'command' };
+      return { label: rule.build(hay), glyph: rule.glyph };
+    }
   }
   // Fallback: cleaned tool name, title-ish, always non-empty.
   const clean = (node.name || 'tool').replace(/[_-]+/g, ' ').trim();

--- a/src/common/chat/activity/projectMessages.ts
+++ b/src/common/chat/activity/projectMessages.ts
@@ -62,10 +62,27 @@ const toolGroupDetail = (rd: IMessageToolGroup['content'][number]['resultDisplay
  */
 const WEB_SEARCH_RE = /^web$|web[_-]?search|google[_-]?search|search[_-]?web|brave[_-]?search/i;
 
+/**
+ * #520 - the humanized command string for a tool item, when the engine gave us
+ * one. For an exec/shell tool the actual command lives in the `exec`
+ * confirmationDetails (`command`), set at tool_request and preserved through the
+ * merge. Fall back to the item `description` (which the wcore mapper carries as
+ * "Execute: <cmd>") so a non-exec command-ish tool still surfaces something.
+ */
+const toolGroupCommand = (t: IMessageToolGroup['content'][number]): string | undefined => {
+  if (t.confirmationDetails?.type === 'exec') {
+    const cmd = t.confirmationDetails.command?.trim();
+    if (cmd) return cmd;
+  }
+  const desc = typeof t.description === 'string' ? t.description.trim() : '';
+  return desc || undefined;
+};
+
 /** Map one wcore tool_group message's items to canonical tool nodes. */
 export const toolGroupToNodes = (content: IMessageToolGroup['content']): ActivityNode[] =>
   content.map((t) => {
     const detail = toolGroupDetail(t.resultDisplay);
+    const command = toolGroupCommand(t);
     const node: ActivityNode = {
       id: t.callId,
       kind: 'tool',
@@ -73,6 +90,7 @@ export const toolGroupToNodes = (content: IMessageToolGroup['content']): Activit
       name: t.name,
       status: TOOLGROUP_STATUS[t.status] ?? 'running',
       ...(detail ? { detail } : {}),
+      ...(command ? { command } : {}),
     };
     if (WEB_SEARCH_RE.test(t.name)) {
       const raw = typeof t.resultDisplay === 'string' ? t.resultDisplay : '';

--- a/src/common/chat/chatLib.ts
+++ b/src/common/chat/chatLib.ts
@@ -492,6 +492,13 @@ export type ActivityNode = {
   endTime?: number;
   /** Accumulated streamed detail (tool_chunk stdout / thinking text / op trail). */
   detail?: string;
+  /**
+   * #520 - the raw tool invocation (a shell command's text, e.g.
+   * `echo hello`). Carried so the timeline can show WHAT ran, not just a
+   * humanized "Running a command". Populated for exec-style tools; the label
+   * layer falls back to the humanized verb when absent.
+   */
+  command?: string;
   children?: ActivityNode[];
   /** Parsed search result sources (web_search tool only). */
   sources?: import('./activity/sources').Source[];

--- a/src/process/agent/wcore/index.ts
+++ b/src/process/agent/wcore/index.ts
@@ -161,6 +161,16 @@ export class WCoreAgent {
   private _onPong: WCoreAgentOptions['onPong'];
   private options: WCoreAgentOptions;
   private activeMsgId: string | null = null;
+  // #520 command visibility: the wire's `tool_running` / `tool_result` events
+  // carry only `call_id` + `tool_name` - not the command/description. The engine
+  // sends the humanized command (e.g. "Execute: ls") once, on the preceding
+  // `tool_request` (ToolInfo.description). The renderer merges tool_group frames
+  // by callId with a plain `{...existing, ...incoming}` spread, so an incoming
+  // empty `description` OVERWRITES the command shown at request time - which is
+  // why the running/finished card lost the command after 0.11.2. We stash the
+  // request-time description per callId and re-attach it to the running/result
+  // frames so the command stays visible for the whole tool lifecycle.
+  private toolDescriptionByCallId = new Map<string, string>();
   private configBackup: { path: string; content: string | null; written: string | null } | null = null;
   private mcpReadyPromise: Promise<void>;
   private mcpReadyResolve!: () => void;
@@ -424,6 +434,9 @@ export class WCoreAgent {
         break;
 
       case 'tool_request':
+        // #520: remember the request-time command so the later running/result
+        // frames (which the wire sends without it) can re-surface it.
+        this.toolDescriptionByCallId.set(event.call_id, event.tool.description);
         this.onStreamEvent({
           type: 'tool_group',
           data: [
@@ -447,7 +460,8 @@ export class WCoreAgent {
             {
               callId: event.call_id,
               name: event.tool_name,
-              description: '',
+              // #520: carry the command forward (empty string would clobber it).
+              description: this.toolDescriptionByCallId.get(event.call_id) ?? '',
               status: 'Executing',
               renderOutputAsMarkdown: false,
             },
@@ -463,7 +477,9 @@ export class WCoreAgent {
             {
               callId: event.call_id,
               name: event.tool_name,
-              description: '',
+              // #520: keep the command on the finished card too (the result frame
+              // omits it, and the merge would otherwise blank it out).
+              description: this.toolDescriptionByCallId.get(event.call_id) ?? '',
               status: event.status === 'success' ? 'Success' : 'Error',
               resultDisplay:
                 event.output_type === 'diff'
@@ -474,6 +490,8 @@ export class WCoreAgent {
           ],
           msg_id: event.msg_id,
         });
+        // #520: the tool is terminal - drop its cached command.
+        this.toolDescriptionByCallId.delete(event.call_id);
         break;
 
       case 'tool_cancelled':
@@ -490,6 +508,8 @@ export class WCoreAgent {
           ],
           msg_id: event.msg_id,
         });
+        // #520: terminal - drop its cached command.
+        this.toolDescriptionByCallId.delete(event.call_id);
         break;
 
       case 'stream_end': {

--- a/tests/unit/activityLabels.test.ts
+++ b/tests/unit/activityLabels.test.ts
@@ -82,3 +82,32 @@ describe('activityLabels.deriveStep - tool name humanizing', () => {
     expect(r.glyph).toBe('tool');
   });
 });
+
+// #520 command visibility: when a command-glyph tool carries the actual command,
+// show it instead of the generic "Running a command" (the regression users hit).
+describe('activityLabels.deriveStep - command surfacing (#520)', () => {
+  it('shows the actual command for a shell tool', () => {
+    const r = deriveStep({ kind: 'tool', name: 'Bash', command: 'echo WL520_LIVE_CHECK' });
+    expect(r).toEqual({ label: 'Running echo WL520_LIVE_CHECK', glyph: 'command' });
+  });
+  it('strips a leading "Execute: " prefix (the wcore description fallback)', () => {
+    const r = deriveStep({ kind: 'tool', name: 'Bash', command: 'Execute: ls -la' });
+    expect(r.label).toBe('Running ls -la');
+  });
+  it('collapses newlines and caps a long command to one legible line', () => {
+    const long = `for i in $(seq 1 100); do echo "line $i of a very long heredoc-ish command"; done`;
+    const r = deriveStep({ kind: 'tool', name: 'Bash', command: long });
+    expect(r.label.startsWith('Running ')).toBe(true);
+    expect(r.label).not.toContain('\n');
+    expect(r.label.endsWith('…')).toBe(true);
+    expect(r.label.length).toBeLessThanOrEqual('Running '.length + 64);
+  });
+  it('falls back to the humanized label when no command is present', () => {
+    const r = deriveStep({ kind: 'tool', name: 'exec_command', detail: 'ls -la' });
+    expect(r).toEqual({ label: 'Running a command', glyph: 'command' });
+  });
+  it('does not hijack non-command glyphs (file/web keep their rich labels)', () => {
+    const r = deriveStep({ kind: 'tool', name: 'Read', detail: '/src/config.ts', command: 'ignored' });
+    expect(r).toEqual({ label: 'Reading config.ts', glyph: 'file' });
+  });
+});

--- a/tests/unit/process/agent/wcore/toolCommandVisibility.test.ts
+++ b/tests/unit/process/agent/wcore/toolCommandVisibility.test.ts
@@ -40,7 +40,8 @@ const makeAgent = () => {
 const lastToolFrame = (emitted: Emitted[]) => {
   const groups = emitted.filter((e) => e.type === 'tool_group');
   const last = groups[groups.length - 1];
-  return (last?.data as Array<{ callId: string; name: string; description: string; status: string }>)[0];
+  const data = (last?.data ?? []) as Array<{ callId: string; name: string; description: string; status: string }>;
+  return data[0];
 };
 
 const request: WCoreEvent = {

--- a/tests/unit/process/agent/wcore/toolCommandVisibility.test.ts
+++ b/tests/unit/process/agent/wcore/toolCommandVisibility.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * #520 command visibility (desktop half). The wire's `tool_running` /
+ * `tool_result` events carry only `call_id` + `tool_name`; the humanized command
+ * ("Execute: ls -la") is sent once, on the preceding `tool_request`
+ * (ToolInfo.description). The renderer merges tool_group frames by callId with a
+ * plain `{...existing, ...incoming}` spread, so the mapper emitting an empty
+ * `description` on the running/result frame OVERWRITES the command shown at
+ * request time - the regression users reported after 0.11.2 ("running a command"
+ * but not WHICH command). The mapper now stashes the request-time description
+ * per callId and re-attaches it, so the command stays visible for the whole
+ * tool lifecycle.
+ */
+import { describe, it, expect } from 'vitest';
+import { WCoreAgent, type WCoreAgentOptions } from '@/process/agent/wcore';
+import type { WCoreEvent } from '@/process/agent/wcore/protocol';
+
+type Emitted = { type: string; data?: unknown; msg_id?: string };
+
+/** A WCoreAgent whose only wiring is a capture of every emitted stream event. */
+const makeAgent = () => {
+  const emitted: Emitted[] = [];
+  const options = {
+    workspace: '/tmp/wcore-test',
+    model: {} as never,
+    onStreamEvent: (event: Emitted) => emitted.push(event),
+  } as unknown as WCoreAgentOptions;
+  const agent = new WCoreAgent(options);
+  // handleEvent is private; drive it directly to exercise the pure mapping.
+  const feed = (event: WCoreEvent) => (agent as unknown as { handleEvent: (e: WCoreEvent) => void }).handleEvent(event);
+  return { emitted, feed };
+};
+
+/** Pull the single tool descriptor out of the most recent tool_group frame. */
+const lastToolFrame = (emitted: Emitted[]) => {
+  const groups = emitted.filter((e) => e.type === 'tool_group');
+  const last = groups[groups.length - 1];
+  return (last?.data as Array<{ callId: string; name: string; description: string; status: string }>)[0];
+};
+
+const request: WCoreEvent = {
+  type: 'tool_request',
+  msg_id: 'm1',
+  call_id: 'c1',
+  tool: { name: 'bash', category: 'exec', args: { command: 'ls -la' }, description: 'Execute: ls -la' },
+};
+const running: WCoreEvent = { type: 'tool_running', msg_id: 'm1', call_id: 'c1', tool_name: 'bash' };
+const result: WCoreEvent = {
+  type: 'tool_result',
+  msg_id: 'm1',
+  call_id: 'c1',
+  tool_name: 'bash',
+  status: 'success',
+  output: 'total 0',
+  output_type: 'text',
+};
+
+describe('#520 wcore tool command visibility', () => {
+  it('carries the request-time command onto the running frame (was blanked)', () => {
+    const { emitted, feed } = makeAgent();
+    feed(request);
+    feed(running);
+    const frame = lastToolFrame(emitted);
+    expect(frame.status).toBe('Executing');
+    expect(frame.description).toBe('Execute: ls -la');
+  });
+
+  it('keeps the command on the finished result frame', () => {
+    const { emitted, feed } = makeAgent();
+    feed(request);
+    feed(running);
+    feed(result);
+    const frame = lastToolFrame(emitted);
+    expect(frame.status).toBe('Success');
+    expect(frame.description).toBe('Execute: ls -la');
+  });
+
+  it('falls back to an empty description when no request preceded the running frame', () => {
+    const { emitted, feed } = makeAgent();
+    feed(running); // no matching tool_request cached
+    expect(lastToolFrame(emitted).description).toBe('');
+  });
+
+  it('drops the cached command once the tool is terminal (no leak / stale reuse)', () => {
+    const { emitted, feed } = makeAgent();
+    feed(request);
+    feed(result); // terminal → cache entry for c1 cleared
+    feed({ ...running }); // a stray later running frame for the same callId
+    expect(lastToolFrame(emitted).description).toBe('');
+  });
+});

--- a/tests/unit/projectMessages.test.ts
+++ b/tests/unit/projectMessages.test.ts
@@ -89,8 +89,52 @@ describe('projectMessages.toolSummaryToSteps', () => {
     const steps = toolSummaryToSteps([toolGroupMsg(), acpMsg()], 'wcore');
     expect(steps).toHaveLength(3);
     expect(steps[0]).toMatchObject({ id: 'c1', label: 'Reading config.ts', glyph: 'file', source: 'wcore' });
-    expect(steps[1].label).toBe('Running a command'); // Bash
+    expect(steps[1].label).toBe('Running a command'); // Bash, no command → humanized fallback
     expect(steps[2].glyph).toBe('web'); // web_search
+  });
+});
+
+// #520 command visibility: an exec tool carries its command in the `exec`
+// confirmationDetails; toolGroupToNodes must lift it onto the node so the
+// timeline label shows the ACTUAL command instead of a generic "Running a command".
+const execToolGroupMsg = (over?: Partial<IMessageToolGroup['content'][number]>): IMessageToolGroup =>
+  ({
+    type: 'tool_group',
+    content: [
+      {
+        callId: 'e1',
+        name: 'Bash',
+        description: '',
+        renderOutputAsMarkdown: false,
+        status: 'Executing',
+        confirmationDetails: { type: 'exec', title: 'Execute: echo hi', rootCommand: 'echo', command: 'echo hi' },
+        ...over,
+      },
+    ],
+  }) as unknown as IMessageToolGroup;
+
+describe('projectMessages.toolGroupToNodes command (#520)', () => {
+  it('lifts the exec command onto the node', () => {
+    const node = toolGroupToNodes(execToolGroupMsg().content)[0];
+    expect(node.command).toBe('echo hi');
+  });
+
+  it('falls back to the item description when there are no exec confirmationDetails', () => {
+    const node = toolGroupToNodes(
+      execToolGroupMsg({ confirmationDetails: undefined, description: 'Execute: ls -la' }).content
+    )[0];
+    expect(node.command).toBe('Execute: ls -la');
+  });
+
+  it('leaves command unset when neither is present', () => {
+    const node = toolGroupToNodes(execToolGroupMsg({ confirmationDetails: undefined, description: '' }).content)[0];
+    expect(node.command).toBeUndefined();
+  });
+
+  it('surfaces the command as the timeline label (not "Running a command")', () => {
+    const step = toolSummaryToSteps([execToolGroupMsg()], 'wcore')[0];
+    expect(step.label).toBe('Running echo hi');
+    expect(step.glyph).toBe('command');
   });
 });
 


### PR DESCRIPTION
Addresses #520 (desktop half — command visibility).

## The bug
Since 0.11.2 a wcore tool card shows a generic **"Running a command"** instead of the actual command — the visibility the reporter (and others) depend on to see what the agent is executing.

## Root cause (two desktop gaps, both required)
1. **Mapper clobber.** `src/process/agent/wcore/index.ts` hardcoded `description: ''` on the `tool_running` / `tool_result` tool_group frames. The renderer merges tool_group items by `callId` with a plain `{...tool, ...incoming}` spread (`chatLib.ts` `composeMessage`), so the empty string wiped the command the preceding `tool_request` carried in `description`.
2. **Render path drops it.** The wcore turn actually renders via the **#252 ActivityTimeline**, not `MessageToolGroup`. `toolGroupToNodes` never lifted the command onto the `ActivityNode`, and `deriveStep` humanized every shell tool to a static `"Running a command"` — so even an intact command never reached the label.

Core's shipped #520 work (PR #151) is the Windows AppContainer output-drain fix; `ToolRunning` carries no args on the wire — the command reaches the host via the `tool_request` `ToolInfo.description` / exec `confirmationDetails.command` (both preserved through the merge). So this is a pure desktop fix; no protocol change.

## The fix
- **Mapper:** cache the request-time `description` per `callId` and re-attach it to the running/result frames (stops the clobber; helps non-exec tools too). Cleared on terminal.
- **Projection:** `toolGroupToNodes` lifts the exec command (`confirmationDetails.command`, falling back to the item `description`) onto a new `ActivityNode.command`.
- **Label:** `deriveStep` renders the command for command-glyph tools — `"Running echo hello"`, whitespace-collapsed and capped to one legible line; the full text stays in the expandable detail. Non-command glyphs keep their richer file/host/query labels.

## Verification
- Unit tests: `toolCommandVisibility.test.ts` (mapper, 4), `projectMessages.test.ts` (command lift + label, +4), `activityLabels.test.ts` (`deriveStep` command surfacing incl. cap / `Execute:`-strip / no-hijack, +5). Full activity + tool-group suites green; `typecheck` clean.
- **Live-verified** @ CDP :9334 on **wayland-core 0.12.21** (Doctor-gated): a real DeepSeek-V4-Flash / Wayland-Core turn running `echo WL520_LIVE_CHECK` now shows the tool step **"Running echo WL520_LIVE_CHECK"** (was "Running a command"), including after reopening the conversation from the DB.

Touches the #252 observability humanization layer (`projectMessages` / `activityLabels` / `ActivityNode`) — low overlap with the in-flight #602 sidebar-tree PR (different files). No self-merge.