### PR TITLE
fix(startup): resolve nvm/volta/fnm node on Finder launch + forward NVM_DIR/VOLTA_HOME (#628)

### DIFF
--- a/src/process/agent/wcore/envBuilder.ts
+++ b/src/process/agent/wcore/envBuilder.ts
@@ -536,6 +536,13 @@ const ENGINE_ENV_ALLOWLIST: readonly string[] = [
   'TMP',
   'TEMP',
   'PWD',
+  // ── Node version managers (#628) ───────────────────────────────────────
+  // getEnhancedEnv captures these when the version manager is installed but
+  // its interactive-rc export never ran (Finder/Dock launch). volta's shims
+  // in particular need VOLTA_HOME to resolve node; forward both so the engine's
+  // bash tool can run node/npm/npx installed via nvm/volta.
+  'NVM_DIR',
+  'VOLTA_HOME',
   // ── Linux dynamic linker ───────────────────────────────────────────────
   // Shared-library search path. Required on ARM64 Ubuntu 24.04 (Noble) when
   // the engine needs OpenSSL 1.1 from a non-system prefix. Without it the

--- a/src/process/utils/shellEnv.ts
+++ b/src/process/utils/shellEnv.ts
@@ -490,6 +490,69 @@ function getPosixExtraToolPaths(): string[] {
 }
 
 /**
+ * Minimum Node.js the desktop tries to surface from a version manager. Matches
+ * the ACP backends' floor (`ensureMinNodeVersion(..., 18, 17)` in
+ * acpConnectors) - Claude Code / Codex / Gemini all require Node >= 18.17.
+ */
+const NODE_MIN = { major: 18, minor: 17 } as const;
+
+/**
+ * #628: node/npm/claude installed via a version manager (nvm/volta/fnm) go on
+ * PATH from the user's INTERACTIVE rc (`~/.zshrc`), which the login-only shell
+ * env capture (`-l -c env`, see loadShellEnvironment) never sources. On a
+ * Finder/Dock/launchd start there is no interactive rc, so those node dirs are
+ * missing and the agent reports "neither Node.js nor npm" even though node is
+ * installed. Return the version-manager node bin dirs (not already on PATH) so
+ * they are discoverable regardless of how the app was launched. Appended (not
+ * prepended) so an explicitly-configured system node in the login PATH still
+ * wins; this only ADDS a fallback, it never overrides.
+ */
+function getPosixNodeManagerPaths(): string[] {
+  if (process.platform === 'win32') return [];
+
+  const homeDir = os.homedir();
+  const currentPath = process.env.PATH || '';
+  const dirs: string[] = [];
+
+  // volta exposes node through stable shims in ~/.volta/bin (they resolve the
+  // active tool via VOLTA_HOME, captured in getEnhancedEnv below).
+  const voltaBin = path.join(homeDir, '.volta', 'bin');
+  if (existsSync(voltaBin)) dirs.push(voltaBin);
+
+  // nvm/fnm (and volta's image dir) have no stable shim - resolve the concrete
+  // latest-suitable versioned bin dir via the existing scanner.
+  const nodeBin = findSuitableNodeBin(NODE_MIN.major, NODE_MIN.minor);
+  if (nodeBin) dirs.push(nodeBin);
+
+  return dirs.filter((p) => !currentPath.includes(p));
+}
+
+/**
+ * #628: capture the version-manager home vars (`NVM_DIR`, `VOLTA_HOME`) when
+ * their install dirs exist but the vars are absent from both the login shell
+ * env and process.env (the interactive rc that normally exports them was never
+ * sourced). volta's shims in particular need `VOLTA_HOME` to resolve node.
+ */
+function getPosixNodeManagerEnv(shellEnv: Record<string, string>): Record<string, string> {
+  if (process.platform === 'win32') return {};
+
+  const homeDir = os.homedir();
+  const extra: Record<string, string> = {};
+
+  const nvmDir = path.join(homeDir, '.nvm');
+  if (!shellEnv.NVM_DIR && !process.env.NVM_DIR && existsSync(nvmDir)) {
+    extra.NVM_DIR = nvmDir;
+  }
+
+  const voltaHome = path.join(homeDir, '.volta');
+  if (!shellEnv.VOLTA_HOME && !process.env.VOLTA_HOME && existsSync(voltaHome)) {
+    extra.VOLTA_HOME = voltaHome;
+  }
+
+  return extra;
+}
+
+/**
  * Get enhanced environment variables by merging shell env with process.env.
  * For PATH, we merge both sources to ensure CLI tools are found regardless of
  * how the app was started (terminal vs Finder/launchd).
@@ -516,6 +579,14 @@ export function getEnhancedEnv(customEnv?: Record<string, string>): Record<strin
     mergedPath = mergePaths(mergedPath, posixExtraPaths.join(':'));
   }
 
+  // #628: append version-manager node dirs (nvm/volta/fnm) so a Finder/Dock
+  // launch can still find node/npm/npx/claude - the login-only shell env never
+  // sourced the interactive rc that puts them on PATH.
+  const nodeManagerPaths = getPosixNodeManagerPaths();
+  if (nodeManagerPaths.length > 0) {
+    mergedPath = mergePaths(mergedPath, nodeManagerPaths.join(':'));
+  }
+
   // Prepend bundled bun directory (highest priority - ensures extensions always
   // have access to bun/bunx even if the user hasn't installed it)
   const bundledBunDir = getBundledBunDir();
@@ -533,7 +604,14 @@ export function getEnhancedEnv(customEnv?: Record<string, string>): Record<strin
     mergedPath = `${bundledNpmBinDirs.join(separator)}${separator}${mergedPath}`;
   }
 
+  // #628: capture NVM_DIR / VOLTA_HOME when their install dirs exist but the
+  // vars are missing (interactive rc that exports them was never sourced), so
+  // the version managers' own shims/CLIs resolve. Placed BEFORE the spreads so
+  // a real value from the shell/process env still wins.
+  const nodeManagerEnv = getPosixNodeManagerEnv(shellEnv);
+
   return {
+    ...nodeManagerEnv,
     ...process.env,
     ...shellEnv,
     ...customEnv,

--- a/tests/unit/shellEnv.test.ts
+++ b/tests/unit/shellEnv.test.ts
@@ -193,13 +193,17 @@ describe('getEnhancedEnv', () => {
 //   node bin and capture NVM_DIR / VOLTA_HOME.
 // -------------------------------------------------------------------
 describe('getEnhancedEnv version-manager node (#628)', () => {
+  // Build every path with path.join so the mock keys use the SAME separators as
+  // the code under test (which uses path.join). The code spoofs platform to
+  // 'darwin', but path.join still follows the REAL runner OS (backslashes on
+  // Windows), so hardcoded forward-slash literals would never match there.
   const HOME = '/home/tester';
-  const NVM_NODE_BASE = `${HOME}/.nvm/versions/node`;
-  const NVM_BIN = `${NVM_NODE_BASE}/v20.11.0/bin`;
-  const NVM_NODE = `${NVM_BIN}/node`;
-  const VOLTA_DIR = `${HOME}/.volta`;
-  const VOLTA_BIN = `${VOLTA_DIR}/bin`;
-  const NVM_DIR = `${HOME}/.nvm`;
+  const NVM_DIR = path.join(HOME, '.nvm');
+  const NVM_NODE_BASE = path.join(NVM_DIR, 'versions', 'node');
+  const NVM_BIN = path.join(NVM_NODE_BASE, 'v20.11.0', 'bin');
+  const NVM_NODE = path.join(NVM_BIN, 'node');
+  const VOLTA_DIR = path.join(HOME, '.volta');
+  const VOLTA_BIN = path.join(VOLTA_DIR, 'bin');
   const originalPlatform = process.platform;
   let savedNvmDir: string | undefined;
   let savedVoltaHome: string | undefined;

--- a/tests/unit/shellEnv.test.ts
+++ b/tests/unit/shellEnv.test.ts
@@ -201,14 +201,28 @@ describe('getEnhancedEnv version-manager node (#628)', () => {
   const VOLTA_BIN = `${VOLTA_DIR}/bin`;
   const NVM_DIR = `${HOME}/.nvm`;
   const originalPlatform = process.platform;
+  let savedNvmDir: string | undefined;
+  let savedVoltaHome: string | undefined;
 
   beforeEach(() => {
     vi.resetModules();
     Object.defineProperty(process, 'platform', { value: 'darwin' });
+    // findSuitableNodeBin derives its nvm search base from process.env.NVM_DIR
+    // (falling back to ~/.nvm). A runner/leaked NVM_DIR would point the base
+    // away from the mocked dirs and defeat the append. Neutralize both vars so
+    // these tests are deterministic regardless of the ambient env or ordering.
+    savedNvmDir = process.env.NVM_DIR;
+    savedVoltaHome = process.env.VOLTA_HOME;
+    delete process.env.NVM_DIR;
+    delete process.env.VOLTA_HOME;
   });
 
   afterEach(() => {
     Object.defineProperty(process, 'platform', { value: originalPlatform });
+    if (savedNvmDir === undefined) delete process.env.NVM_DIR;
+    else process.env.NVM_DIR = savedNvmDir;
+    if (savedVoltaHome === undefined) delete process.env.VOLTA_HOME;
+    else process.env.VOLTA_HOME = savedVoltaHome;
   });
 
   // Mock os.homedir + fs so the version-manager dirs "exist"; the login shell

--- a/tests/unit/shellEnv.test.ts
+++ b/tests/unit/shellEnv.test.ts
@@ -187,6 +187,133 @@ describe('getEnhancedEnv', () => {
 });
 
 // -------------------------------------------------------------------
+// #628 - version-manager node (nvm/volta/fnm) PATH + env on macOS/Linux.
+//   A Finder/Dock launch has a login-only shell whose PATH misses the
+//   interactive-rc node dir; getEnhancedEnv must append the version-manager
+//   node bin and capture NVM_DIR / VOLTA_HOME.
+// -------------------------------------------------------------------
+describe('getEnhancedEnv version-manager node (#628)', () => {
+  const HOME = '/home/tester';
+  const NVM_NODE_BASE = `${HOME}/.nvm/versions/node`;
+  const NVM_BIN = `${NVM_NODE_BASE}/v20.11.0/bin`;
+  const NVM_NODE = `${NVM_BIN}/node`;
+  const VOLTA_DIR = `${HOME}/.volta`;
+  const VOLTA_BIN = `${VOLTA_DIR}/bin`;
+  const NVM_DIR = `${HOME}/.nvm`;
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    vi.resetModules();
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  // Mock os.homedir + fs so the version-manager dirs "exist"; the login shell
+  // returns a PATH WITHOUT the nvm node dir (the Finder-launch condition).
+  const mockManagerFs = (present: Set<string>) => {
+    vi.doMock('os', async () => {
+      const actual = await vi.importActual<typeof import('os')>('os');
+      return { ...actual, default: { ...actual, homedir: () => HOME }, homedir: () => HOME };
+    });
+    vi.doMock('child_process', () => ({
+      // login shell PATH deliberately omits the nvm bin (the bug condition)
+      execFileSync: vi.fn().mockReturnValue('PATH=/usr/bin:/bin\nHOME=/home/tester\n'),
+      execFile: vi.fn(),
+    }));
+    vi.doMock('fs', async () => {
+      const actual = await vi.importActual<typeof import('fs')>('fs');
+      return {
+        ...actual,
+        existsSync: vi.fn((p: string) => present.has(p)),
+        readdirSync: vi.fn((p: string) => (p === NVM_NODE_BASE ? ['v20.11.0'] : [])),
+        accessSync: vi.fn((p: string) => {
+          if (!present.has(p)) throw new Error('ENOENT');
+        }),
+      };
+    });
+  };
+
+  it('appends the nvm versioned node bin dir to PATH', async () => {
+    mockManagerFs(new Set([NVM_DIR, NVM_NODE_BASE, NVM_BIN, NVM_NODE]));
+    const originalPath = process.env.PATH;
+    process.env.PATH = '/usr/bin';
+
+    const { getEnhancedEnv } = await import('@process/utils/shellEnv');
+    const result = getEnhancedEnv();
+
+    expect(result.PATH).toContain(NVM_BIN);
+    process.env.PATH = originalPath;
+  });
+
+  it('appends the volta shim dir to PATH when present', async () => {
+    mockManagerFs(new Set([VOLTA_DIR, VOLTA_BIN]));
+    const originalPath = process.env.PATH;
+    process.env.PATH = '/usr/bin';
+
+    const { getEnhancedEnv } = await import('@process/utils/shellEnv');
+    const result = getEnhancedEnv();
+
+    expect(result.PATH).toContain(VOLTA_BIN);
+    process.env.PATH = originalPath;
+  });
+
+  it('captures NVM_DIR and VOLTA_HOME when the dirs exist and the vars are unset', async () => {
+    mockManagerFs(new Set([NVM_DIR, VOLTA_DIR, VOLTA_BIN, NVM_NODE_BASE, NVM_BIN, NVM_NODE]));
+    const prevNvm = process.env.NVM_DIR;
+    const prevVolta = process.env.VOLTA_HOME;
+    delete process.env.NVM_DIR;
+    delete process.env.VOLTA_HOME;
+
+    const { getEnhancedEnv } = await import('@process/utils/shellEnv');
+    const result = getEnhancedEnv();
+
+    expect(result.NVM_DIR).toBe(NVM_DIR);
+    expect(result.VOLTA_HOME).toBe(VOLTA_DIR);
+    if (prevNvm === undefined) delete process.env.NVM_DIR;
+    else process.env.NVM_DIR = prevNvm;
+    if (prevVolta === undefined) delete process.env.VOLTA_HOME;
+    else process.env.VOLTA_HOME = prevVolta;
+  });
+
+  it('does NOT override an existing NVM_DIR from the environment', async () => {
+    mockManagerFs(new Set([NVM_DIR, NVM_NODE_BASE, NVM_BIN, NVM_NODE]));
+    const prevNvm = process.env.NVM_DIR;
+    process.env.NVM_DIR = '/custom/nvm';
+
+    const { getEnhancedEnv } = await import('@process/utils/shellEnv');
+    const result = getEnhancedEnv();
+
+    expect(result.NVM_DIR).toBe('/custom/nvm');
+    if (prevNvm === undefined) delete process.env.NVM_DIR;
+    else process.env.NVM_DIR = prevNvm;
+  });
+
+  it('adds nothing when no version manager is installed', async () => {
+    mockManagerFs(new Set()); // nothing exists
+    const originalPath = process.env.PATH;
+    process.env.PATH = '/usr/bin';
+    const prevNvm = process.env.NVM_DIR;
+    const prevVolta = process.env.VOLTA_HOME;
+    delete process.env.NVM_DIR;
+    delete process.env.VOLTA_HOME;
+
+    const { getEnhancedEnv } = await import('@process/utils/shellEnv');
+    const result = getEnhancedEnv();
+
+    expect(result.PATH).toContain('/usr/bin');
+    expect(result.NVM_DIR).toBeUndefined();
+    expect(result.VOLTA_HOME).toBeUndefined();
+
+    process.env.PATH = originalPath;
+    if (prevNvm !== undefined) process.env.NVM_DIR = prevNvm;
+    if (prevVolta !== undefined) process.env.VOLTA_HOME = prevVolta;
+  });
+});
+
+// -------------------------------------------------------------------
 // 3. Windows extra tool path detection
 //    getWindowsExtraToolPaths() is private, but its effect is visible
 //    through getEnhancedEnv() on win32.

--- a/tests/unit/wcore-toolKeyEnv.test.ts
+++ b/tests/unit/wcore-toolKeyEnv.test.ts
@@ -141,6 +141,19 @@ describe('buildEngineSpawnEnv - SEC-1 allowlist', () => {
     expect(env.LD_LIBRARY_PATH).toBe('/opt/openssl-1.1/lib:/usr/lib/aarch64-linux-gnu');
   });
 
+  it('forwards NVM_DIR and VOLTA_HOME so the engine bash tool can run version-manager node (#628)', () => {
+    // getEnhancedEnv captures these on a Finder/Dock launch; without the
+    // allowlist entry the engine spawn would strip them and volta's shims (which
+    // resolve node via VOLTA_HOME) would break even with the bin dir on PATH.
+    process.env.NVM_DIR = '/home/tester/.nvm';
+    process.env.VOLTA_HOME = '/home/tester/.volta';
+
+    const env = buildEngineSpawnEnv({ providerEnv: {} });
+
+    expect(env.NVM_DIR).toBe('/home/tester/.nvm');
+    expect(env.VOLTA_HOME).toBe('/home/tester/.volta');
+  });
+
   it('always preserves the provider auth env even though it is a secret name', () => {
     const env = buildEngineSpawnEnv({ providerEnv: { ANTHROPIC_API_KEY: 'sk-ant-123' } });
     expect(env.ANTHROPIC_API_KEY).toBe('sk-ant-123');


### PR DESCRIPTION
## Problem (Addresses #628)

On a Finder / Dock / launchd launch, the agent reported "neither Node nor npm is available" even though the user had node installed via nvm / volta / fnm. Root cause: getEnhancedEnv built PATH from a login-only shell (zsh -l), which never sources the interactive rc (~/.zshrc) where nvm/volta/fnm put node on PATH. A terminal launch (interactive shell) masked the bug; only Finder/launchd hit it.

## Fix

1. shellEnv.ts — getEnhancedEnv now also:
   - appends version-manager node dirs to PATH via findSuitableNodeBin(18.17) + volta shims (getPosixNodeManagerPaths), so a Finder/launchd launch resolves node/npm/npx/claude.
   - captures NVM_DIR / VOLTA_HOME (getPosixNodeManagerEnv) when their install dir exists but the var is absent from both the login-shell env and process.env, so the version managers' own shims/CLIs resolve. A real value from the shell/process env still wins (spread before the other env sources).
2. envBuilder.ts — adds NVM_DIR and VOLTA_HOME to ENGINE_ENV_ALLOWLIST so the allowlisted wcore engine spawn actually forwards them (without this they were captured but then stripped at the spawn seam).

getEnhancedEnv is the single choke point for the wcore engine, ACP, nanobot and openclaw spawns, so the fix covers all of them.

## Tests

- shellEnv.test.ts: +5 (appends nvm bin, appends volta shim, captures NVM_DIR/VOLTA_HOME, does not override an existing NVM_DIR, adds nothing when no manager is installed).
- wcore-toolKeyEnv.test.ts: +1 (buildEngineSpawnEnv forwards NVM_DIR/VOLTA_HOME).
- Full suite + typecheck + lint + format clean.

## Live verification (packaged, Finder/launchd condition)

Built the packaged app (engine v0.12.22) and launched the binary directly with a stripped env (env -i, minimal PATH) so the main process faithfully reproduces a Finder/launchd launch (not a terminal launch, which would leak an nvm-rich PATH and mask the bug). Login shell had no nvm on PATH (bug condition); interactive shell did.

- Agent bash tool resolved node at /Users/.../.nvm/versions/node/v20.20.2/bin/node and node --version = v20.20.2 (primary bug fixed).
- The bundled engine process env carried NVM_DIR=/Users/.../.nvm — verified via ps eww, and uniquely so vs. sibling engines built without this change (clean A/B on the same machine).

## Follow-up for Core (not this PR)

The engine forwards PATH to its own bash-tool child but not NVM_DIR, so $NVM_DIR is empty inside agent bash even though the engine process has it. This only affects tooling that reads $NVM_DIR (node resolution is unaffected — the absolute bin is on PATH). Routing this, plus a packaged-sandbox EPERM (lstat /Users) seen on child node/npm, to Core via #618.
