### PR TITLE
chore(settings): remove dead updateIjfw handler (#509 follow-up)

### DIFF
--- a/src/renderer/components/settings/SettingsModal/contents/ExtensionSettingsTabContent.tsx
+++ b/src/renderer/components/settings/SettingsModal/contents/ExtensionSettingsTabContent.tsx
@@ -6,7 +6,7 @@
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { extensions as extensionsIpc, ijfw as ijfwIpc } from '@/common/adapter/ipcBridge';
+import { extensions as extensionsIpc } from '@/common/adapter/ipcBridge';
 import WebviewHost from '@/renderer/components/media/WebviewHost';
 import { resolveExtensionAssetUrl } from '@/renderer/utils/platform';
 import { runWaylandUpdaterExtensionCheck } from '@/renderer/pages/settings/utils/waylandUpdaterBridge';
@@ -109,11 +109,6 @@ const ExtensionSettingsTabContent: React.FC<ExtensionSettingsTabContentProps> = 
             if (data.action === 'check') {
               const includePrerelease = Boolean(data.payload?.includePrerelease);
               reply(await runWaylandUpdaterExtensionCheck(includePrerelease, '[ExtensionSettingsTabContent]'));
-              return;
-            }
-
-            if (data.action === 'updateIjfw') {
-              reply(await ijfwIpc.triggerInstall.invoke());
               return;
             }
 

--- a/src/renderer/pages/settings/ExtensionSettingsPage.tsx
+++ b/src/renderer/pages/settings/ExtensionSettingsPage.tsx
@@ -7,7 +7,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { extensions as extensionsIpc, ijfw as ijfwIpc, type IExtensionSettingsTab } from '@/common/adapter/ipcBridge';
+import { extensions as extensionsIpc, type IExtensionSettingsTab } from '@/common/adapter/ipcBridge';
 import { useExtI18n } from '@/renderer/hooks/system/useExtI18n';
 import WebviewHost from '@/renderer/components/media/WebviewHost';
 import { resolveExtensionAssetUrl } from '@/renderer/utils/platform';
@@ -137,11 +137,6 @@ const ExtensionSettingsPage: React.FC = () => {
             if (data.action === 'check') {
               const includePrerelease = Boolean(data.payload?.includePrerelease);
               reply(await runWaylandUpdaterExtensionCheck(includePrerelease, '[ExtensionSettingsPage]'));
-              return;
-            }
-
-            if (data.action === 'updateIjfw') {
-              reply(await ijfwIpc.triggerInstall.invoke());
               return;
             }
 


### PR DESCRIPTION
Removes the unreachable `action === 'updateIjfw'` handler branch (and its now-orphaned `ijfwIpc` import) from both ExtensionSettings renderer files. The branch was orphaned by #509 — the updater extension never dispatches `updateIjfw`, so the code was dead surface area. The real update-IJFW UI will come as part of a deliberate IJFW pass.