### PR TITLE
fix(secrets): vault passphrase provisioning for isolated-profile engine spawns

### DIFF
--- a/src/process/agent/wcore/envBuilder.ts
+++ b/src/process/agent/wcore/envBuilder.ts
@@ -10,6 +10,7 @@ import { CHATGPT_SUBSCRIPTION_PROVIDER_ID } from '@process/providers/catalog/cha
 import { loadBaselineProviderCatalog } from '@process/providers/catalog/providerCatalogStore';
 import { PROVIDER_ENV_VARS } from '@process/providers/detection/KeyDiscovery';
 import type { ProviderId } from '@process/providers/types';
+import { VAULT_PASSPHRASE_CHILD_FD } from '@process/secrets';
 import { getEnhancedEnv } from '@process/utils/shellEnv';
 
 /**
@@ -731,6 +732,7 @@ export function buildEngineSpawnEnv(opts: {
   providerEnv: Record<string, string>;
   toolKeys?: Record<string, string>;
   waylandHome?: string;
+  vaultPassphraseEnv?: Record<string, string>;
 }): Record<string, string> {
   const full = getEnhancedEnv(opts.providerEnv);
   const allowed = new Set(ENGINE_ENV_ALLOWLIST.map((name) => name.toUpperCase()));
@@ -756,6 +758,15 @@ export function buildEngineSpawnEnv(opts: {
   // Active-profile config root (Design B). Authoritative - set last.
   if (opts.waylandHome) {
     out.WAYLAND_HOME = opts.waylandHome;
+  }
+
+  // #710: engine credentials-vault unlock material, produced by
+  // {@link planVaultPassphraseDelivery}. Layered after the allowlist filter on
+  // purpose: WAYLAND_VAULT_PASSPHRASE / _FD are deliberately NOT allowlisted,
+  // so a stale value in the user's shell can never leak into the spawn - only
+  // the desktop's own per-profile provisioning sets them.
+  for (const [name, value] of Object.entries(opts.vaultPassphraseEnv ?? {})) {
+    out[name] = value;
   }
 
   // Opt the bundled engine into honoring a wire `set_mode` that loosens
@@ -802,4 +813,41 @@ export function buildEngineSpawnEnv(opts: {
   out.WAYLAND_SEND_MESSAGE_HOST_DELEGATE = '1';
 
   return out;
+}
+
+/**
+ * How the engine-vault passphrase reaches the spawned engine (#710):
+ *  - `fd` (Unix): an extra `'pipe'` stdio slot at index
+ *    {@link VAULT_PASSPHRASE_CHILD_FD}; the parent writes `fdPayload` and
+ *    closes its end, and `WAYLAND_VAULT_PASSPHRASE_FD` tells the engine which
+ *    descriptor to read to EOF. Preferred - the passphrase never appears in
+ *    `/proc/<pid>/environ`.
+ *  - `env` (Windows): `WAYLAND_VAULT_PASSPHRASE` env var. File descriptors are
+ *    not portable to Windows, and the engine's `vault_unlock_material_present`
+ *    deliberately ignores `_FD` there (wcore-config credentials.rs), so the
+ *    env var is the ONLY channel that selects the vault on win32.
+ */
+export type VaultPassphraseDelivery =
+  | { mode: 'fd'; env: Record<string, string>; stdio: ['pipe', 'pipe', 'pipe', 'pipe']; fdPayload: string }
+  | { mode: 'env'; env: Record<string, string>; stdio: ['pipe', 'pipe', 'pipe'] };
+
+/**
+ * Plan the platform-appropriate delivery of a vault passphrase into the engine
+ * spawn: the env entries for {@link buildEngineSpawnEnv}'s `vaultPassphraseEnv`,
+ * the stdio layout for the spawn, and (fd mode) the payload to write into the
+ * extra pipe. Pure - `platform` is injectable for tests.
+ */
+export function planVaultPassphraseDelivery(
+  passphrase: string,
+  platform: NodeJS.Platform = process.platform
+): VaultPassphraseDelivery {
+  if (platform === 'win32') {
+    return { mode: 'env', env: { WAYLAND_VAULT_PASSPHRASE: passphrase }, stdio: ['pipe', 'pipe', 'pipe'] };
+  }
+  return {
+    mode: 'fd',
+    env: { WAYLAND_VAULT_PASSPHRASE_FD: String(VAULT_PASSPHRASE_CHILD_FD) },
+    stdio: ['pipe', 'pipe', 'pipe', 'pipe'],
+    fdPayload: passphrase,
+  };
 }

