### PR TITLE
fix(preview): #621 gate open-in-system success toast on the openFile result

### DIFF
--- a/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx
+++ b/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx
@@ -435,10 +435,17 @@ const PreviewPanel: React.FC = () => {
     }
 
     try {
-      // Open file with system default application
-      await ipcBridge.shell.openFile.invoke(metadata.filePath);
+      // Open file with system default application. openFile resolves with
+      // { ok } even when the OS launcher fails without throwing (e.g. no xdg
+      // association on Linux), so branch on ok instead of assuming success
+      // (#621) - otherwise a failed open shows a misleading success toast.
+      const result = await ipcBridge.shell.openFile.invoke(metadata.filePath);
       try {
-        messageApi.success(t('preview.openInSystemSuccess'));
+        if (result?.ok) {
+          messageApi.success(t('preview.openInSystemSuccess'));
+        } else {
+          messageApi.error(t('preview.openInSystemFailed'));
+        }
       } catch {
         // Context holder may be unmounted after async operation
       }

--- a/src/renderer/pages/conversation/Preview/components/viewers/PDFViewer.tsx
+++ b/src/renderer/pages/conversation/Preview/components/viewers/PDFViewer.tsx
@@ -43,8 +43,15 @@ const PDFPreview: React.FC<PDFPreviewProps> = ({ filePath, content, hideToolbar 
     }
 
     try {
-      await ipcBridge.shell.openFile.invoke(filePath);
-      messageApi.success(t('preview.openInSystemSuccess'));
+      // openFile resolves with { ok } even when the OS launcher fails without
+      // throwing (e.g. no xdg association on Linux), so branch on ok instead of
+      // assuming success (#621) - otherwise a failed open shows a success toast.
+      const result = await ipcBridge.shell.openFile.invoke(filePath);
+      if (result?.ok) {
+        messageApi.success(t('preview.openInSystemSuccess'));
+      } else {
+        messageApi.error(t('preview.openInSystemFailed'));
+      }
     } catch (err) {
       messageApi.error(t('preview.openInSystemFailed'));
     }

--- a/tests/unit/previewPanelMessageApi.test.ts
+++ b/tests/unit/previewPanelMessageApi.test.ts
@@ -69,3 +69,46 @@ describe('handleOpenInSystem defensive messageApi pattern', () => {
     expect(messageApi.success).toHaveBeenCalledWith('Open in system succeeded');
   });
 });
+
+/**
+ * #621: shell.openFile resolves with a { ok, error? } result and does NOT throw
+ * when the OS launcher fails (e.g. no xdg association on Linux). Both open-in-
+ * system handlers (PreviewPanel + PDFViewer) must branch on `result.ok` rather
+ * than assuming success, or a failed open shows a misleading success toast.
+ * This mirrors the isolation approach above (the components are deeply coupled
+ * to React contexts + the IPC bridge).
+ */
+describe('handleOpenInSystem success is gated on the openFile result (#621)', () => {
+  // The exact decision both handlers make once openFile resolves.
+  function reportOpenOutcome(
+    result: { ok: boolean; error?: string } | undefined,
+    messageApi: { success: (m: string) => void; error: (m: string) => void }
+  ) {
+    if (result?.ok) {
+      messageApi.success('preview.openInSystemSuccess');
+    } else {
+      messageApi.error('preview.openInSystemFailed');
+    }
+  }
+
+  it('shows success only when the launcher reports ok', () => {
+    const messageApi = { success: vi.fn(), error: vi.fn() };
+    reportOpenOutcome({ ok: true }, messageApi);
+    expect(messageApi.success).toHaveBeenCalledWith('preview.openInSystemSuccess');
+    expect(messageApi.error).not.toHaveBeenCalled();
+  });
+
+  it('shows an error (not success) when the launcher reports ok:false without throwing', () => {
+    const messageApi = { success: vi.fn(), error: vi.fn() };
+    reportOpenOutcome({ ok: false, error: 'xdg-open: not found' }, messageApi);
+    expect(messageApi.error).toHaveBeenCalledWith('preview.openInSystemFailed');
+    expect(messageApi.success).not.toHaveBeenCalled();
+  });
+
+  it('treats a missing/undefined result as failure', () => {
+    const messageApi = { success: vi.fn(), error: vi.fn() };
+    reportOpenOutcome(undefined, messageApi);
+    expect(messageApi.error).toHaveBeenCalledWith('preview.openInSystemFailed');
+    expect(messageApi.success).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #621. The Preview and PDF "open in system" buttons showed a success toast even when the open failed. shell.openFile now resolves with a { ok, error? } result (from #616 / #620) and does NOT throw when the OS launcher fails (e.g. no xdg association on Linux), so the unconditional success toast was misleading.

## Fix
Both handlers (PreviewPanel.tsx and PDFViewer.tsx) now branch on result.ok: success toast only when ok is true, error toast otherwise (and still on a thrown IPC error). A missing/undefined result is treated as failure.

## Verification
Unit tests in previewPanelMessageApi.test.ts (the repo's isolation harness for this deeply-coupled handler) cover ok:true → success, ok:false → error, and undefined → error. typecheck + lint clean. Live-verified in the running 0.12.22 build (see PR comment).
