### PR TITLE
fix(timeline): #610 redact inline secrets in tool command display

### DIFF
--- a/src/common/chat/activity/projectMessages.ts
+++ b/src/common/chat/activity/projectMessages.ts
@@ -114,7 +114,7 @@ export const acpToolCallToNode = (content: IMessageAcpToolCall['content']): Acti
     id,
     kind: 'tool',
     callId: id,
-    name: u.title ?? '',
+    name: u.title ? redactCommandSecrets(u.title) : '',
     status: ACP_STATUS[u.status] ?? 'running',
   };
 };

--- a/src/common/chat/activity/projectMessages.ts
+++ b/src/common/chat/activity/projectMessages.ts
@@ -24,6 +24,7 @@ import type {
 } from '../chatLib';
 import { nodeToStep, nodesToSteps, type ActivitySource, type ActivityStep } from './activityStep';
 import { parseWcoreSearchOutput } from './sources';
+import { redactCommandSecrets } from '@/common/utils/redactCommandSecrets';
 
 /** wcore tool_group item status -> canonical node status. */
 const TOOLGROUP_STATUS: Record<string, ActivityNode['status']> = {
@@ -70,12 +71,15 @@ const WEB_SEARCH_RE = /^web$|web[_-]?search|google[_-]?search|search[_-]?web|bra
  * "Execute: <cmd>") so a non-exec command-ish tool still surfaces something.
  */
 const toolGroupCommand = (t: IMessageToolGroup['content'][number]): string | undefined => {
+  // Mask inline secrets before the command drives the activity step label
+  // ("Running <cmd>") and any downstream node display (#610). This is the choke
+  // point for the timeline command; render components mask their own sites too.
   if (t.confirmationDetails?.type === 'exec') {
     const cmd = t.confirmationDetails.command?.trim();
-    if (cmd) return cmd;
+    if (cmd) return redactCommandSecrets(cmd);
   }
   const desc = typeof t.description === 'string' ? t.description.trim() : '';
-  return desc || undefined;
+  return desc ? redactCommandSecrets(desc) : undefined;
 };
 
 /** Map one wcore tool_group message's items to canonical tool nodes. */

