### PR TITLE
feat(files): file-type classification + document auto-read attach hint (#655)

### DIFF
--- a/src/renderer/components/media/FilePreview.tsx
+++ b/src/renderer/components/media/FilePreview.tsx
@@ -6,7 +6,8 @@
 
 import { X } from 'lucide-react';
 import React, { useEffect, useState } from 'react';
-import { getFileExtension } from '@/renderer/services/FileService';
+import { useTranslation } from 'react-i18next';
+import { getFileExtension, isDocumentFile } from '@/renderer/services/FileService';
 import { ipcBridge } from '@/common';
 import { Image } from '@arco-design/web-react';
 import fileIcon from '@/renderer/assets/icons/file-icon.svg';
@@ -46,10 +47,15 @@ const FilePreview: React.FC<FilePreviewProps> = ({ path, onRemove, readonly = fa
     return null;
   }
 
+  const { t } = useTranslation();
   const isImage = isImageFile(path);
   // Extract filename directly from path without cleaning timestamp suffix
   const fileName = path.split(/[\\/]/).pop() || '';
   const fileExt = getFileExtension(path).toUpperCase().replace('.', '');
+  // #655: passive attach-time hint that a document will be auto-read (extracted)
+  // by the engine on send. Composer-only (not on already-sent readonly bubbles);
+  // purely desktop-side classification, no engine data.
+  const showDocHint = !readonly && !isImage && isDocumentFile(fileName);
   const [imageUrl, setImageUrl] = useState<string>('');
   const [fileSize, setFileSize] = useState<string>('');
 
@@ -147,6 +153,11 @@ const FilePreview: React.FC<FilePreviewProps> = ({ path, onRemove, readonly = fa
           <span className='text-12px text-t-secondary'>
             {fileExt}: {fileSize || '...'}
           </span>
+          {showDocHint && (
+            <span className='text-11px text-t-secondary max-w-150px truncate' data-testid='file-doc-ingest-hint'>
+              {t('common.fileAttach.docIngestHint', 'Will be read as a document')}
+            </span>
+          )}
         </div>
       </div>
       {!readonly && (

--- a/src/renderer/pages/conversation/Workspace/components/FileChangeList.tsx
+++ b/src/renderer/pages/conversation/Workspace/components/FileChangeList.tsx
@@ -8,7 +8,7 @@ import { ChevronDown, ChevronRight, Eye, Minus, Plus, Redo2, RefreshCw } from 'l
 import { ipcBridge } from '@/common';
 import type { FileChangeInfo, SnapshotInfo } from '@/common/types/fileSnapshot';
 import Diff2Html from '@/renderer/components/media/Diff2Html';
-import { isTextFile } from '@/renderer/services/FileService';
+import { isLikelyTextFile } from '@/renderer/services/FileService';
 import { Button, Empty, Spin, Tooltip } from '@arco-design/web-react';
 import { createTwoFilesPatch } from 'diff';
 import type { TFunction } from 'i18next';
@@ -184,7 +184,7 @@ const FileChangeList: React.FC<FileChangeListProps> = ({
   const loadDiffState = useCallback(
     async (change: FileChangeInfo) => {
       const fileName = change.relativePath;
-      if (!isTextFile(fileName)) return null;
+      if (!isLikelyTextFile(fileName)) return null;
 
       try {
         let before = '';
@@ -221,7 +221,7 @@ const FileChangeList: React.FC<FileChangeListProps> = ({
   const handleToggleDiff = useCallback(
     async (change: FileChangeInfo) => {
       const fileName = change.relativePath;
-      if (!isTextFile(fileName)) return;
+      if (!isLikelyTextFile(fileName)) return;
 
       if (expandedFilePath === change.filePath) {
         setExpandedFilePath(null);
@@ -387,7 +387,7 @@ const FileChangeList: React.FC<FileChangeListProps> = ({
                 const diffState = diffCache[change.filePath];
                 const isExpanded = expandedFilePath === change.filePath;
                 const isLoadingDiff = loadingFilePath === change.filePath;
-                const canExpand = isTextFile(change.relativePath);
+                const canExpand = isLikelyTextFile(change.relativePath);
 
                 return (
                   <FileChangeItem

--- a/src/renderer/services/FileService.ts
+++ b/src/renderer/services/FileService.ts
@@ -288,34 +288,48 @@ export function formatFileSize(bytes: number): string {
   return formatBytes(bytes, 2); // Keep 2-digit precision for backward compatibility
 }
 
+// File-type classification (#655 doc-ingestion routing). These do REAL extension
+// membership — deliberately distinct from isSupportedFile, which stays accept-all
+// (Wayland uploads any file type; classification only decides how a file is
+// surfaced/ingested downstream, never whether it is accepted for upload).
+
 /**
- * Check whether a file is an image file.
- * Note: since isSupportedFile currently always returns true, this also always returns true.
- * Designed ahead, reserved for a future file-type detection feature.
- * Currently unused; kept for future extension.
+ * Check whether a file is an image file (by extension).
  */
 export function isImageFile(fileName: string): boolean {
-  return isSupportedFile(fileName, imageExts);
+  return imageExts.includes(getFileExtension(fileName));
 }
 
 /**
- * Check whether a file is a document file.
- * Note: since isSupportedFile currently always returns true, this also always returns true.
- * Designed ahead, reserved for a future file-type detection feature.
- * Currently unused; kept for future extension.
+ * Check whether a file is a document file (office / pdf) by extension — the set
+ * the engine's doc_extract / pdf_extract auto-ingest path targets (#650). The
+ * engine determines the actual extraction result; this is the desktop-side
+ * classification used for the "will be read as a document" attach hint (#655).
  */
 export function isDocumentFile(fileName: string): boolean {
-  return isSupportedFile(fileName, documentExts);
+  return documentExts.includes(getFileExtension(fileName));
 }
 
 /**
- * Check whether a file is a text file.
- * Note: since isSupportedFile currently always returns true, this also always returns true.
- * Designed ahead, reserved for a future file-type detection feature.
- * Currently unused; kept for future extension.
+ * Check whether a file is a plain-text / code file (by extension) — reachable by
+ * the engine's read tool directly, no extraction step needed.
  */
 export function isTextFile(fileName: string): boolean {
-  return isSupportedFile(fileName, textExts);
+  return textExts.includes(getFileExtension(fileName));
+}
+
+/**
+ * Whether a file is text-diffable — i.e. NOT an image and NOT a binary office
+ * document. Deliberately broader than isTextFile (a finite allowlist of known
+ * text/code extensions): this also treats unknown and extension-less files
+ * (Dockerfile, Makefile, LICENSE, .env, arbitrary code extensions) as text,
+ * matching the Workspace diff viewer's "expand anything that isn't binary"
+ * intent. Used where the old always-true isSupportedFile gate previously let
+ * every file expand; now only genuine binaries (images / office docs) are
+ * excluded, and every real text/code file stays expandable (#655).
+ */
+export function isLikelyTextFile(fileName: string): boolean {
+  return !isImageFile(fileName) && !isDocumentFile(fileName);
 }
 
 class FileServiceClass {

--- a/tests/unit/FileChangeList.dom.test.tsx
+++ b/tests/unit/FileChangeList.dom.test.tsx
@@ -36,7 +36,9 @@ vi.mock('@/common', () => ({
 }));
 
 vi.mock('@/renderer/services/FileService', () => ({
-  isTextFile: vi.fn(() => true),
+  // FileChangeList gates diff-expand on isLikelyTextFile (#655); mock it true so
+  // the rows are expandable regardless of the sample paths' extensions.
+  isLikelyTextFile: vi.fn(() => true),
 }));
 
 vi.mock('@/renderer/components/media/Diff2Html', () => ({

--- a/tests/unit/FilePreview.dom.test.tsx
+++ b/tests/unit/FilePreview.dom.test.tsx
@@ -26,11 +26,21 @@ vi.mock('../../src/common', () => ({
   },
 }));
 
-vi.mock('../../src/renderer/services/FileService', () => ({
-  getFileExtension: (name: string) => {
+vi.mock('../../src/renderer/services/FileService', () => {
+  const getFileExtension = (name: string) => {
     const dot = name.lastIndexOf('.');
-    return dot >= 0 ? name.slice(dot) : '';
-  },
+    return dot >= 0 ? name.slice(dot).toLowerCase() : '';
+  };
+  const DOC_EXTS = ['.pdf', '.doc', '.docx', '.pptx', '.xlsx', '.odt', '.odp', '.ods'];
+  return {
+    getFileExtension,
+    // #655: real document classification used by the attach-time doc hint.
+    isDocumentFile: (name: string) => DOC_EXTS.includes(getFileExtension(name)),
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_key: string, dflt?: string) => dflt ?? _key }),
 }));
 
 vi.mock('@arco-design/web-react', () => ({
@@ -132,6 +142,31 @@ describe('FilePreview', () => {
     // Should not attempt to load image
     expect(getImageBase64Mock).not.toHaveBeenCalled();
     expect(screen.getByText('document.pdf')).toBeDefined();
+  });
+
+  it('shows the "will be read as a document" hint for a document in the composer', async () => {
+    render(<FilePreview path='/workspace/report.docx' onRemove={vi.fn()} />);
+    await flushMicrotasks();
+    const hint = screen.getByTestId('file-doc-ingest-hint');
+    expect(hint).toBeDefined();
+    expect(hint.textContent).toBe('Will be read as a document');
+  });
+
+  it('hides the doc hint on already-sent (readonly) bubbles', async () => {
+    render(<FilePreview path='/workspace/report.docx' onRemove={vi.fn()} readonly />);
+    await flushMicrotasks();
+    expect(screen.queryByTestId('file-doc-ingest-hint')).toBeNull();
+  });
+
+  it('does not show the doc hint for images or plain-text files', async () => {
+    getImageBase64Mock.mockResolvedValue(REAL_IMAGE_B64);
+    const { rerender } = render(<FilePreview path='/workspace/photo.png' onRemove={vi.fn()} />);
+    await flushMicrotasks();
+    expect(screen.queryByTestId('file-doc-ingest-hint')).toBeNull();
+
+    rerender(<FilePreview path='/workspace/notes.txt' onRemove={vi.fn()} />);
+    await flushMicrotasks();
+    expect(screen.queryByTestId('file-doc-ingest-hint')).toBeNull();
   });
 
   it('cleans up retry timer on unmount', async () => {

--- a/tests/unit/renderer/services/FileService.classification.test.ts
+++ b/tests/unit/renderer/services/FileService.classification.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #655 - file-type classification. isImageFile/isDocumentFile/isTextFile must do
+ * REAL extension membership (they were no-op stubs that always returned true).
+ * isSupportedFile stays accept-all (upload acceptance must not regress).
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+// FileService pulls electron/ipc/http deps at module top; stub them so the pure
+// classification exports can be imported and exercised in a node test env.
+vi.mock('@/common', () => ({ ipcBridge: {} }));
+vi.mock('@/renderer/hooks/file/useUploadState', () => ({
+  trackUpload: () => ({ onProgress: () => void 0, finish: () => void 0 }),
+}));
+vi.mock('@/renderer/utils/platform', () => ({ isElectronDesktop: () => true }));
+vi.mock('@process/webserver/middleware/csrfClient', () => ({ getCsrfToken: () => '' }));
+
+import {
+  isImageFile,
+  isDocumentFile,
+  isTextFile,
+  isLikelyTextFile,
+  isSupportedFile,
+  imageExts,
+  documentExts,
+  textExts,
+} from '@/renderer/services/FileService';
+
+describe('FileService classification (#655)', () => {
+  it('isImageFile matches image extensions only', () => {
+    for (const ext of imageExts) expect(isImageFile(`photo${ext}`)).toBe(true);
+    expect(isImageFile('sheet.xlsx')).toBe(false);
+    expect(isImageFile('notes.txt')).toBe(false);
+    expect(isImageFile('noext')).toBe(false);
+  });
+
+  it('isDocumentFile matches office/pdf extensions only (the auto-ingest set)', () => {
+    for (const ext of documentExts) expect(isDocumentFile(`report${ext}`)).toBe(true);
+    // The headline office types the engine doc_extract targets.
+    expect(isDocumentFile('q3.xlsx')).toBe(true);
+    expect(isDocumentFile('memo.docx')).toBe(true);
+    expect(isDocumentFile('deck.pptx')).toBe(true);
+    expect(isDocumentFile('invoice.pdf')).toBe(true);
+    // Not documents.
+    expect(isDocumentFile('logo.png')).toBe(false);
+    expect(isDocumentFile('data.csv')).toBe(false); // csv is text (read tool), not doc_extract
+    expect(isDocumentFile('main.ts')).toBe(false);
+  });
+
+  it('isTextFile matches text/code extensions only', () => {
+    for (const ext of textExts) expect(isTextFile(`file${ext}`)).toBe(true);
+    expect(isTextFile('slides.pptx')).toBe(false);
+    expect(isTextFile('pic.jpeg')).toBe(false);
+  });
+
+  it('is case-insensitive on extension', () => {
+    expect(isImageFile('PHOTO.PNG')).toBe(true);
+    expect(isDocumentFile('REPORT.DOCX')).toBe(true);
+    expect(isTextFile('README.MD')).toBe(true);
+  });
+
+  it('the three classes are mutually exclusive for a given file', () => {
+    const classify = (name: string) =>
+      [isImageFile(name), isDocumentFile(name), isTextFile(name)].filter(Boolean).length;
+    expect(classify('a.png')).toBe(1);
+    expect(classify('a.xlsx')).toBe(1);
+    expect(classify('a.md')).toBe(1);
+    expect(classify('a.unknownext')).toBe(0);
+  });
+
+  it('isLikelyTextFile keeps every real text/code file diffable (regression guard for FileChangeList)', () => {
+    // These are text/code files NOT in the finite textExts allowlist, plus
+    // extension-less files. Pre-#655 they were all expandable via the always-true
+    // gate; isLikelyTextFile must keep them true (not-image, not-binary-doc).
+    for (const name of [
+      'deploy.sh',
+      'schema.sql',
+      'App.vue',
+      'main.rb',
+      'Api.kt',
+      '.env',
+      'Dockerfile',
+      'Makefile',
+      'LICENSE',
+      'README',
+    ]) {
+      expect(isLikelyTextFile(name)).toBe(true);
+    }
+    // Files in the allowlist stay true too.
+    expect(isLikelyTextFile('index.ts')).toBe(true);
+    expect(isLikelyTextFile('notes.md')).toBe(true);
+  });
+
+  it('isLikelyTextFile excludes genuine binaries (images + office docs)', () => {
+    for (const name of ['logo.png', 'photo.jpeg', 'diagram.svg']) expect(isLikelyTextFile(name)).toBe(false);
+    for (const name of ['report.docx', 'q3.xlsx', 'deck.pptx', 'invoice.pdf'])
+      expect(isLikelyTextFile(name)).toBe(false);
+  });
+
+  it('isSupportedFile stays accept-all (upload acceptance is NOT gated by type)', () => {
+    // Regression guard: classification must not turn into an upload filter.
+    expect(isSupportedFile('anything.zip', documentExts)).toBe(true);
+    expect(isSupportedFile('weird.xyz', imageExts)).toBe(true);
+  });
+});


### PR DESCRIPTION
Addresses #655 (desktop half of #650, Phase 2 doc-ingestion). Does not close it — Phase B (observe the doc_extract tool_call for chip status + extracted-content preview) follows once Core ships a dev engine carrying doc_extract, per the ratified contract on #650.

## Scope (Phase A — zero-rework, engine-independent)
Per the Overwatch-ratified sequencing on #650: build only the engine-independent slice now (file-type classification + the desktop "will be read as a document" attach hint); do not blind-build the data-dependent UI before the contract is ratified AND a dev engine has doc_extract. Both preconditions for Phase B are not yet met, so this PR is deliberately just Phase A.

## Changes
- FileService isImageFile / isDocumentFile / isTextFile now do REAL extension membership. They were no-op stubs delegating to isSupportedFile, which returns true unconditionally. isSupportedFile stays accept-all, so upload acceptance is unchanged (a file of any type is still accepted); classification only decides how a file is surfaced downstream, never whether it is accepted. A regression test guards this.
- New isLikelyTextFile (not-image AND not-binary-document). FileChangeList's Workspace diff-expand gate previously rode the always-true isTextFile, so every changed file was expandable. Simply making isTextFile a finite allowlist would have silently dropped the expand affordance for .sh / .sql / .vue / Dockerfile / extension-less files (caught in cross-audit). FileChangeList now uses isLikelyTextFile, which keeps every real text/code file expandable and correctly excludes only images and office binaries (an improvement for those, which are not text-diffable).
- FilePreview shows a passive "Will be read as a document" hint on document attachments in the composer. Computed from the file path (no engine data). Hidden on already-sent readonly bubbles and on images. i18n key common.fileAttach.docIngestHint (en-US reference; non-en backfill via the standard i18n workflow, consistent with existing en-only keys — CI check-i18n gate passes).

## Tests + verification
- 8 classification unit tests (incl. an isLikelyTextFile regression guard for the FileChangeList behavior) + 3 FilePreview DOM tests (hint shows for docx-in-composer, hidden for readonly / image / text).
- typecheck clean, oxlint 0 errors (12 pre-existing warnings in the untouched processDroppedFiles block), oxfmt clean, CI check-i18n passes.
- Live-verified in the running app against real modules: real FileService classification correct for docx/xlsx/pdf (document), png (image), csv/md (text), with accept-all preserved; the real FilePreview renders the hint for a docx in the composer and omits it for readonly/image/text.

## Cross-audit
Independently cross-audited (non-author). One should-fix finding (the FileChangeList diff-expand regression) fixed via isLikelyTextFile + a regression test; other findings verified clean/nit (i18n key resolution correct, getFileExtension edge cases clean, hint surface/readonly/image gating correct).
