### PR TITLE
fix(permission): a denied approval reads as denied, not green success (#663)

### DIFF
--- a/src/renderer/pages/conversation/Messages/acp/MessageAcpPermission.tsx
+++ b/src/renderer/pages/conversation/Messages/acp/MessageAcpPermission.tsx
@@ -52,6 +52,11 @@ const MessageAcpPermission: React.FC<MessageAcpPermissionProps> = React.memo(({ 
   const [isResponding, setIsResponding] = useState(false);
   const [hasResponded, setHasResponded] = useState(false);
 
+  // #663 P3: a denial must NOT read as a green success. Derive whether the
+  // chosen option was a reject (reject_once / reject_always) so the outcome
+  // banner reflects allowed vs denied.
+  const respondedDenied = (options.find((o) => o.optionId === selected)?.kind ?? '').startsWith('reject');
+
   const handleConfirm = async () => {
     if (hasResponded || !selected) return;
 
@@ -129,10 +134,20 @@ const MessageAcpPermission: React.FC<MessageAcpPermissionProps> = React.memo(({ 
         {hasResponded && (
           <div
             className='mt-10px p-2 rounded-md border'
-            style={{ backgroundColor: 'var(--color-success-light-1)', borderColor: 'rgb(var(--success-3))' }}
+            data-testid={respondedDenied ? 'acp-permission-denied' : 'acp-permission-allowed'}
+            style={
+              respondedDenied
+                ? { backgroundColor: 'var(--color-danger-light-1)', borderColor: 'rgb(var(--danger-3))' }
+                : { backgroundColor: 'var(--color-success-light-1)', borderColor: 'rgb(var(--success-3))' }
+            }
           >
-            <Text className='text-sm' style={{ color: 'rgb(var(--success-6))' }}>
-              ✓ {t('messages.responseSentSuccessfully')}
+            <Text
+              className='text-sm'
+              style={{ color: respondedDenied ? 'rgb(var(--danger-6))' : 'rgb(var(--success-6))' }}
+            >
+              {respondedDenied
+                ? `✕ ${t('messages.permissionDenied', 'Request denied')}`
+                : `✓ ${t('messages.responseSentSuccessfully')}`}
             </Text>
           </div>
         )}

--- a/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/src/renderer/services/i18n/i18n-keys.d.ts
@@ -1680,6 +1680,7 @@ export type I18nKey =
   | 'messages.noOptionsAvailable'
   | 'messages.openLinkFailed'
   | 'messages.option'
+  | 'messages.permissionDenied'
   | 'messages.permissionRequest'
   | 'messages.processing'
   | 'messages.responseSentSuccessfully'

--- a/src/renderer/services/i18n/locales/de-DE/messages.json
+++ b/src/renderer/services/i18n/locales/de-DE/messages.json
@@ -59,6 +59,7 @@
   "noOptionsAvailable": "Keine Optionen verfügbar",
   "processing": "Wird verarbeitet...",
   "responseSentSuccessfully": "Antwort erfolgreich gesendet",
+  "permissionDenied": "Anfrage abgelehnt",
   "confirmation": {
     "applyChange": "Diese Änderung anwenden?",
     "allowExecution": "Ausführung erlauben?",

--- a/src/renderer/services/i18n/locales/en-US/messages.json
+++ b/src/renderer/services/i18n/locales/en-US/messages.json
@@ -62,6 +62,7 @@
   "noOptionsAvailable": "No options available",
   "processing": "Processing...",
   "responseSentSuccessfully": "Response sent successfully",
+  "permissionDenied": "Request denied",
   "confirmation": {
     "applyChange": "Apply this change?",
     "allowExecution": "Allow execution?",

--- a/src/renderer/services/i18n/locales/es-ES/messages.json
+++ b/src/renderer/services/i18n/locales/es-ES/messages.json
@@ -59,6 +59,7 @@
   "noOptionsAvailable": "No hay opciones disponibles",
   "processing": "Procesando...",
   "responseSentSuccessfully": "Respuesta enviada correctamente",
+  "permissionDenied": "Solicitud denegada",
   "confirmation": {
     "applyChange": "¿Aplicar este cambio?",
     "allowExecution": "¿Permitir la ejecución?",

--- a/src/renderer/services/i18n/locales/fr-FR/messages.json
+++ b/src/renderer/services/i18n/locales/fr-FR/messages.json
@@ -59,6 +59,7 @@
   "noOptionsAvailable": "Aucune option disponible",
   "processing": "Traitement en cours...",
   "responseSentSuccessfully": "Réponse envoyée avec succès",
+  "permissionDenied": "Demande refusée",
   "confirmation": {
     "applyChange": "Appliquer cette modification ?",
     "allowExecution": "Autoriser l'exécution ?",

--- a/src/renderer/services/i18n/locales/ja-JP/messages.json
+++ b/src/renderer/services/i18n/locales/ja-JP/messages.json
@@ -59,6 +59,7 @@
   "noOptionsAvailable": "利用可能なオプションはありません",
   "processing": "Processing...",
   "responseSentSuccessfully": "応答が正常に送信されました",
+  "permissionDenied": "リクエストを拒否しました",
   "confirmation": {
     "applyChange": "この変更を適用しますか？",
     "allowExecution": "実行を許可しますか？",

--- a/src/renderer/services/i18n/locales/ko-KR/messages.json
+++ b/src/renderer/services/i18n/locales/ko-KR/messages.json
@@ -59,6 +59,7 @@
   "noOptionsAvailable": "사용 가능한 옵션 없음",
   "processing": "처리 중...",
   "responseSentSuccessfully": "응답 전송 성공",
+  "permissionDenied": "요청이 거부되었습니다",
   "confirmation": {
     "applyChange": "이 변경 사항을 적용하시겠습니까?",
     "allowExecution": "실행을 허용하시겠습니까?",

--- a/src/renderer/services/i18n/locales/pt-BR/messages.json
+++ b/src/renderer/services/i18n/locales/pt-BR/messages.json
@@ -59,6 +59,7 @@
   "noOptionsAvailable": "Nenhuma opção disponível",
   "processing": "Processando...",
   "responseSentSuccessfully": "Resposta enviada com sucesso",
+  "permissionDenied": "Solicitação negada",
   "confirmation": {
     "applyChange": "Aplicar esta alteração?",
     "allowExecution": "Permitir a execução?",

--- a/src/renderer/services/i18n/locales/ru-RU/messages.json
+++ b/src/renderer/services/i18n/locales/ru-RU/messages.json
@@ -56,6 +56,7 @@
   "noOptionsAvailable": "Нет доступных опций",
   "processing": "Обработка...",
   "responseSentSuccessfully": "Ответ успешно отправлен",
+  "permissionDenied": "Запрос отклонён",
   "confirmation": {
     "applyChange": "Применить это изменение?",
     "allowExecution": "Разрешить выполнение?",

--- a/src/renderer/services/i18n/locales/tr-TR/messages.json
+++ b/src/renderer/services/i18n/locales/tr-TR/messages.json
@@ -59,6 +59,7 @@
   "noOptionsAvailable": "Seçenek yok",
   "processing": "İşleniyor...",
   "responseSentSuccessfully": "Yanıt başarıyla gönderildi",
+  "permissionDenied": "İstek reddedildi",
   "confirmation": {
     "applyChange": "Bu değişikliği uygula?",
     "allowExecution": "Yürütmeye izin ver?",

--- a/src/renderer/services/i18n/locales/uk-UA/messages.json
+++ b/src/renderer/services/i18n/locales/uk-UA/messages.json
@@ -58,6 +58,7 @@
   "noOptionsAvailable": "Немає доступних варіантів",
   "processing": "Обробка...",
   "responseSentSuccessfully": "Відповідь надіслано успішно",
+  "permissionDenied": "Запит відхилено",
   "confirmation": {
     "applyChange": "Застосувати цю зміну?",
     "allowExecution": "Дозволити виконання?",

--- a/src/renderer/services/i18n/locales/zh-CN/messages.json
+++ b/src/renderer/services/i18n/locales/zh-CN/messages.json
@@ -59,6 +59,7 @@
   "noOptionsAvailable": "无可用选项",
   "processing": "处理中...",
   "responseSentSuccessfully": "响应已成功发送",
+  "permissionDenied": "请求已拒绝",
   "confirmation": {
     "applyChange": "应用此更改？",
     "allowExecution": "允许执行？",

--- a/src/renderer/services/i18n/locales/zh-TW/messages.json
+++ b/src/renderer/services/i18n/locales/zh-TW/messages.json
@@ -59,6 +59,7 @@
   "noOptionsAvailable": "沒有可用選項",
   "processing": "處理中...",
   "responseSentSuccessfully": "回覆已成功送出",
+  "permissionDenied": "請求已拒絕",
   "confirmation": {
     "applyChange": "應用此更改？",
     "allowExecution": "允許執行？",

--- a/tests/unit/renderer/MessageAcpPermission.dom.test.tsx
+++ b/tests/unit/renderer/MessageAcpPermission.dom.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #663 P3: a denied permission must NOT render as a green success banner.
+ * The outcome banner branches on the chosen option's kind (reject_* => denied).
+ */
+// @vitest-environment jsdom
+
+import React from 'react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const confirmMessageMock = vi.fn();
+vi.mock('@/common/adapter/ipcBridge', () => ({
+  conversation: { confirmMessage: { invoke: (...a: unknown[]) => confirmMessageMock(...a) } },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string, dflt?: string) => dflt ?? key }),
+}));
+
+import MessageAcpPermission from '@/renderer/pages/conversation/Messages/acp/MessageAcpPermission';
+
+const makeMessage = () =>
+  ({
+    id: 'msg-1',
+    type: 'acp_permission',
+    conversation_id: 'conv-1',
+    content: {
+      toolCall: { toolCallId: 'call-1', title: 'rm -rf /tmp/x', kind: 'execute' },
+      options: [
+        { optionId: 'allow_once', name: 'Allow once', kind: 'allow_once' },
+        { optionId: 'reject_once', name: 'Deny', kind: 'reject_once' },
+      ],
+    },
+  }) as never;
+
+async function respondWith(optionId: string) {
+  // Arco Radio renders a hidden input[value=optionId]; click it, then Confirm.
+  const radio = document.querySelector(`input[value="${optionId}"]`) as HTMLInputElement;
+  expect(radio).toBeTruthy();
+  await act(async () => {
+    fireEvent.click(radio);
+  });
+  const confirmBtn = screen.getByText('messages.confirm').closest('button') as HTMLButtonElement;
+  await act(async () => {
+    fireEvent.click(confirmBtn);
+  });
+}
+
+describe('MessageAcpPermission — allow vs deny banner (#663 P3)', () => {
+  beforeEach(() => {
+    confirmMessageMock.mockReset();
+    confirmMessageMock.mockResolvedValue({ success: true });
+  });
+  afterEach(() => cleanup());
+
+  it('renders a DENIED (not success) banner when a reject option is chosen', async () => {
+    render(<MessageAcpPermission message={makeMessage()} />);
+    await respondWith('reject_once');
+    await waitFor(() => expect(screen.getByTestId('acp-permission-denied')).toBeTruthy());
+    expect(screen.queryByTestId('acp-permission-allowed')).toBeNull();
+    // Confirm the decision was actually sent for the reject option.
+    expect(confirmMessageMock).toHaveBeenCalledWith(expect.objectContaining({ confirmKey: 'reject_once' }));
+  });
+
+  it('renders an ALLOWED (success) banner when an allow option is chosen', async () => {
+    render(<MessageAcpPermission message={makeMessage()} />);
+    await respondWith('allow_once');
+    await waitFor(() => expect(screen.getByTestId('acp-permission-allowed')).toBeTruthy());
+    expect(screen.queryByTestId('acp-permission-denied')).toBeNull();
+  });
+});


### PR DESCRIPTION
Addresses #663 (P3 slice only — the deny-banner silent-lie). Does not close #663: the remaining scope is being re-organized per the Overwatch ruling on the issue (the P1 "render an approval modal" is a no-op — the existing tool_group Confirming gate already covers it; the #264 auto-mode wedge becomes escalate-through-that-gate; the Trusted-workspace axis is splitting into its own issue).

## The bug (a silent lie)
MessageAcpPermission rendered a green "Response sent successfully" banner on ANY response — so a DENIAL displayed as a green success. That is the exact fail/refuse-while-reporting-success class #656 exists to kill.

## Fix
Branch the outcome banner on the chosen option's kind. AcpPermissionOption.kind is one of allow_once / allow_always / reject_once / reject_always; a reject_* choice now renders a danger "Request denied" banner, while allow options keep the success banner. Renderer-only, no behavior change to the actual approve/deny decision that was already sent.

## Tests + checks
- 2 new DOM tests (real Arco radio interaction): choosing a reject option renders the denied banner (not success) and sends confirmKey=reject_once; choosing an allow option renders the success banner.
- typecheck clean, oxlint 0 errors, oxfmt clean, prek CI-parity green (incl. i18n Check + UI Tokens). i18n: the new messages.permissionDenied key was added + translated across all 12 locales by the i18n toolchain.

## Verification note (why this is only P3)
Verified #663 against current main (the audit clone was ~1 month stale): the P1 "approval_required renders nothing -> hang" is already handled (WCoreManager auto-resumes auto-mode/info; interactive is covered by the existing tool_group Confirming gate). So the modal is intentionally NOT built, and this PR is the one genuine renderer bug. Overwatch cross-audits diff-at-head + packaged live-verify (allow=success, deny=danger) and merges.
