### PR TITLE
fix(workflow): surface the model switcher inside workflows (#587)

### DIFF
--- a/src/renderer/pages/conversation/components/ChatConversation.tsx
+++ b/src/renderer/pages/conversation/components/ChatConversation.tsx
@@ -268,13 +268,12 @@ const WCoreConversationPanel: React.FC<{ conversation: WCoreConversation; slider
   );
 };
 
-// #132: wcore/gemini conversations wrapped in WorkflowSurface previously got a
-// null-object model selection (currentModel: undefined), so typing in the
-// composer threw "No model selected for current session" - the send box gate
-// requires currentModel?.useModel. These panels own the real selection hook
-// seeded from conversation.model (identical to the non-workflow panels above).
-// The surface still hides the header (hideHeader), so no in-workflow model
-// switcher is shown; the selection exists purely so the composer can send.
+// #132: wcore/gemini conversations wrapped in WorkflowSurface own the real
+// selection hook seeded from conversation.model (identical to the non-workflow
+// panels above), so the composer can send and - since #587 - the user can
+// switch models mid-workflow. The ChatLayout header stays hidden (hideHeader)
+// in workflow mode; the model switcher is surfaced inside WorkflowSurface's
+// top control row via `headerAccessory` instead.
 const WCoreWorkflowPanel: React.FC<{ conversation: WCoreConversation } & WorkflowPanelExtras> = ({
   conversation,
   sliderTitle,
@@ -314,6 +313,7 @@ const WCoreWorkflowPanel: React.FC<{ conversation: WCoreConversation } & Workflo
           sessionId={workflowSessionId}
           initialSession={initialWorkflowSession}
           onLaunchWorkflow={onLaunchWorkflow}
+          headerAccessory={<WCoreModelSelector selection={modelSelection} conversationId={conversation.id} />}
         >
           <WCoreChat
             key={conversation.id}
@@ -370,6 +370,7 @@ const GeminiWorkflowPanel: React.FC<
           sessionId={workflowSessionId}
           initialSession={initialWorkflowSession}
           onLaunchWorkflow={onLaunchWorkflow}
+          headerAccessory={<GeminiModelSelector selection={modelSelection} />}
         >
           <GeminiChat
             key={conversation.id}

--- a/src/renderer/pages/guid/components/workflow/WorkflowSurface.module.css
+++ b/src/renderer/pages/guid/components/workflow/WorkflowSurface.module.css
@@ -46,9 +46,18 @@
   flex-shrink: 0;
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: 8px;
   padding: 8px 16px;
   border-bottom: 1px solid var(--border-base);
   background-color: var(--color-bg-2);
+}
+
+/* #587: right-aligned model switcher next to the view-mode toggle. */
+.headerAccessory {
+  display: flex;
+  align-items: center;
+  min-width: 0;
 }
 
 .asks {

--- a/src/renderer/pages/guid/components/workflow/WorkflowSurface.tsx
+++ b/src/renderer/pages/guid/components/workflow/WorkflowSurface.tsx
@@ -74,6 +74,13 @@ export type WorkflowSurfaceProps = {
    * the suggested slug. The caller (ChatConversation) routes to the launcher.
    */
   onLaunchWorkflow?: (workflowName: string) => void;
+  /**
+   * #587: right-aligned control shown in the workflow's top control row (next
+   * to the view-mode toggle). The caller passes the platform model selector so
+   * users can switch chat models mid-workflow, just like a normal chat header -
+   * the ChatLayout header itself stays hidden (`hideHeader`) in workflow mode.
+   */
+  headerAccessory?: React.ReactNode;
 };
 
 const isFreshLaunch = (session: WorkflowSession): boolean => {
@@ -102,6 +109,7 @@ export const WorkflowSurface: React.FC<WorkflowSurfaceProps> = ({
   children,
   suggestedNext,
   onLaunchWorkflow,
+  headerAccessory,
 }) => {
   const { t } = useTranslation();
   const session = useWorkflowSession(sessionId, initialSession);
@@ -475,6 +483,9 @@ export const WorkflowSurface: React.FC<WorkflowSurfaceProps> = ({
                 <Radio value='workflow'>{t('workflow.view.workflow')}</Radio>
                 <Radio value='conversation'>{t('workflow.view.conversation')}</Radio>
               </Radio.Group>
+              {/* #587: model switcher lives here so it stays reachable in a
+                  workflow (the ChatLayout header is hidden in workflow mode). */}
+              {headerAccessory && <div className={styles.headerAccessory}>{headerAccessory}</div>}
             </div>
             {showClarifyCard ? (
               <WorkflowClarifyCard

--- a/tests/unit/renderer/pages/conversation/components/ChatConversation.dom.test.tsx
+++ b/tests/unit/renderer/pages/conversation/components/ChatConversation.dom.test.tsx
@@ -348,6 +348,29 @@ describe('ChatConversation - workflow composer model selection (#132)', () => {
   });
 });
 
+describe('ChatConversation - workflow model switcher (#587)', () => {
+  // The reported bug: in a workflow the ChatLayout header is hidden, so no model
+  // switcher showed. The fix passes the platform selector to WorkflowSurface's
+  // `headerAccessory` slot. These assert the wiring actually happens.
+  it('passes the WCore model selector to WorkflowSurface via headerAccessory', () => {
+    render(<ChatConversation conversation={buildWCoreConversation({ workflowSessionId: 'sess-acc-wcore' })} />);
+
+    const accessory = workflowSurfaceCalls.at(-1)?.headerAccessory as React.ReactElement | undefined;
+    expect(accessory).toBeTruthy();
+    const { getByTestId } = render(<>{accessory}</>);
+    expect(getByTestId('mock-wcore-model-selector')).toBeTruthy();
+  });
+
+  it('passes the Gemini model selector to WorkflowSurface via headerAccessory', () => {
+    render(<ChatConversation conversation={buildGeminiConversation({ workflowSessionId: 'sess-acc-gemini' })} />);
+
+    const accessory = workflowSurfaceCalls.at(-1)?.headerAccessory as React.ReactElement | undefined;
+    expect(accessory).toBeTruthy();
+    const { getByTestId } = render(<>{accessory}</>);
+    expect(getByTestId('mock-gemini-model-selector')).toBeTruthy();
+  });
+});
+
 describe('ChatConversation - workflowSessionId from location.state', () => {
   it('state.workflowSessionId takes precedence when both state and extra are present', () => {
     // State says 'state-sess', extra says 'extra-sess' - state wins.

--- a/tests/unit/renderer/pages/guid/components/workflow/WorkflowSurface.dom.test.tsx
+++ b/tests/unit/renderer/pages/guid/components/workflow/WorkflowSurface.dom.test.tsx
@@ -59,9 +59,7 @@ vi.mock('@/renderer/pages/guid/components/workflow/WorkflowHeader', () => ({
     const paused = Boolean(props.paused);
     return (
       <div data-testid='mock-workflow-header' data-paused={paused ? 'true' : 'false'}>
-        <button onClick={props.onPauseToggle as () => void}>
-          {paused ? 'Resume' : 'Pause'}
-        </button>
+        <button onClick={props.onPauseToggle as () => void}>{paused ? 'Resume' : 'Pause'}</button>
         <button onClick={props.onEnd as () => void}>End workflow</button>
       </div>
     );
@@ -85,9 +83,15 @@ vi.mock('@/renderer/pages/guid/components/workflow/WorkflowStepRail', () => ({
 vi.mock('@/renderer/pages/guid/components/workflow/StepReviewBeat', () => ({
   StepReviewBeat: (props: CapturedProps) => (
     <div data-testid='mock-step-review-beat'>
-      <button onClick={props.onAccept as () => void} data-testid='review-beat-accept'>Accept</button>
-      <button onClick={props.onRevise as () => void} data-testid='review-beat-revise'>Revise</button>
-      <button onClick={props.onGoBack as () => void} data-testid='review-beat-go-back'>Go back</button>
+      <button onClick={props.onAccept as () => void} data-testid='review-beat-accept'>
+        Accept
+      </button>
+      <button onClick={props.onRevise as () => void} data-testid='review-beat-revise'>
+        Revise
+      </button>
+      <button onClick={props.onGoBack as () => void} data-testid='review-beat-go-back'>
+        Go back
+      </button>
     </div>
   ),
   default: () => null,
@@ -150,10 +154,7 @@ vi.mock('@/renderer/pages/guid/components/workflow/AskCard', () => ({
 vi.mock('@/renderer/pages/guid/components/workflow/WorkflowClarifyCard', () => ({
   WorkflowClarifyCard: (props: CapturedProps) => (
     <div data-testid='mock-workflow-clarify-card'>
-      <button
-        data-testid='mock-clarify-start'
-        onClick={() => (props.onStart as (note: string) => void)('')}
-      >
+      <button data-testid='mock-clarify-start' onClick={() => (props.onStart as (note: string) => void)('')}>
         Start
       </button>
       <button
@@ -177,22 +178,13 @@ vi.mock('@arco-design/web-react', () => ({
       {children}
     </button>
   ),
-  Radio: Object.assign(
-    ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
-    {
-      Group: ({
-        children,
-        value,
-      }: {
-        children?: React.ReactNode;
-        value?: string;
-      }) => (
-        <div data-testid='mock-radio-group' data-value={value}>
-          {children}
-        </div>
-      ),
-    }
-  ),
+  Radio: Object.assign(({ children }: { children?: React.ReactNode }) => <span>{children}</span>, {
+    Group: ({ children, value }: { children?: React.ReactNode; value?: string }) => (
+      <div data-testid='mock-radio-group' data-value={value}>
+        {children}
+      </div>
+    ),
+  }),
 }));
 
 // useWorkflowSession is the hook under composition. Stub it with a
@@ -697,5 +689,40 @@ describe('WorkflowSurface', () => {
 
     // sendMessage must NOT fire for a mid-flight resume.
     expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  // #587: the caller (ChatConversation workflow panels) passes the platform
+  // model selector as `headerAccessory` so users can switch chat models
+  // mid-workflow - the ChatLayout header is hidden in workflow mode, so without
+  // this slot there was no model switcher at all (the reported bug).
+  describe('#587 headerAccessory (model switcher slot)', () => {
+    const accessory = <div data-testid='model-accessory'>MODEL-SWITCHER</div>;
+
+    it('renders the headerAccessory alongside the view-mode toggle once launched (resumed session)', () => {
+      renderPostOverlay(buildSession({ begin_sent_at: NOW - 1000 }), { headerAccessory: accessory });
+
+      // The switcher is present next to the workflow/conversation view toggle.
+      expect(screen.getByTestId('model-accessory')).toBeTruthy();
+      expect(screen.getByTestId('mock-radio-group')).toBeTruthy();
+    });
+
+    it('surfaces the switcher even at the clarify beat (fresh session, before Start)', () => {
+      // A user whose model ran out of credits needs to switch BEFORE the first
+      // send. The accessory row renders above the clarify card, so it must show
+      // even while the clarify card is up.
+      renderPostOverlay(buildSession({ begin_sent_at: null }), { headerAccessory: accessory }, { skipClarify: false });
+
+      expect(screen.getByTestId('mock-workflow-clarify-card')).toBeTruthy();
+      expect(screen.getByTestId('model-accessory')).toBeTruthy();
+    });
+
+    it('renders nothing extra when no headerAccessory is provided (back-compat)', () => {
+      renderPostOverlay(buildSession({ begin_sent_at: NOW - 1000 }));
+
+      expect(screen.queryByTestId('model-accessory')).toBeNull();
+      // The surface still renders its normal launched layout.
+      expect(screen.getByTestId('mock-radio-group')).toBeTruthy();
+      expect(screen.getByTestId('caller-children')).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
## What & why

Addresses #587 — "LLM Model Selector isn't available after starting a Workflow."

In a normal chat the model name/switcher sits in the ChatLayout header. Workflow conversations render inside `WorkflowSurface` with the ChatLayout header **hidden** (`hideHeader={true}`), so that switcher was never shown — a user whose model ran out of credits mid-workflow had no way to change it (exactly the reported bug).

## Fix

- `WorkflowSurface` gains an optional `headerAccessory` slot, rendered right-aligned in the workflow's top control row (next to the Workflow/Conversation view toggle). It stays visible across the clarify beat, running, and complete states (it lives outside the collapse-on-complete `WorkflowHeader`).
- `WCoreWorkflowPanel` / `GeminiWorkflowPanel` pass their **already-existing** `modelSelection` into the slot as `<WCoreModelSelector>` / `<GeminiModelSelector>`. These panels already owned a real selection hook (from #132) with a working `onSelectModel` (stop engine → persist model) — the selector was simply never surfaced. No new model-switch logic; it reuses the same picker + persistence as a normal chat header.
- Updated the stale #132 comment that said "no in-workflow model switcher is shown."

Net: **+headerAccessory slot, wired for both wcore and gemini workflows.** ACP workflows are unchanged (out of scope; they use a different selector path).

## Verification

- `bun run typecheck` clean; `oxlint` 0/0 on changed files; `oxfmt --check` clean.
- **36 unit tests pass** (both touched files):
  - `WorkflowSurface.dom.test.tsx` (+3): renders the accessory alongside the view toggle once launched (resumed), surfaces it even at the clarify beat (fresh, pre-Start), and renders nothing extra when the slot is omitted (back-compat).
  - `ChatConversation.dom.test.tsx` (+2): the wcore **and** gemini workflow panels pass their model selector to `WorkflowSurface` via `headerAccessory` (the exact wiring the bug was missing).
- **Live-verified** on a running dev build (engine 0.12.21): opened a workflow conversation → the model control (`gemma3:4b`) now shows in the top row → clicking opens the full model picker (79 enabled, Flux Auto, effort, search) → switching to **DeepSeek V4 Pro** updated the active model mid-workflow. Confirmed via DOM + screenshots.

Does not auto-close #587.
