### PR TITLE
fix(workflow): surface the model switcher for ACP/codex/remote backends (#626)

### DIFF
--- a/src/renderer/pages/conversation/components/ChatConversation.tsx
+++ b/src/renderer/pages/conversation/components/ChatConversation.tsx
@@ -635,6 +635,7 @@ const ChatConversation: React.FC<{
             sessionId={workflowSessionId}
             initialSession={initialWorkflowSession}
             onLaunchWorkflow={handleLaunchWorkflow}
+            headerAccessory={modelSelector}
           >
             {conversationNode}
           </WorkflowSurface>

--- a/tests/unit/renderer/pages/conversation/components/ChatConversation.dom.test.tsx
+++ b/tests/unit/renderer/pages/conversation/components/ChatConversation.dom.test.tsx
@@ -371,6 +371,60 @@ describe('ChatConversation - workflow model switcher (#587)', () => {
   });
 });
 
+describe('ChatConversation - workflow model switcher for ACP/codex/remote backends (#626)', () => {
+  // Follow-up to #587: the generic/ACP workflow panel rendered WorkflowSurface
+  // without a headerAccessory, so ACP/codex conversations lost their model
+  // switcher inside a workflow. The fix passes the same per-backend `modelSelector`
+  // memo the non-workflow header uses. ACP/codex get the live AcpModelSelector;
+  // openclaw/nanobot/remote get the disabled placeholder (parity with normal chat).
+  it('passes the ACP model selector to WorkflowSurface via headerAccessory', () => {
+    render(<ChatConversation conversation={buildAcpConversation({ workflowSessionId: 'sess-acc-acp' })} />);
+
+    const accessory = workflowSurfaceCalls.at(-1)?.headerAccessory as React.ReactElement | undefined;
+    expect(accessory).toBeTruthy();
+    const { getByTestId } = render(<>{accessory}</>);
+    expect(getByTestId('mock-acp-model-selector')).toBeTruthy();
+  });
+
+  it('passes the ACP model selector for a codex conversation via headerAccessory', () => {
+    const conv = {
+      id: 'conv-codex',
+      name: 'Codex Chat',
+      type: 'codex',
+      extra: { workflowSessionId: 'sess-acc-codex' },
+      createTime: 0,
+      modifyTime: 0,
+    } as unknown as Parameters<typeof ChatConversation>[0]['conversation'];
+
+    render(<ChatConversation conversation={conv} />);
+
+    const accessory = workflowSurfaceCalls.at(-1)?.headerAccessory as React.ReactElement | undefined;
+    expect(accessory).toBeTruthy();
+    const { getByTestId } = render(<>{accessory}</>);
+    expect(getByTestId('mock-acp-model-selector')).toBeTruthy();
+  });
+
+  it('passes the disabled placeholder selector for a fixed-model backend (openclaw) via headerAccessory', () => {
+    const conv = {
+      id: 'conv-openclaw',
+      name: 'OpenClaw Chat',
+      type: 'openclaw-gateway',
+      extra: { workflowSessionId: 'sess-acc-openclaw' },
+      createTime: 0,
+      modifyTime: 0,
+    } as unknown as Parameters<typeof ChatConversation>[0]['conversation'];
+
+    render(<ChatConversation conversation={conv} />);
+
+    const accessory = workflowSurfaceCalls.at(-1)?.headerAccessory as React.ReactElement | undefined;
+    expect(accessory).toBeTruthy();
+    const { getByTestId } = render(<>{accessory}</>);
+    // openclaw/nanobot/remote are fixed-model: the header shows the same disabled
+    // GeminiModelSelector placeholder it shows in normal (non-workflow) chat.
+    expect(getByTestId('mock-gemini-model-selector')).toBeTruthy();
+  });
+});
+
 describe('ChatConversation - workflowSessionId from location.state', () => {
   it('state.workflowSessionId takes precedence when both state and extra are present', () => {
     // State says 'state-sess', extra says 'extra-sess' - state wins.

--- a/tests/unit/renderer/pages/conversation/components/ChatConversation.dom.test.tsx
+++ b/tests/unit/renderer/pages/conversation/components/ChatConversation.dom.test.tsx
@@ -371,7 +371,7 @@ describe('ChatConversation - workflow model switcher (#587)', () => {
   });
 });
 
-describe('ChatConversation - workflow model switcher for ACP/codex/remote backends (#626)', () => {
+describe('ChatConversation - workflow model switcher for ACP/codex and fixed-model backends (#626)', () => {
   // Follow-up to #587: the generic/ACP workflow panel rendered WorkflowSurface
   // without a headerAccessory, so ACP/codex conversations lost their model
   // switcher inside a workflow. The fix passes the same per-backend `modelSelector`


### PR DESCRIPTION
## Addresses #626 (follow-up to #587)

#587 surfaced the model switcher inside workflows for WCore and Gemini panels via WorkflowSurface's headerAccessory slot. The generic panel that serves ACP, codex, openclaw-gateway, nanobot and remote rendered WorkflowSurface without that slot, so those backends lost their model switcher once inside a workflow (the ChatLayout header is hidden in workflow mode).

## Fix

Pass the existing per-backend modelSelector memo (the same one the non-workflow header already uses via headerLeft) to the generic workflow panel's WorkflowSurface headerAccessory. One line; no new components.

Result matches normal-chat behavior exactly:
- ACP and codex conversations get the live AcpModelSelector (switch models mid-workflow).
- openclaw-gateway, nanobot and remote are fixed-model / externally-configured backends with no in-app model switching; they get the same disabled placeholder they already show in normal chat (not a dead control).

## Tests

- ChatConversation.dom.test.tsx: +3 (ACP and codex render the AcpModelSelector in headerAccessory; openclaw renders the disabled placeholder). Mirrors the #587 test block.
- WorkflowSurface.dom.test.tsx: existing #587 headerAccessory slot coverage already proves the slot renders arbitrary accessories; no change needed.
- 39/39 affected DOM tests pass; typecheck, oxlint, oxfmt clean.
