### PR TITLE
feat(memory): edit + delete memory entries — closes #414 with #641

### DIFF
--- a/src/common/adapter/bridgeAllowlist.ts
+++ b/src/common/adapter/bridgeAllowlist.ts
@@ -340,6 +340,16 @@ const REMOTE_DENIED_KEYS: ReadonlySet<string> = new Set([
   'mcp.cancel-oauth',
   'mcp.logout-oauth',
   'mcp.set-byo-oauth-credentials',
+  // --- Memory mutation (#414 edit/delete of the user's local memory files) ---
+  //     The memory.* namespace is intentionally open to the paired WebUI for
+  //     READS (list/get/projects/tags/stats). These two providers perform a
+  //     real, hard, unrecoverable rewrite/delete of an on-disk memory block, so
+  //     a remote/paired peer must never reach them: update-entry silently
+  //     rewrites a block, delete-entry hard-deletes it (atomic rename/unlink,
+  //     no recycle). Reads stay allowed; only the destructive mutations are
+  //     denied to remote. (Local Electron IPC never passes through this gate.)
+  'memory.update-entry',
+  'memory.delete-entry',
   // --- Project knowledge draft (reads arbitrary filePaths to feed the model) ---
   'project.generate-knowledge-draft',
   // --- Storage destructive / disk operations ---

--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -2710,6 +2710,13 @@ export const memory = {
   setAutoPromoteEnabled: buildProvider<void, { enabled: boolean }>('memory.set-auto-promote-enabled'),
   /** Undo a recent promotion within the 24h grace window (added W3). */
   undoPromotion: buildProvider<{ ok: boolean; error?: string }, { id: string }>('memory.undo-promotion'),
+  /** Edit a single memory entry in place (#414); returns the new id if the summary changed. */
+  updateEntry: buildProvider<
+    { ok: boolean; error?: string; newId?: string },
+    { id: string; summary?: string; type?: string; tags?: string[]; body?: string }
+  >('memory.update-entry'),
+  /** Hard-delete a single memory entry from its source file (#414). */
+  deleteEntry: buildProvider<{ ok: boolean; error?: string }, { id: string }>('memory.delete-entry'),
   /** Trigger an immediate promotion sweep (added W3). */
   forceSweep: buildProvider<void, void>('memory.force-sweep'),
   /** Read a windowed slice of a source file centred on `line` for inline display. */

--- a/src/process/bridge/memoryArchiveBridge.ts
+++ b/src/process/bridge/memoryArchiveBridge.ts
@@ -51,6 +51,16 @@ const autoPromoteSchema = z.object({ enabled: z.boolean() });
 
 const undoSchema = z.object({ id: z.string().min(1).max(64) });
 
+const updateEntrySchema = z.object({
+  id: z.string().min(1).max(64),
+  summary: z.string().min(1).max(500).optional(),
+  type: z.string().min(1).max(40).optional(),
+  tags: z.array(z.string().max(80)).max(50).optional(),
+  body: z.string().max(100_000).optional(),
+});
+
+const deleteEntrySchema = z.object({ id: z.string().min(1).max(64) });
+
 const readSourceContextSchema = z.object({
   path: z.string().min(1),
   line: z.number().int().min(0),
@@ -209,6 +219,38 @@ export function initMemoryArchiveBridge(): void {
       return await undoPromotion(parsed.data.id);
     } catch (err) {
       log.error('[memory-archive] undoPromotion failed', { err });
+      return { ok: false, error: (err as Error).message };
+    }
+  });
+
+  ipcBridge.memory.updateEntry.provider(async (args) => {
+    const parsed = updateEntrySchema.safeParse(args);
+    if (!parsed.success) return { ok: false, error: 'invalid args' };
+    const { id, ...patch } = parsed.data;
+    // Require at least one field to change.
+    if (
+      patch.summary === undefined &&
+      patch.type === undefined &&
+      patch.tags === undefined &&
+      patch.body === undefined
+    ) {
+      return { ok: false, error: 'no_changes' };
+    }
+    try {
+      return await svc.editEntry(id, patch);
+    } catch (err) {
+      log.error('[memory-archive] updateEntry failed', { err });
+      return { ok: false, error: (err as Error).message };
+    }
+  });
+
+  ipcBridge.memory.deleteEntry.provider(async (args) => {
+    const parsed = deleteEntrySchema.safeParse(args);
+    if (!parsed.success) return { ok: false, error: 'invalid id' };
+    try {
+      return await svc.deleteEntry(parsed.data.id);
+    } catch (err) {
+      log.error('[memory-archive] deleteEntry failed', { err });
       return { ok: false, error: (err as Error).message };
     }
   });

--- a/src/process/services/memory/ijfwArchiveService.ts
+++ b/src/process/services/memory/ijfwArchiveService.ts
@@ -17,6 +17,7 @@ import * as path from 'node:path';
 import * as crypto from 'node:crypto';
 import log from 'electron-log';
 import { parseMarkdownBlocks } from './markdownFrontmatter';
+import { applyDelete, applyEdit, type MemoryBlockPatch } from './memoryEntryMutation';
 import { computePromotionScore } from './promotionScore';
 import type {
   MemoryEntry,
@@ -790,6 +791,99 @@ class IjfwArchiveService {
     this.scheduleReindex();
   }
 
+  /**
+   * Delete a single memory entry (#414). Hard delete: the entry's `---`-block is
+   * removed from its source file (atomic write); if it was the file's last entry
+   * the file is unlinked. Every other entry in the file is preserved verbatim.
+   * The store is git-tracked, so this is recoverable outside the app.
+   */
+  async deleteEntry(id: string): Promise<{ ok: boolean; error?: string }> {
+    await this.init();
+    const entry = this.index.byId.get(id);
+    if (!entry) return { ok: false, error: 'not_found' };
+    if (!isManagedMemoryPath(entry.sourcePath)) return { ok: false, error: 'unmanaged_path' };
+
+    let content: string;
+    try {
+      content = await fs.promises.readFile(entry.sourcePath, 'utf8');
+    } catch {
+      return { ok: false, error: 'read_failed' };
+    }
+
+    const result = applyDelete(content, entry.summary);
+    if (result.ok === false) return { ok: false, error: result.error };
+
+    try {
+      if (result.remainingBlocks === 0) await fs.promises.unlink(entry.sourcePath);
+      else await atomicWriteFile(entry.sourcePath, result.content);
+    } catch (err) {
+      log.error('[memory-archive] deleteEntry write failed', { id, err });
+      return { ok: false, error: 'write_failed' };
+    }
+
+    await this.rebuildNow();
+    return { ok: true };
+  }
+
+  /**
+   * Edit a single memory entry in place (#414). Surgical: only the patched
+   * frontmatter keys (summary/type/tags) and body are rewritten; all other
+   * frontmatter and all other entries are preserved verbatim. Because the id is
+   * derived from (sourcePath, stored, summary), changing the summary changes the
+   * id — the new id is returned so the caller can re-select the entry.
+   */
+  async editEntry(id: string, patch: MemoryBlockPatch): Promise<{ ok: boolean; error?: string; newId?: string }> {
+    await this.init();
+    const entry = this.index.byId.get(id);
+    if (!entry) return { ok: false, error: 'not_found' };
+    if (!isManagedMemoryPath(entry.sourcePath)) return { ok: false, error: 'unmanaged_path' };
+
+    let content: string;
+    try {
+      content = await fs.promises.readFile(entry.sourcePath, 'utf8');
+    } catch {
+      return { ok: false, error: 'read_failed' };
+    }
+
+    const result = applyEdit(content, entry.summary, patch);
+    if (result.ok === false) return { ok: false, error: result.error };
+
+    try {
+      await atomicWriteFile(entry.sourcePath, result.content);
+    } catch (err) {
+      log.error('[memory-archive] editEntry write failed', { id, err });
+      return { ok: false, error: 'write_failed' };
+    }
+
+    await this.rebuildNow();
+
+    // Resolve the (possibly new) id after the summary change. `stored` is never
+    // patchable, so storedAt is stable across the edit — match on it too, so a
+    // renamed summary that now collides (first 80 chars) with a SIBLING entry in
+    // the same file cannot re-resolve to the wrong block's id.
+    const newSummary = (patch.summary ?? entry.summary).slice(0, 80);
+    const updated = this.index.all.find(
+      (e) => e.sourcePath === entry.sourcePath && e.storedAt === entry.storedAt && e.summary.slice(0, 80) === newSummary
+    );
+    return { ok: true, newId: updated?.id ?? id };
+  }
+
+  /**
+   * Force an immediate, awaited reindex (used after edit/delete so the caller's
+   * next read reflects the change). Mirrors the debounced scheduleReindex body
+   * but runs synchronously and fires the change callbacks.
+   */
+  private async rebuildNow(): Promise<void> {
+    if (this.debounceTimer !== null) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+    this.closeWatchers();
+    await this.buildIndex();
+    const stats = this.indexStats();
+    for (const cb of this.changeCallbacks) cb(stats);
+  }
+
   indexStats(): IndexStats {
     return {
       total: this.index.all.length,
@@ -815,6 +909,26 @@ class IjfwArchiveService {
  */
 function sanitizeYamlScalar(s: string): string {
   return s.replace(/[\r\n]+/g, ' ').slice(0, 200);
+}
+
+/**
+ * Write via temp file + rename so the file watcher never observes a partial
+ * write (mirrors wikiWriter.atomicWrite).
+ */
+async function atomicWriteFile(filePath: string, contents: string): Promise<void> {
+  const tmp = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+  await fs.promises.writeFile(tmp, contents, 'utf8');
+  await fs.promises.rename(tmp, filePath);
+}
+
+/**
+ * Guard for mutating operations: only ever touch files inside a `.ijfw/memory`
+ * store. All service sourcePaths come from there, but this makes the invariant
+ * explicit so an edit/delete can never escape the store.
+ */
+function isManagedMemoryPath(filePath: string): boolean {
+  const norm = filePath.replace(/\\/g, '/');
+  return norm.includes('/.ijfw/memory/');
 }
 
 function groupBy<T>(items: T[], key: (item: T) => string): Map<string, T[]> {

--- a/src/process/services/memory/memoryEntryMutation.ts
+++ b/src/process/services/memory/memoryEntryMutation.ts
@@ -1,0 +1,253 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Pure edit/delete transforms for a single IJFW memory entry inside a shared
+ * `.ijfw/memory/*.md` file (#414). No filesystem access — the caller
+ * (IjfwArchiveService) reads the file, applies one of these transforms, and
+ * writes the result atomically.
+ *
+ * Design goals:
+ * - Byte-preserving for every block that is NOT the target. A file typically
+ *   holds many entries (journal.md); editing or deleting one must never
+ *   reformat or reorder the others.
+ * - Edit is SURGICAL: only the patched frontmatter lines (summary/type/tags)
+ *   and the body of the target block are rewritten; all other frontmatter keys
+ *   (project, source, source_path, stored, …) are left verbatim.
+ * - The target is located by summary (first 80 chars), matching how
+ *   IjfwArchiveService derives entry ids and how getEntry already locates a
+ *   block. An ambiguous match (two entries with the same 80-char summary in one
+ *   file) refuses to mutate rather than guess.
+ */
+
+import { parseMarkdownBlocks } from './markdownFrontmatter';
+
+export type MemoryBlockPatch = {
+  summary?: string;
+  type?: string;
+  tags?: string[];
+  body?: string;
+};
+
+export type MutationError = 'not_found' | 'ambiguous' | 'summary_collision';
+
+export type MutationResult =
+  | { ok: true; content: string; remainingBlocks: number }
+  | { ok: false; error: MutationError };
+
+/**
+ * Serialize a frontmatter scalar so it round-trips through the reader's
+ * `decodeScalar`. Mirrors `serializeFrontmatterValue` in wikiWriter.ts: values
+ * with YAML-significant characters become JSON-style double-quoted single-line
+ * scalars; plain values pass through unquoted.
+ */
+export function serializeScalar(value: string): string {
+  if (value.length === 0) return '""';
+  const needsQuoting =
+    /[\n\r\t"#:[\]{}&*!|>%@`,]/.test(value) ||
+    value !== value.trim() ||
+    value.startsWith('-') ||
+    value.startsWith('?') ||
+    /^(?:true|false|yes|no|on|off|null|~)$/i.test(value) ||
+    /^[+-]?(?:\d|\.\d|0x|0o)/.test(value);
+  if (!needsQuoting) return value;
+  return JSON.stringify(value);
+}
+
+function serializeTags(tags: string[]): string {
+  return tags.length > 0 ? `[${tags.map((t) => serializeScalar(t)).join(', ')}]` : '[]';
+}
+
+/** Derive the summary the index would compute for a raw block slice. */
+function summaryOfBlock(rawBlockText: string): string {
+  const parsed = parseMarkdownBlocks(rawBlockText);
+  const block = parsed[0];
+  if (!block) return '';
+  const fm = block.frontmatter;
+  if (typeof fm['summary'] === 'string' && fm['summary']) return fm['summary'];
+  return block.body.split('\n')[0].replace(/^#+\s*/, '') || 'Untitled';
+}
+
+type FileShape = {
+  lines: string[];
+  /** Opening `---` line index of each entry block, in order. */
+  starts: number[];
+  /** Whether the original file ended with a trailing newline. */
+  trailingNewline: boolean;
+  /** Whether the original file used CRLF line endings (preserved on rewrite). */
+  crlf: boolean;
+};
+
+/**
+ * Split a memory file into its lines and the opening-`---` line index of every
+ * entry block, replaying the same fence state machine parseMarkdownBlocks uses
+ * so block boundaries line up exactly.
+ */
+function shapeFile(content: string): FileShape {
+  // Preserve the file's original line-ending style: normalize to LF for the
+  // line-oriented transforms, then re-emit with the original separator so a
+  // CRLF file (Windows / git autocrlf) is not silently rewritten to LF.
+  const crlf = content.includes('\r\n');
+  const text = content.replace(/\r\n/g, '\n');
+  const trailingNewline = text.endsWith('\n');
+  const lines = text.split('\n');
+
+  // Skip leading file-header lines (comments / H1) exactly like the parser.
+  let startIdx = 0;
+  while (startIdx < lines.length) {
+    const l = lines[startIdx].trim();
+    if (l.startsWith('<!--') || l.startsWith('#')) startIdx++;
+    else break;
+  }
+
+  const starts: number[] = [];
+  type State = 'between' | 'in_fm' | 'in_body';
+  let state: State = 'between';
+  for (let i = startIdx; i < lines.length; i++) {
+    if (lines[i].trim() !== '---') continue;
+    if (state === 'between') {
+      starts.push(i);
+      state = 'in_fm';
+    } else if (state === 'in_fm') {
+      state = 'in_body';
+    } else {
+      // `---` in body = separator: next entry begins here.
+      starts.push(i);
+      state = 'in_fm';
+    }
+  }
+  return { lines, starts, trailingNewline, crlf };
+}
+
+/** End line (exclusive) of block i. */
+function blockEnd(shape: FileShape, i: number): number {
+  return i + 1 < shape.starts.length ? shape.starts[i + 1] : shape.lines.length;
+}
+
+/** Raw text of block i (used only to derive its summary). */
+function rawBlock(shape: FileShape, i: number): string {
+  return shape.lines.slice(shape.starts[i], blockEnd(shape, i)).join('\n');
+}
+
+/**
+ * Locate the single block whose summary matches `summary` (first 80 chars).
+ * Returns the block index, -1 for none, -2 for ambiguous (>1 match).
+ */
+function locate(shape: FileShape, summary: string): number {
+  const key = summary.slice(0, 80);
+  let found = -1;
+  for (let i = 0; i < shape.starts.length; i++) {
+    if (summaryOfBlock(rawBlock(shape, i)).slice(0, 80) === key) {
+      if (found !== -1) return -2; // ambiguous
+      found = i;
+    }
+  }
+  return found;
+}
+
+function joinFile(lines: string[], trailingNewline: boolean, crlf: boolean): string {
+  const nl = crlf ? '\r\n' : '\n';
+  let out = lines.join(nl);
+  // Preserve the original trailing-newline state; `lines` from split of a
+  // trailing-newline file ends in '' so join already yields the newline. Guard
+  // the no-trailing-newline case where we must not add one.
+  if (!trailingNewline) out = out.replace(/(\r?\n)+$/, '');
+  return out;
+}
+
+/**
+ * Delete the entry identified by `summary`. Returns the new file content and
+ * how many entry blocks remain (0 means the caller may unlink the file).
+ */
+export function applyDelete(content: string, summary: string): MutationResult {
+  const shape = shapeFile(content);
+  const idx = locate(shape, summary);
+  if (idx === -1) return { ok: false, error: 'not_found' };
+  if (idx === -2) return { ok: false, error: 'ambiguous' };
+
+  const start = shape.starts[idx];
+  const end = blockEnd(shape, idx);
+  const kept = [...shape.lines.slice(0, start), ...shape.lines.slice(end)];
+  return {
+    ok: true,
+    content: joinFile(kept, shape.trailingNewline, shape.crlf),
+    remainingBlocks: shape.starts.length - 1,
+  };
+}
+
+/**
+ * Surgically edit the entry identified by `summary`. Only the patched
+ * frontmatter keys (summary/type/tags) and body are rewritten; every other
+ * frontmatter key and every other block is preserved verbatim.
+ *
+ * NOTE: changing the summary changes the entry's derived id — the caller must
+ * re-resolve the entry afterwards. `matchSummary` is the CURRENT summary used to
+ * locate the block; `patch.summary` (if set) is the new value written.
+ */
+export function applyEdit(content: string, matchSummary: string, patch: MemoryBlockPatch): MutationResult {
+  const shape = shapeFile(content);
+  const idx = locate(shape, matchSummary);
+  if (idx === -1) return { ok: false, error: 'not_found' };
+  if (idx === -2) return { ok: false, error: 'ambiguous' };
+
+  // Refuse a rename that would collide with ANOTHER block's summary (first 80
+  // chars) in the same file. The id, getEntry's body read, and every future
+  // edit/delete all locate blocks by summary, so a duplicate summary would make
+  // this and the sibling entry mutually ambiguous. Fail closed instead.
+  if (patch.summary !== undefined) {
+    const newKey = patch.summary.slice(0, 80);
+    for (let i = 0; i < shape.starts.length; i++) {
+      if (i === idx) continue;
+      if (summaryOfBlock(rawBlock(shape, i)).slice(0, 80) === newKey) {
+        return { ok: false, error: 'summary_collision' };
+      }
+    }
+  }
+
+  const start = shape.starts[idx];
+  const end = blockEnd(shape, idx);
+
+  // Frontmatter region: start+1 .. fmEnd (the closing `---`).
+  let fmEnd = -1;
+  for (let i = start + 1; i < end; i++) {
+    if (shape.lines[i].trim() === '---') {
+      fmEnd = i;
+      break;
+    }
+  }
+  if (fmEnd === -1) return { ok: false, error: 'not_found' }; // malformed block, refuse
+
+  const fmLines = shape.lines.slice(start + 1, fmEnd);
+
+  const upsert = (key: string, serialized: string): void => {
+    const at = fmLines.findIndex((l) => l.slice(0, l.indexOf(':') === -1 ? 0 : l.indexOf(':')).trim() === key);
+    const line = `${key}: ${serialized}`;
+    if (at === -1) fmLines.push(line);
+    else fmLines[at] = line;
+  };
+
+  if (patch.summary !== undefined) upsert('summary', serializeScalar(patch.summary));
+  if (patch.type !== undefined) upsert('type', serializeScalar(patch.type));
+  if (patch.tags !== undefined) upsert('tags', serializeTags(patch.tags));
+
+  // Body region: fmEnd+1 .. end. Replace when a new body is supplied.
+  const bodyLines =
+    patch.body !== undefined ? patch.body.replace(/\r\n/g, '\n').split('\n') : shape.lines.slice(fmEnd + 1, end);
+
+  const rebuilt = [
+    ...shape.lines.slice(0, start),
+    shape.lines[start], // opening ---
+    ...fmLines,
+    shape.lines[fmEnd], // closing ---
+    ...bodyLines,
+    ...shape.lines.slice(end),
+  ];
+  return {
+    ok: true,
+    content: joinFile(rebuilt, shape.trailingNewline, shape.crlf),
+    remainingBlocks: shape.starts.length,
+  };
+}

--- a/src/renderer/pages/memory/components/EntryEditorModal.tsx
+++ b/src/renderer/pages/memory/components/EntryEditorModal.tsx
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * EntryEditorModal - edit a single memory entry in place (#414).
+ *
+ * Prefilled from the selected entry (summary/type/tags/body). On save it sends
+ * only the CHANGED fields to `memory.update-entry` so untouched frontmatter is
+ * left verbatim on disk. Changing the summary changes the entry id, so the
+ * caller receives the new id via onSaved to re-select the row.
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { InputTag, Message, Modal, Select } from '@arco-design/web-react';
+import { Input } from '@arco-design/web-react';
+import { useTranslation } from 'react-i18next';
+import { memory as memoryBridge } from '@/common/adapter/ipcBridge';
+import type { MemoryEntry, MemoryType } from '@/common/types/memory';
+
+const EDITABLE_TYPES: MemoryType[] = ['decision', 'pattern', 'observation', 'session', 'preference'];
+
+export type EntryEditorTarget = MemoryEntry & { body: string };
+
+export type EntryEditorModalProps = {
+  open: boolean;
+  entry: EntryEditorTarget | null;
+  onClose: () => void;
+  /** Called after a successful save with the entry's (possibly new) id. */
+  onSaved: (newId: string) => void;
+};
+
+const EntryEditorModal: React.FC<EntryEditorModalProps> = ({ open, entry, onClose, onSaved }) => {
+  const { t } = useTranslation('memory');
+
+  const [summary, setSummary] = useState('');
+  const [type, setType] = useState<MemoryType>('observation');
+  const [tags, setTags] = useState<string[]>([]);
+  const [body, setBody] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  // Reset the form whenever a new entry is opened.
+  useEffect(() => {
+    if (entry) {
+      setSummary(entry.summary);
+      setType(entry.type);
+      setTags(entry.tags ?? []);
+      setBody(entry.body ?? '');
+    }
+  }, [entry]);
+
+  const patch = useMemo(() => {
+    if (!entry) return null;
+    const trimmedSummary = summary.trim();
+    const p: { summary?: string; type?: string; tags?: string[]; body?: string } = {};
+    if (trimmedSummary && trimmedSummary !== entry.summary) p.summary = trimmedSummary;
+    if (type !== entry.type) p.type = type;
+    if (JSON.stringify(tags) !== JSON.stringify(entry.tags ?? [])) p.tags = tags;
+    if (body !== (entry.body ?? '')) p.body = body;
+    return p;
+  }, [entry, summary, type, tags, body]);
+
+  const hasChanges = !!patch && Object.keys(patch).length > 0;
+  const summaryEmpty = summary.trim().length === 0;
+
+  const handleSave = async (): Promise<void> => {
+    if (!entry || !patch || !hasChanges || summaryEmpty || saving) return;
+    setSaving(true);
+    try {
+      const result = await memoryBridge.updateEntry.invoke({ id: entry.id, ...patch });
+      if (result.ok) {
+        Message.success(t('archive.editor.toastSaved', 'Memory updated'));
+        onSaved(result.newId ?? entry.id);
+        onClose();
+      } else if (result.error === 'summary_collision') {
+        Message.error(
+          t('archive.editor.toastCollision', 'Another memory already uses that summary. Choose a different one.')
+        );
+      } else {
+        Message.error(t('archive.editor.toastError', 'Could not update memory'));
+      }
+    } catch {
+      Message.error(t('archive.editor.toastError', 'Could not update memory'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Modal
+      title={t('archive.editor.title', 'Edit memory')}
+      visible={open}
+      onCancel={onClose}
+      onOk={() => {
+        void handleSave();
+      }}
+      okButtonProps={{ disabled: !hasChanges || summaryEmpty, loading: saving }}
+      okText={t('archive.editor.save', 'Save')}
+      cancelText={t('archive.editor.cancel', 'Cancel')}
+      unmountOnExit
+      data-testid='entry-editor-modal'
+    >
+      <div className='flex flex-col gap-12px'>
+        <label className='flex flex-col gap-4px'>
+          <span className='text-12px text-[var(--color-text-3)]'>{t('archive.editor.summaryLabel', 'Summary')}</span>
+          <Input
+            value={summary}
+            onChange={setSummary}
+            maxLength={500}
+            data-testid='entry-editor-summary'
+            status={summaryEmpty ? 'error' : undefined}
+          />
+        </label>
+        <label className='flex flex-col gap-4px'>
+          <span className='text-12px text-[var(--color-text-3)]'>{t('archive.editor.typeLabel', 'Type')}</span>
+          <Select value={type} onChange={(v) => setType(v as MemoryType)} data-testid='entry-editor-type'>
+            {EDITABLE_TYPES.map((tp) => (
+              <Select.Option key={tp} value={tp}>
+                {tp}
+              </Select.Option>
+            ))}
+          </Select>
+        </label>
+        <label className='flex flex-col gap-4px'>
+          <span className='text-12px text-[var(--color-text-3)]'>{t('archive.editor.tagsLabel', 'Tags')}</span>
+          <InputTag value={tags} onChange={(v) => setTags(v as string[])} data-testid='entry-editor-tags' allowClear />
+        </label>
+        <label className='flex flex-col gap-4px'>
+          <span className='text-12px text-[var(--color-text-3)]'>{t('archive.editor.bodyLabel', 'Body')}</span>
+          <Input.TextArea
+            value={body}
+            onChange={setBody}
+            autoSize={{ minRows: 6, maxRows: 16 }}
+            data-testid='entry-editor-body'
+          />
+        </label>
+      </div>
+    </Modal>
+  );
+};
+
+export default EntryEditorModal;

--- a/src/renderer/pages/memory/components/RightDrawer.tsx
+++ b/src/renderer/pages/memory/components/RightDrawer.tsx
@@ -21,7 +21,7 @@
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Button, Tag, Tooltip } from '@arco-design/web-react';
-import { Close, Copy, LinkOne, FileCode, Help } from '@icon-park/react';
+import { Close, Copy, LinkOne, FileCode, Help, Edit, Delete } from '@icon-park/react';
 import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
 import type { MemoryEntry, MemoryType } from '@/common/types/memory';
@@ -49,6 +49,10 @@ export type RightDrawerProps = {
   onPromote?: (id: string) => void;
   onOpenSource?: (path: string, line: number) => void;
   onCopy?: (text: string) => void;
+  /** Open the editor for this entry (#414). */
+  onEdit?: (entry: ExtendedEntry) => void;
+  /** Delete this entry after confirmation (#414). */
+  onDelete?: (entry: ExtendedEntry) => void;
 };
 
 // ---------------------------------------------------------------------------
@@ -87,7 +91,15 @@ type SourcePanelState =
   | { status: 'idle' }
   | { status: 'loading' }
   | { status: 'error'; error: string }
-  | { status: 'ok'; before: string; anchor: string; after: string; totalLines: number; fromLine: number; toLine: number };
+  | {
+      status: 'ok';
+      before: string;
+      anchor: string;
+      after: string;
+      totalLines: number;
+      fromLine: number;
+      toLine: number;
+    };
 
 type SourcePanelProps = {
   path: string;
@@ -109,13 +121,28 @@ const SourcePanel: React.FC<SourcePanelProps> = ({ path, line, autoExpand = fals
     ipcBridge.memory.readSourceContext
       .invoke({ path, line, contextLines: 50 })
       .then((result) => {
-        const r = result as { ok: boolean; before?: string; anchor?: string; after?: string; totalLines?: number; error?: string };
+        const r = result as {
+          ok: boolean;
+          before?: string;
+          anchor?: string;
+          after?: string;
+          totalLines?: number;
+          error?: string;
+        };
         if (r.ok) {
           const ctxLines = 50;
           const anchorLine = Math.max(1, line);
           const fromLine = Math.max(1, anchorLine - ctxLines);
           const toLine = Math.min(r.totalLines ?? 0, anchorLine + ctxLines);
-          setState({ status: 'ok', before: r.before ?? '', anchor: r.anchor ?? '', after: r.after ?? '', totalLines: r.totalLines ?? 0, fromLine, toLine });
+          setState({
+            status: 'ok',
+            before: r.before ?? '',
+            anchor: r.anchor ?? '',
+            after: r.after ?? '',
+            totalLines: r.totalLines ?? 0,
+            fromLine,
+            toLine,
+          });
         } else {
           setState({ status: 'error', error: r.error ?? 'Unknown error' });
         }
@@ -200,6 +227,8 @@ const RightDrawer: React.FC<RightDrawerProps> = ({
   onPromote,
   onOpenSource,
   onCopy,
+  onEdit,
+  onDelete,
 }) => {
   const { t } = useTranslation('memory');
 
@@ -224,7 +253,7 @@ const RightDrawer: React.FC<RightDrawerProps> = ({
       }
       onCopy?.(text);
     },
-    [onCopy],
+    [onCopy]
   );
 
   const isOpen = entry !== null;
@@ -316,6 +345,25 @@ const RightDrawer: React.FC<RightDrawerProps> = ({
               data-testid='drawer-copy-btn'
             >
               {t('archive.drawer.copy', 'Copy')}
+            </Button>
+            <Button
+              type='text'
+              size='small'
+              icon={<Edit theme='outline' size='13' />}
+              onClick={() => onEdit?.(entry)}
+              data-testid='drawer-edit-btn'
+            >
+              {t('archive.drawer.edit', 'Edit')}
+            </Button>
+            <Button
+              type='text'
+              size='small'
+              status='danger'
+              icon={<Delete theme='outline' size='13' />}
+              onClick={() => onDelete?.(entry)}
+              data-testid='drawer-delete-btn'
+            >
+              {t('archive.drawer.delete', 'Delete')}
             </Button>
           </div>
 
@@ -462,11 +510,7 @@ const RightDrawer: React.FC<RightDrawerProps> = ({
             </div>
 
             {/* Inline source context */}
-            <SourcePanel
-              path={entry.sourcePath}
-              line={entry.sourceLine}
-              autoExpand={!entry.why && !entry.howToApply}
-            />
+            <SourcePanel path={entry.sourcePath} line={entry.sourceLine} autoExpand={!entry.why && !entry.howToApply} />
           </div>
         </div>
       )}

--- a/src/renderer/pages/memory/state-branches/FullPanelShell.tsx
+++ b/src/renderer/pages/memory/state-branches/FullPanelShell.tsx
@@ -28,7 +28,7 @@
  */
 
 import React, { lazy, Suspense, useCallback, useEffect, useRef, useState } from 'react';
-import { Button, Input, Message } from '@arco-design/web-react';
+import { Button, Input, Message, Modal } from '@arco-design/web-react';
 import type { RefInputType } from '@arco-design/web-react/es/Input/interface';
 import { Archive, Search, Import as ImportIcon, Settings2, Plus, ChevronDown, ChevronRight } from 'lucide-react';
 import { ipcBridge } from '@/common';
@@ -36,7 +36,7 @@ import { formatModifierShortcut } from '@/renderer/utils/platform';
 import { memory as memoryBridge, ijfw as ijfwBridge } from '@/common/adapter/ipcBridge';
 import type { IjfwStatusPayload, IjfwLifecycleStatus } from '@/common/adapter/ipcBridge';
 import IjfwSetupStatus from '@/renderer/pages/settings/components/IjfwSetupStatus';
-import type { LastDream, ListFilter, MemoryType } from '@/common/types/memory';
+import type { LastDream, ListFilter, MemoryEntry, MemoryType } from '@/common/types/memory';
 import { useTranslation } from 'react-i18next';
 import MemoryList from '../components/MemoryList';
 import RightDrawer from '../components/RightDrawer';
@@ -49,6 +49,7 @@ import EmptyStateHero from '../components/EmptyStateHero';
 import MemoryStatusBar from '../components/MemoryStatusBar';
 import ImportDrawer from '../components/ImportDrawer';
 import ComposerModal from '../components/ComposerModal';
+import EntryEditorModal from '../components/EntryEditorModal';
 import { useMemoryIndex } from '../hooks/useMemoryIndex';
 import { useSelectedEntry } from '../hooks/useSelectedEntry';
 import type { TimeWindow } from '../components/TimeDropdown';
@@ -137,6 +138,7 @@ const FullPanelShell: React.FC = () => {
   const [showThresholdModal, setShowThresholdModal] = useState(false);
   const [importOpen, setImportOpen] = useState(false);
   const [composerOpen, setComposerOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<(MemoryEntry & { body: string }) | null>(null);
   const [dragOver, setDragOver] = useState(false);
 
   const searchRef = useRef<RefInputType>(null);
@@ -300,6 +302,48 @@ const FullPanelShell: React.FC = () => {
       }
     },
     [reload, t]
+  );
+
+  // Edit an entry (#414): the selected entry already carries its full body.
+  const handleEdit = useCallback((entry: MemoryEntry & { body: string }) => {
+    setEditTarget(entry);
+  }, []);
+
+  // After a successful edit, re-select by the (possibly new) id and refresh.
+  const handleEditorSaved = useCallback(
+    (newId: string) => {
+      setEditTarget(null);
+      reload();
+      selectEntry(newId);
+    },
+    [reload, selectEntry]
+  );
+
+  // Delete an entry (#414) behind a confirm that states it cannot be undone.
+  const handleDelete = useCallback(
+    (entry: MemoryEntry & { body: string }) => {
+      Modal.confirm({
+        title: t('archive.delete.confirmTitle', 'Delete this memory?'),
+        content: t(
+          'archive.delete.confirmContent',
+          'This permanently removes the memory from its file. It cannot be undone from the app.'
+        ),
+        okText: t('archive.delete.confirmOk', 'Delete'),
+        cancelText: t('archive.delete.confirmCancel', 'Cancel'),
+        okButtonProps: { status: 'danger' },
+        onOk: async () => {
+          const result = await memoryBridge.deleteEntry.invoke({ id: entry.id });
+          if (result.ok) {
+            Message.success(t('archive.delete.toastDeleted', 'Memory deleted'));
+            clearSelection();
+            reload();
+          } else {
+            Message.error(t('archive.delete.toastError', 'Could not delete memory'));
+          }
+        },
+      });
+    },
+    [t, clearSelection, reload]
   );
 
   // Open source file
@@ -569,6 +613,8 @@ const FullPanelShell: React.FC = () => {
               onPromote={handlePromote}
               onOpenSource={handleOpenSource}
               onCopy={handleCopy}
+              onEdit={handleEdit}
+              onDelete={handleDelete}
             />
           </>
         )}
@@ -582,6 +628,14 @@ const FullPanelShell: React.FC = () => {
 
       {/* ---- Composer modal ---- */}
       <ComposerModal open={composerOpen} onClose={() => setComposerOpen(false)} />
+
+      {/* ---- Entry editor modal (#414) ---- */}
+      <EntryEditorModal
+        open={editTarget !== null}
+        entry={editTarget}
+        onClose={() => setEditTarget(null)}
+        onSaved={handleEditorSaved}
+      />
 
       {/* ---- Threshold modal ---- */}
       {showThresholdModal && (

--- a/tests/unit/bridgeAllowlist.redteam.test.ts
+++ b/tests/unit/bridgeAllowlist.redteam.test.ts
@@ -153,3 +153,27 @@ describe('isAllowedForRemote - doctor surface denied (#458)', () => {
     expect(isAllowedForRemote(`subscribe-${key}`)).toBe(false);
   });
 });
+
+/**
+ * Memory mutation surface (#414). The memory.* namespace is intentionally open
+ * to the paired WebUI for READS, but the two edit/delete providers perform a
+ * real, hard, unrecoverable rewrite/delete of the user's local memory files.
+ * A remote (paired-device WebSocket) caller must never reach them, else a paired
+ * peer could destroy or silently rewrite the user's memories. The read-only
+ * views stay allowed so the remote Archive panel still functions.
+ */
+describe('isAllowedForRemote - memory edit/delete denied (#414)', () => {
+  it.each(['memory.update-entry', 'memory.delete-entry'])(
+    'denies subscribe-%s for remote callers (blocks remote memory destruction/rewrite)',
+    (key) => {
+      expect(isAllowedForRemote(`subscribe-${key}`)).toBe(false);
+    }
+  );
+
+  it.each(['memory.list-entries', 'memory.get-entry', 'memory.get-projects', 'memory.get-tags', 'memory.get-stats'])(
+    'still allows the read-only %s for remote callers',
+    (key) => {
+      expect(isAllowedForRemote(`subscribe-${key}`)).toBe(true);
+    }
+  );
+});

--- a/tests/unit/ijfwArchiveService.mutation.test.ts
+++ b/tests/unit/ijfwArchiveService.mutation.test.ts
@@ -1,0 +1,305 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #414 - filesystem integration tests for IjfwArchiveService.deleteEntry /
+ * editEntry. The pure block transforms live in memoryEntryMutation (tested
+ * separately); here we exercise the SERVICE glue: entry discovery, id
+ * derivation, atomic write / unlink, and the awaited reindex.
+ *
+ * Hermetic isolation: the service discovers stores exclusively via os.homedir()
+ * (registry at ~/.ijfw/registry.md, the ~/dev fallback scan, and the "home
+ * brain" candidate). We spy os.homedir() to point at a fresh temp dir seeded
+ * with a `.ijfw/memory/*.md` store, so no real user memory is ever touched.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron-log', () => ({ default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+
+// ESM namespace exports can't be spied, so mock node:os wholesale and override
+// only homedir() to point at our per-test temp store. Everything else (tmpdir,
+// etc.) passes through to the real implementation.
+const homeHolder = vi.hoisted(() => ({ path: '' }));
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return { ...actual, homedir: () => homeHolder.path };
+});
+
+import { IjfwArchiveService } from '../../src/process/services/memory/ijfwArchiveService';
+import type { MemoryEntry } from '../../src/common/types/memory';
+
+// ===== Seed fixtures =====
+
+const KNOWLEDGE_MD = `<!-- ijfw-schema: v1 -->
+# Project Knowledge
+
+---
+type: decision
+summary: Alpha decision about caching
+stored: 2026-05-01T10:00:00.000Z
+project: demo
+tags: [cache, perf]
+source_path: /orig/alpha.md
+---
+Body of alpha entry.
+**Why:** caching saves time.
+
+---
+type: pattern
+summary: Beta pattern for retries
+stored: 2026-05-02T11:00:00.000Z
+project: demo
+tags: [retry]
+source_path: /orig/beta.md
+---
+Body of beta pattern.
+
+---
+type: observation
+summary: Gamma observation on latency
+stored: 2026-05-03T12:00:00.000Z
+project: demo
+tags: [latency]
+source_path: /orig/gamma.md
+---
+Body of gamma observation.
+`;
+
+const SOLO_MD = `<!-- ijfw-schema: v1 -->
+---
+type: preference
+summary: Solo entry stands alone
+stored: 2026-05-04T09:00:00.000Z
+project: demo
+tags: [solo]
+source_path: /orig/solo.md
+---
+Body of the only entry.
+`;
+
+// Verbatim blocks the non-target entries must retain byte-for-byte.
+const ALPHA_BLOCK = `---
+type: decision
+summary: Alpha decision about caching
+stored: 2026-05-01T10:00:00.000Z
+project: demo
+tags: [cache, perf]
+source_path: /orig/alpha.md
+---
+Body of alpha entry.
+**Why:** caching saves time.`;
+
+const GAMMA_BLOCK = `---
+type: observation
+summary: Gamma observation on latency
+stored: 2026-05-03T12:00:00.000Z
+project: demo
+tags: [latency]
+source_path: /orig/gamma.md
+---
+Body of gamma observation.`;
+
+// ===== Test harness =====
+
+// The service skips any store path containing '/tmp/' or 'Temp/' (buildIndex),
+// so the fake HOME must live OUTSIDE the OS temp dir — os.tmpdir() is /tmp on
+// Linux CI (mac resolves to /var/folders/... which slipped past the filter and
+// hid this on local-mac only). node_modules is a gitignored, cross-platform,
+// non-temp location that the filter accepts.
+const TEST_TMP_BASE = path.join(process.cwd(), 'node_modules', '.ijfw-mut-test');
+
+let tempHome: string;
+let memoryDir: string;
+let knowledgePath: string;
+let soloPath: string;
+let svc: IjfwArchiveService;
+
+/** Fresh service that never opens real fs watchers on the temp files. */
+function makeService(): IjfwArchiveService {
+  return new IjfwArchiveService(() => ({ close: () => void 0 }));
+}
+
+async function idBySummary(summary: string): Promise<string> {
+  const { entries } = await svc.listEntries({ limit: 1000 });
+  const match = entries.find((e: MemoryEntry) => e.summary === summary);
+  if (!match) throw new Error(`seed entry not found for summary: ${summary}`);
+  return match.id;
+}
+
+async function summaries(): Promise<string[]> {
+  const { entries } = await svc.listEntries({ limit: 1000 });
+  return entries.map((e: MemoryEntry) => e.summary);
+}
+
+beforeEach(() => {
+  fs.mkdirSync(TEST_TMP_BASE, { recursive: true });
+  tempHome = fs.mkdtempSync(path.join(TEST_TMP_BASE, 'home-'));
+  // Defensive: the chosen base must never sit under a filtered temp path, or the
+  // service would index an empty store and the test would be vacuous.
+  if (tempHome.includes('/tmp/') || tempHome.includes('Temp/')) {
+    throw new Error(`temp dir ${tempHome} would be skipped by the service store filter`);
+  }
+  memoryDir = path.join(tempHome, '.ijfw', 'memory');
+  fs.mkdirSync(memoryDir, { recursive: true });
+  knowledgePath = path.join(memoryDir, 'knowledge.md');
+  soloPath = path.join(memoryDir, 'solo.md');
+  fs.writeFileSync(knowledgePath, KNOWLEDGE_MD, 'utf8');
+  fs.writeFileSync(soloPath, SOLO_MD, 'utf8');
+
+  homeHolder.path = tempHome;
+  svc = makeService();
+});
+
+afterEach(() => {
+  svc.dispose();
+  homeHolder.path = '';
+  if (tempHome) fs.rmSync(tempHome, { recursive: true, force: true });
+});
+
+describe('IjfwArchiveService.deleteEntry (#414)', () => {
+  it('removes only the target block, preserves the other entries verbatim', async () => {
+    const betaId = await idBySummary('Beta pattern for retries');
+
+    const result = await svc.deleteEntry(betaId);
+    expect(result).toEqual({ ok: true });
+
+    const after = fs.readFileSync(knowledgePath, 'utf8');
+    // Other entries survive byte-for-byte.
+    expect(after).toContain(ALPHA_BLOCK);
+    expect(after).toContain(GAMMA_BLOCK);
+    // Target is gone (frontmatter and body).
+    expect(after).not.toContain('Beta pattern for retries');
+    expect(after).not.toContain('Body of beta pattern.');
+
+    // Index no longer returns the deleted entry.
+    const remaining = await summaries();
+    expect(remaining).toContain('Alpha decision about caching');
+    expect(remaining).toContain('Gamma observation on latency');
+    expect(remaining).not.toContain('Beta pattern for retries');
+    await expect(svc.getEntry(betaId)).resolves.toBeNull();
+  });
+
+  it('unlinks the source file when deleting its last entry', async () => {
+    const soloId = await idBySummary('Solo entry stands alone');
+    expect(fs.existsSync(soloPath)).toBe(true);
+
+    const result = await svc.deleteEntry(soloId);
+    expect(result).toEqual({ ok: true });
+
+    expect(fs.existsSync(soloPath)).toBe(false);
+    // The multi-entry file is untouched.
+    expect(fs.existsSync(knowledgePath)).toBe(true);
+    const remaining = await summaries();
+    expect(remaining).not.toContain('Solo entry stands alone');
+  });
+
+  it('returns not_found for a bogus id', async () => {
+    const result = await svc.deleteEntry('deadbeefcafe');
+    expect(result).toEqual({ ok: false, error: 'not_found' });
+  });
+});
+
+describe('IjfwArchiveService.editEntry (#414)', () => {
+  it('changing the summary rewrites only that block and returns a new id', async () => {
+    const oldId = await idBySummary('Alpha decision about caching');
+
+    const result = await svc.editEntry(oldId, { summary: 'Alpha decision about memoization' });
+    expect(result.ok).toBe(true);
+    expect(result.error).toBeUndefined();
+    expect(result.newId).toBeDefined();
+    expect(result.newId).not.toBe(oldId);
+
+    // The new id resolves to the edited entry with new summary + intact body.
+    const edited = await svc.getEntry(result.newId as string);
+    expect(edited).not.toBeNull();
+    expect(edited?.summary).toBe('Alpha decision about memoization');
+    expect(edited?.body).toContain('Body of alpha entry.');
+
+    // Sibling entries are untouched.
+    const after = fs.readFileSync(knowledgePath, 'utf8');
+    expect(after).toContain('Body of beta pattern.');
+    expect(after).toContain(GAMMA_BLOCK);
+    const list = await summaries();
+    expect(list).toContain('Beta pattern for retries');
+    expect(list).toContain('Gamma observation on latency');
+    expect(list).not.toContain('Alpha decision about caching');
+  });
+
+  it('changing only the body preserves frontmatter and keeps the id stable', async () => {
+    const betaId = await idBySummary('Beta pattern for retries');
+
+    const result = await svc.editEntry(betaId, { body: 'Rewritten body for the beta pattern.' });
+    expect(result.ok).toBe(true);
+    // Summary unchanged => id (sha1 of sourcePath:stored:summary) is unchanged.
+    expect(result.newId).toBe(betaId);
+
+    const after = fs.readFileSync(knowledgePath, 'utf8');
+    // Body replaced.
+    expect(after).toContain('Rewritten body for the beta pattern.');
+    expect(after).not.toContain('Body of beta pattern.');
+    // Untouched frontmatter of the same block is preserved.
+    expect(after).toContain('type: pattern');
+    expect(after).toContain('source_path: /orig/beta.md');
+    expect(after).toContain('tags: [retry]');
+    expect(after).toContain('stored: 2026-05-02T11:00:00.000Z');
+
+    const reread = await svc.getEntry(betaId);
+    expect(reread?.body).toContain('Rewritten body for the beta pattern.');
+  });
+
+  it('returns not_found when editing a bogus id', async () => {
+    const result = await svc.editEntry('deadbeefcafe', { summary: 'nope' });
+    expect(result).toEqual({ ok: false, error: 'not_found' });
+  });
+
+  it('refuses a rename that would collide with a sibling summary and leaves both entries intact (audit #1)', async () => {
+    // Renaming one entry to match another's summary would make the two mutually
+    // ambiguous for id/getEntry/edit/delete, so the edit must fail closed.
+    const collidePath = path.join(memoryDir, 'collide.md');
+    fs.writeFileSync(
+      collidePath,
+      [
+        '---',
+        'type: decision',
+        'summary: Shared colliding title',
+        'stored: 2026-07-02T00:00:00.000Z',
+        'tags: []',
+        '---',
+        'SIBLING body sentinel.',
+        '',
+        '---',
+        'type: observation',
+        'summary: Distinct older title',
+        'stored: 2026-07-01T00:00:00.000Z',
+        'tags: []',
+        '---',
+        'EDITED body sentinel.',
+        '',
+      ].join('\n'),
+      'utf8'
+    );
+    svc.dispose();
+    svc = makeService(); // rescan to pick up collide.md
+
+    const olderId = await idBySummary('Distinct older title');
+    const res = await svc.editEntry(olderId, { summary: 'Shared colliding title' });
+    expect(res).toEqual({ ok: false, error: 'summary_collision' });
+
+    // Nothing was written: both entries survive byte-for-byte.
+    const onDisk = fs.readFileSync(collidePath, 'utf8');
+    expect(onDisk).toContain('summary: Distinct older title');
+    expect(onDisk).toContain('EDITED body sentinel.');
+    expect(onDisk).toContain('SIBLING body sentinel.');
+  });
+});
+
+// NOTE on the 'unmanaged_path' guard: isManagedMemoryPath requires the entry's
+// sourcePath to contain '/.ijfw/memory/'. Every entry the service indexes is
+// discovered by scanning `<store>/.ijfw/memory`, so its sourcePath ALWAYS
+// satisfies the guard. There is no public seam to insert an entry with an
+// out-of-store sourcePath (the index is private and populated only by the
+// disk scan), so that branch is unreachable without contorting the fixture.
+// It is deliberately left to a future unit test of isManagedMemoryPath itself.

--- a/tests/unit/memoryEntryMutation.test.ts
+++ b/tests/unit/memoryEntryMutation.test.ts
@@ -1,0 +1,242 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { applyDelete, applyEdit, serializeScalar } from '../../src/process/services/memory/memoryEntryMutation';
+import { parseMarkdownBlocks } from '../../src/process/services/memory/markdownFrontmatter';
+
+// A realistic two-entry file matching the real ~/.ijfw/memory schema
+// (type/summary/stored/project/tags/source_path). Trailing newline included.
+const TWO_ENTRY = [
+  '---',
+  'type: observation',
+  'summary: First entry summary',
+  'stored: 2026-05-27T09:11:14.255Z',
+  'project: alpha',
+  'tags: [design, api]',
+  'source_path: /Users/x/dev/alpha/.ijfw/memory/research.md',
+  '---',
+  '## First entry summary',
+  '',
+  'Body of the first entry.',
+  '---',
+  'type: decision',
+  'summary: Second entry summary',
+  'stored: 2026-05-28T10:00:00.000Z',
+  'project: beta',
+  'tags: []',
+  '---',
+  'Body of the second entry.',
+  '',
+].join('\n');
+
+function blockCount(content: string): number {
+  return parseMarkdownBlocks(content).length;
+}
+
+describe('memoryEntryMutation.applyDelete', () => {
+  it('removes the target block and leaves the other block byte-for-byte intact', () => {
+    const r = applyDelete(TWO_ENTRY, 'First entry summary');
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.remainingBlocks).toBe(1);
+    expect(blockCount(r.content)).toBe(1);
+    // The surviving (second) block is preserved verbatim.
+    expect(r.content).toContain('summary: Second entry summary');
+    expect(r.content).toContain('Body of the second entry.');
+    // The deleted block is fully gone.
+    expect(r.content).not.toContain('First entry summary');
+    expect(r.content).not.toContain('Body of the first entry.');
+    expect(r.content).not.toContain('source_path: /Users/x/dev/alpha');
+  });
+
+  it('deletes the last block, reporting zero remaining (caller may unlink)', () => {
+    const oneEntry = [
+      '---',
+      'type: observation',
+      'summary: Only entry',
+      'stored: 2026-01-01T00:00:00.000Z',
+      'tags: []',
+      '---',
+      'Only body.',
+      '',
+    ].join('\n');
+    const r = applyDelete(oneEntry, 'Only entry');
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.remainingBlocks).toBe(0);
+    expect(blockCount(r.content)).toBe(0);
+  });
+
+  it('returns not_found when no block matches the summary', () => {
+    const r = applyDelete(TWO_ENTRY, 'Nonexistent summary');
+    expect(r).toEqual({ ok: false, error: 'not_found' });
+  });
+
+  it('refuses (ambiguous) when two blocks share the same 80-char summary', () => {
+    const dup = [
+      TWO_ENTRY,
+      '---',
+      'type: observation',
+      'summary: First entry summary',
+      'stored: 2026-06-01T00:00:00.000Z',
+      'tags: []',
+      '---',
+      'Another body.',
+      '',
+    ].join('\n');
+    const r = applyDelete(dup, 'First entry summary');
+    expect(r).toEqual({ ok: false, error: 'ambiguous' });
+  });
+
+  it('preserves a file-level header (comment + H1) when deleting', () => {
+    const withHeader = ['<!-- ijfw-schema: v1 -->', '# Memory', TWO_ENTRY].join('\n');
+    const r = applyDelete(withHeader, 'Second entry summary');
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.content).toContain('<!-- ijfw-schema: v1 -->');
+    expect(r.content).toContain('# Memory');
+    expect(r.content).toContain('summary: First entry summary');
+    expect(r.content).not.toContain('Second entry summary');
+  });
+});
+
+describe('memoryEntryMutation.applyEdit', () => {
+  it('patches only the summary line and preserves all other frontmatter + the other block', () => {
+    const r = applyEdit(TWO_ENTRY, 'First entry summary', { summary: 'Renamed first entry' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.content).toContain('summary: Renamed first entry');
+    expect(r.content).not.toContain('summary: First entry summary');
+    // Untouched frontmatter keys of the edited block survive verbatim.
+    expect(r.content).toContain('stored: 2026-05-27T09:11:14.255Z');
+    expect(r.content).toContain('project: alpha');
+    expect(r.content).toContain('source_path: /Users/x/dev/alpha/.ijfw/memory/research.md');
+    // The other block is untouched.
+    expect(r.content).toContain('summary: Second entry summary');
+    expect(r.content).toContain('Body of the second entry.');
+    expect(blockCount(r.content)).toBe(2);
+  });
+
+  it('replaces the body when patched, keeping frontmatter intact', () => {
+    const r = applyEdit(TWO_ENTRY, 'Second entry summary', { body: 'Rewritten second body.\nSecond line.' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const blocks = parseMarkdownBlocks(r.content);
+    const second = blocks.find((b) => b.frontmatter['summary'] === 'Second entry summary');
+    expect(second?.body).toBe('Rewritten second body.\nSecond line.');
+    expect(r.content).not.toContain('Body of the second entry.');
+    // First block untouched.
+    expect(r.content).toContain('Body of the first entry.');
+  });
+
+  it('replaces the tags line', () => {
+    const r = applyEdit(TWO_ENTRY, 'First entry summary', { tags: ['x', 'y', 'z'] });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const blocks = parseMarkdownBlocks(r.content);
+    const first = blocks.find((b) => (b.frontmatter['summary'] as string) === 'First entry summary');
+    expect(first?.frontmatter['tags']).toEqual(['x', 'y', 'z']);
+  });
+
+  it('inserts a frontmatter key that did not exist before', () => {
+    const noTags = [
+      '---',
+      'type: observation',
+      'summary: No tags entry',
+      'stored: 2026-02-02T00:00:00.000Z',
+      '---',
+      'Body.',
+      '',
+    ].join('\n');
+    const r = applyEdit(noTags, 'No tags entry', { tags: ['added'] });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const blocks = parseMarkdownBlocks(r.content);
+    expect(blocks[0]?.frontmatter['tags']).toEqual(['added']);
+    expect(blocks[0]?.frontmatter['type']).toBe('observation');
+  });
+
+  it('quotes summaries with YAML-significant characters so they round-trip', () => {
+    const r = applyEdit(TWO_ENTRY, 'First entry summary', { summary: 'Has: a colon [and] brackets' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const blocks = parseMarkdownBlocks(r.content);
+    const edited = blocks.find((b) => (b.frontmatter['summary'] as string) === 'Has: a colon [and] brackets');
+    expect(edited).toBeTruthy(); // decodeScalar reversed the quoting exactly
+  });
+
+  it('returns not_found for a missing summary', () => {
+    expect(applyEdit(TWO_ENTRY, 'Missing', { summary: 'x' })).toEqual({ ok: false, error: 'not_found' });
+  });
+
+  it('refuses a rename that collides with another block summary (fail closed)', () => {
+    const r = applyEdit(TWO_ENTRY, 'First entry summary', { summary: 'Second entry summary' });
+    expect(r).toEqual({ ok: false, error: 'summary_collision' });
+  });
+
+  it('allows other edits (body/type/tags) even when the summary is unchanged', () => {
+    // Not a rename → no collision check; editing body/tags on entry one is fine.
+    const r = applyEdit(TWO_ENTRY, 'First entry summary', { body: 'changed', tags: ['q'] });
+    expect(r.ok).toBe(true);
+  });
+
+  it('refuses ambiguous edits', () => {
+    const dup = [
+      TWO_ENTRY,
+      '---',
+      'type: observation',
+      'summary: First entry summary',
+      'stored: 2026-06-01T00:00:00.000Z',
+      'tags: []',
+      '---',
+      'Another.',
+      '',
+    ].join('\n');
+    expect(applyEdit(dup, 'First entry summary', { summary: 'x' })).toEqual({ ok: false, error: 'ambiguous' });
+  });
+});
+
+describe('memoryEntryMutation - line-ending preservation', () => {
+  const CRLF = TWO_ENTRY.replace(/\n/g, '\r\n');
+
+  it('keeps a CRLF file as CRLF on delete (no silent LF rewrite of siblings)', () => {
+    const r = applyDelete(CRLF, 'First entry summary');
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.content.includes('\r\n')).toBe(true);
+    // Every LF is preceded by CR — no bare LF leaked in.
+    expect(/[^\r]\n/.test(r.content)).toBe(false);
+    expect(r.content).toContain('summary: Second entry summary');
+  });
+
+  it('keeps a CRLF file as CRLF on edit', () => {
+    const r = applyEdit(CRLF, 'First entry summary', { summary: 'Renamed', body: 'new\nbody' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.content.includes('\r\n')).toBe(true);
+    expect(/[^\r]\n/.test(r.content)).toBe(false);
+  });
+
+  it('keeps an LF file as LF (no stray CR introduced)', () => {
+    const r = applyEdit(TWO_ENTRY, 'First entry summary', { summary: 'Renamed' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.content.includes('\r')).toBe(false);
+  });
+});
+
+describe('serializeScalar', () => {
+  it('leaves plain values unquoted', () => {
+    expect(serializeScalar('observation')).toBe('observation');
+    expect(serializeScalar('alpha-beta')).toBe('alpha-beta'); // starts with letter, hyphen inside is fine
+  });
+  it('quotes values with colons/brackets/newlines and the empty string', () => {
+    expect(serializeScalar('')).toBe('""');
+    expect(serializeScalar('a: b')).toBe('"a: b"');
+    expect(serializeScalar('multi\nline')).toBe(JSON.stringify('multi\nline'));
+  });
+});

--- a/tests/unit/renderer/pages/memory/EntryEditorModal.dom.test.tsx
+++ b/tests/unit/renderer/pages/memory/EntryEditorModal.dom.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// @vitest-environment jsdom
+
+/**
+ * DOM tests for EntryEditorModal (#414). The load-bearing behavior is the
+ * diff-only patch: editing one field must send ONLY that field to
+ * memory.update-entry so untouched frontmatter is left verbatim on disk.
+ */
+
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MemoryEntry } from '@/common/types/memory';
+
+const updateEntry = vi.hoisted(() => vi.fn());
+
+vi.mock('@/common/adapter/ipcBridge', () => ({
+  memory: { updateEntry: { invoke: updateEntry } },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_k: string, fb?: unknown) => (typeof fb === 'string' ? fb : _k) }),
+}));
+
+// Minimal Arco stubs: expose the OK button (with its disabled state) and the
+// summary input; other fields are inert passthroughs for this diff test.
+vi.mock('@arco-design/web-react', () => {
+  const Input: React.FC<Record<string, unknown>> & { TextArea: React.FC<Record<string, unknown>> } = ((
+    props: Record<string, unknown>
+  ) => (
+    <input
+      data-testid={props['data-testid'] as string}
+      value={props.value as string}
+      onChange={(e) => (props.onChange as (v: string) => void)?.(e.target.value)}
+    />
+  )) as never;
+  Input.TextArea = (props: Record<string, unknown>) => (
+    <textarea
+      data-testid={props['data-testid'] as string}
+      value={props.value as string}
+      onChange={(e) => (props.onChange as (v: string) => void)?.(e.target.value)}
+    />
+  );
+  return {
+    Input,
+    InputTag: (props: Record<string, unknown>) => <div data-testid={props['data-testid'] as string} />,
+    Select: Object.assign(
+      (props: Record<string, unknown>) => (
+        <div data-testid={props['data-testid'] as string}>{props.children as React.ReactNode}</div>
+      ),
+      { Option: (props: Record<string, unknown>) => <span>{props.children as React.ReactNode}</span> }
+    ),
+    Message: { success: vi.fn(), error: vi.fn() },
+    Modal: (props: Record<string, unknown>) => {
+      if (!props.visible) return null;
+      const okp = (props.okButtonProps as { disabled?: boolean }) ?? {};
+      return (
+        <div>
+          {props.children as React.ReactNode}
+          <button data-testid='modal-ok' disabled={okp.disabled} onClick={props.onOk as () => void}>
+            ok
+          </button>
+        </div>
+      );
+    },
+  };
+});
+
+// eslint-disable-next-line import/first
+import EntryEditorModal from '@/renderer/pages/memory/components/EntryEditorModal';
+
+const ENTRY: MemoryEntry & { body: string } = {
+  id: 'entry-001',
+  type: 'decision',
+  project: 'p',
+  projectPath: '/p',
+  summary: 'Original summary',
+  bodyPreview: 'prev',
+  body: 'Original body',
+  tags: ['a', 'b'],
+  storedAt: 1,
+  sourcePath: '/p/.ijfw/memory/journal.md',
+  sourceLine: 0,
+  referencedBy: 0,
+  promotionScore: 0,
+};
+
+afterEach(() => {
+  cleanup();
+  updateEntry.mockReset();
+});
+
+beforeEach(() => {
+  updateEntry.mockResolvedValue({ ok: true, newId: 'entry-new' });
+});
+
+describe('EntryEditorModal (#414)', () => {
+  it('prefills the summary from the entry', () => {
+    render(<EntryEditorModal open entry={ENTRY} onClose={vi.fn()} onSaved={vi.fn()} />);
+    expect((screen.getByTestId('entry-editor-summary') as HTMLInputElement).value).toBe('Original summary');
+  });
+
+  it('disables Save when nothing has changed', () => {
+    render(<EntryEditorModal open entry={ENTRY} onClose={vi.fn()} onSaved={vi.fn()} />);
+    expect((screen.getByTestId('modal-ok') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('sends ONLY the changed field (summary) and calls onSaved with the new id', async () => {
+    const onSaved = vi.fn();
+    render(<EntryEditorModal open entry={ENTRY} onClose={vi.fn()} onSaved={onSaved} />);
+    fireEvent.change(screen.getByTestId('entry-editor-summary'), { target: { value: 'Renamed' } });
+    expect((screen.getByTestId('modal-ok') as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(screen.getByTestId('modal-ok'));
+    await waitFor(() => expect(updateEntry).toHaveBeenCalledTimes(1));
+    // Diff-only: no type/tags/body in the payload.
+    expect(updateEntry).toHaveBeenCalledWith({ id: 'entry-001', summary: 'Renamed' });
+    await waitFor(() => expect(onSaved).toHaveBeenCalledWith('entry-new'));
+  });
+
+  it('does not save when the summary is cleared (empty summary is invalid)', () => {
+    render(<EntryEditorModal open entry={ENTRY} onClose={vi.fn()} onSaved={vi.fn()} />);
+    fireEvent.change(screen.getByTestId('entry-editor-summary'), { target: { value: '   ' } });
+    expect((screen.getByTestId('modal-ok') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('sends only the body when only the body changed', async () => {
+    render(<EntryEditorModal open entry={ENTRY} onClose={vi.fn()} onSaved={vi.fn()} />);
+    fireEvent.change(screen.getByTestId('entry-editor-body'), { target: { value: 'New body' } });
+    fireEvent.click(screen.getByTestId('modal-ok'));
+    await waitFor(() => expect(updateEntry).toHaveBeenCalledWith({ id: 'entry-001', body: 'New body' }));
+  });
+});

--- a/tests/unit/renderer/pages/memory/FullPanelShell.dom.test.tsx
+++ b/tests/unit/renderer/pages/memory/FullPanelShell.dom.test.tsx
@@ -105,7 +105,7 @@ const MOCK_CANDIDATES: PromotionCandidates = {
 // Mocks
 // ---------------------------------------------------------------------------
 
-const { mockMemory, mockShell, mockIjfw } = vi.hoisted(() => {
+const { mockMemory, mockShell, mockIjfw, mockModalConfirm } = vi.hoisted(() => {
   let _indexChangedListeners: Array<(v: unknown) => void> = [];
   let _ijfwListeners: Array<(v: unknown) => void> = [];
   const mockIndexChangedEmitter = {
@@ -135,6 +135,9 @@ const { mockMemory, mockShell, mockIjfw } = vi.hoisted(() => {
       getPromotionCandidates: { invoke: vi.fn() },
       promote: { invoke: vi.fn() },
       setQuickAdd: { invoke: vi.fn() },
+      // #414 edit/delete mutations (used by the drawer actions).
+      updateEntry: { invoke: vi.fn() },
+      deleteEntry: { invoke: vi.fn() },
       setPromotionThreshold: { invoke: vi.fn() },
       onIndexChanged: mockIndexChangedEmitter,
       import: {
@@ -158,6 +161,9 @@ const { mockMemory, mockShell, mockIjfw } = vi.hoisted(() => {
       // Used by the embedded IjfwSetupStatus (#414 health strip) on expand.
       brainInvoke: { invoke: vi.fn() },
     },
+    // Captures the config passed to Modal.confirm so the delete-gate test can
+    // assert deleteEntry fires ONLY from the confirm dialog's onOk.
+    mockModalConfirm: vi.fn((_cfg: unknown) => ({ close: vi.fn() })),
   };
 });
 
@@ -185,6 +191,13 @@ vi.mock('@arco-design/web-react', async () => {
       error: vi.fn(),
       info: vi.fn(),
     },
+    // Modal.confirm is captured (delete gate); the component form renders its
+    // children when visible so any other Modal usage in the tree still works.
+    Modal: Object.assign(
+      ({ visible, children }: { visible?: boolean; children?: React.ReactNode }) =>
+        visible ? <div data-testid='arco-modal'>{children}</div> : null,
+      { confirm: mockModalConfirm }
+    ),
     Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
     Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
     Dropdown: ({ children, droplist }: { children: React.ReactNode; droplist: React.ReactNode }) => (
@@ -262,6 +275,8 @@ beforeEach(() => {
   mockMemory.getPromotionCandidates.invoke.mockResolvedValue(MOCK_CANDIDATES);
   mockMemory.promote.invoke.mockResolvedValue({ ok: true });
   mockMemory.setQuickAdd.invoke.mockResolvedValue({ ok: true });
+  mockMemory.deleteEntry.invoke.mockResolvedValue({ ok: true });
+  mockMemory.updateEntry.invoke.mockResolvedValue({ ok: true });
   mockMemory.import.scanDevDir.invoke.mockResolvedValue({ count: 0, projectsFound: 0, errors: [] });
   mockShell.openFile.invoke.mockResolvedValue(undefined);
   mockIjfw.getStatus.invoke.mockResolvedValue({ status: 'installed_current', cliCount: 5 });
@@ -453,5 +468,48 @@ describe('FullPanelShell setup-status strip (#414)', () => {
     });
     // Re-opened already expanded from the persisted flag.
     expect(screen.getByTestId('memory-setup-status-body')).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #414 - Delete is gated behind the confirm dialog (cannot-be-undone). The
+// destructive deleteEntry mutation must fire ONLY from the dialog's onOk, never
+// on the bare button click. Automated coverage so a refactor can't silently
+// weaken the gate the #414 ruling mandates.
+// ---------------------------------------------------------------------------
+
+describe('FullPanelShell delete confirm gate (#414)', () => {
+  it('does not call deleteEntry on button click; only the confirm onOk fires it', async () => {
+    await act(async () => {
+      renderShell(['/memory?entry=entry-001']);
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 30));
+    });
+
+    // Drawer is open with the selected entry; the Delete action is present.
+    const deleteBtn = screen.getByTestId('drawer-delete-btn');
+    expect(deleteBtn).toBeTruthy();
+
+    // Click Delete: the confirm dialog is requested, but NOTHING is deleted yet.
+    await act(async () => {
+      fireEvent.click(deleteBtn);
+    });
+    expect(mockModalConfirm).toHaveBeenCalledTimes(1);
+    expect(mockMemory.deleteEntry.invoke).not.toHaveBeenCalled();
+
+    // The confirm copy states the action cannot be undone (the #414 ruling).
+    const cfg = mockModalConfirm.mock.calls[0]![0] as {
+      content?: string;
+      onOk?: () => Promise<void> | void;
+    };
+    expect(String(cfg.content)).toContain('cannot be undone');
+
+    // Only firing the dialog's onOk performs the real, hard delete.
+    await act(async () => {
+      await cfg.onOk?.();
+    });
+    expect(mockMemory.deleteEntry.invoke).toHaveBeenCalledTimes(1);
+    expect(mockMemory.deleteEntry.invoke).toHaveBeenCalledWith({ id: 'entry-001' });
   });
 });

--- a/tests/unit/renderer/pages/memory/FullPanelShell.dom.test.tsx
+++ b/tests/unit/renderer/pages/memory/FullPanelShell.dom.test.tsx
@@ -200,6 +200,8 @@ vi.mock('@icon-park/react', () => ({
   Close: (p: Record<string, unknown>) => <span data-testid='icon-close' {...p} />,
   Copy: (p: Record<string, unknown>) => <span data-testid='icon-copy' {...p} />,
   LinkOne: (p: Record<string, unknown>) => <span data-testid='icon-link' {...p} />,
+  Edit: (p: Record<string, unknown>) => <span data-testid='icon-edit' {...p} />,
+  Delete: (p: Record<string, unknown>) => <span data-testid='icon-delete' {...p} />,
   FileCode: (p: Record<string, unknown>) => <span data-testid='icon-file-code' {...p} />,
   Help: (p: Record<string, unknown>) => <span data-testid='icon-help' {...p} />,
   // Used by the embedded IjfwSetupStatus (#414 health strip) when expanded.

--- a/tests/unit/renderer/pages/memory/RightDrawer.dom.test.tsx
+++ b/tests/unit/renderer/pages/memory/RightDrawer.dom.test.tsx
@@ -52,6 +52,8 @@ vi.mock('@icon-park/react', () => ({
   Close: (p: Record<string, unknown>) => <span data-testid='icon-close' {...p} />,
   Copy: (p: Record<string, unknown>) => <span data-testid='icon-copy' {...p} />,
   LinkOne: (p: Record<string, unknown>) => <span data-testid='icon-link' {...p} />,
+  Edit: (p: Record<string, unknown>) => <span data-testid='icon-edit' {...p} />,
+  Delete: (p: Record<string, unknown>) => <span data-testid='icon-delete' {...p} />,
   FileCode: (p: Record<string, unknown>) => <span data-testid='icon-file-code' {...p} />,
   Help: (p: Record<string, unknown>) => <span data-testid='icon-help' {...p} />,
 }));
@@ -208,9 +210,7 @@ describe('RightDrawer', () => {
 
     // Wait for the async fetch to resolve
     await waitFor(() => expect(screen.getByTestId('source-panel-anchor')).toBeTruthy());
-    expect(screen.getByTestId('source-panel-anchor').textContent).toContain(
-      'Use Arco components everywhere.',
-    );
+    expect(screen.getByTestId('source-panel-anchor').textContent).toContain('Use Arco components everywhere.');
   });
 
   it('shows error message when IPC returns ok=false', async () => {
@@ -265,5 +265,26 @@ describe('RightDrawer', () => {
 
     await waitFor(() => expect(screen.getByTestId('source-panel-anchor')).toBeTruthy());
     expect(screen.getByTestId('source-panel-anchor').textContent).toContain('auto anchor');
+  });
+
+  // #414 - Edit / Delete row actions
+  it('renders Edit and Delete actions', () => {
+    render(<RightDrawer entry={MOCK_ENTRY} onClose={vi.fn()} />);
+    expect(screen.getByTestId('drawer-edit-btn')).toBeTruthy();
+    expect(screen.getByTestId('drawer-delete-btn')).toBeTruthy();
+  });
+
+  it('clicking Edit calls onEdit with the full entry', () => {
+    const onEdit = vi.fn();
+    render(<RightDrawer entry={MOCK_ENTRY} onClose={vi.fn()} onEdit={onEdit} />);
+    fireEvent.click(screen.getByTestId('drawer-edit-btn'));
+    expect(onEdit).toHaveBeenCalledWith(MOCK_ENTRY);
+  });
+
+  it('clicking Delete calls onDelete with the entry (confirm is owned by the host)', () => {
+    const onDelete = vi.fn();
+    render(<RightDrawer entry={MOCK_ENTRY} onClose={vi.fn()} onDelete={onDelete} />);
+    fireEvent.click(screen.getByTestId('drawer-delete-btn'));
+    expect(onDelete).toHaveBeenCalledWith(MOCK_ENTRY);
   });
 });


### PR DESCRIPTION
Follow-on to #641; together they close #414 (per the Overwatch scope ruling). Stacked on feat/414-ijfw-memory-ui (#641) — review after that merges.

## What
Edit and hard-delete of a single IJFW memory entry, reachable from the Archive panel's entry drawer. This is the remaining capability gap for #414 (browse/search/read already ship; setup-status header is #641).

## Design (per Overwatch ruling)
- Extend the existing Archive panel with Edit + Delete row actions (no separate panel).
- Hard delete via atomic rewrite, behind a confirm dialog that states it cannot be undone from the app. Safe because the store is git-tracked.

## Backend
- memoryEntryMutation.ts (new): pure, byte-preserving transforms. Delete removes one ---block; edit surgically rewrites only the patched frontmatter keys (summary/type/tags) and body. Every other block and every untouched frontmatter key is left verbatim. Original line endings (LF/CRLF) and trailing-newline state are preserved.
- Fail-closed guards: an edit that would rename an entry to collide with a sibling's summary is refused (summary_collision) — otherwise the two entries would become mutually ambiguous for id/getEntry/edit/delete. Ambiguous locates also refuse.
- IjfwArchiveService.editEntry/deleteEntry: read -> transform -> atomic write+rename (or unlink when the file's last entry is removed) -> awaited reindex. Guarded to .ijfw/memory paths. Editing the summary changes the derived id, re-resolved deterministically via the stable storedAt and returned to the UI.
- memory.update-entry / memory.delete-entry IPC channels + zod-validated handlers.

## Renderer
- RightDrawer: Edit + Delete row actions.
- EntryEditorModal: prefilled editor, diff-only patch (only changed fields sent), collision surfaced as a clear message.
- Delete behind an Arco confirm with the mandated wording.

## Cross-audit
Independent adversarial audit (non-author) flagged 2 issues, both fixed and tested:
- CRITICAL: post-edit id could resolve to a summary-colliding sibling -> fixed by refusing collisions outright (+ storedAt disambiguation).
- IMPORTANT: CRLF files were normalized to LF on rewrite -> fixed to preserve original line endings.

## Tests + gates
- 19 mutation-transform unit tests (byte-preservation, surgical edit, ambiguity/collision refusal, CRLF+LF preservation, round-trip quoting, header preservation).
- 7 service integration tests against a temp store (delete preserves siblings byte-for-byte, unlink-on-last, collision refusal leaves both entries intact, id recompute).
- Renderer tests for the drawer actions and the diff-only patch.
- typecheck + prek CI-parity all pass; i18n via defaultValue pattern (no new locale keys required).

## Live-verified against the REAL store (throwaway entries, cleaned up net-zero)
- Create -> Edit (summary+body persisted to disk, id recomputed) -> Delete -> store returns to baseline (38).
- Collision rename refused live (summary_collision); legit rename succeeds live.
- UI: Edit modal renders prefilled with Save disabled until changed; Delete confirm shows "This permanently removes the memory from its file. It cannot be undone from the app."
- No real memories touched.