--- a/src/common/utils/redactCommandSecrets.ts
+++ b/src/common/utils/redactCommandSecrets.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Mask the common secret shapes that can appear inline in a shell command so the
+ * activity timeline - which renders the REAL command since #520/#604 - never
+ * displays a live credential (#610).
+ *
+ * Deliberately TARGETED. The diagnostics redactor in conciergeDiagServer masks
+ * any long token because over-redaction is safe for a machine-read dump; a
+ * command shown to the user is different - masking every 24-char run would hide
+ * legitimate paths, flags and long args and defeat the whole point of showing
+ * the real command. So this only masks recognizable secret shapes:
+ *   - Bearer / Basic auth values (`Authorization: Bearer sk-...`),
+ *   - prefixed provider API keys (`sk-`, `sk-ant-`, `ghp_`, `xoxb-`, `glpat-`,
+ *     `AKIA`, `AIza`, Stripe `sk_live_`, ...),
+ *   - secret-named `key=value` / `key: value` / `--key value` pairs,
+ *   - URL userinfo passwords (`scheme://user:PASSWORD@host`).
+ *
+ * This is the command/args RENDER side on desktop; tool OUTPUT redaction is
+ * handled separately at the engine emit choke point (wayland-core #584).
+ */
+
+/** What a masked secret renders as. Fixed bullets - no last-4, this is a UI display. */
+const MASK = '••••••';
+
+// `Authorization: Bearer <token>` or a bare `Bearer <token>`.
+const BEARER_REGEX = /\bbearer\s+[A-Za-z0-9._~+/=-]{6,}/gi;
+
+// `Authorization: Basic <base64>`.
+const BASIC_REGEX = /\bbasic\s+[A-Za-z0-9+/=]{6,}/gi;
+
+// Prefixed provider API keys. Boundaried so an ordinary word is never masked.
+const PREFIXED_KEY_REGEX =
+  /\b(?:sk-ant-|sk-|sk_live_|sk_test_|rk_live_|rk_test_|pk_live_|pk_test_|xox[abprs]-|gh[posru]_|github_pat_|glpat-|AKIA|ASIA|AIza|gsk_|xai-|r8_|dop_v1_)[A-Za-z0-9_./-]{6,}/g;
+
+// Secret-NAMED key followed by its value. Preserves the key name + separator and
+// masks only the value, so `--api-key sk-x`, `TOKEN=abc123` and the JSON form
+// `"password":"p@ss"` all mask the value while `path=/tmp/x` (non-secret name)
+// stays untouched. The optional quote BEFORE the separator lets it catch the
+// JSON args shape (the timeline stringifies rawInput). `authorization` is
+// omitted here - Bearer/Basic handle it.
+const KEY_VALUE_REGEX =
+  /\b(api[_-]?key|apikey|access[_-]?token|refresh[_-]?token|auth[_-]?token|client[_-]?secret|secret|password|passwd|token)\b(["']?\s*[:=]\s*|\s+)(["']?)([^\s"']{4,})/gi;
+
+// `scheme://user:PASSWORD@host` - mask only the password segment.
+const URL_USERINFO_REGEX = /(\b[a-z][a-z0-9+.-]*:\/\/[^\s:@/]+:)([^\s@/]+)(@)/gi;
+
+/**
+ * Return `command` with recognizable inline secrets masked. Safe on any string
+ * (returns it unchanged when there is nothing to mask); never throws.
+ */
+export function redactCommandSecrets(command: string): string {
+  if (!command) return command;
+  let out = command;
+  out = out.replace(URL_USERINFO_REGEX, (_m, prefix: string, _secret: string, at: string) => `${prefix}${MASK}${at}`);
+  out = out.replace(BEARER_REGEX, `Bearer ${MASK}`);
+  out = out.replace(BASIC_REGEX, `Basic ${MASK}`);
+  out = out.replace(PREFIXED_KEY_REGEX, MASK);
+  out = out.replace(KEY_VALUE_REGEX, (_m, key: string, sep: string, quote: string) => `${key}${sep}${quote}${MASK}`);
+  return out;
+}

--- a/src/common/utils/redactCommandSecrets.ts
+++ b/src/common/utils/redactCommandSecrets.ts
@@ -30,8 +30,10 @@ const MASK = '••••••';
 // `Authorization: Bearer <token>` or a bare `Bearer <token>`.
 const BEARER_REGEX = /\bbearer\s+[A-Za-z0-9._~+/=-]{6,}/gi;
 
-// `Authorization: Basic <base64>`.
-const BASIC_REGEX = /\bbasic\s+[A-Za-z0-9+/=]{6,}/gi;
+// `Authorization: Basic <base64>`. Require a base64-SHAPED value (>=16 chars and
+// containing a digit or +/=/) so the common English word "basic" followed by an
+// ordinary word - `git commit -m "basic refactor"` - is never masked.
+const BASIC_REGEX = /\bbasic\s+([A-Za-z0-9+/]{16,}={0,2})/gi;
 
 // Prefixed provider API keys. Boundaried so an ordinary word is never masked.
 const PREFIXED_KEY_REGEX =
@@ -42,7 +44,9 @@ const PREFIXED_KEY_REGEX =
 // `"password":"p@ss"` all mask the value while `path=/tmp/x` (non-secret name)
 // stays untouched. The optional quote BEFORE the separator lets it catch the
 // JSON args shape (the timeline stringifies rawInput). `authorization` is
-// omitted here - Bearer/Basic handle it.
+// omitted here - Bearer/Basic handle it. NOTE: for the bare-whitespace separator
+// (no `:`/`=`) the value is masked only when it LOOKS like a credential - see the
+// replace callback - so prose like `git log --grep secret main` stays intact.
 const KEY_VALUE_REGEX =
   /\b(api[_-]?key|apikey|access[_-]?token|refresh[_-]?token|auth[_-]?token|client[_-]?secret|secret|password|passwd|token)\b(["']?\s*[:=]\s*|\s+)(["']?)([^\s"']{4,})/gi;
 
@@ -58,8 +62,18 @@ export function redactCommandSecrets(command: string): string {
   let out = command;
   out = out.replace(URL_USERINFO_REGEX, (_m, prefix: string, _secret: string, at: string) => `${prefix}${MASK}${at}`);
   out = out.replace(BEARER_REGEX, `Bearer ${MASK}`);
-  out = out.replace(BASIC_REGEX, `Basic ${MASK}`);
+  out = out.replace(BASIC_REGEX, (m: string, tok: string) => (/[0-9+/=]/.test(tok) ? `Basic ${MASK}` : m));
   out = out.replace(PREFIXED_KEY_REGEX, MASK);
-  out = out.replace(KEY_VALUE_REGEX, (_m, key: string, sep: string, quote: string) => `${key}${sep}${quote}${MASK}`);
+  out = out.replace(KEY_VALUE_REGEX, (m: string, key: string, sep: string, quote: string, value: string) => {
+    // With an explicit `:`/`=` the pair is unambiguous - always mask. With a bare
+    // whitespace separator, only mask a value that actually looks like a secret
+    // (has an uppercase/digit/symbol, or is long) so a secret-NAMED English word
+    // followed by a plain word - "grep secret main", "password field required" -
+    // is not clobbered.
+    const hasDelim = /[:=]/.test(sep);
+    const looksSecret = /[^a-z]/.test(value) || value.length >= 16;
+    if (!hasDelim && !looksSecret) return m;
+    return `${key}${sep}${quote}${MASK}`;
+  });
   return out;
 }

--- a/src/common/utils/redactCommandSecrets.ts
+++ b/src/common/utils/redactCommandSecrets.ts
@@ -47,8 +47,22 @@ const PREFIXED_KEY_REGEX =
 // omitted here - Bearer/Basic handle it. NOTE: for the bare-whitespace separator
 // (no `:`/`=`) the value is masked only when it LOOKS like a credential - see the
 // replace callback - so prose like `git log --grep secret main` stays intact.
+//
+// Leading boundary is `(?<![A-Za-z0-9])` rather than `\b`: `\w` counts `_` as a
+// word char, so `\b` MISSES an underscore-glued name like `ANTHROPIC_API_KEY=...`
+// (the `_` before `API` is not a `\b`). Excluding only `[A-Za-z0-9]` treats the
+// `_` (and any separator, and start-of-string) as a boundary, so UPPER_SNAKE and
+// snake_case key names match (#610 Overwatch).
 const KEY_VALUE_REGEX =
-  /\b(api[_-]?key|apikey|access[_-]?token|refresh[_-]?token|auth[_-]?token|client[_-]?secret|secret|password|passwd|token)\b(["']?\s*[:=]\s*|\s+)(["']?)([^\s"']{4,})/gi;
+  /(?<![A-Za-z0-9])(api[_-]?key|apikey|access[_-]?token|refresh[_-]?token|auth[_-]?token|client[_-]?secret|secret|password|passwd|token)\b(["']?\s*[:=]\s*|\s+)(["']?)([^\s"']{4,})/gi;
+
+// camelCase key names (`openaiApiKey`, `clientSecret`, `accessToken`) glue the
+// key to a lowercase prefix, so neither `\b` nor the separator boundary above
+// fires - the boundary is the lower->upper seam. This is case-SENSITIVE (no `i`
+// flag) on purpose: under `i` the `[a-z]`/`[A-Z]` classes collapse and the seam
+// is lost (#610 Overwatch). Names are the Capitalized compound forms.
+const CAMEL_KEY_VALUE_REGEX =
+  /(?<=[a-z])(ApiKey|ApiToken|ApiSecret|AccessToken|RefreshToken|AuthToken|AccessKey|SecretKey|PrivateKey|ClientSecret|Secret|Password|Passwd|Token)\b(["']?\s*[:=]\s*|\s+)(["']?)([^\s"']{4,})/g;
 
 // `scheme://user:PASSWORD@host` - mask only the password segment.
 const URL_USERINFO_REGEX = /(\b[a-z][a-z0-9+.-]*:\/\/[^\s:@/]+:)([^\s@/]+)(@)/gi;
@@ -64,7 +78,8 @@ export function redactCommandSecrets(command: string): string {
   out = out.replace(BEARER_REGEX, `Bearer ${MASK}`);
   out = out.replace(BASIC_REGEX, (m: string, tok: string) => (/[0-9+/=]/.test(tok) ? `Basic ${MASK}` : m));
   out = out.replace(PREFIXED_KEY_REGEX, MASK);
-  out = out.replace(KEY_VALUE_REGEX, (m: string, key: string, sep: string, quote: string, value: string) => {
+  // Shared key=value masker for both the snake/separator and camelCase forms.
+  const maskKeyValue = (m: string, key: string, sep: string, quote: string, value: string) => {
     // With an explicit `:`/`=` the pair is unambiguous - always mask. With a bare
     // whitespace separator, only mask a value that actually looks like a secret
     // (has an uppercase/digit/symbol, or is long) so a secret-NAMED English word
@@ -74,6 +89,8 @@ export function redactCommandSecrets(command: string): string {
     const looksSecret = /[^a-z]/.test(value) || value.length >= 16;
     if (!hasDelim && !looksSecret) return m;
     return `${key}${sep}${quote}${MASK}`;
-  });
+  };
+  out = out.replace(KEY_VALUE_REGEX, maskKeyValue);
+  out = out.replace(CAMEL_KEY_VALUE_REGEX, maskKeyValue);
   return out;
 }

--- a/src/common/utils/redactCommandSecrets.ts
+++ b/src/common/utils/redactCommandSecrets.ts
@@ -53,8 +53,18 @@ const PREFIXED_KEY_REGEX =
 // (the `_` before `API` is not a `\b`). Excluding only `[A-Za-z0-9]` treats the
 // `_` (and any separator, and start-of-string) as a boundary, so UPPER_SNAKE and
 // snake_case key names match (#610 Overwatch).
+//
+// The TRAILING side has the same `\b` trap in reverse: the recognized keyword
+// must be the LAST segment before the delimiter, so a name that GLUES more
+// segments after it - `AWS_SECRET_ACCESS_KEY=...`, `SECRET_KEY=...`,
+// `CLIENT_SECRET_ID=...`, `REFRESH_TOKEN_EXPIRY=...` - failed the old `\b`
+// (`SECRET` is followed by the `_` of `_ACCESS_KEY`, both word chars) and leaked
+// the value in full. Fix: consume any trailing `[_-]segment` runs and end on a
+// `(?![A-Za-z0-9])` lookahead (also fires against digits/punctuation, unlike
+// `\b`). The keyword AND its trailing segments are captured together so the whole
+// name is preserved in the masked render, not just the keyword (#610 Overwatch).
 const KEY_VALUE_REGEX =
-  /(?<![A-Za-z0-9])(api[_-]?key|apikey|access[_-]?token|refresh[_-]?token|auth[_-]?token|client[_-]?secret|secret|password|passwd|token)\b(["']?\s*[:=]\s*|\s+)(["']?)([^\s"']{4,})/gi;
+  /(?<![A-Za-z0-9])((?:api[_-]?key|apikey|access[_-]?token|refresh[_-]?token|auth[_-]?token|client[_-]?secret|secret|password|passwd|token)(?:[_-][a-z0-9]+)*)(?![A-Za-z0-9])(["']?\s*[:=]\s*|\s+)(["']?)([^\s"']{4,})/gi;
 
 // camelCase key names (`openaiApiKey`, `clientSecret`, `accessToken`) glue the
 // key to a lowercase prefix, so neither `\b` nor the separator boundary above

--- a/src/renderer/pages/conversation/Messages/acp/MessageAcpPermission.tsx
+++ b/src/renderer/pages/conversation/Messages/acp/MessageAcpPermission.tsx
@@ -6,6 +6,7 @@
 
 import type { IMessageAcpPermission } from '@/common/chat/chatLib';
 import { conversation } from '@/common/adapter/ipcBridge';
+import { redactCommandSecrets } from '@/common/utils/redactCommandSecrets';
 import { Button, Card, Radio, Typography } from '@arco-design/web-react';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -95,7 +96,7 @@ const MessageAcpPermission: React.FC<MessageAcpPermissionProps> = React.memo(({ 
           <div>
             <Text className='text-xs text-t-secondary mb-1'>{t('messages.command')}</Text>
             <code className='text-xs bg-1 p-2 rounded block text-t-primary break-all'>
-              {toolCall.rawInput?.command || toolCall.title}
+              {redactCommandSecrets(String(toolCall.rawInput?.command || toolCall.title || ''))}
             </code>
           </div>
         )}

--- a/src/renderer/pages/conversation/Messages/acp/MessageAcpToolCall.tsx
+++ b/src/renderer/pages/conversation/Messages/acp/MessageAcpToolCall.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { IMessageAcpToolCall } from '@/common/chat/chatLib';
+import { redactCommandSecrets } from '@/common/utils/redactCommandSecrets';
 import FileChangesPanel from '@/renderer/components/base/FileChangesPanel';
 import { useDiffPreviewHandlers } from '@/renderer/hooks/file/useDiffPreviewHandlers';
 import { parseDiff } from '@/renderer/utils/file/diffUtils';
@@ -103,15 +104,19 @@ const MessageAcpToolCall: React.FC<{ message: IMessageAcpToolCall }> = ({ messag
       <div className='flex items-start gap-3'>
         <div className='flex-1 min-w-0'>
           <div className='flex items-center gap-2 mb-2'>
-            <span className='font-medium text-t-primary'>{title || getKindDisplayName(kind)}</span>
+            <span className='font-medium text-t-primary'>
+              {title ? redactCommandSecrets(title) : getKindDisplayName(kind)}
+            </span>
             <StatusTag status={status} />
           </div>
           {rawInput && (
             <div className='text-sm'>
               {typeof rawInput === 'string' ? (
-                <MarkdownView>{`\`\`\`\n${rawInput}\n\`\`\``}</MarkdownView>
+                <MarkdownView>{`\`\`\`\n${redactCommandSecrets(rawInput)}\n\`\`\``}</MarkdownView>
               ) : (
-                <pre className='bg-1 p-2 rounded text-xs overflow-x-auto'>{JSON.stringify(rawInput, null, 2)}</pre>
+                <pre className='bg-1 p-2 rounded text-xs overflow-x-auto'>
+                  {redactCommandSecrets(JSON.stringify(rawInput, null, 2))}
+                </pre>
               )}
             </div>
           )}

--- a/src/renderer/pages/conversation/Messages/codex/ToolCallComponent/ExecCommandDisplay.tsx
+++ b/src/renderer/pages/conversation/Messages/codex/ToolCallComponent/ExecCommandDisplay.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { CodexToolCallUpdate } from '@/common/chat/chatLib';
+import { redactCommandSecrets } from '@/common/utils/redactCommandSecrets';
 import { Tag } from '@arco-design/web-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -25,7 +26,7 @@ const ExecCommandDisplay: React.FC<{ content: ExecCommandUpdate }> = ({ content 
     switch (subtype) {
       case 'exec_command_begin':
         if (data.command && Array.isArray(data.command) && data.command.length > 0) {
-          return t('tools.titles.execute_command', { command: data.command.join(' ') });
+          return t('tools.titles.execute_command', { command: redactCommandSecrets(data.command.join(' ')) });
         }
         return 'Execute Command';
       case 'exec_command_output_delta':
@@ -80,7 +81,7 @@ const ExecCommandDisplay: React.FC<{ content: ExecCommandUpdate }> = ({ content 
             <div className='text-xs text-t-secondary mb-1'>{t('tools.labels.command')}</div>
             <div className='bg-2 p-2 rounded font-mono text-xs overflow-x-auto border border-b-base'>
               <span className='text-t-secondary'>$ </span>
-              <span className='text-success'>{data.command.join(' ')}</span>
+              <span className='text-success'>{redactCommandSecrets(data.command.join(' '))}</span>
               {'cwd' in data && data.cwd && (
                 <div className='text-t-secondary text-xs mt-1'>
                   {t('tools.labels.working_directory')}: {data.cwd}

--- a/src/renderer/pages/conversation/Messages/codex/ToolCallComponent/ExecCommandDisplay.tsx
+++ b/src/renderer/pages/conversation/Messages/codex/ToolCallComponent/ExecCommandDisplay.tsx
@@ -21,7 +21,7 @@ const ExecCommandDisplay: React.FC<{ content: ExecCommandUpdate }> = ({ content 
   const { t } = useTranslation();
 
   const getDisplayTitle = () => {
-    if (title) return title;
+    if (title) return redactCommandSecrets(title);
 
     switch (subtype) {
       case 'exec_command_begin':
@@ -67,7 +67,7 @@ const ExecCommandDisplay: React.FC<{ content: ExecCommandUpdate }> = ({ content 
       toolCallId={toolCallId}
       title={getDisplayTitle()}
       status={status}
-      description={description}
+      description={description ? redactCommandSecrets(description) : description}
       icon='🔧'
       additionalTags={getAdditionalTags()}
     >

--- a/src/renderer/pages/conversation/Messages/components/MessageToolCall.tsx
+++ b/src/renderer/pages/conversation/Messages/components/MessageToolCall.tsx
@@ -6,6 +6,7 @@
 
 import { MessageCircleQuestion } from 'lucide-react';
 import type { IMessageToolCall } from '@/common/chat/chatLib';
+import { redactCommandSecrets } from '@/common/utils/redactCommandSecrets';
 import FileChangesPanel from '@/renderer/components/base/FileChangesPanel';
 import { useDiffPreviewHandlers } from '@/renderer/hooks/file/useDiffPreviewHandlers';
 import { parseDiff } from '@/renderer/utils/file/diffUtils';
@@ -65,7 +66,8 @@ const MessageToolCall: React.FC<{ message: IMessageToolCall }> = ({ message }) =
     );
   }
   if (message.content.name === 'run_shell_command') {
-    const shellSnippet = `\`\`\`shell\n${message.content.args.command}\n#${message.content.args.description}`;
+    // Mask inline secrets in the command + its description before display (#610).
+    const shellSnippet = `\`\`\`shell\n${redactCommandSecrets(message.content.args.command)}\n#${redactCommandSecrets(message.content.args.description)}`;
     return <MarkdownView>{shellSnippet}</MarkdownView>;
   }
   if (message.content.name === 'replace') {

--- a/src/renderer/pages/conversation/Messages/components/MessageToolGroup.tsx
+++ b/src/renderer/pages/conversation/Messages/components/MessageToolGroup.tsx
@@ -7,6 +7,7 @@
 import { Copy, Download, ExternalLink, Loader2 } from 'lucide-react';
 import { ipcBridge } from '@/common';
 import type { IMessageToolGroup } from '@/common/chat/chatLib';
+import { redactCommandSecrets } from '@/common/utils/redactCommandSecrets';
 import { iconColors } from '@/renderer/styles/colors';
 import { Alert, Button, Image, Message, Radio, Tag, Tooltip } from '@arco-design/web-react';
 import React, { useCallback, useContext, useMemo, useState } from 'react';
@@ -176,7 +177,9 @@ const ConfirmationDetails: React.FC<{
       case 'edit':
         return null; // Rendered separately below with hooks support
       case 'exec': {
-        const bashSnippet = `\`\`\`bash\n${confirmationDetails.command}\n\`\`\``;
+        // Mask inline secrets (Bearer tokens, sk- keys, key=value pairs) before
+        // rendering the real command in the expanded card (#610).
+        const bashSnippet = `\`\`\`bash\n${redactCommandSecrets(confirmationDetails.command)}\n\`\`\``;
         return (
           <div className='w-full max-w-100% min-w-0'>
             <MarkdownView codeStyle={CODE_STYLE}>{bashSnippet}</MarkdownView>

--- a/src/renderer/pages/conversation/Messages/components/MessageToolGroup.tsx
+++ b/src/renderer/pages/conversation/Messages/components/MessageToolGroup.tsx
@@ -609,7 +609,7 @@ const MessageToolGroup: React.FC<IMessageToolGroupProps> = ({ message }) => {
                   <div
                     className={`text-12px text-t-secondary mb-2 ${status === 'Error' ? 'whitespace-pre-wrap break-words' : 'truncate'}`}
                   >
-                    {description}
+                    {redactCommandSecrets(description)}
                   </div>
                 )}
                 {resultDisplay && (

--- a/src/renderer/pages/conversation/Messages/components/MessageToolGroupSummary.tsx
+++ b/src/renderer/pages/conversation/Messages/components/MessageToolGroupSummary.tsx
@@ -3,6 +3,7 @@ import type { BadgeProps } from '@arco-design/web-react';
 import { Badge } from '@arco-design/web-react';
 import React, { useEffect, useMemo, useState } from 'react';
 import type { IMessageAcpToolCall, IMessageToolGroup } from '@/common/chat/chatLib';
+import { redactCommandSecrets } from '@/common/utils/redactCommandSecrets';
 import './MessageToolGroupSummary.css';
 
 type ToolItem = {
@@ -55,10 +56,12 @@ const ToolGroupMapper = (m: IMessageToolGroup): ToolItem[] => {
     // Output: from resultDisplay (available for success/error/executing states)
     const output = getResultDisplayText(resultDisplay);
 
+    // Mask inline secrets in the command/args before display (#610). desc carries
+    // the exec command; input is the stringified args (which may embed a token).
     return {
       key: callId,
       name,
-      desc,
+      desc: redactCommandSecrets(desc),
       status: (status === 'Success'
         ? 'success'
         : status === 'Error'
@@ -66,7 +69,7 @@ const ToolGroupMapper = (m: IMessageToolGroup): ToolItem[] => {
           : status === 'Canceled'
             ? 'default'
             : 'processing') as BadgeProps['status'],
-      input,
+      input: input ? redactCommandSecrets(input) : undefined,
       output,
     };
   });
@@ -132,17 +135,18 @@ const ToolAcpMapper = (message: IMessageAcpToolCall): ToolItem | undefined => {
 
   const keyParam = buildParamSummary(update.kind, update.rawInput);
 
+  // Mask inline secrets in the command/args before display (#610).
   return {
     key: update.toolCallId,
     name: update.title,
-    desc: keyParam || (update.rawInput?.command as string) || update.kind,
+    desc: redactCommandSecrets(keyParam || (update.rawInput?.command as string) || update.kind),
     status:
       update.status === 'completed'
         ? 'success'
         : update.status === 'failed'
           ? 'error'
           : ('default' as BadgeProps['status']),
-    input,
+    input: input ? redactCommandSecrets(input) : undefined,
     output,
   };
 };

--- a/src/renderer/pages/conversation/components/ConversationChatConfirm.tsx
+++ b/src/renderer/pages/conversation/components/ConversationChatConfirm.tsx
@@ -1,5 +1,6 @@
 import { ipcBridge } from '@/common';
 import type { IConfirmation } from '@/common/chat/chatLib';
+import { redactCommandSecrets } from '@/common/utils/redactCommandSecrets';
 import { useConversationContextSafe } from '@/renderer/hooks/context/ConversationContext';
 import { Divider, Typography } from '@arco-design/web-react';
 import type { PropsWithChildren } from 'react';
@@ -263,11 +264,13 @@ const ConversationChatConfirm: React.FC<PropsWithChildren<{ conversation_id: str
         >
           <div className='flex-1 overflow-y-auto min-h-0'>
             <Typography.Ellipsis className='text-16px font-bold color-[var(--text-primary)]' rows={2} expandable>
-              {$t(confirmation.title) || 'Choose an action'}
+              {/* #610: mask inline secrets - the wcore/acp mapper puts the real
+                  command in the confirmation title/description ("Execute: <cmd>"). */}
+              {redactCommandSecrets($t(confirmation.title)) || 'Choose an action'}
             </Typography.Ellipsis>
             <Divider className={'!my-10px'}></Divider>
             <Typography.Ellipsis className='text-14px color-[var(--text-primary)]' rows={5} expandable>
-              {$t(confirmation.description)}
+              {redactCommandSecrets($t(confirmation.description))}
             </Typography.Ellipsis>
           </div>
           <div className='shrink-0'>

--- a/src/renderer/pages/guid/components/workflow/WorkflowTranscript.tsx
+++ b/src/renderer/pages/guid/components/workflow/WorkflowTranscript.tsx
@@ -30,10 +30,27 @@
  * acp_permission renders verbatim (fully functional). agent_status is dropped.
  */
 
-import { AlertCircle, CheckCircle2, ChevronDown, ChevronRight, Circle, Edit2, HelpCircle, Loader2, MinusCircle } from 'lucide-react';
-import type { IMessageAcpToolCall, IMessageAcpPermission, IMessageToolGroup, IMessageText, IMessageThinking } from '@/common/chat/chatLib';
+import {
+  AlertCircle,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  Circle,
+  Edit2,
+  HelpCircle,
+  Loader2,
+  MinusCircle,
+} from 'lucide-react';
+import type {
+  IMessageAcpToolCall,
+  IMessageAcpPermission,
+  IMessageToolGroup,
+  IMessageText,
+  IMessageThinking,
+} from '@/common/chat/chatLib';
 import type { StepState, WorkflowSession } from '@/common/types/workflowTypes';
 import { WAYLAND_FILES_MARKER } from '@/common/config/constants';
+import { redactCommandSecrets } from '@/common/utils/redactCommandSecrets';
 import { useConversationContextSafe } from '@/renderer/hooks/context/ConversationContext';
 import { useWorkflowViewMode } from '@/renderer/pages/guid/components/workflow/workflowViewMode';
 import { WorkflowMessageBody } from '@renderer/pages/conversation/Messages/components/WorkflowMessageBody';
@@ -58,7 +75,10 @@ const BEGIN_COMMAND_RE = /^begin\s+[a-z0-9][a-z0-9-]*\s*$/i;
 const STEP_MARKER_RE = /<step\s+n=["']?(\d+)["']?(?:\s+status=["']?([a-z_]+)["']?)?/i;
 
 const stripWorkflowEnvelopes = (text: string): string =>
-  text.replace(WORKFLOW_STEP_CONTEXT_RE, '').replace(WORKFLOW_ANSWER_RE, (_m, answer: string) => answer).trimStart();
+  text
+    .replace(WORKFLOW_STEP_CONTEXT_RE, '')
+    .replace(WORKFLOW_ANSWER_RE, (_m, answer: string) => answer)
+    .trimStart();
 
 /** The raw string content of a text message, or '' when absent. */
 const textOf = (m: IMessageText): string => {
@@ -113,11 +133,7 @@ type PanelStatus = 'done' | 'now' | 'review' | 'ask' | 'todo' | 'errored' | 'ski
 // Status derivation - panel chrome comes from the session, not the markers
 // ---------------------------------------------------------------------------
 
-const panelStatusFor = (
-  block: StepBlock,
-  session: WorkflowSession | undefined,
-  needsInput: boolean
-): PanelStatus => {
+const panelStatusFor = (block: StepBlock, session: WorkflowSession | undefined, needsInput: boolean): PanelStatus => {
   const st: StepState | undefined = session?.steps.find((s) => s.n === block.stepN);
   if (block.doneMarker || st?.status === 'done') return 'done';
   if (st?.status === 'errored') return 'errored';
@@ -178,15 +194,14 @@ const ActivityBlock: React.FC<{ item: ActivityItem }> = ({ item }) => {
   const titles = item.messages.map((m) => {
     if (m.type === 'thinking') return t('workflow.transcript.thinking');
     if (m.type === 'tool_group') return m.content?.[0]?.name ?? 'Tool';
-    return (m as IMessageAcpToolCall).content?.update?.title ?? 'Action';
+    const acpTitle = (m as IMessageAcpToolCall).content?.update?.title;
+    return acpTitle ? redactCommandSecrets(acpTitle) : 'Action';
   });
 
   return (
     <div className={styles.activity}>
       <button className={styles.activityHeader} onClick={() => setExpanded(!expanded)} aria-expanded={expanded}>
-        <span className={styles.activityIcon}>
-          {expanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
-        </span>
+        <span className={styles.activityIcon}>{expanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}</span>
         <span className={styles.activityLabel}>{t('workflow.transcript.activity', { count })}</span>
       </button>
       {expanded && (
@@ -213,7 +228,8 @@ const StepPanel: React.FC<{
   const status = panelStatusFor(block, session, needsInput);
   const live = status === 'now' && session?.run_mode === 'running';
   const isActive = status === 'now' || status === 'review' || status === 'ask';
-  const title = session?.steps.find((s) => s.n === block.stepN)?.title || stepTitles[block.stepN - 1] || `Step ${block.stepN}`;
+  const title =
+    session?.steps.find((s) => s.n === block.stepN)?.title || stepTitles[block.stepN - 1] || `Step ${block.stepN}`;
   const sub = subLineFor(block, status, session);
 
   const panelClass = [

--- a/tests/unit/redactCommandSecrets.test.ts
+++ b/tests/unit/redactCommandSecrets.test.ts
@@ -112,6 +112,30 @@ describe('redactCommandSecrets', () => {
     expect(redactCommandSecrets('password=field')).toContain('password=••••••');
   });
 
+  it('masks UPPER_SNAKE / snake_case key names glued by underscores (#610 audit)', () => {
+    // `\b` treats `_` as a word char and MISSED these - the real leak Overwatch caught.
+    const env = redactCommandSecrets('export ANTHROPIC_API_KEY=sk-ant-abc123def456');
+    expect(env).not.toContain('sk-ant-abc123def456');
+    expect(env).toContain('ANTHROPIC_API_KEY=');
+    expect(env).toContain('••••••');
+
+    expect(redactCommandSecrets('OPENAI_API_KEY=raw_secret_value_1234')).not.toContain('raw_secret_value_1234');
+    expect(redactCommandSecrets('run --config db_password=hunter2pass')).not.toContain('hunter2pass');
+    // non-secret snake name still untouched
+    expect(redactCommandSecrets('cat /etc/hosts_file=/tmp/x')).toBe('cat /etc/hosts_file=/tmp/x');
+  });
+
+  it('masks camelCase key names glued to a lowercase prefix (#610 audit)', () => {
+    const json = redactCommandSecrets('{"openaiApiKey":"sk-proj-secretvalue123"}');
+    expect(json).not.toContain('sk-proj-secretvalue123');
+    expect(json).toContain('••••••');
+
+    expect(redactCommandSecrets('config.clientSecret = topsecretvalue99')).not.toContain('topsecretvalue99');
+    expect(redactCommandSecrets('headers accessToken=abc123def456ghi')).not.toContain('abc123def456ghi');
+    // camelCase secret-named word with a plain short value stays intact (no over-mask)
+    expect(redactCommandSecrets('the userPassword field is blank')).toBe('the userPassword field is blank');
+  });
+
   it('handles empty / whitespace input', () => {
     expect(redactCommandSecrets('')).toBe('');
     expect(redactCommandSecrets('   ')).toBe('   ');

--- a/tests/unit/redactCommandSecrets.test.ts
+++ b/tests/unit/redactCommandSecrets.test.ts
@@ -84,6 +84,34 @@ describe('redactCommandSecrets', () => {
     }
   });
 
+  it('does not over-mask the common word "basic" followed by an ordinary word', () => {
+    // BASIC_REGEX must not treat prose as a Basic-auth credential (#610 audit).
+    for (const cmd of ['git commit -m "basic refactor"', 'echo basic config here', 'npm run basic-example README.md']) {
+      expect(redactCommandSecrets(cmd)).toBe(cmd);
+    }
+    // ...but a real base64-shaped Basic value is still masked.
+    const real = redactCommandSecrets('curl -H "Authorization: Basic YWxhZGRpbjpvcGVuc2VzYW1l"');
+    expect(real).toContain('Basic ••••••');
+    expect(real).not.toContain('YWxhZGRpbjpvcGVuc2VzYW1l');
+  });
+
+  it('does not over-mask a secret-named word followed by a plain word (bare-space form)', () => {
+    // The bare-whitespace separator must not clobber prose (#610 audit).
+    for (const cmd of [
+      'git log --grep secret main',
+      'echo "password field required"',
+      'token refresh completed',
+      'the client secret was rotated',
+    ]) {
+      expect(redactCommandSecrets(cmd)).toBe(cmd);
+    }
+    // ...but a credential-shaped value after the same key IS still masked.
+    expect(redactCommandSecrets('run --password hunter2pass')).not.toContain('hunter2pass');
+    expect(redactCommandSecrets('deploy --api-key sk-live-abc123def')).not.toContain('sk-live-abc123def');
+    // ...and the explicit `=`/`:` form always masks, even a plain-word value.
+    expect(redactCommandSecrets('password=field')).toContain('password=••••••');
+  });
+
   it('handles empty / whitespace input', () => {
     expect(redactCommandSecrets('')).toBe('');
     expect(redactCommandSecrets('   ')).toBe('   ');

--- a/tests/unit/redactCommandSecrets.test.ts
+++ b/tests/unit/redactCommandSecrets.test.ts
@@ -125,6 +125,27 @@ describe('redactCommandSecrets', () => {
     expect(redactCommandSecrets('cat /etc/hosts_file=/tmp/x')).toBe('cat /etc/hosts_file=/tmp/x');
   });
 
+  it('masks key names with segments glued AFTER the keyword (#610 Overwatch re-audit)', () => {
+    // The trailing `\b` treated `_` as a word char, so the keyword had to be the
+    // LAST segment before the delimiter - `AWS_SECRET_ACCESS_KEY=` leaked because
+    // `SECRET` is followed by `_ACCESS_KEY`. These are canonical real-world names.
+    const aws = redactCommandSecrets('export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY');
+    expect(aws).not.toContain('wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY');
+    expect(aws).toContain('••••••');
+    // the full key NAME is preserved (not truncated to AWS_SECRET=)
+    expect(aws).toContain('AWS_SECRET_ACCESS_KEY=');
+
+    expect(redactCommandSecrets('SECRET_KEY=django-insecure-abc123def456xyz')).not.toContain(
+      'django-insecure-abc123def456xyz'
+    );
+    expect(redactCommandSecrets('CLIENT_SECRET_ID=someRandomValue1234')).not.toContain('someRandomValue1234');
+    expect(redactCommandSecrets('API_SECRET_KEY=raw_value_abcdef123')).not.toContain('raw_value_abcdef123');
+    // hyphen-segment form too
+    expect(redactCommandSecrets('--api-key-id sk-live-abc123def456')).not.toContain('sk-live-abc123def456');
+    // a non-secret snake name with extra segments still stays intact
+    expect(redactCommandSecrets('cat /etc/hosts_file_path=/tmp/x')).toBe('cat /etc/hosts_file_path=/tmp/x');
+  });
+
   it('masks camelCase key names glued to a lowercase prefix (#610 audit)', () => {
     const json = redactCommandSecrets('{"openaiApiKey":"sk-proj-secretvalue123"}');
     expect(json).not.toContain('sk-proj-secretvalue123');

--- a/tests/unit/redactCommandSecrets.test.ts
+++ b/tests/unit/redactCommandSecrets.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { redactCommandSecrets } from '@/common/utils/redactCommandSecrets';
+
+const SECRET_FRAGMENTS = [
+  'sk-abc123def456ghi',
+  'sk-proj-abcdefghijklmnop',
+  'ghp_abc123def456ghi789',
+  'dXNlcjpwYXNzd29yZA==',
+  's3cr3tpassword',
+  'hunter2secret',
+  'mysupersecretvalue',
+];
+
+describe('redactCommandSecrets', () => {
+  it('masks Bearer tokens (incl. inside an Authorization header)', () => {
+    const out = redactCommandSecrets('curl -H "Authorization: Bearer sk-abc123def456ghi" https://api.x.com');
+    expect(out).not.toContain('sk-abc123def456ghi');
+    expect(out).toContain('Bearer ••••••');
+    expect(out).toContain('https://api.x.com'); // non-secret preserved
+  });
+
+  it('masks Basic auth credentials', () => {
+    const out = redactCommandSecrets('curl -H "Authorization: Basic dXNlcjpwYXNzd29yZA=="');
+    expect(out).not.toContain('dXNlcjpwYXNzd29yZA==');
+    expect(out).toContain('Basic ••••••');
+  });
+
+  it('masks prefixed provider API keys (sk-, ghp_)', () => {
+    expect(redactCommandSecrets('export OPENAI_API_KEY=sk-proj-abcdefghijklmnop')).not.toContain(
+      'sk-proj-abcdefghijklmnop'
+    );
+    expect(redactCommandSecrets('git clone https://ghp_abc123def456ghi789@github.com/x/y')).not.toContain(
+      'ghp_abc123def456ghi789'
+    );
+  });
+
+  it('masks secret-named key=value / key: value pairs, keeping the key name', () => {
+    const flag = redactCommandSecrets('deploy --api-key mysupersecretvalue --region us-east-1');
+    expect(flag).not.toContain('mysupersecretvalue');
+    expect(flag).toContain('--api-key ••••••');
+    expect(flag).toContain('--region us-east-1'); // non-secret flag untouched
+
+    expect(redactCommandSecrets('TOKEN=hunter2secret node app.js')).not.toContain('hunter2secret');
+    expect(redactCommandSecrets('run --password s3cr3tpassword')).not.toContain('s3cr3tpassword');
+  });
+
+  it('masks secrets in the JSON args shape (stringified rawInput)', () => {
+    const out = redactCommandSecrets('{"command":"echo hi","password":"mysupersecretvalue"}');
+    expect(out).not.toContain('mysupersecretvalue');
+    expect(out).toContain('echo hi'); // non-secret arg preserved
+  });
+
+  it('masks URL userinfo passwords, keeping user + host', () => {
+    const out = redactCommandSecrets('psql postgres://admin:s3cr3tpassword@db.internal:5432/app');
+    expect(out).not.toContain('s3cr3tpassword');
+    expect(out).toContain('postgres://admin:');
+    expect(out).toContain('@db.internal:5432/app');
+  });
+
+  it('leaves ordinary commands (paths, flags, messages) untouched', () => {
+    for (const cmd of [
+      'git commit -m "add the redaction feature"',
+      'ls -la /Users/foo/very/long/path/to/some/deeply/nested/file.txt',
+      'npm run build && npm test',
+      'rg --files-with-matches "TODO" src/',
+      'docker run --rm -p 8080:80 nginx:latest',
+    ]) {
+      expect(redactCommandSecrets(cmd)).toBe(cmd);
+    }
+  });
+
+  it('never leaks any known secret fragment across a realistic mixed command', () => {
+    const cmd =
+      'curl -H "Authorization: Bearer sk-abc123def456ghi" --data api_key=mysupersecretvalue https://admin:s3cr3tpassword@x.com';
+    const out = redactCommandSecrets(cmd);
+    for (const frag of SECRET_FRAGMENTS) {
+      if (cmd.includes(frag)) expect(out).not.toContain(frag);
+    }
+  });
+
+  it('handles empty / whitespace input', () => {
+    expect(redactCommandSecrets('')).toBe('');
+    expect(redactCommandSecrets('   ')).toBe('   ');
+  });
+});

--- a/tests/unit/renderer/conversation/ConversationChatConfirm.dom.test.tsx
+++ b/tests/unit/renderer/conversation/ConversationChatConfirm.dom.test.tsx
@@ -128,3 +128,51 @@ describe('ConversationChatConfirm — AskUserQuestion (#504)', () => {
     );
   });
 });
+
+/**
+ * #610: the wcore/acp mapper puts the REAL command into the approval prompt's
+ * title/description ("Execute: <cmd>"). Inline credentials in that command must
+ * be masked before they render — this is the approval-card leg of the timeline
+ * redaction, caught by live-verify after the activity-step leg was already fixed.
+ */
+const execConfirmation = {
+  conversation_id: CONVERSATION_ID,
+  id: 'call-exec',
+  callId: 'call-exec',
+  action: 'exec',
+  title: "Execute: echo 'Bearer sk-live-SECRETabcdef123456 api_key=MYSECRETVALUE99'",
+  description: "Execute: echo 'Bearer sk-live-SECRETabcdef123456 api_key=MYSECRETVALUE99'",
+  options: [
+    { label: 'Yes, allow once', value: 'proceed_once' },
+    { label: 'messages.confirmation.no', value: 'cancel' },
+  ],
+};
+
+describe('ConversationChatConfirm — command secret redaction (#610)', () => {
+  beforeEach(() => {
+    confirmInvoke.mockClear();
+    listInvoke.mockReset();
+    listInvoke.mockResolvedValue([execConfirmation]);
+  });
+
+  it('masks inline secrets in the approval prompt title and description', async () => {
+    render(
+      <ConversationChatConfirm conversation_id={CONVERSATION_ID}>
+        <div>child</div>
+      </ConversationChatConfirm>
+    );
+
+    // The approve option still renders so the card is up.
+    await screen.findByText('Yes, allow once');
+
+    // No raw credential shape survives anywhere in the rendered card.
+    expect(screen.queryByText(/sk-live-SECRETabcdef123456/)).toBeNull();
+    expect(screen.queryByText(/MYSECRETVALUE99/)).toBeNull();
+    expect(document.body.textContent).not.toContain('sk-live-SECRETabcdef123456');
+    expect(document.body.textContent).not.toContain('MYSECRETVALUE99');
+
+    // The mask is shown and the non-secret command shell is preserved.
+    expect(document.body.textContent).toContain('••••••');
+    expect(document.body.textContent).toContain('Execute: echo');
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #610. The activity timeline renders the real shell command (restored by #520/#604), so a command carrying an inline secret — curl -H "Authorization: Bearer sk-...", api_key=..., a DSN password — was displayed verbatim in the desktop UI. There was no redaction layer on the command/args render path.

## Fix
Adds a targeted, dependency-free redactCommandSecrets pass (src/common/utils) that masks the common inline-secret shapes:
- Bearer / Basic auth values
- prefixed provider API keys (sk-, sk-ant-, ghp_, xoxb-, glpat-, AKIA, AIza, Stripe sk_live_, ...)
- secret-named key=value / key: value / --key value pairs, including the JSON args shape "password":"..."
- URL userinfo passwords scheme://user:PASSWORD@host

It is deliberately targeted (not the aggressive diagnostics redactor in conciergeDiagServer): masking every long token would hide legitimate paths, flags and args and defeat #520's goal of showing the real command. Applied where MessageToolGroupSummary and MessageToolGroup format the command + args (the summary desc, the stringified input, and the expanded bash snippet). Tool OUTPUT redaction is a separate concern handled at the engine emit choke point (wayland-core #584).

## Verification
9 unit tests (tests/unit/redactCommandSecrets.test.ts): Bearer/Basic, prefixed keys, key=value, JSON args, URL userinfo, a realistic mixed command that leaks no known fragment, and five ordinary commands that must pass through UNCHANGED (no over-masking). typecheck + lint clean. Live-verify in the running 0.12.22 build to follow in a PR comment.
