### PR TITLE
fix(preview): show an error toast when 'open in system' fails (#621)

### DIFF
--- a/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx
+++ b/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx
@@ -38,6 +38,7 @@ import {
   type PreviewTab,
 } from '.';
 import { DEFAULT_SPLIT_RATIO, FILE_TYPES_WITH_BUILTIN_OPEN, MAX_SPLIT_WIDTH, MIN_SPLIT_WIDTH } from '../../constants';
+import { resolveOpenInSystemToast } from '../../fileUtils';
 import {
   usePreviewHistory,
   usePreviewKeyboardShortcuts,
@@ -435,10 +436,17 @@ const PreviewPanel: React.FC = () => {
     }
 
     try {
-      // Open file with system default application
-      await ipcBridge.shell.openFile.invoke(metadata.filePath);
+      // Open file with system default application. #621: openFile resolves to
+      // { ok, error? } (#616 contract) and does NOT throw on a failed shell
+      // open (e.g. no Linux xdg association), so gate the toast on `ok` (see
+      // resolveOpenInSystemToast) instead of an unconditional success.
+      const result = await ipcBridge.shell.openFile.invoke(metadata.filePath);
+      const toast = resolveOpenInSystemToast(result, {
+        success: t('preview.openInSystemSuccess'),
+        failed: t('preview.openInSystemFailed'),
+      });
       try {
-        messageApi.success(t('preview.openInSystemSuccess'));
+        messageApi[toast.kind](toast.message);
       } catch {
         // Context holder may be unmounted after async operation
       }

--- a/src/renderer/pages/conversation/Preview/components/viewers/PDFViewer.tsx
+++ b/src/renderer/pages/conversation/Preview/components/viewers/PDFViewer.tsx
@@ -5,6 +5,7 @@
  */
 
 import { ipcBridge } from '@/common';
+import { resolveOpenInSystemToast } from '../../fileUtils';
 import { usePreviewToolbarExtras } from '../../context/PreviewToolbarExtrasContext';
 import { Button, Message } from '@arco-design/web-react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -43,8 +44,15 @@ const PDFPreview: React.FC<PDFPreviewProps> = ({ filePath, content, hideToolbar 
     }
 
     try {
-      await ipcBridge.shell.openFile.invoke(filePath);
-      messageApi.success(t('preview.openInSystemSuccess'));
+      // #621: openFile resolves to { ok, error? } (#616 contract) and does NOT
+      // throw on a failed shell open, so gate the toast on `ok` (see
+      // resolveOpenInSystemToast) instead of showing an unconditional success.
+      const result = await ipcBridge.shell.openFile.invoke(filePath);
+      const toast = resolveOpenInSystemToast(result, {
+        success: t('preview.openInSystemSuccess'),
+        failed: t('preview.openInSystemFailed'),
+      });
+      messageApi[toast.kind](toast.message);
     } catch (err) {
       messageApi.error(t('preview.openInSystemFailed'));
     }

--- a/src/renderer/pages/conversation/Preview/fileUtils.ts
+++ b/src/renderer/pages/conversation/Preview/fileUtils.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { ShellOpenResult } from '@/common/adapter/ipcBridge';
 import type { PreviewContentType } from '@/common/types/preview';
 
 /**
@@ -109,3 +110,26 @@ export const isOfficeFile = (filePath: string): boolean => {
   const contentType = getContentTypeByExtension(filePath);
   return ['word', 'excel', 'ppt'].includes(contentType);
 };
+
+/** The toast an "open in system" action should show. */
+export type OpenInSystemToast = { kind: 'success' | 'error'; message: string };
+
+/**
+ * #621: decide the toast for an "open in system" action.
+ *
+ * `shell.openFile` resolves to `{ ok, error? }` (the #616 contract) and does
+ * NOT throw when the shell open fails (e.g. a Linux file type with no xdg
+ * association). Callers that only caught a thrown error therefore showed a
+ * misleading success toast. Gate success on `ok`, and on failure surface the
+ * real `error` when present, falling back to the localized failed message.
+ *
+ * @param result - the ShellOpenResult (undefined tolerated → treated as failure)
+ * @param messages - already-localized success/failed strings
+ */
+export const resolveOpenInSystemToast = (
+  result: ShellOpenResult | undefined,
+  messages: { success: string; failed: string }
+): OpenInSystemToast =>
+  result?.ok
+    ? { kind: 'success', message: messages.success }
+    : { kind: 'error', message: result?.error || messages.failed };

--- a/tests/unit/previewPanelMessageApi.test.ts
+++ b/tests/unit/previewPanelMessageApi.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 
+import { resolveOpenInSystemToast } from '@/renderer/pages/conversation/Preview/fileUtils';
+
 /**
  * Tests for the defensive messageApi pattern used in PreviewPanel's handleOpenInSystem.
  *
@@ -67,5 +69,31 @@ describe('handleOpenInSystem defensive messageApi pattern', () => {
     }
 
     expect(messageApi.success).toHaveBeenCalledWith('Open in system succeeded');
+  });
+});
+
+// #621: the "open in system" handlers (PreviewPanel + PDFViewer) must gate the
+// success toast on ShellOpenResult.ok - a failed shell open resolves { ok:false }
+// rather than throwing, so the old catch-only code showed a misleading success.
+describe('resolveOpenInSystemToast (#621)', () => {
+  const messages = { success: 'Opened', failed: 'Failed to open' };
+
+  it('shows the success toast when the shell open succeeded (ok:true)', () => {
+    expect(resolveOpenInSystemToast({ ok: true }, messages)).toEqual({ kind: 'success', message: 'Opened' });
+  });
+
+  it('shows an error toast surfacing the real error when the open failed (ok:false with error)', () => {
+    expect(resolveOpenInSystemToast({ ok: false, error: 'no xdg association' }, messages)).toEqual({
+      kind: 'error',
+      message: 'no xdg association',
+    });
+  });
+
+  it('falls back to the localized failed message when ok:false has no error string', () => {
+    expect(resolveOpenInSystemToast({ ok: false }, messages)).toEqual({ kind: 'error', message: 'Failed to open' });
+  });
+
+  it('treats a missing/undefined result as a failure (never a false success)', () => {
+    expect(resolveOpenInSystemToast(undefined, messages)).toEqual({ kind: 'error', message: 'Failed to open' });
   });
 });


### PR DESCRIPTION
## What & why

Addresses #621 — the Preview/PDF "open in system" buttons showed a **success toast even when the open failed**.

Root cause (adjacent to #616): `shell.openFile` used to throw on failure, so both call sites caught the throw and showed error-on-catch / success-otherwise. Since #616/PR #620 changed the contract to resolve `{ ok, error? }` (a failed shell open — e.g. a Linux file type with no xdg association — no longer throws), the catch-only code never observed the failure and always showed success.

## Fix

- New shared pure helper `resolveOpenInSystemToast(result, { success, failed })` in `Preview/fileUtils.ts`: returns `{ kind: 'success' }` only when `result.ok`, else `{ kind: 'error' }` surfacing `result.error` (falling back to the localized failed message). Undefined result is treated as failure (never a false success).
- `PreviewPanel.tsx` (~439) and `PDFViewer.tsx` (~46) now call the helper and dispatch the resulting toast, keeping their existing defensive try/catch (unmounted-context-holder guard) intact.

DRYs the two identical branches and follows the established `result.error || t(...)` pattern (useMcpConnection, AgentSetupCard).

## Verification

- `bun run typecheck` clean; `oxlint` 0 errors on changed files (pre-existing warnings only, none on the new lines); `oxfmt --check` clean.
- **7 unit tests pass** in `previewPanelMessageApi.test.ts` (+4 for `resolveOpenInSystemToast`): success on `ok:true`; error surfacing the real message on `ok:false` with error; localized fallback on `ok:false` without error; failure on `undefined` result (never a false success).
- No live-verify of the Linux-no-xdg failure path (requires a Linux host with no association); the contract-level behavior is covered by the helper tests. The success path is unchanged from today.

Does not auto-close #621.
