### PR TITLE
fix(markdown): also escape cent-only prices in currency guard

### DIFF
--- a/src/renderer/utils/chat/latexDelimiters.ts
+++ b/src/renderer/utils/chat/latexDelimiters.ts
@@ -36,13 +36,15 @@ export function convertLatexDelimiters(text: string): string {
 
 function replaceDelimiters(text: string): string {
   // Neutralize currency before remark-math runs. A lone `$` immediately followed by a
-  // digit (`$2k`, `$25`, `$10k`, `$50k+`) is a dollar amount, not a math delimiter —
-  // without this, remark-math pairs two such `$` into an inline-math span and renders
-  // the text between them in italic KaTeX with spaces collapsed (prices garbled in chat).
-  // Escaping to `\$` makes it a literal `$`. Skips `$$` display delimiters (a `$` preceded
-  // by `$`) and already-escaped `\$` (preceded by `\`). Real inline math (`$x$`,
-  // `$\alpha$`) starts with a non-digit and is unaffected.
-  text = text.replace(/(?<![\\$])\$(?=\d)/g, () => '\\$');
+  // digit or a decimal point then a digit (`$2k`, `$25`, `$10k`, `$50k+`, `$.99`) is a
+  // dollar amount, not a math delimiter — without this, remark-math pairs two such `$`
+  // into an inline-math span and renders the text between them in italic KaTeX with
+  // spaces collapsed (prices garbled in chat). Escaping to `\$` makes it a literal `$`.
+  // Skips `$$` display delimiters (a `$` preceded by `$`) and already-escaped `\$`
+  // (preceded by `\`). The `\.?\d` lookahead requires a digit after the optional dot, so
+  // a closing math `$` followed by a period (`$x$.`) is left alone. Real inline math
+  // (`$x$`, `$\alpha$`) starts with a non-digit and is unaffected.
+  text = text.replace(/(?<![\\$])\$(?=\.?\d)/g, () => '\\$');
   // Replace \[...\] with $$...$$ (block display math, supports multiline)
   text = text.replace(/\\\[([\s\S]*?)\\\]/g, (_match, content: string) => `$$${content}$$`);
   // Replace \(...\) with $...$ (inline math)

--- a/tests/unit/latexDelimiters.test.ts
+++ b/tests/unit/latexDelimiters.test.ts
@@ -108,6 +108,22 @@ describe('convertLatexDelimiters', () => {
     it('should not escape currency inside code', () => {
       expect(convertLatexDelimiters('run `echo $5` now')).toBe('run `echo $5` now');
     });
+
+    it('should escape cent-only prices with no leading digit ($.50, $.75)', () => {
+      expect(convertLatexDelimiters('candy is $.50 and gum is $.75')).toBe('candy is \\$.50 and gum is \\$.75');
+    });
+
+    it('should leave inline math followed by a period intact (the \\.?\\d guard)', () => {
+      // A closing `$` followed by a period must NOT be escaped, or "$x$." breaks.
+      expect(convertLatexDelimiters('the value is $x$.')).toBe('the value is $x$.');
+    });
+
+    it('documents the accepted tradeoff: raw single-$ math starting with a bare digit degrades to literal', () => {
+      // Currency and digit-led inline math are ambiguous with a bare `$`; we favour
+      // currency (far more common in chat). "$3x+1$" degrades to readable literal text
+      // rather than a garbled KaTeX span. Use \\(3x+1\\) for real inline math.
+      expect(convertLatexDelimiters('$3x+1$')).toBe('\\$3x+1$');
+    });
   });
 
   describe('no math content', () => {


### PR DESCRIPTION
Follow-on to #704. The currency guard escaped a lone dollar sign only when immediately followed by a digit, so cent-only prices with no leading digit still garbled: "candy is $.50 and gum is $.75" got paired by remark-math into an italic KaTeX span.

This broadens the lookahead from a bare digit to an optional decimal point then a required digit. Requiring the digit after the optional dot keeps a closing math dollar sign followed by a period (for example inline math ending a sentence) untouched, so it does not regress real math.

Adds three tests: cent-only prices are escaped, inline math followed by a period is left intact, and the accepted currency-over-digit-led-math tradeoff is documented and locked in. Full suite: 23 tests, all passing.
