### PR TITLE
fix(markdown): stop rendering currency amounts as LaTeX math

### DIFF
--- a/src/renderer/utils/chat/latexDelimiters.ts
+++ b/src/renderer/utils/chat/latexDelimiters.ts
@@ -35,6 +35,14 @@ export function convertLatexDelimiters(text: string): string {
 }
 
 function replaceDelimiters(text: string): string {
+  // Neutralize currency before remark-math runs. A lone `$` immediately followed by a
+  // digit (`$2k`, `$25`, `$10k`, `$50k+`) is a dollar amount, not a math delimiter —
+  // without this, remark-math pairs two such `$` into an inline-math span and renders
+  // the text between them in italic KaTeX with spaces collapsed (prices garbled in chat).
+  // Escaping to `\$` makes it a literal `$`. Skips `$$` display delimiters (a `$` preceded
+  // by `$`) and already-escaped `\$` (preceded by `\`). Real inline math (`$x$`,
+  // `$\alpha$`) starts with a non-digit and is unaffected.
+  text = text.replace(/(?<![\\$])\$(?=\d)/g, () => '\\$');
   // Replace \[...\] with $$...$$ (block display math, supports multiline)
   text = text.replace(/\\\[([\s\S]*?)\\\]/g, (_match, content: string) => `$$${content}$$`);
   // Replace \(...\) with $...$ (inline math)

--- a/tests/unit/latexDelimiters.test.ts
+++ b/tests/unit/latexDelimiters.test.ts
@@ -76,6 +76,40 @@ describe('convertLatexDelimiters', () => {
     });
   });
 
+  describe('currency is not parsed as math', () => {
+    it('should escape a single dollar amount so it stays literal text', () => {
+      expect(convertLatexDelimiters('the $2k cohort')).toBe('the \\$2k cohort');
+    });
+
+    it('should escape multiple amounts so remark-math cannot pair them into a math span', () => {
+      // Regression: "$2k cohort and the $25-50k tier" was rendered as italic KaTeX
+      // with the spaces collapsed and the dollar signs eaten.
+      expect(convertLatexDelimiters('the $2k cohort and the $25-50k tier')).toBe(
+        'the \\$2k cohort and the \\$25-50k tier'
+      );
+    });
+
+    it('should handle suffixes and plus signs ($10k, $50k+, $5-10k)', () => {
+      expect(convertLatexDelimiters('$10k whales at $50k+ or $5-10k')).toBe('\\$10k whales at \\$50k+ or \\$5-10k');
+    });
+
+    it('should not double-escape already-escaped currency', () => {
+      expect(convertLatexDelimiters('costs \\$5 today')).toBe('costs \\$5 today');
+    });
+
+    it('should leave $$ display math starting with a digit intact', () => {
+      expect(convertLatexDelimiters('$$3x^2 + 1$$')).toBe('$$3x^2 + 1$$');
+    });
+
+    it('should still convert \\(...\\) inline math that starts with a digit', () => {
+      expect(convertLatexDelimiters('\\(3x + 1\\)')).toBe('$3x + 1$');
+    });
+
+    it('should not escape currency inside code', () => {
+      expect(convertLatexDelimiters('run `echo $5` now')).toBe('run `echo $5` now');
+    });
+  });
+
   describe('no math content', () => {
     it('should return plain text unchanged', () => {
       const input = 'Hello, this is just normal text.';


### PR DESCRIPTION
## Problem

Dollar amounts in chat were being rendered as LaTeX math. remark-math is configured with single-dollar inline math on, so a message like "the $2k cohort and the $25-50k tier" has its two dollar signs paired into an inline-math span: everything between them renders in italic KaTeX with the spaces collapsed and the dollar signs eaten. Any message discussing prices ($7 front end, $10k whales, $50k+, $5-10k) came out garbled and unreadable. Screenshots of the failure are in the tracking discussion.

## Root cause

convertLatexDelimiters (the shared preprocessor for both the chat renderer and the Preview renderer) hands text to remark-math, whose default single-dollar rule treats any pair of dollar signs as an inline-math delimiter. It cannot tell currency from math.

## Fix

Before the LaTeX-delimiter conversion runs, escape a lone dollar sign that is immediately followed by a digit to a literal dollar, so remark-math never pairs currency amounts. The guard:

- Skips double-dollar display delimiters (a dollar preceded by a dollar), so $$3x^2$$ still renders.
- Skips already-escaped currency (a dollar preceded by a backslash), so no double-escaping.
- Leaves real inline math untouched: it starts with a non-digit ($x$, $\alpha$), and the \(...\) and \[...\] conversions still produce working math, including when their content starts with a digit.

Real inline math that starts with a bare digit written as raw single-dollar (rare) degrades to readable literal text rather than a garbled span, which is strictly better than the current behavior.

## Tests

Extends tests/unit/latexDelimiters.test.ts with a currency suite: single and multiple amounts escaped, suffixes and plus signs, no double-escape, display math with a leading digit preserved, inline \(...\) with a leading digit preserved, and currency inside code left alone. Full file: 20 tests, all passing. Fixes both the chat and Preview renderers, which share this preprocessor.
