### PR TITLE
fix: SkillGuard tags normalization (#712) + blockmap release chain for differential updates (#715)

### DIFF
--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -687,6 +687,7 @@ jobs:
             out/Wayland-*-win32-*.zip
             out/Wayland-*-mac-*.zip
             out/*.yml
+            out/*.blockmap
           if-no-files-found: warn
           retention-days: 7
 

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -251,6 +251,7 @@ jobs:
             release-assets/**/*.rpm
             release-assets/**/*.zip
             release-assets/**/*.yml
+            release-assets/**/*.blockmap
           generate_release_notes: true
           draft: true
           prerelease: ${{ steps.version.outputs.is_dev == 'true' || contains(steps.version.outputs.tag_name, 'beta') || contains(steps.version.outputs.tag_name, 'alpha') || contains(steps.version.outputs.tag_name, 'rc') }}

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -199,7 +199,9 @@ nsis:
   # are user-owned and intentionally left in place.
   deleteAppDataOnUninstall: true
   artifactName: ${productName}-${version}-${os}-${arch}.${ext}
-  differentialPackage: false
+  # #715: emit a .blockmap next to the installer so electron-updater can do
+  # differential downloads instead of always falling back to the full package.
+  differentialPackage: true
 
 mac:
   target:

--- a/scripts/prepare-release-assets.sh
+++ b/scripts/prepare-release-assets.sh
@@ -30,7 +30,8 @@ mapfile -t DISTRIBUTABLES < <(find "$ARTIFACTS_DIR" -type f \( \
   -name "*.deb" -o \
   -name "*.AppImage" -o \
   -name "*.rpm" -o \
-  -name "*.zip" \
+  -name "*.zip" -o \
+  -name "*.blockmap" \
 \) | sort)
 
 DUPLICATE_BASENAMES=$(for file in "${DISTRIBUTABLES[@]}"; do basename "$file"; done | sort | uniq -d || true)

--- a/src/process/services/skills/SkillGuard.ts
+++ b/src/process/services/skills/SkillGuard.ts
@@ -27,6 +27,19 @@ export class SkillGuard {
     skills: SkillScanInput[],
     opts: { llm?: boolean; llmCall?: LlmScanCall } = {}
   ): Promise<SkillSecurityReport[]> {
+    // Imported frontmatter can carry `tags` as a bare string (e.g. YAML
+    // `tags: foo bar`) despite the declared type. Normalize once here so the
+    // regex rules can rely on an array (fixes "input.tags.join is not a
+    // function", #712).
+    skills = skills.map((s) => ({
+      ...s,
+      tags: Array.isArray(s.tags)
+        ? s.tags
+        : String((s.tags as unknown) ?? '')
+            .split(/\s+/)
+            .filter(Boolean),
+    }));
+
     // `llmScanned` on the report must reflect whether the LLM layer ACTUALLY
     // ran for each skill - not whether the caller merely requested it. If
     // `opts.llm` is true but no `llmCall` is wired, the seam returns

--- a/tests/unit/process/services/skills/skillGuard.test.ts
+++ b/tests/unit/process/services/skills/skillGuard.test.ts
@@ -34,6 +34,37 @@ describe('SkillGuard.scan - clean', () => {
   });
 });
 
+describe('SkillGuard.scan - tags normalization (#712)', () => {
+  it('tags as a bare string is split on whitespace instead of crashing', async () => {
+    const stringTags = skill({
+      tags: 'kubernetes terraform aws compliance audit security' as unknown as string[],
+      body: '# unrelated\n\nThis skill teaches you to write better recipes.',
+      description: 'cooking helper',
+    });
+    const [report] = await SkillGuard.scan([stringTags]);
+    // The split produced 6 real tags, so index-poisoning still fires on them.
+    expect(report.findings.some((f) => f.threat === 'index-poisoning')).toBe(true);
+  });
+
+  it('tags undefined is treated as no tags', async () => {
+    const noTags = skill({ tags: undefined as unknown as string[] });
+    const [report] = await SkillGuard.scan([noTags]);
+    expect(report.verdict).toBe('clean');
+    expect(report.findings).toEqual([]);
+  });
+
+  it('tags as a proper array is passed through unchanged', async () => {
+    const stuffed = skill({
+      tags: ['kubernetes', 'terraform', 'aws', 'compliance', 'audit', 'security'],
+      body: '# unrelated\n\nThis skill teaches you to write better recipes.',
+      description: 'cooking helper',
+    });
+    const [report] = await SkillGuard.scan([stuffed]);
+    const poisoning = report.findings.find((f) => f.threat === 'index-poisoning');
+    expect(poisoning?.evidence).toBe('kubernetes, terraform, aws, compliance, audit, security');
+  });
+});
+
 describe('SkillGuard.scan - regex layer', () => {
   it('credential-access patterns produce a blocked verdict with evidence', async () => {
     const malicious = skill({


### PR DESCRIPTION
Two customer-audit-verified fixes (from the second field-audit PDF verification, 2026-07-05).

Fixes #712: SkillGuard.scan normalizes the tags field (string / undefined / array) at the single choke point, covering both crash sites in skillGuardRules.ts (join at :42, filter at :137). 3 new unit tests (string tags, undefined tags, array passthrough with byte-identical evidence).

Fixes #715: .blockmap assets now survive the full release chain — nsis differentialPackage true (electron-builder.yml), per-platform artifact upload (_build-reusable.yml), prepare-release-assets.sh distributables find, and the Create Release globs. Differential updates work again instead of always falling back to full downloads.

Audit trail: builder gates green (tsc 0, lint 0 errors, 15/15 vitest). Gemini adversarial audit: single finding (latest.yml allegedly dropped by the prep script) REFUTED with evidence — the script has a dedicated per-platform latest*.yml copy pipeline (scripts/prepare-release-assets.sh lines 53-67) independent of the distributables find; auto-update metadata unaffected. No other findings.
