### PR TITLE
fix(wcore): credential-recovery UI for missing-key engine init failure (Addresses #629)

### DIFF
--- a/src/process/agent/wcore/envBuilder.ts
+++ b/src/process/agent/wcore/envBuilder.ts
@@ -303,6 +303,25 @@ function stripTrailingV1(url: string): string {
 }
 
 /**
+ * Thrown by the wcore spawn path (#629) BEFORE spawning the engine when the
+ * chosen provider requires an API key but `model.apiKey` is empty - e.g. a
+ * Flux/BYO key that was injected only per-spawn and never persisted, so it came
+ * back empty on a re-run after a credit top-up. Spawning anyway would bail 30s
+ * later with a raw "No API key found" and no recovery path (the reported
+ * dead-end). The message carries the classifiable "No API key found" phrasing so
+ * the renderer's auth-failure classifier routes it to the credential-recovery
+ * card (re-enter key / reconnect Flux) instead of a raw stderr bubble.
+ */
+export class MissingApiKeyError extends Error {
+  readonly code = 'MISSING_API_KEY' as const;
+  constructor(modelLabel?: string) {
+    const suffix = modelLabel ? ` for "${modelLabel}"` : '';
+    super(`No API key found${suffix}. Re-enter your API key or reconnect Flux to continue.`);
+    this.name = 'MissingApiKeyError';
+  }
+}
+
+/**
  * Build CLI args and env vars for spawning wcore.
  */
 export function buildSpawnConfig(
@@ -339,6 +358,16 @@ export function buildSpawnConfig(
    * signal is the emitted `finish_reason:'length'`, which is budget-independent.
    */
   resolvedMaxTokens: number | undefined;
+  /**
+   * True when this spawn would hit the engine's "No API key found" init bail
+   * (#629): a key-based provider (catalog / engine-native / anthropic / cloud
+   * openai) whose `model.apiKey` is empty - the post-top-up dead-end. Callers
+   * MUST NOT spawn a doomed keyless engine; they throw a {@link MissingApiKeyError}
+   * so the credential-recovery card shows instead of a 30s ready-timeout + raw
+   * stderr. False for ChatGPT-OAuth, keyless-local openai, bedrock/vertex
+   * (non-key auth), and raw-engine mode - none require `model.apiKey`.
+   */
+  missingRequiredApiKey: boolean;
 } {
   // Raw-engine mode: pass ONLY the session-protocol args and let the engine
   // resolve provider/model/auth/tokens/security from its own config.toml. No
@@ -351,7 +380,7 @@ export function buildSpawnConfig(
     } else if (options.sessionId) {
       args.push('--session-id', options.sessionId);
     }
-    return { args, env: {}, projectConfig: '', resolvedMaxTokens: undefined };
+    return { args, env: {}, projectConfig: '', resolvedMaxTokens: undefined, missingRequiredApiKey: false };
   }
 
   const provider = mapProvider(model);
@@ -396,7 +425,9 @@ export function buildSpawnConfig(
     const envVar = catalogEnvVarById().get(catalogId);
     if (envVar && model.apiKey) env[envVar] = model.apiKey;
     const projectConfig = buildProjectConfig(model, provider);
-    return { args, env, projectConfig, resolvedMaxTokens };
+    // A catalog provider needs its scoped key; an empty one dooms the spawn (#629).
+    const missingRequiredApiKey = !!envVar && !model.apiKey?.trim();
+    return { args, env, projectConfig, resolvedMaxTokens, missingRequiredApiKey };
   }
 
   // Engine-native providers (#177): the app persists these as openai-compatible
@@ -408,7 +439,9 @@ export function buildSpawnConfig(
   if (nativeEnvVar !== undefined) {
     if (model.apiKey) env[nativeEnvVar] = model.apiKey;
     const projectConfig = buildProjectConfig(model, provider);
-    return { args, env, projectConfig, resolvedMaxTokens };
+    // An engine-native provider needs its scoped key; empty dooms the spawn (#629).
+    const missingRequiredApiKey = !model.apiKey?.trim();
+    return { args, env, projectConfig, resolvedMaxTokens, missingRequiredApiKey };
   }
 
   // ChatGPT subscription (#243): the engine owns the ChatGPT backend host and
@@ -419,26 +452,39 @@ export function buildSpawnConfig(
   // engine-owned, not the openai-compatible backend URL on the legacy row.
   if (provider === CHATGPT_SUBSCRIPTION_ENGINE_PROVIDER) {
     const projectConfig = buildProjectConfig(model, provider);
-    return { args, env, projectConfig, resolvedMaxTokens };
+    // OAuth backend (token from ~/.codex/auth.json) - no `model.apiKey` needed.
+    return { args, env, projectConfig, resolvedMaxTokens, missingRequiredApiKey: false };
   }
 
+  // Set for the key-based `switch` providers below (anthropic + cloud openai);
+  // the final return reports it so the caller can refuse a doomed keyless spawn.
+  let missingRequiredApiKey = false;
   switch (provider) {
-    case 'anthropic':
-      if (model.apiKey) env.ANTHROPIC_API_KEY = model.apiKey;
+    case 'anthropic': {
+      // Trim like the openai branch so a whitespace-only key is treated as empty
+      // (and flagged for recovery), not passed to the engine as a bogus key.
+      const key = model.apiKey?.trim();
+      if (key) env.ANTHROPIC_API_KEY = key;
+      else missingRequiredApiKey = true;
       if (model.baseUrl) args.push('--base-url', stripTrailingV1(model.baseUrl));
       break;
+    }
 
     case 'openai': {
       const baseUrl = resolveOpenAIBaseUrl(model);
       // Keyless LOCAL backend (local Ollama, #268): the engine still demands a
       // key for `--provider openai` or it bails at init, so inject the dummy
       // placeholder (the local daemon ignores Authorization). A keyless CLOUD
-      // endpoint is a genuine misconfig and is left to fail as before.
+      // endpoint is a genuine misconfig - #629 catches it pre-spawn (below) and
+      // routes the user to recovery instead of a raw "No API key found" bail.
       const trimmedKey = model.apiKey?.trim();
       if (trimmedKey) {
         env.OPENAI_API_KEY = trimmedKey;
       } else if (isLocalBaseUrl(baseUrl)) {
         env.OPENAI_API_KEY = LOCAL_KEYLESS_PLACEHOLDER;
+      } else {
+        // Cloud openai-compatible endpoint with no key: the spawn would bail.
+        missingRequiredApiKey = true;
       }
       if (baseUrl) args.push('--base-url', stripTrailingV1(baseUrl));
       break;
@@ -466,7 +512,7 @@ export function buildSpawnConfig(
   // Generate project config for compat overrides (e.g., max_tokens_field)
   const projectConfig = buildProjectConfig(model, provider);
 
-  return { args, env, projectConfig, resolvedMaxTokens };
+  return { args, env, projectConfig, resolvedMaxTokens, missingRequiredApiKey };
 }
 
 /**

--- a/src/process/agent/wcore/envBuilder.ts
+++ b/src/process/agent/wcore/envBuilder.ts
@@ -322,6 +322,38 @@ export class MissingApiKeyError extends Error {
 }
 
 /**
+ * Provider-key env vars the engine can read straight from the user's SHELL - the
+ * allowlisted subset of {@link ENGINE_ENV_ALLOWLIST} that carries a real key. A
+ * shell-exported one of these survives `buildEngineSpawnEnv` and satisfies the
+ * engine even when `model.apiKey` is empty, so a keyless in-app model is NOT
+ * actually doomed and must not trip the #629 missing-key guard.
+ */
+const SHELL_EXPORTABLE_KEY_VARS: ReadonlySet<string> = new Set([
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
+  'OPENAI_API_KEY',
+  'GEMINI_API_KEY',
+  'GOOGLE_API_KEY',
+]);
+
+/**
+ * True when the engine would inherit a non-empty `varName` from the user's shell
+ * (case-insensitive, mirroring `buildEngineSpawnEnv`'s allowlist), so a spawn
+ * whose `model.apiKey` is empty is still authenticated and must NOT be refused.
+ * Only the allowlisted provider-key vars pass through - a non-allowlisted scoped
+ * var (e.g. a catalog PERPLEXITY_API_KEY) never reaches the engine from the
+ * shell, so it stays "missing" (#629 audit). `env` is injectable for tests.
+ */
+export function engineInheritsShellKey(varName: string | undefined, env: NodeJS.ProcessEnv = process.env): boolean {
+  if (!varName || !SHELL_EXPORTABLE_KEY_VARS.has(varName.toUpperCase())) return false;
+  const target = varName.toUpperCase();
+  for (const [k, v] of Object.entries(env)) {
+    if (k.toUpperCase() === target && typeof v === 'string' && v.trim()) return true;
+  }
+  return false;
+}
+
+/**
  * Build CLI args and env vars for spawning wcore.
  */
 export function buildSpawnConfig(
@@ -368,6 +400,14 @@ export function buildSpawnConfig(
    * (non-key auth), and raw-engine mode - none require `model.apiKey`.
    */
   missingRequiredApiKey: boolean;
+  /**
+   * The scoped key env var the engine reads for this provider (e.g.
+   * `OPENAI_API_KEY`), when key-based. The spawn guard uses it to check whether a
+   * shell-exported key would satisfy the engine before refusing an empty
+   * `model.apiKey` (#629 audit) - so a user who exported the key in their shell
+   * is not wrongly pushed to re-enter it. Undefined for keyless spawns.
+   */
+  requiredKeyEnvVar?: string;
 } {
   // Raw-engine mode: pass ONLY the session-protocol args and let the engine
   // resolve provider/model/auth/tokens/security from its own config.toml. No
@@ -423,11 +463,12 @@ export function buildSpawnConfig(
     // here would override the engine's authority) and NO shared OPENAI_API_KEY
     // (ghost-key: a catalog provider must use its OWN scoped var).
     const envVar = catalogEnvVarById().get(catalogId);
-    if (envVar && model.apiKey) env[envVar] = model.apiKey;
+    const catalogKey = model.apiKey?.trim();
+    if (envVar && catalogKey) env[envVar] = catalogKey;
     const projectConfig = buildProjectConfig(model, provider);
     // A catalog provider needs its scoped key; an empty one dooms the spawn (#629).
-    const missingRequiredApiKey = !!envVar && !model.apiKey?.trim();
-    return { args, env, projectConfig, resolvedMaxTokens, missingRequiredApiKey };
+    const missingRequiredApiKey = !!envVar && !catalogKey;
+    return { args, env, projectConfig, resolvedMaxTokens, missingRequiredApiKey, requiredKeyEnvVar: envVar };
   }
 
   // Engine-native providers (#177): the app persists these as openai-compatible
@@ -437,11 +478,12 @@ export function buildSpawnConfig(
   // api.openai.com. Mirrors the catalog block above.
   const nativeEnvVar = nativeEngineEnvVar(provider);
   if (nativeEnvVar !== undefined) {
-    if (model.apiKey) env[nativeEnvVar] = model.apiKey;
+    const nativeKey = model.apiKey?.trim();
+    if (nativeKey) env[nativeEnvVar] = nativeKey;
     const projectConfig = buildProjectConfig(model, provider);
     // An engine-native provider needs its scoped key; empty dooms the spawn (#629).
-    const missingRequiredApiKey = !model.apiKey?.trim();
-    return { args, env, projectConfig, resolvedMaxTokens, missingRequiredApiKey };
+    const missingRequiredApiKey = !nativeKey;
+    return { args, env, projectConfig, resolvedMaxTokens, missingRequiredApiKey, requiredKeyEnvVar: nativeEnvVar };
   }
 
   // ChatGPT subscription (#243): the engine owns the ChatGPT backend host and
@@ -457,15 +499,19 @@ export function buildSpawnConfig(
   }
 
   // Set for the key-based `switch` providers below (anthropic + cloud openai);
-  // the final return reports it so the caller can refuse a doomed keyless spawn.
+  // the final return reports them so the caller can refuse a doomed keyless spawn.
   let missingRequiredApiKey = false;
+  let requiredKeyEnvVar: string | undefined;
   switch (provider) {
     case 'anthropic': {
       // Trim like the openai branch so a whitespace-only key is treated as empty
       // (and flagged for recovery), not passed to the engine as a bogus key.
       const key = model.apiKey?.trim();
       if (key) env.ANTHROPIC_API_KEY = key;
-      else missingRequiredApiKey = true;
+      else {
+        missingRequiredApiKey = true;
+        requiredKeyEnvVar = 'ANTHROPIC_API_KEY';
+      }
       if (model.baseUrl) args.push('--base-url', stripTrailingV1(model.baseUrl));
       break;
     }
@@ -485,6 +531,7 @@ export function buildSpawnConfig(
       } else {
         // Cloud openai-compatible endpoint with no key: the spawn would bail.
         missingRequiredApiKey = true;
+        requiredKeyEnvVar = 'OPENAI_API_KEY';
       }
       if (baseUrl) args.push('--base-url', stripTrailingV1(baseUrl));
       break;
@@ -512,7 +559,7 @@ export function buildSpawnConfig(
   // Generate project config for compat overrides (e.g., max_tokens_field)
   const projectConfig = buildProjectConfig(model, provider);
 
-  return { args, env, projectConfig, resolvedMaxTokens, missingRequiredApiKey };
+  return { args, env, projectConfig, resolvedMaxTokens, missingRequiredApiKey, requiredKeyEnvVar };
 }
 
 /**

--- a/src/process/agent/wcore/index.ts
+++ b/src/process/agent/wcore/index.ts
@@ -11,7 +11,7 @@ import { createInterface } from 'node:readline';
 import { parse, stringify } from 'smol-toml';
 import type { TProviderWithModel } from '@/common/config/storage';
 import { resolveWCoreBinary } from './binaryResolver';
-import { buildEngineSpawnEnv, buildSpawnConfig, MissingApiKeyError } from './envBuilder';
+import { buildEngineSpawnEnv, buildSpawnConfig, engineInheritsShellKey, MissingApiKeyError } from './envBuilder';
 import { resolveActiveConfigDir } from './profilePaths';
 import { getToolKeyStore } from './toolKeyStore';
 import { hydrateModelForSpawn } from '@process/providers/ipc/modelRegistryIpc';
@@ -243,15 +243,18 @@ export class WCoreAgent {
     // (it uses the engine's own config.toml), so skip the lookup there.
     const spawnModel = this.options.rawEngineMode ? this.options.model : await hydrateModelForSpawn(this.options.model);
 
-    const { args, env, projectConfig, resolvedMaxTokens, missingRequiredApiKey } = buildSpawnConfig(spawnModel, {
-      workspace: this.options.workspace,
-      maxTokens: this.options.maxTokens,
-      maxTurns: this.options.maxTurns,
-      autoApprove: this.options.yoloMode,
-      sessionId: this.options.sessionId,
-      resume: this.options.resume,
-      rawEngine: this.options.rawEngineMode,
-    });
+    const { args, env, projectConfig, resolvedMaxTokens, missingRequiredApiKey, requiredKeyEnvVar } = buildSpawnConfig(
+      spawnModel,
+      {
+        workspace: this.options.workspace,
+        maxTokens: this.options.maxTokens,
+        maxTurns: this.options.maxTurns,
+        autoApprove: this.options.yoloMode,
+        sessionId: this.options.sessionId,
+        resume: this.options.resume,
+        rawEngine: this.options.rawEngineMode,
+      }
+    );
 
     // #629: refuse to spawn a doomed keyless engine. When the chosen provider
     // needs an API key but `model.apiKey` resolved empty (e.g. a Flux/BYO key
@@ -260,8 +263,11 @@ export class WCoreAgent {
     // with no recovery path. Fail fast with a classifiable error so the desktop
     // routes the user to the credential-recovery card (re-enter key / reconnect
     // Flux) instead. ChatGPT-OAuth, keyless-local openai, and raw-engine mode
-    // never set this flag, so their legitimately keyless spawns are unaffected.
-    if (missingRequiredApiKey) {
+    // never set this flag. Skip the guard when the engine would still inherit a
+    // matching provider key from the user's SHELL (buildEngineSpawnEnv passes
+    // allowlisted keys through) - that spawn is authenticated, so blocking it
+    // would wrongly push a shell-key user to re-enter a key they already have.
+    if (missingRequiredApiKey && !engineInheritsShellKey(requiredKeyEnvVar)) {
       throw new MissingApiKeyError(spawnModel.useModel);
     }
 

--- a/src/process/agent/wcore/index.ts
+++ b/src/process/agent/wcore/index.ts
@@ -11,7 +11,7 @@ import { createInterface } from 'node:readline';
 import { parse, stringify } from 'smol-toml';
 import type { TProviderWithModel } from '@/common/config/storage';
 import { resolveWCoreBinary } from './binaryResolver';
-import { buildEngineSpawnEnv, buildSpawnConfig } from './envBuilder';
+import { buildEngineSpawnEnv, buildSpawnConfig, MissingApiKeyError } from './envBuilder';
 import { resolveActiveConfigDir } from './profilePaths';
 import { getToolKeyStore } from './toolKeyStore';
 import { hydrateModelForSpawn } from '@process/providers/ipc/modelRegistryIpc';
@@ -243,7 +243,7 @@ export class WCoreAgent {
     // (it uses the engine's own config.toml), so skip the lookup there.
     const spawnModel = this.options.rawEngineMode ? this.options.model : await hydrateModelForSpawn(this.options.model);
 
-    const { args, env, projectConfig, resolvedMaxTokens } = buildSpawnConfig(spawnModel, {
+    const { args, env, projectConfig, resolvedMaxTokens, missingRequiredApiKey } = buildSpawnConfig(spawnModel, {
       workspace: this.options.workspace,
       maxTokens: this.options.maxTokens,
       maxTurns: this.options.maxTurns,
@@ -252,6 +252,19 @@ export class WCoreAgent {
       resume: this.options.resume,
       rawEngine: this.options.rawEngineMode,
     });
+
+    // #629: refuse to spawn a doomed keyless engine. When the chosen provider
+    // needs an API key but `model.apiKey` resolved empty (e.g. a Flux/BYO key
+    // that was never persisted came back blank after a credit top-up), spawning
+    // would burn a 30s ready-timeout and then surface a raw "No API key found"
+    // with no recovery path. Fail fast with a classifiable error so the desktop
+    // routes the user to the credential-recovery card (re-enter key / reconnect
+    // Flux) instead. ChatGPT-OAuth, keyless-local openai, and raw-engine mode
+    // never set this flag, so their legitimately keyless spawns are unaffected.
+    if (missingRequiredApiKey) {
+      throw new MissingApiKeyError(spawnModel.useModel);
+    }
+
     this.resolvedMaxTokens = resolvedMaxTokens;
 
     // Write temporary .wcore.toml for provider compat overrides

--- a/src/renderer/pages/conversation/platforms/acp/acpAuthFailure.ts
+++ b/src/renderer/pages/conversation/platforms/acp/acpAuthFailure.ts
@@ -20,6 +20,16 @@ const AUTH_FAILURE_SIGNATURES = [
   'oauth',
   'unauthorized',
   '401',
+  // Engine-start credential failures (#629): the wcore engine bails during init
+  // with "No API key found" (engine config.rs) when it is spawned without a
+  // working key - the exact dead-end a paid user hit after a credit top-up left
+  // `model.apiKey` empty. Treat it as an auth failure so the recovery card
+  // (re-enter key / reconnect Flux) shows instead of a raw stderr bubble. The
+  // desktop's pre-spawn guard (MissingApiKeyError) also surfaces this phrasing.
+  'no api key',
+  'missingapikey',
+  'api key not found',
+  'no working provider',
 ] as const;
 
 /** A descriptor for how to remedy an ACP auth failure for a given backend. */

--- a/tests/unit/renderer/acpAuthFailure.test.ts
+++ b/tests/unit/renderer/acpAuthFailure.test.ts
@@ -22,6 +22,18 @@ describe('looksLikeAuthFailure', () => {
   it('returns false for an unrelated error', () => {
     expect(looksLikeAuthFailure('network timeout while reading file')).toBe(false);
   });
+
+  // #629 - engine-start credential failures must classify as auth failures so the
+  // recovery card shows instead of a raw stderr bubble (the post-top-up dead-end).
+  it.each([
+    'Agent failed to start: wcore exited with code 1 during init: Error: No API key found',
+    'No API key found',
+    'MissingApiKey: provider requires a key',
+    'API key not found for provider',
+    'engine start aborted: no working provider configured',
+  ])('returns true for the engine-start credential failure %s', (errorMsg) => {
+    expect(looksLikeAuthFailure(errorMsg)).toBe(true);
+  });
 });
 
 describe('classifyAcpAuthFailure', () => {
@@ -54,6 +66,18 @@ describe('classifyAcpAuthFailure', () => {
 
   it('returns null for a non-auth error', () => {
     expect(classifyAcpAuthFailure('claude', 'network timeout while reading file')).toBeNull();
+  });
+
+  it('classifies an engine-start "No API key found" failure for wcore into the recovery remedy (#629)', () => {
+    const remedy = classifyAcpAuthFailure(
+      'wcore',
+      'Agent failed to start: wcore exited with code 1 during init: Error: No API key found'
+    );
+    expect(remedy).not.toBeNull();
+    expect(remedy?.backendLabel).toBe('Wayland Core');
+    // The two remedies #629 requires: reconnect Flux + add any provider key.
+    expect(remedy?.fluxRoutable).toBe(true);
+    expect(remedy?.genericProviderKey).toBe(true);
   });
 
   it('classifies wcore as flux-routable, no CLI login, with a tailored explainer', () => {

--- a/tests/unit/wcoreEnvBuilder.missingApiKey.test.ts
+++ b/tests/unit/wcoreEnvBuilder.missingApiKey.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { buildSpawnConfig, MissingApiKeyError } from '../../src/process/agent/wcore/envBuilder';
+import { buildSpawnConfig, engineInheritsShellKey, MissingApiKeyError } from '../../src/process/agent/wcore/envBuilder';
 import { looksLikeAuthFailure } from '../../src/renderer/pages/conversation/platforms/acp/acpAuthFailure';
 import type { TProviderWithModel } from '../../src/common/config/storage';
 
@@ -80,6 +80,43 @@ describe('buildSpawnConfig - missingRequiredApiKey (#629)', () => {
     });
   });
 
+  describe('reports the scoped key env var the engine reads (for the shell-key guard)', () => {
+    it('anthropic -> ANTHROPIC_API_KEY when empty', () => {
+      const r = buildSpawnConfig(makeModel({ platform: 'anthropic', useModel: 'claude-opus-4-8', apiKey: '' }), {
+        workspace,
+      });
+      expect(r.requiredKeyEnvVar).toBe('ANTHROPIC_API_KEY');
+    });
+    it('cloud openai -> OPENAI_API_KEY when empty', () => {
+      const r = buildSpawnConfig(
+        makeModel({ platform: 'openai', useModel: 'gpt-5.1', baseUrl: 'https://api.openai.com/v1', apiKey: '' }),
+        { workspace }
+      );
+      expect(r.requiredKeyEnvVar).toBe('OPENAI_API_KEY');
+    });
+  });
+
+  describe('does NOT flag providers that use non-key credentials', () => {
+    it('bedrock (AWS creds via bedrockConfig, not model.apiKey)', () => {
+      const r = buildSpawnConfig(
+        makeModel({
+          platform: 'bedrock',
+          useModel: 'claude',
+          apiKey: '',
+          bedrockConfig: { region: 'us-east-1', authMethod: 'profile', profile: 'default' },
+        } as never),
+        { workspace }
+      );
+      expect(r.missingRequiredApiKey).toBe(false);
+    });
+    it('gemini-vertex-ai (ADC / service account, not model.apiKey)', () => {
+      const r = buildSpawnConfig(makeModel({ platform: 'gemini-vertex-ai', useModel: 'gemini-2.5-pro', apiKey: '' }), {
+        workspace,
+      });
+      expect(r.missingRequiredApiKey).toBe(false);
+    });
+  });
+
   describe('does NOT flag legitimately keyless spawns', () => {
     it('local openai (localhost) - engine gets the keyless placeholder', () => {
       const r = buildSpawnConfig(
@@ -110,6 +147,32 @@ describe('buildSpawnConfig - missingRequiredApiKey (#629)', () => {
       });
       expect(r.missingRequiredApiKey).toBe(false);
     });
+  });
+});
+
+describe('engineInheritsShellKey (#629 audit - shell-exported key must not trip the guard)', () => {
+  it('is true when the engine would inherit a non-empty allowlisted key from the shell', () => {
+    expect(engineInheritsShellKey('OPENAI_API_KEY', { OPENAI_API_KEY: 'sk-shell' })).toBe(true);
+    expect(engineInheritsShellKey('ANTHROPIC_API_KEY', { ANTHROPIC_API_KEY: 'sk-ant' })).toBe(true);
+  });
+
+  it('is case-insensitive on the env var name (mirrors buildEngineSpawnEnv)', () => {
+    expect(engineInheritsShellKey('OPENAI_API_KEY', { openai_api_key: 'sk-x' } as never)).toBe(true);
+  });
+
+  it('is false when the var is unset or blank', () => {
+    expect(engineInheritsShellKey('OPENAI_API_KEY', {})).toBe(false);
+    expect(engineInheritsShellKey('OPENAI_API_KEY', { OPENAI_API_KEY: '   ' })).toBe(false);
+  });
+
+  it('is false for a non-allowlisted scoped var even if exported (it never reaches the engine)', () => {
+    // A catalog/native scoped var is NOT in ENGINE_ENV_ALLOWLIST, so a shell export
+    // of it does not authenticate the engine - the spawn stays "missing".
+    expect(engineInheritsShellKey('PERPLEXITY_API_KEY', { PERPLEXITY_API_KEY: 'pk-x' })).toBe(false);
+  });
+
+  it('is false for an undefined var', () => {
+    expect(engineInheritsShellKey(undefined, { OPENAI_API_KEY: 'sk-x' })).toBe(false);
   });
 });
 

--- a/tests/unit/wcoreEnvBuilder.missingApiKey.test.ts
+++ b/tests/unit/wcoreEnvBuilder.missingApiKey.test.ts
@@ -1,0 +1,140 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildSpawnConfig, MissingApiKeyError } from '../../src/process/agent/wcore/envBuilder';
+import { looksLikeAuthFailure } from '../../src/renderer/pages/conversation/platforms/acp/acpAuthFailure';
+import type { TProviderWithModel } from '../../src/common/config/storage';
+
+// #629 - the desktop must not spawn a doomed keyless engine. When the chosen
+// provider needs an API key but `model.apiKey` is empty (the post-top-up
+// dead-end, where a Flux/BYO key that was only ever a per-spawn env var came back
+// blank), buildSpawnConfig reports `missingRequiredApiKey: true` so the caller
+// refuses the spawn and routes the user to the credential-recovery card.
+
+const workspace = '/tmp/ws';
+
+function makeModel(over: Partial<TProviderWithModel> & { platform: string; useModel: string }): TProviderWithModel {
+  return {
+    id: 'test-provider',
+    name: 'Test Provider',
+    baseUrl: '',
+    apiKey: '',
+    ...over,
+  } as TProviderWithModel;
+}
+
+describe('buildSpawnConfig - missingRequiredApiKey (#629)', () => {
+  describe('flags a key-requiring provider with an EMPTY key', () => {
+    it('anthropic with no key', () => {
+      const r = buildSpawnConfig(makeModel({ platform: 'anthropic', useModel: 'claude-opus-4-8', apiKey: '' }), {
+        workspace,
+      });
+      expect(r.missingRequiredApiKey).toBe(true);
+      expect(r.env.ANTHROPIC_API_KEY).toBeUndefined();
+    });
+
+    it('cloud openai with no key', () => {
+      const r = buildSpawnConfig(
+        makeModel({ platform: 'openai', useModel: 'gpt-5.1', baseUrl: 'https://api.openai.com/v1', apiKey: '' }),
+        { workspace }
+      );
+      expect(r.missingRequiredApiKey).toBe(true);
+      expect(r.env.OPENAI_API_KEY).toBeUndefined();
+    });
+
+    it('flux-router with no key (the reported post-top-up scenario)', () => {
+      const r = buildSpawnConfig(makeModel({ platform: 'flux-router', useModel: 'flux-auto', apiKey: '' }), {
+        workspace,
+      });
+      expect(r.missingRequiredApiKey).toBe(true);
+    });
+
+    it('treats a whitespace-only key as empty', () => {
+      const r = buildSpawnConfig(makeModel({ platform: 'anthropic', useModel: 'claude-opus-4-8', apiKey: '   ' }), {
+        workspace,
+      });
+      expect(r.missingRequiredApiKey).toBe(true);
+    });
+  });
+
+  describe('does NOT flag when a key is present', () => {
+    it('anthropic with a key', () => {
+      const r = buildSpawnConfig(makeModel({ platform: 'anthropic', useModel: 'claude-opus-4-8', apiKey: 'sk-x' }), {
+        workspace,
+      });
+      expect(r.missingRequiredApiKey).toBe(false);
+      expect(r.env.ANTHROPIC_API_KEY).toBe('sk-x');
+    });
+
+    it('cloud openai with a key', () => {
+      const r = buildSpawnConfig(
+        makeModel({ platform: 'openai', useModel: 'gpt-5.1', baseUrl: 'https://api.openai.com/v1', apiKey: 'sk-x' }),
+        { workspace }
+      );
+      expect(r.missingRequiredApiKey).toBe(false);
+      expect(r.env.OPENAI_API_KEY).toBe('sk-x');
+    });
+  });
+
+  describe('does NOT flag legitimately keyless spawns', () => {
+    it('local openai (localhost) - engine gets the keyless placeholder', () => {
+      const r = buildSpawnConfig(
+        makeModel({ platform: 'openai', useModel: 'llama3', baseUrl: 'http://localhost:11434/v1', apiKey: '' }),
+        { workspace }
+      );
+      expect(r.missingRequiredApiKey).toBe(false);
+      expect(r.env.OPENAI_API_KEY).toBeTruthy(); // LOCAL_KEYLESS_PLACEHOLDER
+    });
+
+    it('ChatGPT subscription (OAuth, token from ~/.codex/auth.json)', () => {
+      const r = buildSpawnConfig(
+        makeModel({
+          platform: 'openai-compatible',
+          useModel: 'gpt-5.1',
+          apiKey: '',
+          __waylandModelRegistryBridge: 'v2:chatgpt-subscription',
+        } as never),
+        { workspace }
+      );
+      expect(r.missingRequiredApiKey).toBe(false);
+    });
+
+    it('raw-engine mode (engine owns its own config.toml)', () => {
+      const r = buildSpawnConfig(makeModel({ platform: 'anthropic', useModel: 'claude-opus-4-8', apiKey: '' }), {
+        workspace,
+        rawEngine: true,
+      });
+      expect(r.missingRequiredApiKey).toBe(false);
+    });
+  });
+});
+
+describe('MissingApiKeyError (#629)', () => {
+  it('carries the classifiable "No API key found" phrasing so the recovery card fires', () => {
+    const err = new MissingApiKeyError('gpt-5.1');
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('MissingApiKeyError');
+    expect(err.code).toBe('MISSING_API_KEY');
+    expect(err.message.toLowerCase()).toContain('no api key found');
+    expect(err.message).toContain('gpt-5.1');
+    // The renderer classifier matches this phrasing (see acpAuthFailure.test.ts).
+  });
+
+  it('is usable without a model label', () => {
+    expect(new MissingApiKeyError().message.toLowerCase()).toContain('no api key found');
+  });
+
+  // End-to-end contract (#629): the spawn guard throws MissingApiKeyError ->
+  // WCoreManager.emitStartFailure wraps it as `Agent failed to start: <message>`
+  // -> the renderer's auth classifier must recognize it and show the recovery
+  // card. This ties the main-process failure to the renderer remedy so neither
+  // side can drift the "No API key found" phrasing without breaking a test.
+  it('the emitStartFailure-wrapped MissingApiKeyError is classified as an auth failure', () => {
+    const wrapped = `Agent failed to start: ${new MissingApiKeyError('gpt-5.1').message}`;
+    expect(looksLikeAuthFailure(wrapped)).toBe(true);
+  });
+});


### PR DESCRIPTION
Addresses #629.

A paid user ran out of credits mid-Ignition, topped up, re-ran, and hit a dead end: the desktop spawned wcore with an empty model.apiKey, the engine bailed at init with No API key found, and the raw stderr was shown with no way forward. This routes that failure to the existing recovery card (re-enter key / reconnect Flux) and stops the doomed keyless spawn.

What changed

- envBuilder.buildSpawnConfig now reports missingRequiredApiKey when a key-based provider (catalog / engine-native / anthropic / cloud openai / flux-router) resolves an empty or whitespace-only key, plus the scoped requiredKeyEnvVar the engine reads. ChatGPT-OAuth, keyless-local openai, bedrock/vertex (non-key auth) and raw-engine mode are never flagged.
- WCoreAgent.start throws a typed MissingApiKeyError before spawning, so the turn fails fast (no 30s ready-timeout) with classifiable text, instead of a doomed engine. The throw is captured by WCoreManager (startError) and surfaced via emitStartFailure, exactly like the existing bootstrap-failure path.
- The guard is skipped when the engine would still inherit a matching provider key from the user shell (buildEngineSpawnEnv passes allowlisted keys through), so a shell-key user is not wrongly told to re-enter a key they already have.
- The wcore auth-failure classifier learns the engine-start credential signatures (No API key found, etc.), so the bootstrap rejection surfaces the recovery card rather than a dead-end tips bubble.

The engine-side WAYLAND_HOME/keyring footgun noted in the issue is companion engine work, out of scope for this desktop PR.

Tests

- Renderer classifier: engine-start credential strings now classify to the wcore recovery remedy.
- envBuilder flag matrix across every provider branch (empty vs keyed vs legitimately-keyless), the shell-key guard (engineInheritsShellKey), requiredKeyEnvVar, and an end-to-end phrasing contract tying the main-process error to the renderer classifier.

Cross-audited (SHIP-with-nits; the MEDIUM shell-exported-key regression is fixed in the second commit). prek clean. Engine 0.12.22.
