### PR TITLE
chore: bump to 0.11.13 (bundle wayland-core 0.12.22)

### DIFF
--- a/installer/scripts/postinstall.mjs
+++ b/installer/scripts/postinstall.mjs
@@ -17,7 +17,7 @@ import { fileURLToPath } from 'node:url';
 
 // Kept in lockstep with scripts/prepareWaylandCore.js DEFAULT_WCORE_VERSION by
 // scripts/stage-wcore-bump.mjs. Do not hand-edit; run that tool so both move.
-const WCORE_VERSION = 'v0.12.21';
+const WCORE_VERSION = 'v0.12.22';
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PAYLOAD = resolve(HERE, '..', 'payload');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Wayland",
-  "version": "0.11.12",
+  "version": "0.11.13",
   "description": "The local-first desktop AI agent that drives every AI CLI on your machine - Claude Code, Codex, Gemini and more, on your keys.",
   "keywords": [],
   "license": "AGPL-3.0-or-later",

--- a/scripts/bundled-wcore-shasums.json
+++ b/scripts/bundled-wcore-shasums.json
@@ -1,5 +1,13 @@
 {
   "_comment": "Authoritative SHA-256 checksums for bundled wayland-core release archives (the downloaded .tar.gz / .zip assets), keyed by release tag then asset filename. Mirrors scripts/bundled-bun-shasums.json. Source of truth: the SHASUMS published alongside each signed FerroxLabs/wayland-core release. The downloaded archive is verified against this file BEFORE it is extracted, copied, or executed. Update this file in lockstep with DEFAULT_WCORE_VERSION in scripts/prepareWaylandCore.js and regenerate on every engine version bump.",
+  "v0.12.22": {
+    "wayland-core-v0.12.22-aarch64-apple-darwin.tar.gz": "sha256:554e2568564bf018f7179f38f442e1c9f15944fbe983a13d3692c65aedd42716",
+    "wayland-core-v0.12.22-x86_64-apple-darwin.tar.gz": "sha256:a362c02a7390199e0588550fe0d5783220241a0ff4f7215723c1e4b5211f8451",
+    "wayland-core-v0.12.22-aarch64-unknown-linux-gnu.tar.gz": "sha256:1865d313c1fbd6c49d5682cc2fe478606ae2306967e64cb2f9d59b93c9266859",
+    "wayland-core-v0.12.22-x86_64-unknown-linux-gnu.tar.gz": "sha256:66aa86b347645176c14f466dfcdf8087203f6a44b266fca6c305998f6deba152",
+    "wayland-core-v0.12.22-aarch64-pc-windows-msvc.zip": "sha256:13b40f3efbcb1185f8b99234712a415855587e65454fc922624427d96a60796c",
+    "wayland-core-v0.12.22-x86_64-pc-windows-msvc.zip": "sha256:6d6715c82f17bcd271fa28c7adf1c136f84e638b0ecbb7cc2d4d775d82a48ced"
+  },
   "v0.12.21": {
     "wayland-core-v0.12.21-aarch64-apple-darwin.tar.gz": "sha256:13a6c4a8010673d3736bdee0b6e4d1e366f9b1c8b9556dc006a69aca80c0375b",
     "wayland-core-v0.12.21-x86_64-apple-darwin.tar.gz": "sha256:6b10dbc2676ba017985e557c4494959d43e5d7363168fd8268bc2fc719c98626",

--- a/scripts/prepareWaylandCore.js
+++ b/scripts/prepareWaylandCore.js
@@ -184,7 +184,7 @@ function verifyArchiveChecksum(archivePath, expectedHex, assetName, tag) {
 // FerroxLabs/wayland-core; Desktop integrates against a specific tag rather
 // than tracking `latest` so version drift can't sneak in via a release made
 // while a CI build is mid-flight. Override with WCORE_VERSION=... when bumping.
-const DEFAULT_WCORE_VERSION = 'v0.12.21';
+const DEFAULT_WCORE_VERSION = 'v0.12.22';
 
 function getVersion() {
   return (process.env.WCORE_VERSION || DEFAULT_WCORE_VERSION).trim();


### PR DESCRIPTION
STAGED release PR for 0.11.13 — do NOT merge/tag until the packaged smokes pass and Sean gives the GO. Tagging triggers the outward 6-platform signed build + npm publish.

Engine bump 0.12.21 -> 0.12.22 (4 coupled files via scripts/stage-wcore-bump.mjs; all six platform shasums pulled from the published wayland-core-checksums.txt; darwin-arm64 archive download-verified locally, sha256 554e2568...; wcorePinLockstep test 3/3 green):
- scripts/prepareWaylandCore.js DEFAULT_WCORE_VERSION
- installer/scripts/postinstall.mjs WCORE_VERSION
- scripts/bundled-wcore-shasums.json (v0.12.22 block)
- package.json 0.11.12 -> 0.11.13

wayland-core 0.12.22 adds: True-Continue (#457, hosts show Continue instead of restarting), consecutive-tool-failure retry-cap + MCP isError propagation (#159, Overwatch-audited SHIP on all 6 guardrails), /mcp add idempotent (#135), OpenAI tool-call accumulator bound (#136).

Desktop 0.11.13 batch already merged to main (each independently cross-audited):
- #607 Ignition six-skill pin (packaging-survival proven)
- #596 Wayland Doctor /doctor slash command + checks
- #594 streamlined left nav, #602 live agent-activity tree, #588 voice download progress, #604 real shell command in tool timeline, #589 chat creation date/time, #590 email self-reply guard, #599 one-click GitHub bug report, #591 IJFW Memory setup-status + Test

REMAINING PRE-TAG GATES (Sean): packaged smokes (fresh Ignition chat Loaded Skills shows the six curated skills NOT portfolio-allocation-framework, AND Doctor renders, on a real packaged build); announcement; Sean GO. Revert the engine bump to 0.12.21 if 0.12.22 is not wanted this cut.