### PR TITLE
fix(cost-meter): per-run usage deltas via computeUsageDelta (kills cumulative double-summing)

### DIFF
--- a/src/process/team/TeammateManager.ts
+++ b/src/process/team/TeammateManager.ts
@@ -68,6 +68,34 @@ type TeammateManagerParams = {
   taskRepo?: ITaskRepository;
 };
 
+/** One reading of the ACP cumulative usage gauge for an agent session. */
+export type UsageSnapshot = { used: number; cost: number };
+
+/**
+ * DESK-1 - per-event spend delta between two CUMULATIVE usage snapshots.
+ *
+ * ACP's `acp_context_usage` gauge is a running session total, so summing raw
+ * snapshots N-counts. The meter must sum deltas instead:
+ *   - no previous snapshot (genuinely fresh session) -> delta = full `next`
+ *     (a fresh session's first snapshot is real new spend);
+ *   - gauge grew  -> delta = next - prev;
+ *   - gauge dropped (compaction / session reset) -> delta = 0. The spend that
+ *     produced the drop is unknowable; undercounting is safer than
+ *     overcounting. The caller then tracks `next` as the new baseline so
+ *     growth from the lower value is counted again.
+ * Token and cost gauges are clamped independently.
+ */
+export function computeUsageDelta(
+  prev: UsageSnapshot | undefined,
+  next: UsageSnapshot
+): { tokensDelta: number; costDelta: number } {
+  if (!prev) return { tokensDelta: next.used, costDelta: next.cost };
+  return {
+    tokensDelta: next.used >= prev.used ? next.used - prev.used : 0,
+    costDelta: next.cost >= prev.cost ? next.cost - prev.cost : 0,
+  };
+}
+
 /**
  * Core orchestration engine that manages teammate state machines
  * and coordinates agent communication via mailbox and task board.
@@ -103,15 +131,17 @@ export class TeammateManager extends EventEmitter {
   private readonly renamedAgents = new Map<string, string>();
 
   /**
-   * Per-conversation high-water mark of the ACP cumulative usage gauge
-   * (`acp_context_usage.used` + `cost.amount`). ACP re-emits these CUMULATIVE
-   * values on every update, so writing one `token_usage` row per event with the
-   * raw `used`/`cost` made the meter (useTeamCostMeter, which SUMS rows)
-   * N-count. We now write the per-event DELTA against this baseline (clamped
-   * >= 0) and advance the baseline, so summing the rows reconstructs the true
-   * running total exactly once.
+   * DESK-1 - previous ACP cumulative usage gauge snapshot per agent session,
+   * keyed by conversationId (one conversation per (teamId, slotId) session in
+   * this team-scoped manager). ACP re-emits `acp_context_usage.used` +
+   * `cost.amount` as CUMULATIVE session values on every update; each
+   * `token_usage` row records the raw snapshot PLUS the per-event spend delta
+   * against this previous snapshot (see {@link computeUsageDelta}). Cleared
+   * whenever the agent session ends/restarts (killAgentProcess /
+   * handleAgentCrash / removeAgent / dispose) so a fresh session's first
+   * snapshot counts fully.
    */
-  private readonly tokenUsageBaselines = new Map<string, { used: number; cost: number }>();
+  private readonly tokenUsageBaselines = new Map<string, UsageSnapshot>();
 
   /** Maximum time (ms) to wait for a turnCompleted event before force-releasing a wake */
   private static readonly WAKE_TIMEOUT_MS = 60 * 1000;
@@ -217,6 +247,9 @@ export class TeammateManager extends EventEmitter {
       this.unregisterAcpTeamContext(agent.conversationId);
       this.workerTaskManager.kill(agent.conversationId);
       this.finalizedTurns.delete(agent.conversationId);
+      // DESK-1: the session died - the next process starts a fresh cumulative
+      // gauge, whose first snapshot must count fully (no stale baseline).
+      this.tokenUsageBaselines.delete(agent.conversationId);
     }
 
     const timeoutHandle = this.wakeTimeouts.get(slotId);
@@ -462,6 +495,7 @@ export class TeammateManager extends EventEmitter {
     }
     this.wakeTimeouts.clear();
     this.activeWakes.clear();
+    this.tokenUsageBaselines.clear();
     // W5 audit HIGH-2 fix (2026-05-19): drain ACP team-context registry
     // entries for every owned conversation so a disposed session cannot
     // leak gate-routing data into the next team that reuses any of these
