### PR TITLE
fix(acp): #624 match HTTP 401 as a bounded token, not a bare substring

### DIFF
--- a/src/renderer/pages/conversation/platforms/acp/acpAuthFailure.ts
+++ b/src/renderer/pages/conversation/platforms/acp/acpAuthFailure.ts
@@ -19,7 +19,6 @@ const AUTH_FAILURE_SIGNATURES = [
   '[acp-auth-',
   'oauth',
   'unauthorized',
-  '401',
   // Engine-start credential failures (#629): the wcore engine bails during init
   // with "No API key found" (engine config.rs) when it is spawned without a
   // working key - the exact dead-end a paid user hit after a credit top-up left
@@ -30,7 +29,20 @@ const AUTH_FAILURE_SIGNATURES = [
   'missingapikey',
   'api key not found',
   'no working provider',
+  // NOTE: bare '401' intentionally removed (#624) - a raw substring misroutes
+  // non-auth errors that merely contain "401"; HTTP_401_PATTERN (\b401\b) below
+  // handles the real status-code shapes with word boundaries.
 ] as const;
+
+/**
+ * HTTP 401 as a standalone status code. Matched with word boundaries rather
+ * than a bare `includes('401')` so an unrelated number that merely CONTAINS
+ * "401" - e.g. a token count like 40100, or an id like 124015 - does not
+ * misroute a non-auth error to the auth-failure card (#624). `\b401\b` still
+ * matches the real shapes: "401 Unauthorized", "error 401", "status=401",
+ * "HTTP/1.1 401".
+ */
+const HTTP_401_PATTERN = /\b401\b/;
 
 /** A descriptor for how to remedy an ACP auth failure for a given backend. */
 export type AcpAuthRemedy = {
@@ -68,7 +80,7 @@ export type AcpAuthRemedy = {
 /** Case-insensitive substring match against the generic auth-failure signatures. */
 export function looksLikeAuthFailure(errorMsg: string): boolean {
   const haystack = errorMsg.toLowerCase();
-  return AUTH_FAILURE_SIGNATURES.some((signature) => haystack.includes(signature));
+  return AUTH_FAILURE_SIGNATURES.some((signature) => haystack.includes(signature)) || HTTP_401_PATTERN.test(haystack);
 }
 
 /** Display labels for backend ids that do not Title-case cleanly. */

--- a/tests/unit/acpAuthFailure.test.ts
+++ b/tests/unit/acpAuthFailure.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  looksLikeAuthFailure,
+  classifyAcpAuthFailure,
+} from '@renderer/pages/conversation/platforms/acp/acpAuthFailure';
+
+describe('looksLikeAuthFailure', () => {
+  it('matches genuine auth-failure signatures', () => {
+    for (const msg of [
+      'Invalid API key',
+      'authentication failed',
+      '认证失败',
+      '[acp-auth-blocked] subscription login rejected',
+      'OAuth token expired',
+      'Unauthorized',
+      'createSession returned an error',
+    ]) {
+      expect(looksLikeAuthFailure(msg)).toBe(true);
+    }
+  });
+
+  it('matches HTTP 401 only as a standalone status code', () => {
+    for (const msg of [
+      '401 Unauthorized',
+      'Error: 401',
+      'request failed with status 401',
+      'status=401',
+      'HTTP/1.1 401 Unauthorized',
+      '(401)',
+      'code: 401.',
+    ]) {
+      expect(looksLikeAuthFailure(msg)).toBe(true);
+    }
+  });
+
+  it('does NOT match a number that merely CONTAINS 401 (#624 regression guard)', () => {
+    for (const msg of [
+      'processed 40100 tokens',
+      'context window used: 8401923 tokens',
+      'job id 124015 failed to schedule',
+      'retry after 4011 ms',
+      'wrote 40160 bytes to disk',
+      'rate limit: 24012 requests',
+    ]) {
+      expect(looksLikeAuthFailure(msg)).toBe(false);
+    }
+  });
+
+  it('returns false for unrelated errors with no auth signal', () => {
+    for (const msg of ['ECONNREFUSED', 'model not found', 'timeout after 30s', '']) {
+      expect(looksLikeAuthFailure(msg)).toBe(false);
+    }
+  });
+});
+
+describe('classifyAcpAuthFailure', () => {
+  it('returns a remedy for a real 401 auth failure', () => {
+    const remedy = classifyAcpAuthFailure('claude', 'Error: 401 Unauthorized');
+    expect(remedy).not.toBeNull();
+    expect(remedy?.backend).toBe('claude');
+    expect(remedy?.backendLabel).toBe('Claude Code');
+  });
+
+  it('returns null for a non-auth error whose numbers embed 401', () => {
+    expect(classifyAcpAuthFailure('claude', 'streamed 40100 tokens then stopped')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #624. classifyAcpAuthFailure detected HTTP 401 by testing whether the error text contained the bare substring 401. Any unrelated number that embeds "401" — a token count like 40100, an id like 124015 — therefore misrouted a non-auth error to the ACP auth-failure card.

## Fix
Drop 401 from the plain substring list and match it as a bounded status-code token with a word-boundary regex. This still matches every real shape (401 Unauthorized, error 401, status=401, HTTP/1.1 401) while ignoring numbers that merely contain the digits. This mirrors the already-correct isProviderKeyAuthFailure detector in providers/detection/authFailure.ts, which uses the same boundaried pattern.

## Verification
Comprehensive unit tests (tests/unit/acpAuthFailure.test.ts, 6 cases): real 401 shapes classify as auth; embedded-number errors (40100, 8401923, 124015, 4011, 40160, 24012) do NOT; the other auth signatures still match; the classifier returns a remedy for a real 401 and null for the embedded-number case. Live-triggering an ACP turn error that contains such a number is impractical, so the classifier is verified by tests against the exact reported failure shape. typecheck + lint clean.
