### PR TITLE
docs(bug-report): #611 correct two stale doc-comments

### DIFF
--- a/src/process/services/bugReport/collectBugReport.ts
+++ b/src/process/services/bugReport/collectBugReport.ts
@@ -9,8 +9,9 @@
  *
  * Gathers everything needed to file a DETAILED GitHub issue in one click:
  *   1. An app-window screenshot via Electron `webContents.capturePage()` — copied
- *      to the OS clipboard (nativeImage) and written to a temp PNG. `capturePage`
- *      needs NO OS Screen-Recording permission and captures exactly the Wayland UI.
+ *      to the OS clipboard only (as a nativeImage); no temp file is written.
+ *      `capturePage` needs NO OS Screen-Recording permission and captures exactly
+ *      the Wayland UI.
  *   2. App + bundled-engine versions and OS/arch, for the environment block.
  *   3. The sanitized `wayland_concierge_diag` overview (already secret-masked) as a
  *      compact, problem-focused markdown block.

--- a/src/renderer/utils/bugReport.ts
+++ b/src/renderer/utils/bugReport.ts
@@ -97,7 +97,9 @@ export function buildBugReportIssueUrl(data: IBugReportData | null): string {
 /**
  * Run the full one-click flow: capture + collect in main, open a pre-filled issue,
  * and toast the user that the screenshot is on the clipboard. Falls back to the
- * template chooser if the capture/collect step fails. Never throws.
+ * template chooser if the capture/collect step fails. The capture/collect phase
+ * is swallowed, but the trailing `openExternalUrl(url)` can still reject (e.g. the
+ * shell open fails), so callers should treat this as potentially throwing.
  */
 export async function fileBugReport(t: TFunction): Promise<void> {
   let data: IBugReportData | null = null;


### PR DESCRIPTION
## Summary
Fixes #611. Two doc-only corrections from the #599 cross-audit, no behavior change.

1. collectBugReport.ts module doc claimed the screenshot is copied to the clipboard AND written to a temp PNG. The implementation is clipboard-only (confirmed by its own test, "copies ONLY to clipboard (no temp file)"). The stale claim was security-relevant — a false threat model could be re-derived from it — so it is corrected to clipboard-only.
2. fileBugReport JSDoc said "Never throws", but the trailing openExternalUrl(url) can reject. Softened to note the call can throw so callers do not over-trust the guarantee.

## Verification
Doc-only; lint clean. No runtime change.