@@ -541,15 +575,20 @@ export class TeammateManager extends EventEmitter {
     const agent = this.agents.find((a) => a.conversationId === msg.conversation_id);
     if (!agent) return;
 
-    // W1e: token-usage events flow through the response stream as `acp_context_usage`.
-    // Capture them as `'token_usage'` rows so the W2d cost meter can sum tokens
-    // and cost across teammates. ACP emits `used`/`cost` as a per-conversation
-    // CUMULATIVE gauge re-sent on every update, and useTeamCostMeter SUMS the
-    // rows, so we write the per-event DELTA against a per-conversation baseline
-    // (clamped >= 0) and advance the baseline - the sum then equals the true
-    // running total exactly once instead of N-counting (R1). We still lack a
-    // clean prompt/completion split (ACP gives `used` total only), so the split
-    // fields stay 0 with the per-turn delta preserved as `total_tokens`.
+    // W1e/DESK-1: token-usage events flow through the response stream as
+    // `acp_context_usage`. ACP emits `used`/`cost` as a per-conversation
+    // CUMULATIVE session gauge re-sent on every update (acpTypes: "total
+    // tokens currently in context"), so summing raw rows N-counts. Each
+    // `token_usage` row therefore carries BOTH the raw snapshot fields
+    // (prompt_tokens / total_tokens / cost_estimate_usd - the original W1e
+    // shape, kept for back-compat) AND the per-event spend deltas
+    // (`tokens_delta` / `cost_delta`) computed against the previous snapshot
+    // for this agent session ({@link computeUsageDelta}). The W2d cost meter
+    // sums ONLY the delta fields. The baseline tracks the LATEST snapshot
+    // (not a high-water mark): after a compaction/reset drop the gauge
+    // legitimately grows again from the lower value, and that growth is real
+    // new spend that must be counted. ACP gives a `used` total only (no
+    // prompt/completion split), so completion_tokens stays 0.
     if (msg.type === 'acp_context_usage') {
       const usage = msg.data as { used?: number; size?: number; cost?: { amount?: number; currency?: string } } | null;
       if (usage && typeof usage.used === 'number') {
@@ -560,17 +599,12 @@ export class TeammateManager extends EventEmitter {
         // currencies are recorded but normalized to 0 in cost_estimate_usd.
         const cumulativeCostUsd = currency === 'USD' ? costAmount : 0;
 
-        const baseline = this.tokenUsageBaselines.get(msg.conversation_id) ?? { used: 0, cost: 0 };
-        const deltaTokens = Math.max(0, cumulativeUsed - baseline.used);
-        const deltaCostUsd = Math.max(0, cumulativeCostUsd - baseline.cost);
-        // Advance to the new high-water mark; never regress (survives the
-        // cumulative gauge dropping after a session reset / compaction).
-        this.tokenUsageBaselines.set(msg.conversation_id, {
-          used: Math.max(baseline.used, cumulativeUsed),
-          cost: Math.max(baseline.cost, cumulativeCostUsd),
-        });
+        const prev = this.tokenUsageBaselines.get(msg.conversation_id);
+        const next: UsageSnapshot = { used: cumulativeUsed, cost: cumulativeCostUsd };
+        const { tokensDelta, costDelta } = computeUsageDelta(prev, next);
+        this.tokenUsageBaselines.set(msg.conversation_id, next);
 
-        if (this.eventLogger && (deltaTokens > 0 || deltaCostUsd > 0)) {
+        if (this.eventLogger && (tokensDelta > 0 || costDelta > 0)) {
           void this.eventLogger.append({
             teamId: this.teamId,
             eventType: 'token_usage',
@@ -578,10 +612,14 @@ export class TeammateManager extends EventEmitter {
             payload: {
               slot_id: agent.slotId,
               backend: agent.agentType,
-              prompt_tokens: deltaTokens,
+              // Raw cumulative session snapshot (back-compat W1e shape).
+              prompt_tokens: cumulativeUsed,
               completion_tokens: 0,
-              cost_estimate_usd: deltaCostUsd,
-              total_tokens: deltaTokens,
+              total_tokens: cumulativeUsed,
+              cost_estimate_usd: cumulativeCostUsd,
+              // Per-event spend deltas - the ONLY fields the meter sums.
+              tokens_delta: tokensDelta,
+              cost_delta: costDelta,
               currency,
               context_window: typeof usage.size === 'number' ? usage.size : 0,
             },
@@ -849,6 +887,12 @@ export class TeammateManager extends EventEmitter {
    * For **leader**: only marks it as failed - leader must never be auto-removed.
    */
   private async handleAgentCrash(agent: TeamAgent, errorMessage: string): Promise<void> {
+    // DESK-1: crashed session -> reset the usage-gauge baseline so the
+    // recovered session's first cumulative snapshot counts fully.
+    if (agent.conversationId) {
+      this.tokenUsageBaselines.delete(agent.conversationId);
+    }
+
     // Leader crash: mark as failed so the frontend shows the error, but never auto-remove.
     if (agent.role === 'leader') {
       console.warn(
@@ -961,6 +1005,7 @@ export class TeammateManager extends EventEmitter {
       this.ownedConversationIds.delete(agent.conversationId);
       this.unregisterAcpTeamContext(agent.conversationId);
       this.finalizedTurns.delete(agent.conversationId);
+      this.tokenUsageBaselines.delete(agent.conversationId);
     }
 
     this.agents = this.agents.filter((a) => a.slotId !== slotId);

--- a/src/renderer/hooks/team/useTeamCostMeter.ts
+++ b/src/renderer/hooks/team/useTeamCostMeter.ts
@@ -5,19 +5,24 @@
 // `event_type='token_usage'` every 30 seconds and aggregates the totals
 // the sidebar Active section needs.
 //
-// === Two upstream conventions to know about ===
+// === Upstream row shapes to know about (DESK-1) ===
 //
-// 1. Total-tokens shape. W1e currently writes
-//      `{ prompt_tokens: usage.used, completion_tokens: 0,
-//         cost_estimate_usd: number, ... }`
-//    where `usage.used` is actually the *total* (prompt + completion) from
-//    the source `acp_context_usage` event, not a prompt-only count.
-//    For W2d we treat `prompt_tokens + completion_tokens` as the total
-//    tokens, which works under both the current convention (total + 0)
-//    and any future fix that splits them honestly. Only the aggregation
-//    below needs to change if the upstream shape ever changes.
+// The source `acp_context_usage` event is a CUMULATIVE session gauge -
+// `used` is "total tokens currently in context", re-sent on every update,
+// and `cost` is the cumulative session cost. Summing those snapshots
+// grossly inflates the meter, so:
 //
-// 2. `WHERE created_at > ?` strict inequality. The W1e listEvents reader
+// 1. New rows (delta-aware writer in TeammateManager) carry per-event
+//    spend deltas as `tokens_delta` / `cost_delta` alongside the raw
+//    snapshot fields. Deltas are safe to SUM - that is all we sum.
+//
+// 2. Legacy rows without the delta fields hold a cumulative snapshot in
+//    `prompt_tokens`/`completion_tokens`/`cost_estimate_usd`. A snapshot
+//    IS that actor's session total, so we keep only the NEWEST such row
+//    per actor (actor_slot_id) as an approximation of that actor's total.
+//    Snapshots are never summed across events.
+//
+// 3. `WHERE created_at > ?` strict inequality. The W1e listEvents reader
 //    excludes rows tied to the cursor timestamp. At a 30s polling cadence
 //    on a cost-meter (rough-estimate, not penny-accurate) this is fine;
 //    we lose at most sibling same-millisecond events on a hot burst,
@@ -49,6 +54,8 @@ type Options = {
   pollIntervalMs?: number;
 };
 
+type LegacySnapshot = { tokens: number; usd: number; createdAt: number };
+
 /**
  * Polls `team_event_log` `token_usage` rows for `teamId` and returns the
  * accumulated `totalTokens` + `totalUsd` over the sliding window.
@@ -61,6 +68,11 @@ export function useTeamCostMeter(teamId: string, opts: Options = {}): TeamCostMe
   const [totalUsd, setTotalUsd] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const cursorRef = useRef<number>(0);
+  /** Running sum of the delta-aware rows' `tokens_delta` / `cost_delta`. */
+  const deltaTokensRef = useRef(0);
+  const deltaUsdRef = useRef(0);
+  /** Newest legacy (snapshot-only) row per actor - never summed per-event. */
+  const legacySnapshotsRef = useRef<Map<string, LegacySnapshot>>(new Map());
 
   useEffect(() => {
     if (!teamId) return;
@@ -69,6 +81,9 @@ export function useTeamCostMeter(teamId: string, opts: Options = {}): TeamCostMe
     // bleed one team's totals into another.
     let cancelled = false;
     cursorRef.current = Date.now() - windowMs;
+    deltaTokensRef.current = 0;
+    deltaUsdRef.current = 0;
+    legacySnapshotsRef.current = new Map();
     setTotalTokens(0);
     setTotalUsd(0);
     setIsLoading(true);
@@ -88,21 +103,40 @@ export function useTeamCostMeter(teamId: string, opts: Options = {}): TeamCostMe
           return;
         }
 
-        let tokensDelta = 0;
-        let usdDelta = 0;
         let maxCreatedAt = since;
         for (const e of events) {
           const p = (e.payload ?? {}) as Record<string, unknown>;
-          const prompt = typeof p.prompt_tokens === 'number' ? p.prompt_tokens : 0;
-          const completion = typeof p.completion_tokens === 'number' ? p.completion_tokens : 0;
-          const cost = typeof p.cost_estimate_usd === 'number' ? p.cost_estimate_usd : 0;
-          tokensDelta += prompt + completion;
-          usdDelta += cost;
+          const tokensDelta = typeof p.tokens_delta === 'number' ? p.tokens_delta : undefined;
+          const costDelta = typeof p.cost_delta === 'number' ? p.cost_delta : undefined;
+          if (tokensDelta !== undefined || costDelta !== undefined) {
+            // Delta-aware row: per-event spend, safe to sum.
+            deltaTokensRef.current += tokensDelta ?? 0;
+            deltaUsdRef.current += costDelta ?? 0;
+          } else {
+            // Legacy row: fields are a CUMULATIVE session snapshot. The
+            // newest snapshot per actor approximates that actor's session
+            // total - never sum snapshots across events.
+            const prompt = typeof p.prompt_tokens === 'number' ? p.prompt_tokens : 0;
+            const completion = typeof p.completion_tokens === 'number' ? p.completion_tokens : 0;
+            const usd = typeof p.cost_estimate_usd === 'number' ? p.cost_estimate_usd : 0;
+            const actor = typeof p.slot_id === 'string' && p.slot_id ? p.slot_id : (e.actorSlotId ?? 'unknown');
+            const existing = legacySnapshotsRef.current.get(actor);
+            if (!existing || e.createdAt >= existing.createdAt) {
+              legacySnapshotsRef.current.set(actor, { tokens: prompt + completion, usd, createdAt: e.createdAt });
+            }
+          }
           if (e.createdAt > maxCreatedAt) maxCreatedAt = e.createdAt;
         }
         cursorRef.current = maxCreatedAt;
-        setTotalTokens((prev) => prev + tokensDelta);
-        setTotalUsd((prev) => prev + usdDelta);
+
+        let tokens = deltaTokensRef.current;
+        let usd = deltaUsdRef.current;
+        for (const snap of legacySnapshotsRef.current.values()) {
+          tokens += snap.tokens;
+          usd += snap.usd;
+        }
+        setTotalTokens(tokens);
+        setTotalUsd(usd);
         setIsLoading(false);
       } catch (error) {
         // Cost meter is best-effort - a single failed poll shouldn't tear

--- a/src/renderer/pages/team/components/TeamActivityTab.tsx
+++ b/src/renderer/pages/team/components/TeamActivityTab.tsx
@@ -98,10 +98,22 @@ const summarizeEvent = (event: TeamEvent): string => {
       return duration ? `${label} (${duration})` : label;
     }
     case 'token_usage': {
-      const total = typeof p.total_tokens === 'number' ? p.total_tokens : undefined;
-      const cost = typeof p.cost_estimate_usd === 'number' ? p.cost_estimate_usd : undefined;
       const backend = typeof p.backend === 'string' ? p.backend : undefined;
       const parts: string[] = [];
+      // DESK-1: delta-aware rows carry this event's spend in `tokens_delta` /
+      // `cost_delta` - show that (prefixed `+`), not the cumulative session
+      // snapshot the raw fields hold.
+      const tokensDelta = typeof p.tokens_delta === 'number' ? p.tokens_delta : undefined;
+      const costDelta = typeof p.cost_delta === 'number' ? p.cost_delta : undefined;
+      if (tokensDelta !== undefined || costDelta !== undefined) {
+        if (tokensDelta !== undefined) parts.push(`+${tokensDelta.toLocaleString()} tokens`);
+        if (costDelta !== undefined && costDelta > 0) parts.push(`+$${costDelta.toFixed(4)}`);
+        if (backend) parts.push(backend);
+        return parts.length > 0 ? parts.join(' · ') : 'token usage';
+      }
+      // Legacy rows without delta fields: keep the original snapshot rendering.
+      const total = typeof p.total_tokens === 'number' ? p.total_tokens : undefined;
+      const cost = typeof p.cost_estimate_usd === 'number' ? p.cost_estimate_usd : undefined;
       if (total !== undefined) parts.push(`${total.toLocaleString()} tokens`);
       if (cost !== undefined) parts.push(`$${cost.toFixed(4)}`);
       if (backend) parts.push(backend);

--- a/src/renderer/pages/team/components/TeamActivityTab.tsx
+++ b/src/renderer/pages/team/components/TeamActivityTab.tsx
@@ -14,17 +14,7 @@
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  AlertTriangle,
-  ArrowRight,
-  ClipboardList,
-  Coins,
-  Inbox,
-  Power,
-  Sparkles,
-  UserPlus,
-  Wand2,
-} from 'lucide-react';
+import { AlertTriangle, ArrowRight, ClipboardList, Coins, Inbox, Power, Sparkles, UserPlus, Wand2 } from 'lucide-react';
 import { ipcBridge } from '@/common';
 import type { TeamEvent, TeamEventType } from '@process/team/types';
 

--- a/tests/unit/renderer/hooks/useTeamCostMeter.dom.test.ts
+++ b/tests/unit/renderer/hooks/useTeamCostMeter.dom.test.ts
@@ -10,7 +10,9 @@
  * W2d - useTeamCostMeter hook tests. Covers:
  *   - Invokes ipcBridge.team.listEvents with the correct args
  *     (teamId + sliding-window `since` + eventType: 'token_usage' filter)
- *   - Aggregates prompt + completion tokens AND cost_estimate_usd
+ *   - DESK-1 aggregation: SUMS `tokens_delta` / `cost_delta` on delta-aware
+ *     rows; for legacy rows without delta fields (cumulative snapshots) it
+ *     counts only the NEWEST row per actor - snapshots are never summed
  *   - Re-polls on interval; subsequent calls advance `since` past the
  *     last-seen createdAt so each event is counted exactly once
  *   - Clears the interval on unmount (no leaked timers)
@@ -40,7 +42,7 @@ const makeTokenEvent = (over: Partial<TeamEvent> & { payload?: Record<string, un
   teamId: 'team-1',
   eventType: 'token_usage',
   createdAt: Date.now(),
-  payload: { prompt_tokens: 100, completion_tokens: 50, cost_estimate_usd: 0.01 },
+  payload: { tokens_delta: 100, cost_delta: 0.01 },
   ...over,
 });
 
@@ -71,22 +73,52 @@ describe('useTeamCostMeter', () => {
     expect(call.since).toBeLessThanOrEqual(before - sevenDays + 500);
   });
 
-  it('aggregates prompt + completion tokens AND cost_estimate_usd across events', async () => {
+  it('sums tokens_delta and cost_delta across delta-aware rows', async () => {
+    const events: TeamEvent[] = [
+      makeTokenEvent({ id: 'a', createdAt: 1000, payload: { tokens_delta: 100, cost_delta: 0.012 } }),
+      makeTokenEvent({ id: 'b', createdAt: 2000, payload: { tokens_delta: 250, cost_delta: 0.034 } }),
+      makeTokenEvent({ id: 'c', createdAt: 3000, payload: { tokens_delta: 50, cost_delta: 0.005 } }),
+    ];
+    listEventsInvoke.mockResolvedValue(events);
+
+    const { result } = renderHook(() => useTeamCostMeter('team-1', { pollIntervalMs: 10_000 }));
+
+    await waitFor(() => {
+      expect(result.current.totalTokens).toBe(100 + 250 + 50); // 400
+    });
+    expect(result.current.totalUsd).toBeCloseTo(0.012 + 0.034 + 0.005, 5);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('never sums legacy snapshot rows - counts only the newest per actor', async () => {
+    // Legacy rows (no tokens_delta / cost_delta) hold a CUMULATIVE session
+    // snapshot. Three snapshots from the same actor must contribute the
+    // NEWEST value (400), not the inflated sum (100 + 250 + 400 = 750).
     const events: TeamEvent[] = [
       makeTokenEvent({
         id: 'a',
         createdAt: 1000,
-        payload: { prompt_tokens: 100, completion_tokens: 50, cost_estimate_usd: 0.012 },
+        actorSlotId: 'slot-1',
+        payload: { prompt_tokens: 100, completion_tokens: 0, cost_estimate_usd: 0.01 },
       }),
       makeTokenEvent({
         id: 'b',
         createdAt: 2000,
-        payload: { prompt_tokens: 200, completion_tokens: 75, cost_estimate_usd: 0.034 },
+        actorSlotId: 'slot-1',
+        payload: { prompt_tokens: 250, completion_tokens: 0, cost_estimate_usd: 0.025 },
       }),
       makeTokenEvent({
         id: 'c',
         createdAt: 3000,
-        payload: { prompt_tokens: 50, completion_tokens: 25, cost_estimate_usd: 0.005 },
+        actorSlotId: 'slot-1',
+        payload: { prompt_tokens: 400, completion_tokens: 0, cost_estimate_usd: 0.04 },
+      }),
+      // A second actor's snapshot is tracked independently.
+      makeTokenEvent({
+        id: 'd',
+        createdAt: 2500,
+        actorSlotId: 'slot-2',
+        payload: { prompt_tokens: 60, completion_tokens: 40, cost_estimate_usd: 0.01 },
       }),
     ];
     listEventsInvoke.mockResolvedValue(events);
@@ -94,25 +126,51 @@ describe('useTeamCostMeter', () => {
     const { result } = renderHook(() => useTeamCostMeter('team-1', { pollIntervalMs: 10_000 }));
 
     await waitFor(() => {
-      expect(result.current.totalTokens).toBe(100 + 50 + 200 + 75 + 50 + 25); // 500
+      expect(result.current.totalTokens).toBe(400 + 100); // newest per actor
     });
-    expect(result.current.totalUsd).toBeCloseTo(0.012 + 0.034 + 0.005, 5);
-    expect(result.current.isLoading).toBe(false);
+    expect(result.current.totalUsd).toBeCloseTo(0.04 + 0.01, 5);
   });
 
-  it('treats missing prompt_tokens / completion_tokens / cost_estimate_usd as 0', async () => {
+  it('combines delta-aware rows (summed) with legacy snapshot rows (newest per actor)', async () => {
+    const events: TeamEvent[] = [
+      makeTokenEvent({ id: 'a', createdAt: 1000, payload: { tokens_delta: 100, cost_delta: 0.01 } }),
+      makeTokenEvent({ id: 'b', createdAt: 2000, payload: { tokens_delta: 50, cost_delta: 0.005 } }),
+      // Legacy snapshots from one actor: only the newest (300) counts.
+      makeTokenEvent({
+        id: 'c',
+        createdAt: 1500,
+        actorSlotId: 'slot-legacy',
+        payload: { prompt_tokens: 200, completion_tokens: 0, cost_estimate_usd: 0.02 },
+      }),
+      makeTokenEvent({
+        id: 'd',
+        createdAt: 2500,
+        actorSlotId: 'slot-legacy',
+        payload: { prompt_tokens: 300, completion_tokens: 0, cost_estimate_usd: 0.03 },
+      }),
+    ];
+    listEventsInvoke.mockResolvedValue(events);
+
+    const { result } = renderHook(() => useTeamCostMeter('team-1', { pollIntervalMs: 10_000 }));
+
+    await waitFor(() => {
+      expect(result.current.totalTokens).toBe(100 + 50 + 300);
+    });
+    expect(result.current.totalUsd).toBeCloseTo(0.01 + 0.005 + 0.03, 5);
+  });
+
+  it('treats a missing tokens_delta / cost_delta as 0 on delta-aware rows', async () => {
     listEventsInvoke.mockResolvedValue([
-      makeTokenEvent({ id: 'a', payload: { prompt_tokens: 100 } }), // no completion, no cost
-      makeTokenEvent({ id: 'b', payload: { completion_tokens: 50 } }), // no prompt, no cost
-      makeTokenEvent({ id: 'c', payload: {} }), // empty payload
+      makeTokenEvent({ id: 'a', payload: { tokens_delta: 100 } }), // no cost_delta
+      makeTokenEvent({ id: 'b', payload: { cost_delta: 0.02 } }), // no tokens_delta
     ]);
 
     const { result } = renderHook(() => useTeamCostMeter('team-1', { pollIntervalMs: 10_000 }));
 
     await waitFor(() => {
-      expect(result.current.totalTokens).toBe(150);
+      expect(result.current.totalTokens).toBe(100);
     });
-    expect(result.current.totalUsd).toBe(0);
+    expect(result.current.totalUsd).toBeCloseTo(0.02, 5);
   });
 
   it('re-polls on the interval and only counts new events (advances cursor past seen createdAt)', async () => {
@@ -124,18 +182,10 @@ describe('useTeamCostMeter', () => {
     const tB = now - 30_000; // 30s ago
     listEventsInvoke
       .mockResolvedValueOnce([
-        makeTokenEvent({
-          id: 'a',
-          createdAt: tA,
-          payload: { prompt_tokens: 100, completion_tokens: 0, cost_estimate_usd: 0.01 },
-        }),
+        makeTokenEvent({ id: 'a', createdAt: tA, payload: { tokens_delta: 100, cost_delta: 0.01 } }),
       ])
       .mockResolvedValueOnce([
-        makeTokenEvent({
-          id: 'b',
-          createdAt: tB,
-          payload: { prompt_tokens: 50, completion_tokens: 50, cost_estimate_usd: 0.02 },
-        }),
+        makeTokenEvent({ id: 'b', createdAt: tB, payload: { tokens_delta: 100, cost_delta: 0.02 } }),
       ])
       .mockResolvedValue([]);
 
@@ -176,9 +226,7 @@ describe('useTeamCostMeter', () => {
   });
 
   it('resets totals + cursor when teamId changes', async () => {
-    listEventsInvoke.mockResolvedValue([
-      makeTokenEvent({ payload: { prompt_tokens: 1000, completion_tokens: 0, cost_estimate_usd: 0.5 } }),
-    ]);
+    listEventsInvoke.mockResolvedValue([makeTokenEvent({ payload: { tokens_delta: 1000, cost_delta: 0.5 } })]);
 
     const { result, rerender } = renderHook(({ id }: { id: string }) => useTeamCostMeter(id, { pollIntervalMs: 10_000 }), {
       initialProps: { id: 'team-A' },

--- a/tests/unit/renderer/hooks/useTeamCostMeter.dom.test.ts
+++ b/tests/unit/renderer/hooks/useTeamCostMeter.dom.test.ts
@@ -228,9 +228,12 @@ describe('useTeamCostMeter', () => {
   it('resets totals + cursor when teamId changes', async () => {
     listEventsInvoke.mockResolvedValue([makeTokenEvent({ payload: { tokens_delta: 1000, cost_delta: 0.5 } })]);
 
-    const { result, rerender } = renderHook(({ id }: { id: string }) => useTeamCostMeter(id, { pollIntervalMs: 10_000 }), {
-      initialProps: { id: 'team-A' },
-    });
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => useTeamCostMeter(id, { pollIntervalMs: 10_000 }),
+      {
+        initialProps: { id: 'team-A' },
+      }
+    );
 
     await waitFor(() => {
       expect(result.current.totalTokens).toBe(1000);

--- a/tests/unit/team-TeammateManager.test.ts
+++ b/tests/unit/team-TeammateManager.test.ts
@@ -31,7 +31,7 @@ vi.mock('@process/utils/initStorage', () => ({
   ProcessConfig: { get: vi.fn(async () => null) },
 }));
 
-import { TeammateManager } from '@process/team/TeammateManager';
+import { TeammateManager, computeUsageDelta } from '@process/team/TeammateManager';
 import { teamEventBus } from '@process/team/teamEventBus';
 import type { TeamAgent } from '@process/team/types';
 import type { Mailbox } from '@process/team/Mailbox';
@@ -817,11 +817,15 @@ describe('TeammateManager', () => {
   });
 
   // -------------------------------------------------------------------------
-  // token_usage delta accounting (R1 N-count fix)
+  // token_usage snapshot-diff accounting (DESK-1, supersedes R1 N-count fix)
   // -------------------------------------------------------------------------
 
   describe('acp_context_usage token_usage delta', () => {
-    it('writes per-turn deltas of the cumulative gauge, not the raw cumulative value', () => {
+    type TokenRow = { eventType?: string; payload: Record<string, unknown> };
+    const tokenRowsOf = (append: ReturnType<typeof vi.fn>): TokenRow[] =>
+      append.mock.calls.map((c) => c[0] as TokenRow).filter((e) => e.eventType === 'token_usage');
+
+    it('writes the raw cumulative snapshot AND per-event tokens_delta on each row', () => {
       const append = vi.fn().mockResolvedValue(undefined);
       const eventLogger = { append } as unknown;
       const agent = makeAgent({ slotId: 'slot-1', conversationId: 'conv-1' });
@@ -837,24 +841,20 @@ describe('TeammateManager', () => {
         });
       }
 
-      const tokenRows = append.mock.calls
-        .map((c) => c[0])
-        .filter((e: { eventType?: string }) => e.eventType === 'token_usage');
-      // Three deltas: 100, 150, 150 (summing to 400 - the true running total),
-      // NOT the N-counted 100+250+400 = 750.
-      expect(tokenRows.map((r: { payload: { total_tokens: number } }) => r.payload.total_tokens)).toEqual([
-        100, 150, 150,
-      ]);
-      const summed = tokenRows.reduce(
-        (acc: number, r: { payload: { total_tokens: number } }) => acc + r.payload.total_tokens,
-        0
-      );
+      const tokenRows = tokenRowsOf(append);
+      // Raw snapshot fields stay cumulative (back-compat W1e shape) ...
+      expect(tokenRows.map((r) => r.payload.total_tokens)).toEqual([100, 250, 400]);
+      expect(tokenRows.map((r) => r.payload.prompt_tokens)).toEqual([100, 250, 400]);
+      // ... while the deltas are per-event spend: 100, 150, 150 - the ONLY
+      // fields the meter sums (total 400, NOT the N-counted 750).
+      expect(tokenRows.map((r) => r.payload.tokens_delta)).toEqual([100, 150, 150]);
+      const summed = tokenRows.reduce((acc, r) => acc + (r.payload.tokens_delta as number), 0);
       expect(summed).toBe(400);
 
       mgr.dispose();
     });
 
-    it('keeps per-conversation baselines independent and clamps a regressed gauge to 0', () => {
+    it('keeps per-conversation baselines independent and clamps a dropped gauge to a 0 delta', () => {
       const append = vi.fn().mockResolvedValue(undefined);
       const eventLogger = { append } as unknown;
       const agents = [
@@ -876,7 +876,7 @@ describe('TeammateManager', () => {
         msg_id: 'm',
         data: { used: 300 },
       });
-      // A regressed gauge on conv-1 (compaction/reset) clamps to a 0 delta and
+      // A dropped gauge on conv-1 (compaction/reset) clamps to a 0 delta and
       // therefore writes no row.
       teamEventBus.emit('responseStream', {
         type: 'acp_context_usage',
@@ -885,12 +885,104 @@ describe('TeammateManager', () => {
         data: { used: 200 },
       });
 
-      const tokenRows = append.mock.calls
-        .map((c) => c[0])
-        .filter((e: { eventType?: string }) => e.eventType === 'token_usage');
-      expect(tokenRows.map((r: { payload: { total_tokens: number } }) => r.payload.total_tokens)).toEqual([500, 300]);
+      const tokenRows = tokenRowsOf(append);
+      expect(tokenRows.map((r) => r.payload.tokens_delta)).toEqual([500, 300]);
 
       mgr.dispose();
+    });
+
+    it('counts growth after a compaction drop from the new lower baseline', () => {
+      const append = vi.fn().mockResolvedValue(undefined);
+      const eventLogger = { append } as unknown;
+      const agent = makeAgent({ slotId: 'slot-1', conversationId: 'conv-1' });
+      const { mgr } = makeTeammateManager([agent], { eventLogger });
+
+      // 500 -> compaction drop to 200 (delta 0, no row) -> grow to 350.
+      // The post-drop growth (150) is real new spend and must be counted - a
+      // high-water baseline would wrongly swallow it until 500 was passed.
+      for (const used of [500, 200, 350]) {
+        teamEventBus.emit('responseStream', {
+          type: 'acp_context_usage',
+          conversation_id: 'conv-1',
+          msg_id: 'm',
+          data: { used },
+        });
+      }
+
+      const tokenRows = tokenRowsOf(append);
+      expect(tokenRows.map((r) => r.payload.tokens_delta)).toEqual([500, 150]);
+
+      mgr.dispose();
+    });
+
+    it('resets the baseline when the agent process is killed so a fresh session counts fully', () => {
+      const append = vi.fn().mockResolvedValue(undefined);
+      const eventLogger = { append } as unknown;
+      const agent = makeAgent({ slotId: 'slot-1', conversationId: 'conv-1' });
+      const { mgr } = makeTeammateManager([agent], { eventLogger });
+
+      teamEventBus.emit('responseStream', {
+        type: 'acp_context_usage',
+        conversation_id: 'conv-1',
+        msg_id: 'm',
+        data: { used: 500 },
+      });
+
+      // Session restart reuses the conversationId; without the reset the new
+      // session's first snapshot (300) would be misread as a drop (delta 0).
+      mgr.killAgentProcess('slot-1');
+
+      teamEventBus.emit('responseStream', {
+        type: 'acp_context_usage',
+        conversation_id: 'conv-1',
+        msg_id: 'm',
+        data: { used: 300 },
+      });
+
+      const tokenRows = tokenRowsOf(append);
+      expect(tokenRows.map((r) => r.payload.tokens_delta)).toEqual([500, 300]);
+
+      mgr.dispose();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // computeUsageDelta - pure snapshot-diff semantics (DESK-1)
+  // -------------------------------------------------------------------------
+
+  describe('computeUsageDelta', () => {
+    it('counts the full snapshot when there is no previous snapshot (fresh session)', () => {
+      expect(computeUsageDelta(undefined, { used: 1234, cost: 0.5 })).toEqual({
+        tokensDelta: 1234,
+        costDelta: 0.5,
+      });
+    });
+
+    it('returns the growth when the gauge grew', () => {
+      const delta = computeUsageDelta({ used: 100, cost: 0.1 }, { used: 250, cost: 0.35 });
+      expect(delta.tokensDelta).toBe(150);
+      expect(delta.costDelta).toBeCloseTo(0.25, 10);
+    });
+
+    it('clamps to 0 when the gauge dropped (compaction/reset)', () => {
+      expect(computeUsageDelta({ used: 500, cost: 0.5 }, { used: 200, cost: 0.1 })).toEqual({
+        tokensDelta: 0,
+        costDelta: 0,
+      });
+    });
+
+    it('clamps tokens and cost independently', () => {
+      // Tokens dropped (compaction) while cumulative cost kept growing.
+      const delta = computeUsageDelta({ used: 500, cost: 0.5 }, { used: 200, cost: 0.6 });
+      expect(delta.tokensDelta).toBe(0);
+      expect(delta.costDelta).toBeCloseTo(0.1, 10);
+    });
+
+    it('returns 0 deltas for an unchanged gauge', () => {
+      expect(computeUsageDelta({ used: 500, cost: 0.5 }, { used: 500, cost: 0.5 })).toEqual({
+        tokensDelta: 0,
+        costDelta: 0,
+      });
     });
   });
 


### PR DESCRIPTION
DESK-1. The cost meter was summing cumulative usage snapshots as if they were per-run deltas, double-counting (and in some paths under-counting) token usage. This computes per-run usage deltas via computeUsageDelta so each run contributes exactly its own consumption.

- Audited: SHIP
- 5 attack vectors held
- Pairs with the wayland-core usage_delta emission (FerroxLabs/wayland-core token-efficiency phase 1)
