### PR TITLE
feat(memory): IJFW setup-status header strip on the Memory panel (Addresses #414)

### DIFF
--- a/src/renderer/pages/memory/state-branches/FullPanelShell.module.css
+++ b/src/renderer/pages/memory/state-branches/FullPanelShell.module.css
@@ -8,11 +8,74 @@
 .shell {
   position: relative;
   display: grid;
-  grid-template-rows: 56px 48px 1fr 28px;
+  /* topbar / setup-status strip (auto) / filterbar / main / statusbar */
+  grid-template-rows: 56px auto 48px 1fr 28px;
   width: 100%;
   height: 100%;
   min-height: 0;
   overflow: hidden;
+}
+
+/* ---- Setup-status health strip (#414) ---- */
+.healthStrip {
+  border-bottom: 1px solid var(--color-border-2);
+  background: var(--color-bg-2);
+  flex-shrink: 0;
+}
+
+.healthHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  height: 40px;
+  padding: 0 16px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-2);
+  text-align: left;
+}
+
+.healthHeader:hover {
+  background: var(--color-fill-1);
+}
+
+.healthDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--color-text-4);
+}
+
+.healthDot[data-tone='ok'] {
+  background: rgb(var(--success-6));
+}
+
+.healthDot[data-tone='warn'] {
+  background: rgb(var(--warning-6));
+}
+
+.healthDot[data-tone='checking'] {
+  background: var(--color-text-4);
+}
+
+.healthTitle {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-1);
+}
+
+.healthChevron {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  color: var(--color-text-3);
+}
+
+.healthBody {
+  padding: 0 16px 12px;
 }
 
 /* ---- Topbar (56px) ---- */

--- a/src/renderer/pages/memory/state-branches/FullPanelShell.tsx
+++ b/src/renderer/pages/memory/state-branches/FullPanelShell.tsx
@@ -30,11 +30,12 @@
 import React, { lazy, Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { Button, Input, Message } from '@arco-design/web-react';
 import type { RefInputType } from '@arco-design/web-react/es/Input/interface';
-import { Archive, Search, Import as ImportIcon, Settings2, Plus } from 'lucide-react';
+import { Archive, Search, Import as ImportIcon, Settings2, Plus, ChevronDown, ChevronRight } from 'lucide-react';
 import { ipcBridge } from '@/common';
 import { formatModifierShortcut } from '@/renderer/utils/platform';
 import { memory as memoryBridge, ijfw as ijfwBridge } from '@/common/adapter/ipcBridge';
-import type { IjfwStatusPayload } from '@/common/adapter/ipcBridge';
+import type { IjfwStatusPayload, IjfwLifecycleStatus } from '@/common/adapter/ipcBridge';
+import IjfwSetupStatus from '@/renderer/pages/settings/components/IjfwSetupStatus';
 import type { LastDream, ListFilter, MemoryType } from '@/common/types/memory';
 import { useTranslation } from 'react-i18next';
 import MemoryList from '../components/MemoryList';
@@ -64,8 +65,8 @@ const PromotionThresholdModalLazy = lazy(
     import('../components/PromotionThresholdModal').catch(
       (): PromotionThresholdModalModule => ({
         default: () => null,
-      }),
-    ) as Promise<PromotionThresholdModalModule>,
+      })
+    ) as Promise<PromotionThresholdModalModule>
 );
 
 // ---------------------------------------------------------------------------
