### PR TITLE
fix(wcore): escalate auto-mode approval_required through the Confirming gate (#264)

### DIFF
--- a/src/process/task/WCoreManager.ts
+++ b/src/process/task/WCoreManager.ts
@@ -188,6 +188,14 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
   // cleared) can be stamped onto the correct turn's activity card.
   private _lastTurnMsgId: string | null = null;
 
+  // #264 - an auto-mode `approval_required` the engine could not self-resolve is
+  // escalated through the existing Confirming gate (see the approval_required
+  // handler). That card is resumed by resume_token, but the renderer only routes
+  // a callId back to confirm(); map callId -> resumeToken here so confirm() can
+  // redirect to resumeApproval(). ONLY escalation callIds are stored, so ordinary
+  // interactive tool_group approvals never hit the redirect and cannot double-drive.
+  private readonly pendingApprovalTokens = new Map<string, string>();
+
   // Heartbeat state
   private heartbeatInterval: ReturnType<typeof setInterval> | null = null;
   private readonly heartbeatIntervalMs = 30_000;
@@ -1100,30 +1108,75 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
       // `approval_resume` so the turn can never hang. (A stale/duplicate token is
       // safely ignored engine-side.)
       if (data.type === 'approval_required') {
-        const appr = (data.data ?? {}) as { resumeToken?: string; reason?: string };
+        const appr = (data.data ?? {}) as {
+          callId?: string;
+          resumeToken?: string;
+          reason?: string;
+          context?: unknown;
+        };
         const autoMode = this.currentMode === 'yolo' || this.currentMode === 'auto_edit';
-        if (appr.resumeToken && (autoMode || appr.reason === 'info')) {
+        const isInfo = appr.reason === 'info';
+
+        // Informational approvals (e.g. the engine's internal todo tool) are safe
+        // to self-resume in ANY mode - unchanged happy path.
+        if (appr.resumeToken && isInfo) {
           this.agent?.resumeApproval(appr.resumeToken, true);
-        } else if (appr.reason && appr.reason !== 'info') {
-          // A non-info approval we did not auto-resume. Whether that is a problem
-          // depends on the mode:
-          //
-          // - Interactive (non-auto) mode: EXPECTED. The renderer tool-confirmation
-          //   gate (the `Confirming` tool_group path above) prompts the user and
-          //   drives the resume; this `approval_required` is the engine's parallel
-          //   signal, not a dropped approval. A normal exec/mcp approval legitimately
-          //   carries no resume token here, so the old error (and a resume-token
-          //   check) fired on every exec approval and falsely read as a failure
-          //   (#390). Keep only a quiet trace for diagnosability.
-          //
-          // - Auto mode (Autopilot/Auto Edit): the engine was supposed to
-          //   self-resolve but we could not (no resume token, or a non-info reason
-          //   the auto path can't satisfy) and there is no HITL UI to fall back on,
-          //   so the turn can genuinely wedge (#264). That is the real error.
-          if (autoMode) {
+          return;
+        }
+
+        // #264: a NON-info `approval_required` reached us in an auto mode
+        // (Autopilot/Auto Edit). The engine expected to self-resolve but could not
+        // (notably Anthropic-format `toolu_` ids routed via Flux), and there is no
+        // dedicated HITL UI - so the turn would wedge, and previously we silently
+        // auto-resumed(true), which is exactly the silent auto-approve the trust
+        // audit fights. Escalate through the EXISTING Confirming gate so the user
+        // explicitly allows/denies; the decision resumes by resume_token in
+        // confirm() (keyed via pendingApprovalTokens).
+        if (autoMode && !isInfo && appr.resumeToken) {
+          const callId = appr.callId ?? '';
+          // A non-interactive spawn (channel/cron sets this.yoloMode) has no user
+          // to prompt. addConfirmation() would auto-pick the first (allow) option
+          // under yoloMode and SILENTLY APPROVE - the opposite of what an
+          // un-anticipated approval needs. So loud-deny instead: a visible,
+          // recorded denial, never a silent approve and never a hang.
+          if (this.yoloMode) {
+            this.agent?.resumeApproval(appr.resumeToken, false);
             mainError(
               '[WCoreManager]',
-              `approval_required reason='${appr.reason}' in auto mode could not self-resume and has no HITL UI; turn may wedge`,
+              `approval_required reason='${appr.reason}' in a non-interactive (yoloMode) session with no user to prompt; denied`,
+              data.data
+            );
+            return;
+          }
+          this.pendingApprovalTokens.set(callId, appr.resumeToken);
+          const context = typeof appr.context === 'string' && appr.context ? appr.context : '';
+          this.addConfirmation({
+            title: 'messages.permissionRequest',
+            id: callId,
+            description: context || `reason: ${appr.reason ?? ''}`,
+            callId,
+            options: [
+              { label: 'messages.confirmation.yesAllowOnce', value: ToolConfirmationOutcome.ProceedOnce },
+              { label: 'messages.confirmation.no', value: ToolConfirmationOutcome.Cancel },
+            ],
+          });
+          return;
+        }
+
+        // Any other non-info approval. In interactive (non-auto) mode this is
+        // EXPECTED: the renderer tool-confirmation gate (the `Confirming`
+        // tool_group path above) prompts the user and drives the resume; this
+        // `approval_required` is the engine's parallel signal, not a dropped
+        // approval. A normal exec/mcp approval legitimately carries no resume
+        // token here, so the old resume-token check fired on every exec approval
+        // and falsely read as a failure (#390) - keep only a quiet trace. The one
+        // genuinely un-actionable case is an auto-mode approval with NO resume
+        // token: we can neither resume nor escalate, so surface a diagnostic.
+        if (appr.reason && !isInfo) {
+          if (autoMode && !appr.resumeToken) {
+            mainError(
+              '[WCoreManager]',
+              `approval_required reason='${appr.reason}' in auto mode has no resume token and no HITL UI; turn may wedge`,
               data.data
             );
           } else {
@@ -1431,6 +1484,19 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
   }
 
   confirm(id: string, callId: string, data: string, answer?: string) {
+    // #264: an escalated auto-mode `approval_required` is resumed by resume_token,
+    // NOT by approveTool/denyTool. If this callId was escalated, clear its card,
+    // drive the engine's approval_resume, and stop - do not also fall through to
+    // approveTool/denyTool. Non-escalation callIds are never in the map, so the
+    // ordinary approval path below is byte-unchanged for them.
+    const pendingToken = this.pendingApprovalTokens.get(callId);
+    if (pendingToken !== undefined) {
+      this.pendingApprovalTokens.delete(callId);
+      super.confirm(id, callId, data);
+      this.agent?.resumeApproval(pendingToken, data !== ToolConfirmationOutcome.Cancel);
+      return;
+    }
+
     // Store "always allow" in approval store
     if (data === ToolConfirmationOutcome.ProceedAlways) {
       const confirmation = this.confirmations.find((c) => c.callId === callId);

--- a/tests/unit/WCoreManagerEventBus.test.ts
+++ b/tests/unit/WCoreManagerEventBus.test.ts
@@ -526,6 +526,134 @@ describe('GAP-8: WCoreManager Multi EventBus Emission', () => {
     });
   });
 
+  // ── #264: auto-mode escalation through the existing Confirming gate ─
+  //
+  // A non-info `approval_required` that carries a resume token and arrives in an
+  // auto mode is the wedge case: the engine could not self-resolve and there is
+  // no dedicated HITL UI. We escalate it through the existing Confirming gate
+  // (interactive) or loud-deny it (non-interactive), and route the card's
+  // allow/deny back to the engine by resume_token via confirm().
+
+  describe('#264: auto-mode escalation through the Confirming gate', () => {
+    const PROCEED_ONCE = 'proceed_once'; // ToolConfirmationOutcome.ProceedOnce
+    const CANCEL = 'cancel'; // ToolConfirmationOutcome.Cancel
+
+    // Attach an agent whose approval calls are observable.
+    function withAgent(m: WCoreManager) {
+      const resumeApproval = vi.fn();
+      const approveTool = vi.fn();
+      const denyTool = vi.fn();
+      (m as any).agent = { resumeApproval, approveTool, denyTool };
+      return { resumeApproval, approveTool, denyTool };
+    }
+
+    // Drive a non-info approval_required with a resume token into `manager`.
+    function escalate(m: WCoreManager, callId = 'c1', resumeToken = 'tok-1') {
+      emitEvent(m, {
+        type: 'approval_required',
+        data: { callId, resumeToken, reason: 'destructive_operation' },
+        msg_id: 'msg-1',
+      });
+    }
+
+    it('interactive auto mode: escalates via the Confirming gate, does NOT auto-resume', () => {
+      (manager as any).currentMode = 'yolo'; // user Autopilot: has a UI (yoloMode stays false)
+      const { resumeApproval } = withAgent(manager);
+
+      escalate(manager);
+
+      // A card was synthesized for this callId with allow-once / deny options.
+      const card = (manager as any).confirmations.find((c: any) => c.callId === 'c1');
+      expect(card).toBeDefined();
+      expect(card.title).toBe('messages.permissionRequest');
+      expect(card.options.map((o: any) => o.value)).toEqual([PROCEED_ONCE, CANCEL]);
+      // The resume token is parked for confirm() to pick up; not auto-resumed.
+      expect((manager as any).pendingApprovalTokens.get('c1')).toBe('tok-1');
+      expect(resumeApproval).not.toHaveBeenCalled();
+    });
+
+    it('confirm(allow) redirects to resumeApproval(true) and NOT approveTool/denyTool; clears the map (#264 a,e)', () => {
+      (manager as any).currentMode = 'yolo';
+      const { resumeApproval, approveTool, denyTool } = withAgent(manager);
+      escalate(manager);
+
+      manager.confirm('c1', 'c1', PROCEED_ONCE);
+
+      expect(resumeApproval).toHaveBeenCalledWith('tok-1', true);
+      expect(approveTool).not.toHaveBeenCalled();
+      expect(denyTool).not.toHaveBeenCalled();
+      // Map entry removed after resume: no leak, no stale reuse.
+      expect((manager as any).pendingApprovalTokens.has('c1')).toBe(false);
+    });
+
+    it('confirm(deny) redirects to resumeApproval(false) (#264 d)', () => {
+      (manager as any).currentMode = 'auto_edit';
+      const { resumeApproval, approveTool, denyTool } = withAgent(manager);
+      escalate(manager);
+
+      manager.confirm('c1', 'c1', CANCEL);
+
+      expect(resumeApproval).toHaveBeenCalledWith('tok-1', false);
+      expect(approveTool).not.toHaveBeenCalled();
+      expect(denyTool).not.toHaveBeenCalled();
+    });
+
+    it('confirm for a non-escalated callId leaves the approveTool/denyTool path byte-unchanged (#264 b)', () => {
+      const { resumeApproval, approveTool } = withAgent(manager);
+      // No escalation: the map is empty, so this is an ordinary tool_group approval.
+      manager.confirm('m', 'other-call', PROCEED_ONCE);
+
+      expect(approveTool).toHaveBeenCalledWith('other-call', 'once', undefined);
+      expect(resumeApproval).not.toHaveBeenCalled();
+    });
+
+    it('interactive tool_group approval never escalates or double-prompts (#264 c)', () => {
+      // Default (non-auto) mode: the renderer tool_group Confirming gate owns the
+      // approval. No escalation card is synthesized and confirm() uses the normal
+      // approveTool path — the callId is never in the map, so no double-drive.
+      (manager as any).currentMode = 'default';
+      const { resumeApproval, approveTool } = withAgent(manager);
+
+      escalate(manager, 'tg-1', 'tok-tg');
+
+      expect((manager as any).confirmations.some((c: any) => c.callId === 'tg-1')).toBe(false);
+      expect((manager as any).pendingApprovalTokens.has('tg-1')).toBe(false);
+
+      manager.confirm('tg-1', 'tg-1', PROCEED_ONCE);
+      expect(approveTool).toHaveBeenCalledWith('tg-1', 'once', undefined);
+      expect(resumeApproval).not.toHaveBeenCalled();
+    });
+
+    it('non-interactive (yoloMode) auto mode: loud-denies via resumeApproval(false), no silent approve, no card', () => {
+      // A channel/cron spawn (yoloMode:true) has no user to prompt. Escalating would
+      // hit addConfirmation's yoloMode auto-approve and SILENTLY APPROVE — so we
+      // loud-deny instead.
+      const data = {
+        workspace: '/test/workspace',
+        model: { name: 'test-provider', useModel: 'test-model', baseUrl: '', platform: 'test' },
+        conversation_id: 'conv-yolo',
+        sessionMode: 'yolo',
+        yoloMode: true,
+      };
+      const m = new WCoreManager(data as any, data.model as any);
+      vi.spyOn(m as any, 'postMessagePromise').mockResolvedValue(undefined);
+      const { resumeApproval } = withAgent(m);
+
+      escalate(m, 'cy', 'tok-y');
+
+      expect(resumeApproval).toHaveBeenCalledWith('tok-y', false);
+      // No confirmation card was created for a headless run.
+      expect((m as any).confirmations.some((c: any) => c.callId === 'cy')).toBe(false);
+      expect((m as any).pendingApprovalTokens.has('cy')).toBe(false);
+      // And it was recorded loudly, not silently.
+      const loud = mockMainError.mock.calls.find(
+        ([, msg]: [unknown, unknown]) =>
+          typeof msg === 'string' && msg.includes("reason='destructive_operation'") && msg.includes('yoloMode')
+      );
+      expect(loud).toBeDefined();
+    });
+  });
+
   // ── ipcBridge still receives all events (no regression) ─────────
 
   describe('Regression: ipcBridge still receives all events', () => {


### PR DESCRIPTION
## What

Fix the #264 auto-mode wedge, built exactly as Overwatch ruled on #663 (14:01Z GO). A non-info `approval_required` that the wcore engine could not self-resolve (notably Anthropic-format `toolu_` ids routed via Flux) previously either silently auto-resumed with `true` (the silent auto-approve the trust audit fights) or, with no resume token, wedged the turn behind a bare log. Now it escalates through the EXISTING Confirming gate so the user explicitly allows/denies — no new modal, no new IPC.

## How

- `src/process/task/WCoreManager.ts`
  - New `pendingApprovalTokens: Map<callId, resumeToken>`.
  - `approval_required` handler: guarded strictly to auto-mode + non-info + has-resumeToken. In an interactive auto session (user Autopilot), synthesize an `IConfirmation` via the existing `addConfirmation` (title `messages.permissionRequest`, options allow-once / deny — existing i18n keys, zero new keys) and park the resume token. A non-interactive spawn (`this.yoloMode`: channel/cron) has no user to prompt and would hit `addConfirmation`'s yoloMode auto-approve, so it loud-denies via `resumeApproval(token, false)` + a recorded error instead of silently approving. Informational (`reason:'info'`) approvals still self-resume in any mode (happy path unchanged); the interactive-mode quiet log and the genuine no-resume-token wedge diagnostic are preserved.
  - Top of `confirm()`: if the callId was escalated, clear its card, call `resumeApproval(token, data !== Cancel)`, and return. Ordinary tool_group approvals are never in the map, so their `approveTool`/`denyTool` path is byte-unchanged.

## Tests

`tests/unit/WCoreManagerEventBus.test.ts` — 6 new cases covering all of Overwatch's required assertions: escalation emits a card and does not auto-resume; allow redirects to `resumeApproval(true)` and NOT approveTool/denyTool; deny redirects to `resumeApproval(false)`; a non-escalated callId leaves the approveTool path byte-unchanged; an interactive tool_group approval never escalates or double-prompts; the map entry is removed after resume; and the non-interactive yoloMode loud-deny path. Full suite: typecheck 0, oxlint 0 errors, oxfmt clean, prek green, 31/31 in this file.

## Verify

Not reproducible locally (the wedge route needs a live engine). Per the #663 ruling, Overwatch owns the packaged live-verify against a real wedge route (a `toolu_`/Flux `approval_required` in auto mode) before merge. Flagging needs:overwatch for the diff-at-head cross-audit + that live wedge verify. No self-merge.

Rolls up to #663 (the canonical #670/#671/#672 + this #264 slice). Addresses #264.