--- a/src/process/agent/wcore/index.ts
+++ b/src/process/agent/wcore/index.ts
@@ -8,10 +8,19 @@ import { spawn, type ChildProcess } from 'node:child_process';
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { createInterface } from 'node:readline';
+import type { Writable } from 'node:stream';
 import { parse, stringify } from 'smol-toml';
 import type { TProviderWithModel } from '@/common/config/storage';
+import { VAULT_PASSPHRASE_CHILD_FD, resolveSpawnVaultPassphrase } from '@process/secrets';
 import { resolveWCoreBinary } from './binaryResolver';
-import { buildEngineSpawnEnv, buildSpawnConfig, engineInheritsShellKey, MissingApiKeyError } from './envBuilder';
+import {
+  buildEngineSpawnEnv,
+  buildSpawnConfig,
+  engineInheritsShellKey,
+  MissingApiKeyError,
+  planVaultPassphraseDelivery,
+  type VaultPassphraseDelivery,
+} from './envBuilder';
 import { resolveActiveConfigDir } from './profilePaths';
 import { getToolKeyStore } from './toolKeyStore';
 import { hydrateModelForSpawn } from '@process/providers/ipc/modelRegistryIpc';
@@ -293,11 +302,37 @@ export class WCoreAgent {
     } catch (err) {
       console.warn('[WCoreAgent] Failed to resolve active profile config dir:', err);
     }
+    // #710: hand the engine the profile's vault passphrase so it encrypts its
+    // credential store (WAYLAND_HOME spawns otherwise fall back to a warned
+    // plaintext credentials.toml). Delivery is fd-based on Unix (an extra pipe
+    // at stdio index 3, invisible in /proc environ) and env-based on Windows.
+    // Best-effort by design: `resolveSpawnVaultPassphrase` returns null on any
+    // keychain/provisioning failure - and when the profile already holds
+    // plaintext secrets the engine cannot migrate (no plaintext→vault import
+    // exists engine-side) - in which case the spawn proceeds exactly as before.
+    let vaultDelivery: VaultPassphraseDelivery | undefined;
+    if (waylandHome) {
+      const vaultPassphrase = await resolveSpawnVaultPassphrase(waylandHome);
+      if (vaultPassphrase !== null) {
+        vaultDelivery = planVaultPassphraseDelivery(vaultPassphrase);
+      }
+    }
     this.childProcess = spawn(binaryPath, args, {
-      env: buildEngineSpawnEnv({ providerEnv: env, toolKeys, waylandHome }),
-      stdio: ['pipe', 'pipe', 'pipe'],
+      env: buildEngineSpawnEnv({ providerEnv: env, toolKeys, waylandHome, vaultPassphraseEnv: vaultDelivery?.env }),
+      stdio: vaultDelivery?.stdio ?? ['pipe', 'pipe', 'pipe'],
       cwd: this.options.workspace,
     });
+    if (vaultDelivery?.mode === 'fd') {
+      // Write the passphrase into the extra pipe and close our end so the
+      // engine's read-to-EOF completes. The engine reads it lazily (first
+      // credential access); the pipe buffers the short payload until then.
+      // Swallow EPIPE - an engine that dies before reading must not crash us.
+      const fdStream = this.childProcess.stdio[VAULT_PASSPHRASE_CHILD_FD] as Writable | null;
+      if (fdStream) {
+        fdStream.on('error', () => {});
+        fdStream.end(vaultDelivery.fdPayload);
+      }
+    }
     // #443: register with the last-resort reaper so a quit that truncates the
     // graceful per-agent kill still force-kills this engine child (auto-removed
     // on exit / graceful kill).