@@ -97,12 +98,25 @@ const DEFAULT_FILTER: ListFilter = {
 
 const DEFAULT_THRESHOLD = 90;
 
+/** Persisted expand/collapse state for the #414 setup-status health strip. */
+const HEALTH_OPEN_KEY = 'wayland.memory.setupStatus.open';
+
+/** Coarse health tone for the strip dot, derived from the install lifecycle. */
+function statusTone(status: IjfwLifecycleStatus | null): 'ok' | 'warn' | 'checking' {
+  if (status === 'installed_current' || status === 'installed_pending_activation') return 'ok';
+  if (status === 'not_installed' || status === 'install_failed') return 'warn';
+  return 'checking'; // installing / upgrading / unknown (null)
+}
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
 const FullPanelShell: React.FC = () => {
   const { t } = useTranslation('memory');
+  // Root-namespace t for the one string reused from #591 (memory.settings.*),
+  // so the strip adds no new i18n keys.
+  const { t: tRoot } = useTranslation();
 
   const [filter, setFilter] = useState<ListFilter>(DEFAULT_FILTER);
   const [timeWindow, setTimeWindow] = useState<TimeWindow>('all');
@@ -112,6 +126,12 @@ const FullPanelShell: React.FC = () => {
 
   // cliCount from IjfwStatusPayload (no-deferment #3)
   const [cliCount, setCliCount] = useState(0);
+  // Install lifecycle status + collapse state for the #414 setup-status strip.
+  const [ijfwStatus, setIjfwStatus] = useState<IjfwLifecycleStatus | null>(null);
+  const [healthOpen, setHealthOpen] = useState<boolean>(() => {
+    const saved = typeof localStorage !== 'undefined' ? localStorage.getItem(HEALTH_OPEN_KEY) : null;
+    return saved === '1'; // default collapsed; the dot still conveys health
+  });
   const [lastDream, setLastDream] = useState<LastDream | undefined>(undefined);
   const [promotionThreshold, setPromotionThreshold] = useState(DEFAULT_THRESHOLD);
   const [showThresholdModal, setShowThresholdModal] = useState(false);
@@ -128,14 +148,20 @@ const FullPanelShell: React.FC = () => {
     const fetchStatus = async (): Promise<void> => {
       try {
         const status: IjfwStatusPayload = await ijfwBridge.getStatus.invoke();
-        if (!cancelled) setCliCount(status.cliCount ?? 0);
+        if (!cancelled) {
+          setCliCount(status.cliCount ?? 0);
+          setIjfwStatus(status.status);
+        }
       } catch {
         // Non-fatal
       }
     };
     void fetchStatus();
     const unsub = ijfwBridge.onStatusChanged.on((payload: IjfwStatusPayload) => {
-      if (!cancelled) setCliCount(payload.cliCount ?? 0);
+      if (!cancelled) {
+        setCliCount(payload.cliCount ?? 0);
+        setIjfwStatus(payload.status);
+      }
     });
     return () => {
       cancelled = true;
@@ -236,6 +262,19 @@ const FullPanelShell: React.FC = () => {
     setFilter((prev) => ({ ...prev, search: val, offset: 0 }));
   }, []);
 
+  // Setup-status strip expand/collapse (#414), persisted.
+  const toggleHealth = useCallback(() => {
+    setHealthOpen((v) => {
+      const next = !v;
+      try {
+        localStorage.setItem(HEALTH_OPEN_KEY, next ? '1' : '0');
+      } catch {
+        // Non-fatal (private mode / storage disabled)
+      }
+      return next;
+    });
+  }, []);
+
   // Row select: click same row → deselect
   const handleSelectRow = useCallback(
     (id: string) => {
@@ -245,7 +284,7 @@ const FullPanelShell: React.FC = () => {
         selectEntry(id);
       }
     },
-    [selectedId, clearSelection, selectEntry],
+    [selectedId, clearSelection, selectEntry]
   );
 
   // Promote entry
@@ -260,23 +299,27 @@ const FullPanelShell: React.FC = () => {
         reload();
       }
     },
-    [reload, t],
+    [reload, t]
   );
 
   // Open source file
-  const handleOpenSource = useCallback((path: string, _line: number) => {
-    ipcBridge.shell.openFile
-      .invoke(path)
-      .catch(() => {
+  const handleOpenSource = useCallback(
+    (path: string, _line: number) => {
+      ipcBridge.shell.openFile.invoke(path).catch(() => {
         void navigator.clipboard.writeText(path);
         Message.success(t('archive.toast.pathCopied', 'Path copied'));
       });
-  }, [t]);
+    },
+    [t]
+  );
 
-  const handleCopy = useCallback((text: string) => {
-    void navigator.clipboard.writeText(text);
-    Message.success(t('archive.toast.copied', 'Copied'));
-  }, [t]);
+  const handleCopy = useCallback(
+    (text: string) => {
+      void navigator.clipboard.writeText(text);
+      Message.success(t('archive.toast.copied', 'Copied'));
+    },
+    [t]
+  );
 
   // Cursor pagination (no-deferment #5)
   const handleEndReached = useCallback(() => {
@@ -295,14 +338,16 @@ const FullPanelShell: React.FC = () => {
   const showEmptyHero = entries.length === 0 && !isLoading && !hasActiveFilters;
 
   // Result count for filter bar
-  const resultCountLabel =
-    isLoading
-      ? ''
-      : `${total.toLocaleString()} ${t('archive.filter.results', 'results')}`;
+  const resultCountLabel = isLoading ? '' : `${total.toLocaleString()} ${t('archive.filter.results', 'results')}`;
 
   const projectSelected = filter.project !== 'all' ? filter.project : null;
   const typeCounts = stats?.typeCounts ?? {
-    decision: 0, pattern: 0, session: 0, observation: 0, wiki: 0, preference: 0,
+    decision: 0,
+    pattern: 0,
+    session: 0,
+    observation: 0,
+    wiki: 0,
+    preference: 0,
   };
 
   // ── Drag-drop handlers ──────────────────────────────────────────────────────
@@ -339,13 +384,11 @@ const FullPanelShell: React.FC = () => {
       if (files.length === 0) return;
 
       try {
-        const filePayloads = await Promise.all(
-          files.map(async (f) => ({ name: f.name, content: await f.text() })),
-        );
+        const filePayloads = await Promise.all(files.map(async (f) => ({ name: f.name, content: await f.text() })));
         const result = await memoryBridge.ingestFiles.invoke({ files: filePayloads });
         if (result.ingested > 0) {
           Message.success(
-            t('archive.dragDrop.toastIngested', `Ingested ${result.ingested} file${result.ingested === 1 ? '' : 's'}`),
+            t('archive.dragDrop.toastIngested', `Ingested ${result.ingested} file${result.ingested === 1 ? '' : 's'}`)
           );
           reload();
         } else {
@@ -356,7 +399,7 @@ const FullPanelShell: React.FC = () => {
         console.error('[FullPanelShell] drag-drop ingest error', err);
       }
     },
-    [reload, t],
+    [reload, t]
   );
 
   return (
@@ -369,7 +412,9 @@ const FullPanelShell: React.FC = () => {
       onDragEnter={handleDragEnter}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
-      onDrop={(e) => { void handleDrop(e); }}
+      onDrop={(e) => {
+        void handleDrop(e);
+      }}
     >
       {/* ---- Drag-drop overlay ---- */}
       {dragOver && (
@@ -385,29 +430,20 @@ const FullPanelShell: React.FC = () => {
             <span className={styles.breadcrumbIcon} aria-hidden>
               <Archive size={20} />
             </span>
-            <span className={styles.breadcrumbPrimary}>
-              {t('archive.topbar.archive', 'Archive')}
+            <span className={styles.breadcrumbPrimary}>{t('archive.topbar.archive', 'Archive')}</span>
+            <span className={styles.breadcrumbSep} aria-hidden>
+              ·
             </span>
-            <span className={styles.breadcrumbSep} aria-hidden>·</span>
             <span className={styles.breadcrumbProject}>
               {projects[0]?.basename ?? t('archive.topbar.allProjects', 'All projects')}
             </span>
           </span>
 
           {/* Type chips (no-deferment #1) */}
-          <TopbarChips
-            typeCounts={typeCounts}
-            activeType={activeChipType}
-            onFilterChange={handleChipFilter}
-          />
+          <TopbarChips typeCounts={typeCounts} activeType={activeChipType} onFilterChange={handleChipFilter} />
 
           {/* Streak pill (no-deferment #2) */}
-          {stats?.streak && (
-            <StreakPill
-              sessions={stats.streak.sessions}
-              longestDays={stats.streak.longestDays}
-            />
-          )}
+          {stats?.streak && <StreakPill sessions={stats.streak.sessions} longestDays={stats.streak.longestDays} />}
         </div>
 
         <div className={styles.topbarActions}>
@@ -443,6 +479,34 @@ const FullPanelShell: React.FC = () => {
         </div>
       </header>
 
+      {/* ---- Setup-status health strip (#414) ---- */}
+      <section
+        className={styles.healthStrip}
+        data-testid='memory-setup-status-strip'
+        data-open={healthOpen ? 'true' : 'false'}
+      >
+        <button
+          type='button'
+          className={styles.healthHeader}
+          onClick={toggleHealth}
+          aria-expanded={healthOpen}
+          data-testid='memory-setup-status-toggle'
+        >
+          <span className={styles.healthDot} data-tone={statusTone(ijfwStatus)} aria-hidden />
+          <span className={styles.healthTitle}>
+            {tRoot('memory.settings.setup_status_title', { defaultValue: 'Setup status' })}
+          </span>
+          <span className={styles.healthChevron} aria-hidden>
+            {healthOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+          </span>
+        </button>
+        {healthOpen && (
+          <div className={styles.healthBody} data-testid='memory-setup-status-body'>
+            <IjfwSetupStatus status={ijfwStatus} cliCount={cliCount} hideTitle />
+          </div>
+        )}
+      </section>
+
       {/* ---- Filter bar (48px) ---- */}
       <div className={styles.filterBar} data-testid='memory-filter-bar'>
         <div className={styles.filterLeft}>
@@ -463,20 +527,9 @@ const FullPanelShell: React.FC = () => {
           />
         </div>
         <div className={styles.filterDropdowns}>
-          <ProjectDropdown
-            projects={projects}
-            selected={projectSelected}
-            onSelect={handleProjectSelect}
-          />
-          <TimeDropdown
-            selected={timeWindow}
-            onSelect={handleTimeSelect}
-          />
-          <TypeDropdown
-            typeCounts={typeCounts}
-            selected={filter.types ?? []}
-            onFilterChange={handleTypeFilter}
-          />
+          <ProjectDropdown projects={projects} selected={projectSelected} onSelect={handleProjectSelect} />
+          <TimeDropdown selected={timeWindow} onSelect={handleTimeSelect} />
+          <TypeDropdown typeCounts={typeCounts} selected={filter.types ?? []} onFilterChange={handleTypeFilter} />
         </div>
         <div className={styles.resultCount} data-testid='memory-result-count'>
           {resultCountLabel}
@@ -486,10 +539,7 @@ const FullPanelShell: React.FC = () => {
       {/* ---- Main area (1fr) ---- */}
       <div className={styles.main} data-testid='memory-body'>
         {showEmptyHero ? (
-          <EmptyStateHero
-            onImportComplete={reload}
-            onSearchChange={handleSearchChange}
-          />
+          <EmptyStateHero onImportComplete={reload} onSearchChange={handleSearchChange} />
         ) : (
           <>
             {/* List column - shrinks when drawer opens (push-content) */}
@@ -525,11 +575,7 @@ const FullPanelShell: React.FC = () => {
       </div>
 
       {/* ---- Status bar (28px) ---- */}
-      <MemoryStatusBar
-        brainLive={!isLoading && stats !== null}
-        cliCount={cliCount}
-        lastDream={lastDream}
-      />
+      <MemoryStatusBar brainLive={!isLoading && stats !== null} cliCount={cliCount} lastDream={lastDream} />
 
       {/* ---- Import drawer ---- */}
       <ImportDrawer open={importOpen} onClose={() => setImportOpen(false)} />

--- a/src/renderer/pages/settings/components/IjfwSetupStatus.tsx
+++ b/src/renderer/pages/settings/components/IjfwSetupStatus.tsx
@@ -27,6 +27,12 @@ export type IjfwSetupStatusProps = {
   status: IjfwLifecycleStatus | null;
   /** Count of detected CLIs (excludes Wayland Core). */
   cliCount: number;
+  /**
+   * Hide the internal "Setup status" heading. Used when a host already labels
+   * the section (e.g. the Memory panel's collapsible health strip in #414),
+   * so the title is not shown twice. Defaults to false (Settings usage).
+   */
+  hideTitle?: boolean;
 };
 
 /**
@@ -47,7 +53,7 @@ type ChecklistItem = {
 
 type TestState = 'idle' | 'running' | 'pass' | 'fail';
 
-const IjfwSetupStatus: React.FC<IjfwSetupStatusProps> = ({ status, cliCount }) => {
+const IjfwSetupStatus: React.FC<IjfwSetupStatusProps> = ({ status, cliCount, hideTitle = false }) => {
   const { t } = useTranslation();
   const [testState, setTestState] = useState<TestState>('idle');
   const [runtimeReachable, setRuntimeReachable] = useState<boolean | null>(null);
@@ -146,9 +152,11 @@ const IjfwSetupStatus: React.FC<IjfwSetupStatusProps> = ({ status, cliCount }) =
 
   return (
     <div className='flex flex-col gap-12px p-16px rd-12px bg-aou-1' data-testid='ijfw-settings-setup-status'>
-      <Typography.Text className='text-14px font-semibold'>
-        {t('memory.settings.setup_status_title', { defaultValue: 'Setup status' })}
-      </Typography.Text>
+      {!hideTitle && (
+        <Typography.Text className='text-14px font-semibold'>
+          {t('memory.settings.setup_status_title', { defaultValue: 'Setup status' })}
+        </Typography.Text>
+      )}
 
       <div className='flex flex-col gap-8px'>
         {items.map((item) => (

--- a/tests/unit/renderer/pages/memory/FullPanelShell.dom.test.tsx
+++ b/tests/unit/renderer/pages/memory/FullPanelShell.dom.test.tsx
@@ -143,9 +143,7 @@ const { mockMemory, mockShell, mockIjfw } = vi.hoisted(() => {
         scanDevDir: { invoke: vi.fn() },
         processDropFolder: { invoke: vi.fn() },
         getDropFolderStatus: {
-          invoke: vi
-            .fn()
-            .mockResolvedValue({ path: '~/Documents/Wayland-Memory', watching: false, ingestedToday: 0 }),
+          invoke: vi.fn().mockResolvedValue({ path: '~/Documents/Wayland-Memory', watching: false, ingestedToday: 0 }),
         },
       },
       readSourceContext: { invoke: vi.fn() },
@@ -157,6 +155,8 @@ const { mockMemory, mockShell, mockIjfw } = vi.hoisted(() => {
     mockIjfw: {
       getStatus: { invoke: vi.fn() },
       onStatusChanged: mockIjfwStatusEmitter,
+      // Used by the embedded IjfwSetupStatus (#414 health strip) on expand.
+      brainInvoke: { invoke: vi.fn() },
     },
   };
 });
@@ -172,6 +172,7 @@ vi.mock('@/common', () => ({
   ipcBridge: {
     shell: mockShell,
     memory: mockMemory,
+    ijfw: mockIjfw,
   },
 }));
 
@@ -186,13 +187,12 @@ vi.mock('@arco-design/web-react', async () => {
     },
     Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
     Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-    Dropdown: ({
-      children,
-      droplist,
-    }: {
-      children: React.ReactNode;
-      droplist: React.ReactNode;
-    }) => <div>{children}{droplist}</div>,
+    Dropdown: ({ children, droplist }: { children: React.ReactNode; droplist: React.ReactNode }) => (
+      <div>
+        {children}
+        {droplist}
+      </div>
+    ),
   };
 });
 
@@ -202,18 +202,38 @@ vi.mock('@icon-park/react', () => ({
   LinkOne: (p: Record<string, unknown>) => <span data-testid='icon-link' {...p} />,
   FileCode: (p: Record<string, unknown>) => <span data-testid='icon-file-code' {...p} />,
   Help: (p: Record<string, unknown>) => <span data-testid='icon-help' {...p} />,
+  // Used by the embedded IjfwSetupStatus (#414 health strip) when expanded.
+  CheckOne: (p: Record<string, unknown>) => <span data-testid='icon-check-one' {...p} />,
+  Attention: (p: Record<string, unknown>) => <span data-testid='icon-attention' {...p} />,
+  CloseOne: (p: Record<string, unknown>) => <span data-testid='icon-close-one' {...p} />,
+  Loading: (p: Record<string, unknown>) => <span data-testid='icon-loading' {...p} />,
+  Round: (p: Record<string, unknown>) => <span data-testid='icon-round' {...p} />,
 }));
 
 vi.mock('react-i18next', () => ({
+  // Unified stub: FullPanelShell calls t(key, 'string fallback'); the embedded
+  // IjfwSetupStatus calls t(key, { defaultValue }). Handle both forms.
   useTranslation: () => ({
-    t: (_key: string, fallback: string, _opts?: Record<string, unknown>) => fallback ?? _key,
+    t: (_key: string, arg?: unknown) => {
+      if (typeof arg === 'string') return arg;
+      if (arg && typeof arg === 'object' && 'defaultValue' in arg) {
+        return (arg as { defaultValue?: string }).defaultValue ?? _key;
+      }
+      return _key;
+    },
   }),
 }));
 
 vi.mock(
   '@renderer/pages/memory/components/PromotionThresholdModal',
-  () => ({ default: ({ onClose }: { onClose: () => void }) => <div data-testid='threshold-modal'><button onClick={onClose}>Close</button></div> }),
-  { ssr: false },
+  () => ({
+    default: ({ onClose }: { onClose: () => void }) => (
+      <div data-testid='threshold-modal'>
+        <button onClick={onClose}>Close</button>
+      </div>
+    ),
+  }),
+  { ssr: false }
 );
 
 import FullPanelShell from '@renderer/pages/memory/state-branches/FullPanelShell';
@@ -222,12 +242,13 @@ const renderShell = (initialEntries: string[] = ['/memory']) =>
   render(
     <MemoryRouter initialEntries={initialEntries}>
       <FullPanelShell />
-    </MemoryRouter>,
+    </MemoryRouter>
   );
 
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  localStorage.clear(); // reset the persisted setup-status strip open state
 });
 
 beforeEach(() => {
@@ -242,6 +263,7 @@ beforeEach(() => {
   mockMemory.import.scanDevDir.invoke.mockResolvedValue({ count: 0, projectsFound: 0, errors: [] });
   mockShell.openFile.invoke.mockResolvedValue(undefined);
   mockIjfw.getStatus.invoke.mockResolvedValue({ status: 'installed_current', cliCount: 5 });
+  mockIjfw.brainInvoke.invoke.mockResolvedValue({ ok: true });
 });
 
 // ---------------------------------------------------------------------------
@@ -347,5 +369,87 @@ describe('FullPanelShell (v0.6.4 Mail-style)', () => {
     });
     expect(screen.getByTestId('memory-list-pane')).toBeTruthy();
     expect(screen.queryByTestId('empty-state-hero')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #414 - Setup-status health strip folded into the Memory panel header
+// ---------------------------------------------------------------------------
+
+describe('FullPanelShell setup-status strip (#414)', () => {
+  it('renders the strip toggle, collapsed by default (no body, no MCP probe)', async () => {
+    await act(async () => {
+      renderShell();
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 30));
+    });
+    expect(screen.getByTestId('memory-setup-status-strip')).toBeTruthy();
+    expect(screen.getByTestId('memory-setup-status-toggle')).toBeTruthy();
+    // Collapsed: the checklist body is not mounted, so no MCP child is spawned.
+    expect(screen.queryByTestId('memory-setup-status-body')).toBeNull();
+    expect(mockIjfw.brainInvoke.invoke).not.toHaveBeenCalled();
+  });
+
+  it('reflects install health on the strip dot (ok when installed_current)', async () => {
+    await act(async () => {
+      renderShell();
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 30));
+    });
+    const dot = screen.getByTestId('memory-setup-status-strip').querySelector('[data-tone]');
+    expect(dot?.getAttribute('data-tone')).toBe('ok');
+  });
+
+  it('marks the dot warn when IJFW is not installed', async () => {
+    mockIjfw.getStatus.invoke.mockResolvedValue({ status: 'not_installed', cliCount: 0 });
+    await act(async () => {
+      renderShell();
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 30));
+    });
+    const dot = screen.getByTestId('memory-setup-status-strip').querySelector('[data-tone]');
+    expect(dot?.getAttribute('data-tone')).toBe('warn');
+  });
+
+  it('expands to show the IjfwSetupStatus checklist when the toggle is clicked', async () => {
+    await act(async () => {
+      renderShell();
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 30));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('memory-setup-status-toggle'));
+      await new Promise((r) => setTimeout(r, 30));
+    });
+    expect(screen.getByTestId('memory-setup-status-body')).toBeTruthy();
+    // The embedded checklist renders its install row (title hidden via hideTitle).
+    expect(screen.getByTestId('ijfw-settings-setup-status')).toBeTruthy();
+    expect(screen.getByTestId('ijfw-status-item-install').getAttribute('data-status')).toBe('ok');
+  });
+
+  it('persists the expanded state across remounts (localStorage)', async () => {
+    await act(async () => {
+      renderShell();
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 30));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('memory-setup-status-toggle'));
+    });
+    expect(localStorage.getItem('wayland.memory.setupStatus.open')).toBe('1');
+    cleanup();
+    await act(async () => {
+      renderShell();
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 30));
+    });
+    // Re-opened already expanded from the persisted flag.
+    expect(screen.getByTestId('memory-setup-status-body')).toBeTruthy();
   });
 });


### PR DESCRIPTION
Addresses #414 (does not close — this is the header/health-strip slice; browse/search/read already ship as the Archive panel, and edit/delete are a follow-up pending an Overwatch scope ruling).

## What
Fold the #591 IJFW setup-status checklist + Test into the Memory Archive panel as a collapsible header/health strip, so a user opening Memory sees install/CLI/runtime health and can run the Test probe from the same surface — not only in Settings. This resolves the issue's original complaint that the Memory UI gave no indication IJFW setup had completed.

## How
- FullPanelShell: a new auto-height grid row hosts a collapsible strip. A coarse health dot (derived from the install lifecycle) is always visible; clicking expands the full IjfwSetupStatus checklist + Test. Open state persists to localStorage (default collapsed). The panel's existing ijfw status fetch now also captures the lifecycle status alongside cliCount.
- IjfwSetupStatus: added a backward-compatible hideTitle prop so the host strip labels the section once. Settings usage is unchanged (defaults to prior behavior).
- Reuses the existing memory.settings.setup_status_title key — no new i18n keys.

## Safety
- While collapsed, IjfwSetupStatus is not mounted, so opening the Memory panel does not spawn the IJFW MCP child process (the checklist's live probe only runs on expand). Covered by a test.

## Tests
6 new DOM tests: collapsed-by-default, no MCP probe while collapsed, dot tone ok/warn, expand-shows-checklist, and localStorage persistence across remounts. All green.

## Verification
- Live-verified in the running app: the strip renders on /memory, collapses/expands, shows IJFW installed + CLIs detected + a live runtime probe, with the Test button — no duplicate title.
- prek CI-parity local: TypeScript, Oxlint, Oxfmt, whitespace, UI Tokens all pass; i18n skipped (no locale changes).

## Not in this PR
Edit and delete of memory entries (the non-trivial mutating path) are held pending an Overwatch ruling on panel scope + delete semantics; the data path is recon'd and de-risked.
