### PR TITLE
fix(providers): strip redundant self-namespace from Perplexity model ids (#603)

### DIFF
--- a/src/process/providers/sources/ApiProviderSource.ts
+++ b/src/process/providers/sources/ApiProviderSource.ts
@@ -268,11 +268,28 @@ export class ApiProviderSource implements CatalogSource {
     const raw = entry as RawModelObject;
     if (typeof raw.id !== 'string' || raw.id.length === 0) return null;
 
-    const model: RawModel = { id: raw.id, providerId: this.providerId };
+    const model: RawModel = { id: this.stripSelfPrefix(raw.id), providerId: this.providerId };
     if (typeof raw.display_name === 'string' && raw.display_name.length > 0) {
       model.rawName = raw.display_name;
     }
     return model;
+  }
+
+  /**
+   * Strip a redundant leading `<providerId>/` self-namespace from a model id.
+   *
+   * Some providers act as their own router and list their native models under a
+   * self-prefixed id — Perplexity's `/models` returns `perplexity/sonar` — but
+   * their `/chat/completions` endpoint rejects that form and expects the bare id
+   * (`sonar`), producing an `invalid_model` 400 (#603). Only the provider's OWN
+   * prefix is removed: an upstream-vendor prefix the provider genuinely routes
+   * on (`anthropic/claude-opus-4-5` under Perplexity) is kept, and a pure router
+   * like OpenRouter — which namespaces by upstream vendor and never by itself —
+   * is never touched, because its ids never start with `openrouter/`.
+   */
+  private stripSelfPrefix(id: string): string {
+    const prefix = `${this.providerId}/`;
+    return id.startsWith(prefix) ? id.slice(prefix.length) : id;
   }
 
   /** Normalize a Gemini `models[]` entry: id derives from `name`, sans `models/` prefix. */

--- a/tests/unit/process/providers/sources.test.ts
+++ b/tests/unit/process/providers/sources.test.ts
@@ -84,6 +84,40 @@ describe('ApiProviderSource', () => {
     expect(models).toEqual([{ id: 'claude-opus-4', providerId: 'anthropic', rawName: 'Claude Opus 4' }]);
   });
 
+  it('strips a redundant <providerId>/ self-prefix from data-shape ids (Perplexity sonar, #603)', async () => {
+    // Perplexity's /models lists its native models self-namespaced
+    // (`perplexity/sonar`) but /chat/completions rejects that form and wants
+    // the bare id (`sonar`). The self-prefix must be stripped at ingestion.
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        data: [{ id: 'perplexity/sonar' }, { id: 'perplexity/sonar-pro' }],
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const models = await new ApiProviderSource('perplexity', 'pplx-key').listModels();
+
+    expect(models).toEqual([
+      { id: 'sonar', providerId: 'perplexity' },
+      { id: 'sonar-pro', providerId: 'perplexity' },
+    ]);
+  });
+
+  it('keeps an upstream-vendor prefix that differs from the providerId (Perplexity routing)', async () => {
+    // Perplexity also proxies other vendors; those ids are namespaced by the
+    // UPSTREAM vendor and must be sent as-is — only the self-prefix is dropped.
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        data: [{ id: 'anthropic/claude-opus-4-5' }, { id: 'perplexity/sonar' }],
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const models = await new ApiProviderSource('perplexity', 'pplx-key').listModels();
+
+    expect(models.map((m) => m.id)).toEqual(['anthropic/claude-opus-4-5', 'sonar']);
+  });
+
   it('strips the models/ prefix from Gemini ids and keeps name as rawName', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       jsonResponse({


### PR DESCRIPTION
## Problem

Selecting any direct Perplexity model returns `API error 400 {"error":{"message":"Invalid model 'perplexity/sonar'\...","type":"invalid_model"}}` (#603). The API has credits and works elsewhere.

## Root cause

Perplexity's `/models` endpoint now behaves like a router and returns OpenRouter-style `vendor/model` ids for its **own** models — `perplexity/sonar`, `perplexity/sonar-pro`, plus proxied `anthropic/claude-*`, `google/gemini-*` (29 models in the reporter's catalog). But Perplexity's `/chat/completions` endpoint rejects the self-prefixed form and expects the bare id (`sonar`).

Desktop ingested the id verbatim (`ApiProviderSource.toDataModel`) → catalog → legacy bridge `model[]` → `useModel` → wcore `--model perplexity/sonar` → the engine sends `"model":"perplexity/sonar"` verbatim to `api.perplexity.ai` → 400.

The engine is told `--provider openai` (generic) and forwards the model id unchanged, so it cannot know to strip `perplexity/`. The desktop is the only layer that knows `providerId === 'perplexity'`, so the fix belongs here.

## Fix

Strip a redundant leading `<providerId>/` self-prefix at catalog ingestion. Only the provider's **own** prefix is removed:

- `perplexity/sonar` → `sonar` (self-prefix, stripped)
- `anthropic/claude-opus-4-5` under Perplexity → kept (upstream-vendor prefix Perplexity routes on)
- OpenRouter is never touched — its ids namespace by upstream vendor and never start with `openrouter/`

The bare id additionally now matches models.dev, so these models enrich correctly (display name, pricing, context) instead of showing raw.

Mirrors the existing Gemini `models/`-prefix strip in the same file.

## Tests

Added two cases to `tests/unit/process/providers/sources.test.ts` (self-prefix stripped; upstream-vendor prefix kept). Full file: 31 passed. `tsc --noEmit` clean; oxfmt clean on changed files.

Fixes #603