--- a/src/process/secrets/index.ts
+++ b/src/process/secrets/index.ts
@@ -16,3 +16,5 @@ export {
 export { FILE_CIPHER_PREFIX } from './fileKeyStore';
 
 export { SENSITIVE_FIELD_NAMES, isSensitiveField } from './fieldClassification';
+
+export { VAULT_PASSPHRASE_CHILD_FD, resolveSpawnVaultPassphrase } from './vaultPassphrase';

--- a/src/process/secrets/vaultPassphrase.ts
+++ b/src/process/secrets/vaultPassphrase.ts
@@ -1,0 +1,180 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Per-profile engine vault passphrases (#710).
+ *
+ * When the desktop spawns the engine with `WAYLAND_HOME` set (directory-isolated
+ * profiles, Design B), the engine refuses the OS keyring (it would bleed secrets
+ * across profiles) and - without a vault passphrase - persists credentials as a
+ * plaintext-0600 `credentials.toml` inside the profile home, warning on every
+ * boot. The engine already ships an encrypted store (Argon2id + XChaCha20,
+ * `credentials.enc` + `credentials.kdf.json` beside the plaintext path) that it
+ * selects whenever unlock material arrives via `WAYLAND_VAULT_PASSPHRASE_FD`
+ * (Unix) or `WAYLAND_VAULT_PASSPHRASE` (all platforms) - see wayland-core
+ * `crates/wcore-config/src/credentials.rs` (`open_store` / `read_passphrase`).
+ *
+ * This module provisions that unlock material: one random 32-byte passphrase
+ * per profile home, generated once and persisted encrypted-at-rest through the
+ * same OS-keychain-backed `safeStorage` rail as every other desktop credential
+ * (the `chatgptTokenStore` pattern: the whole file is opaque ciphertext in a
+ * 0600 JSON file under the desktop's own config dir - never inside the profile
+ * home the engine reads).
+ *
+ * ── Migration gate (verified against the engine source) ─────────────────────
+ * The engine has NO plaintext→vault migration: with unlock material present,
+ * `open_store` returns the encrypted store, which reads ONLY `credentials.enc`
+ * and never imports an existing `credentials.toml` (credentials.rs documents
+ * the migration entrypoint as "wired in a later wave"). Supplying a passphrase
+ * to a profile that already holds plaintext secrets would therefore make those
+ * secrets invisible to the engine - apparent credential loss. So
+ * {@link resolveSpawnVaultPassphrase} gates:
+ *
+ *  - vault already established (`credentials.enc` exists) → unlock it with the
+ *    STORED passphrase only; if the stored passphrase is gone (keychain
+ *    rotation, wiped config dir), return `null` rather than minting a fresh one
+ *    that would fail the engine's unlock-verify on every credential op.
+ *  - plaintext `credentials.toml` holds secrets (and no vault) → return `null`;
+ *    the profile stays on the warned plaintext fallback until the engine ships
+ *    its own migration. Never half-migrate desktop-side.
+ *  - fresh profile (neither file, or an empty plaintext table) → mint + persist
+ *    a passphrase; the engine creates the vault on first credential write.
+ *
+ * SAFETY: every failure path returns `null` (= spawn without a passphrase, the
+ * engine's current warned-plaintext behavior). Vault provisioning must never
+ * block or break an engine spawn.
+ */
+
+import { randomBytes } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { parse as parseToml } from 'smol-toml';
+
+import { getConfigPath } from '@process/utils/utils';
+import { decryptString, encryptString } from './safeStorage';
+
+/** Filename of the encrypted passphrase map inside the desktop config dir. */
+const PASSPHRASE_FILE = 'profile-vault-passphrases.json';
+
+/** Child-process fd number the passphrase pipe occupies (stdio index 3). */
+export const VAULT_PASSPHRASE_CHILD_FD = 3;
+
+/** Absolute path to the encrypted passphrase-map file. */
+function passphraseFilePath(): string {
+  return path.join(getConfigPath(), PASSPHRASE_FILE);
+}
+
+/**
+ * Decrypt and parse the on-disk passphrase map (`profile home dir → passphrase`).
+ *
+ * Discriminates "file absent" (`{}` - safe to mint into) from "file present but
+ * unreadable/undecryptable" (`null` - e.g. an OS keychain rotation; minting
+ * over it could orphan an existing vault, so callers must not write).
+ */
+async function loadPassphraseMap(): Promise<Record<string, string> | null> {
+  let cipher: string;
+  try {
+    cipher = await fs.readFile(passphraseFilePath(), 'utf-8');
+  } catch {
+    return {};
+  }
+  try {
+    const parsed: unknown = JSON.parse(decryptString(cipher.trim()));
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      return parsed as Record<string, string>;
+    }
+  } catch {
+    // Fall through - present but unreadable.
+  }
+  return null;
+}
+
+/** Encrypt and persist the passphrase map (0600, whole file is ciphertext). */
+async function savePassphraseMap(map: Record<string, string>): Promise<void> {
+  await fs.writeFile(passphraseFilePath(), encryptString(JSON.stringify(map)), {
+    encoding: 'utf-8',
+    mode: 0o600,
+  });
+}
+
+/**
+ * Whether the profile's plaintext `credentials.toml` currently holds at least
+ * one secret. A parse failure reads as `true` (fail closed: an unreadable
+ * store might hold secrets, so do not switch the engine away from it).
+ */
+async function plaintextStoreHasSecrets(credentialsTomlPath: string): Promise<boolean> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(credentialsTomlPath, 'utf-8');
+  } catch {
+    return false;
+  }
+  try {
+    const table = parseToml(raw) as Record<string, unknown>;
+    const secrets = table.secrets;
+    if (typeof secrets !== 'object' || secrets === null) return false;
+    return Object.keys(secrets).length > 0;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Resolve the vault passphrase to hand the engine for a spawn whose
+ * `WAYLAND_HOME` is `waylandHome`, applying the migration gate documented in
+ * the module JSDoc. Returns `null` whenever the spawn should proceed WITHOUT
+ * unlock material (current warned-plaintext behavior). Never throws.
+ */
+export async function resolveSpawnVaultPassphrase(waylandHome: string): Promise<string | null> {
+  try {
+    const vaultExists = await fileExists(path.join(waylandHome, 'credentials.enc'));
+    const map = await loadPassphraseMap();
+
+    if (vaultExists) {
+      // An established vault is unlocked ONLY by its original passphrase. When
+      // that is unavailable (undecryptable map, missing entry), fall back to
+      // no-material: the engine uses the plaintext store and the vault stays
+      // intact on disk - degraded but recoverable, and never a hard failure.
+      const stored = map?.[waylandHome];
+      if (typeof stored === 'string' && stored.length > 0) return stored;
+      console.warn(
+        '[vaultPassphrase] profile has an established vault but its stored passphrase is unavailable; ' +
+          'spawning without unlock material (engine falls back to plaintext store)'
+      );
+      return null;
+    }
+
+    // No vault yet. If the plaintext store already holds secrets, enabling the
+    // vault would hide them (the engine has no auto-migration) - stay plaintext.
+    if (await plaintextStoreHasSecrets(path.join(waylandHome, 'credentials.toml'))) {
+      return null;
+    }
+
+    // Fresh profile. Reuse a previously minted passphrase (e.g. the vault has
+    // no writes yet, so credentials.enc does not exist) or mint a new one.
+    if (map === null) return null; // unreadable map - do not overwrite it
+    const existing = map[waylandHome];
+    if (typeof existing === 'string' && existing.length > 0) return existing;
+
+    const fresh = randomBytes(32).toString('base64url');
+    map[waylandHome] = fresh;
+    await savePassphraseMap(map);
+    return fresh;
+  } catch (err) {
+    console.warn('[vaultPassphrase] provisioning failed; engine will use its plaintext fallback:', err);
+    return null;
+  }
+}
+
+/** `true` when `p` exists (any file type). */
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/tests/unit/wcoreStderrSurfacing.test.ts
+++ b/tests/unit/wcoreStderrSurfacing.test.ts
@@ -18,6 +18,14 @@ vi.mock('@process/agent/wcore/binaryResolver', () => ({ resolveWCoreBinary: () =
 vi.mock('@process/agent/wcore/envBuilder', () => ({
   buildEngineSpawnEnv: () => ({}),
   buildSpawnConfig: () => ({ args: [], env: {}, projectConfig: undefined, resolvedMaxTokens: undefined }),
+  planVaultPassphraseDelivery: () => ({ mode: 'env', env: {}, stdio: ['pipe', 'pipe', 'pipe'] }),
+}));
+// #710: vault provisioning is out of scope here - resolve "no unlock material"
+// so the spawn takes the legacy three-slot stdio path (and never touches the
+// real keychain/config dir from a unit test).
+vi.mock('@process/secrets', () => ({
+  VAULT_PASSPHRASE_CHILD_FD: 3,
+  resolveSpawnVaultPassphrase: () => Promise.resolve(null),
 }));
 vi.mock('@process/agent/wcore/profilePaths', () => ({
   resolveActiveConfigDir: () => Promise.resolve('/fake/home'),

--- a/tests/unit/wcoreVaultPassphrase.test.ts
+++ b/tests/unit/wcoreVaultPassphrase.test.ts
@@ -1,0 +1,244 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * #710 - per-profile engine-vault passphrase provisioning + spawn wiring.
+ *
+ * Three units under test, in one file because they are the three halves of one
+ * fix (isolated-profile credentials no longer plaintext):
+ *  1. `resolveSpawnVaultPassphrase` - keychain-backed provisioning (minted
+ *     once, stable across calls, per-profile isolation) plus the migration
+ *     gate: the ENGINE has no plaintext→vault import, so a profile whose
+ *     `credentials.toml` already holds secrets must keep spawning without
+ *     unlock material, and an established vault must never get a freshly
+ *     minted (wrong) passphrase.
+ *  2. `planVaultPassphraseDelivery` - fd-pipe delivery on Unix vs env-var
+ *     delivery on Windows (the engine ignores `_FD` on win32 by design).
+ *  3. `buildEngineSpawnEnv` - the delivery env reaches the spawn env, while
+ *     stray WAYLAND_VAULT_PASSPHRASE* values from the user's shell stay
+ *     excluded by the SEC-1 allowlist.
+ *
+ * `safeStorage` is stubbed the same way as wcore-toolKeyEnv.test.ts; the
+ * desktop config dir (where the encrypted passphrase map lives) and the
+ * profile homes are per-test temp dirs.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── safeStorage stub (Electron + OS keychain are unavailable under Vitest) ────
+const { mockSafeStorage, configDirHolder } = vi.hoisted(() => ({
+  mockSafeStorage: {
+    isEncryptionAvailable: vi.fn(() => true),
+    encryptString: vi.fn((plaintext: string) => Buffer.from(`enc(${plaintext})`)),
+    decryptString: vi.fn((cipher: Buffer) => {
+      const raw = cipher.toString('utf8');
+      const match = raw.match(/^enc\((.*)\)$/s);
+      if (!match) throw new Error('decrypt failed');
+      return match[1];
+    }),
+  },
+  configDirHolder: { dir: '' },
+}));
+
+vi.mock('electron', () => ({ safeStorage: mockSafeStorage }));
+
+// The passphrase map lives in the desktop config dir - point it at a temp dir.
+vi.mock('@process/utils/utils', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getConfigPath: () => configDirHolder.dir,
+}));
+
+// Deterministic stand-in for the login-shell enhancer (same as toolKeyEnv test).
+vi.mock('@process/utils/shellEnv', () => ({
+  getEnhancedEnv: (customEnv?: Record<string, string>) => ({
+    ...process.env,
+    ...customEnv,
+    PATH: process.env.PATH ?? '/usr/bin',
+  }),
+}));
+
+import { resolveSpawnVaultPassphrase } from '@process/secrets';
+import { buildEngineSpawnEnv, planVaultPassphraseDelivery } from '@process/agent/wcore/envBuilder';
+
+const PASSPHRASE_FILE = 'profile-vault-passphrases.json';
+
+let profileHome: string;
+let tempDirs: string[];
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+beforeEach(() => {
+  tempDirs = [];
+  configDirHolder.dir = makeTempDir('wl-vault-config-');
+  profileHome = makeTempDir('wl-vault-profile-');
+  mockSafeStorage.encryptString.mockClear();
+  mockSafeStorage.decryptString.mockClear();
+});
+
+afterEach(() => {
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('resolveSpawnVaultPassphrase - provisioning', () => {
+  it('mints a passphrase for a fresh profile and returns the SAME one on every subsequent call', async () => {
+    const first = await resolveSpawnVaultPassphrase(profileHome);
+    expect(first).toBeTypeOf('string');
+    expect((first as string).length).toBeGreaterThanOrEqual(32);
+
+    const second = await resolveSpawnVaultPassphrase(profileHome);
+    expect(second).toBe(first);
+  });
+
+  it('isolates profiles: two profile homes get two different passphrases, each stable', async () => {
+    const otherHome = makeTempDir('wl-vault-profile-b-');
+
+    const a = await resolveSpawnVaultPassphrase(profileHome);
+    const b = await resolveSpawnVaultPassphrase(otherHome);
+
+    expect(a).not.toBeNull();
+    expect(b).not.toBeNull();
+    expect(a).not.toBe(b);
+    expect(await resolveSpawnVaultPassphrase(profileHome)).toBe(a);
+    expect(await resolveSpawnVaultPassphrase(otherHome)).toBe(b);
+  });
+
+  it('persists the map encrypted - the plaintext passphrase never appears on disk', async () => {
+    const passphrase = (await resolveSpawnVaultPassphrase(profileHome)) as string;
+
+    const raw = await fs.readFile(path.join(configDirHolder.dir, PASSPHRASE_FILE), 'utf-8');
+    expect(raw.startsWith('enc:v1:')).toBe(true);
+    expect(raw).not.toContain(passphrase);
+  });
+});
+
+describe('resolveSpawnVaultPassphrase - migration gate (engine has NO plaintext→vault import)', () => {
+  it('returns null when credentials.toml already holds secrets (profile stays plaintext, no lockout)', async () => {
+    await fs.writeFile(path.join(profileHome, 'credentials.toml'), '[secrets]\nOPENAI_API_KEY = "sk-live"\n');
+
+    expect(await resolveSpawnVaultPassphrase(profileHome)).toBeNull();
+  });
+
+  it('fails closed on a malformed credentials.toml (might hold secrets - stay plaintext)', async () => {
+    await fs.writeFile(path.join(profileHome, 'credentials.toml'), 'not [ valid toml ===');
+
+    expect(await resolveSpawnVaultPassphrase(profileHome)).toBeNull();
+  });
+
+  it('still provisions when credentials.toml exists but its secrets table is empty (nothing to lose)', async () => {
+    await fs.writeFile(path.join(profileHome, 'credentials.toml'), '[secrets]\n');
+
+    expect(await resolveSpawnVaultPassphrase(profileHome)).not.toBeNull();
+  });
+
+  it('keeps unlocking an established vault with its ORIGINAL stored passphrase', async () => {
+    const minted = await resolveSpawnVaultPassphrase(profileHome);
+    // The engine materializes the vault on first credential write.
+    await fs.writeFile(path.join(profileHome, 'credentials.enc'), 'ciphertext');
+
+    expect(await resolveSpawnVaultPassphrase(profileHome)).toBe(minted);
+  });
+
+  it('never mints a NEW passphrase against an existing vault whose passphrase is lost', async () => {
+    // A vault exists but this desktop has no stored passphrase for it (wiped
+    // config dir / keychain rotation). Minting one would fail the engine's
+    // unlock-verify on every credential op - fall back to no-material instead.
+    await fs.writeFile(path.join(profileHome, 'credentials.enc'), 'ciphertext');
+
+    expect(await resolveSpawnVaultPassphrase(profileHome)).toBeNull();
+    // And nothing was written into the map for this profile.
+    expect(await fs.readFile(path.join(configDirHolder.dir, PASSPHRASE_FILE), 'utf-8').catch(() => 'ENOENT')).toBe(
+      'ENOENT'
+    );
+  });
+});
+
+describe('resolveSpawnVaultPassphrase - keychain-failure fallback (never block the spawn)', () => {
+  it('returns null when the keychain write fails, instead of throwing', async () => {
+    mockSafeStorage.encryptString.mockImplementationOnce(() => {
+      throw new Error('keychain locked');
+    });
+
+    await expect(resolveSpawnVaultPassphrase(profileHome)).resolves.toBeNull();
+  });
+
+  it('returns null (and does not overwrite) when the stored map is undecryptable', async () => {
+    // e.g. an OS keychain key rotation: the file is present but opaque.
+    const opaque = `enc:v1:${Buffer.from('garbage-not-our-format').toString('base64')}`;
+    await fs.writeFile(path.join(configDirHolder.dir, PASSPHRASE_FILE), opaque);
+
+    expect(await resolveSpawnVaultPassphrase(profileHome)).toBeNull();
+
+    // The opaque file was left byte-for-byte intact - never clobbered.
+    const raw = await fs.readFile(path.join(configDirHolder.dir, PASSPHRASE_FILE), 'utf-8');
+    expect(raw).toBe(opaque);
+    expect(mockSafeStorage.encryptString).not.toHaveBeenCalled();
+  });
+});
+
+describe('planVaultPassphraseDelivery - platform routing', () => {
+  it('uses an fd pipe on Unix: WAYLAND_VAULT_PASSPHRASE_FD=3, a 4th stdio slot, payload to write', () => {
+    for (const platform of ['darwin', 'linux'] as const) {
+      const plan = planVaultPassphraseDelivery('pp-secret', platform);
+      expect(plan).toEqual({
+        mode: 'fd',
+        env: { WAYLAND_VAULT_PASSPHRASE_FD: '3' },
+        stdio: ['pipe', 'pipe', 'pipe', 'pipe'],
+        fdPayload: 'pp-secret',
+      });
+    }
+  });
+
+  it('uses the env var on Windows (the engine ignores _FD there by design)', () => {
+    expect(planVaultPassphraseDelivery('pp-secret', 'win32')).toEqual({
+      mode: 'env',
+      env: { WAYLAND_VAULT_PASSPHRASE: 'pp-secret' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  });
+});
+
+describe('buildEngineSpawnEnv - vault passphrase env wiring', () => {
+  const SAVED = { ...process.env };
+
+  afterEach(() => {
+    for (const k of Object.keys(process.env)) if (!(k in SAVED)) delete process.env[k];
+    Object.assign(process.env, SAVED);
+  });
+
+  it('forwards the planned delivery env into the spawn env', () => {
+    const plan = planVaultPassphraseDelivery('pp-secret', 'linux');
+    const env = buildEngineSpawnEnv({ providerEnv: {}, vaultPassphraseEnv: plan.env });
+    expect(env.WAYLAND_VAULT_PASSPHRASE_FD).toBe('3');
+
+    const winPlan = planVaultPassphraseDelivery('pp-secret', 'win32');
+    const winEnv = buildEngineSpawnEnv({ providerEnv: {}, vaultPassphraseEnv: winPlan.env });
+    expect(winEnv.WAYLAND_VAULT_PASSPHRASE).toBe('pp-secret');
+  });
+
+  it('sets neither vault var when no delivery is supplied', () => {
+    const env = buildEngineSpawnEnv({ providerEnv: {} });
+    expect(env.WAYLAND_VAULT_PASSPHRASE).toBeUndefined();
+    expect(env.WAYLAND_VAULT_PASSPHRASE_FD).toBeUndefined();
+  });
+
+  it('strips stray WAYLAND_VAULT_PASSPHRASE* from the user shell (not allowlisted)', () => {
+    process.env.WAYLAND_VAULT_PASSPHRASE = 'stale-shell-value';
+    process.env.WAYLAND_VAULT_PASSPHRASE_FD = '99';
+
+    const env = buildEngineSpawnEnv({ providerEnv: {} });
+
+    expect(env.WAYLAND_VAULT_PASSPHRASE).toBeUndefined();
+    expect(env.WAYLAND_VAULT_PASSPHRASE_FD).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #710.

Vault passphrase provisioning for isolated-profile engine spawns: the keychain-backed vault passphrase is delivered to the engine at spawn time so isolated-profile credentials are encrypted rather than falling back to plaintext.

- Audited: SHIP
- Delivery: FD-based on Unix, environment-based on Windows
- Migration gate: stays-plaintext-if-secrets (no silent migration when plaintext secrets already exist)
- Engine-side plaintext-to-vault migration tracked as wayland-core #183
