### PR TITLE
fix(ci): repair pre-existing unit-test rot on main

### DIFF
--- a/tests/unit/WCoreManagerEventBus.test.ts
+++ b/tests/unit/WCoreManagerEventBus.test.ts
@@ -624,10 +624,11 @@ describe('GAP-8: WCoreManager Multi EventBus Emission', () => {
       expect(resumeApproval).not.toHaveBeenCalled();
     });
 
-    it('non-interactive (yoloMode) auto mode: loud-denies via resumeApproval(false), no silent approve, no card', () => {
-      // A channel/cron spawn (yoloMode:true) has no user to prompt. Escalating would
-      // hit addConfirmation's yoloMode auto-approve and SILENTLY APPROVE — so we
-      // loud-deny instead.
+    it('non-interactive (yoloMode) auto mode: auto-approves via resumeApproval(true), recorded, no card', () => {
+      // A channel/cron spawn (yoloMode:true) is genuinely autonomous — there is no
+      // user to prompt and it opted into full-auto. 0.11.15 restored the pre-#264
+      // auto-approve here (the interim loud-deny broke legit yolo/cron egress):
+      // resume(true), record via mainLog, and never synthesize a confirmation card.
       const data = {
         workspace: '/test/workspace',
         model: { name: 'test-provider', useModel: 'test-model', baseUrl: '', platform: 'test' },
@@ -641,16 +642,16 @@ describe('GAP-8: WCoreManager Multi EventBus Emission', () => {
 
       escalate(m, 'cy', 'tok-y');
 
-      expect(resumeApproval).toHaveBeenCalledWith('tok-y', false);
+      expect(resumeApproval).toHaveBeenCalledWith('tok-y', true);
       // No confirmation card was created for a headless run.
       expect((m as any).confirmations.some((c: any) => c.callId === 'cy')).toBe(false);
       expect((m as any).pendingApprovalTokens.has('cy')).toBe(false);
-      // And it was recorded loudly, not silently.
-      const loud = mockMainError.mock.calls.find(
+      // And the auto-approval was recorded (mainLog, not a silent no-op).
+      const recorded = mockMainLog.mock.calls.find(
         ([, msg]: [unknown, unknown]) =>
-          typeof msg === 'string' && msg.includes("reason='destructive_operation'") && msg.includes('yoloMode')
+          typeof msg === 'string' && msg.includes("reason='destructive_operation'") && msg.includes('auto-approved')
       );
-      expect(loud).toBeDefined();
+      expect(recorded).toBeDefined();
     });
   });
 

--- a/tests/unit/autoUpdaterServiceInstallGuard.test.ts
+++ b/tests/unit/autoUpdaterServiceInstallGuard.test.ts
@@ -218,7 +218,7 @@ describe('autoUpdaterService install guard (#286)', () => {
       service.triggerEventForTest('update-downloaded', { version: '2.0.0' });
 
       expect(service.installOnQuitIfReady()).toBe(true);
-      expect(autoUpdater.quitAndInstall).toHaveBeenCalledWith(true, false);
+      expect(autoUpdater.quitAndInstall).toHaveBeenCalledWith(true, true);
     });
 
     it('non-macOS offer → installs the staged update on quit (loop is macOS-only)', () => {
@@ -227,7 +227,7 @@ describe('autoUpdaterService install guard (#286)', () => {
       service.triggerEventForTest('update-downloaded', { version: '2.0.0' });
 
       expect(service.installOnQuitIfReady()).toBe(true);
-      expect(autoUpdater.quitAndInstall).toHaveBeenCalledWith(true, false);
+      expect(autoUpdater.quitAndInstall).toHaveBeenCalledWith(true, true);
     });
 
     it('silent apply failure on reconcile → refuses on-quit install', () => {
@@ -248,7 +248,7 @@ describe('autoUpdaterService install guard (#286)', () => {
       service.triggerEventForTest('update-downloaded', { version: '2.0.0' });
 
       expect(service.installOnQuitIfReady()).toBe(true);
-      expect(autoUpdater.quitAndInstall).toHaveBeenCalledWith(true, false);
+      expect(autoUpdater.quitAndInstall).toHaveBeenCalledWith(true, true);
     });
 
     it('re-offer of a silently-failed version → refuses on-quit install', () => {

--- a/tests/unit/autoUpdaterServiceQuiesce.test.ts
+++ b/tests/unit/autoUpdaterServiceQuiesce.test.ts
@@ -107,12 +107,13 @@ describe('autoUpdaterService update-on-quiesce (#651)', () => {
       expect(autoUpdater.quitAndInstall).not.toHaveBeenCalled();
     });
 
-    it('installs (non-force, no relaunch) when a download is staged and safe', () => {
+    it('installs and relaunches when a download is staged and safe', () => {
       service.triggerEventForTest('update-downloaded', { version: '2.0.0' });
       const result = service.installOnQuitIfReady();
       expect(result).toBe(true);
-      // isSilent=true, isForceRunAfter=false — apply on quit without relaunch.
-      expect(autoUpdater.quitAndInstall).toHaveBeenCalledWith(true, false);
+      // isSilent=true, isForceRunAfter=true — install on quit AND relaunch,
+      // matching the "Install and restart" promise (#651, 0.11.15).
+      expect(autoUpdater.quitAndInstall).toHaveBeenCalledWith(true, true);
       // No force-exit timer: we are already quitting.
       expect(app.exit).not.toHaveBeenCalled();
     });

--- a/tests/unit/chatLayoutHooks.dom.test.ts
+++ b/tests/unit/chatLayoutHooks.dom.test.ts
@@ -406,7 +406,10 @@ describe('useWorkspaceCollapse', () => {
       expect(result.current.rightSiderCollapsed).toBe(false);
     });
 
-    it('defaults EXPANDED on mobile too (Steps must stay reachable)', () => {
+    it('defaults COLLAPSED on mobile (Steps rail must never overlay the chat, #593)', () => {
+      // 0.11.15: a narrow viewport cannot show chat and the Steps rail side by
+      // side, so opening a workflow on mobile must not start with the rail
+      // overlaying the chat full-screen. Desktop still defaults expanded (above).
       mockDetectMobile.mockReturnValue(true);
       globalThis.localStorage.removeItem(CONV_PREF_KEY);
 
@@ -414,7 +417,7 @@ describe('useWorkspaceCollapse', () => {
         useWorkspaceCollapse({ workspaceEnabled: true, isMobile: true, conversationId: 'conv-1', stepsRailMode: true })
       );
 
-      expect(result.current.rightSiderCollapsed).toBe(false);
+      expect(result.current.rightSiderCollapsed).toBe(true);
     });
 
     it('honors an explicit per-conversation collapse preference', () => {

--- a/tests/unit/renderer/components/layout/navItems.dom.test.tsx
+++ b/tests/unit/renderer/components/layout/navItems.dom.test.tsx
@@ -2,7 +2,8 @@
 
 /**
  * #118 - the sider top-zone nav entries come from a config-driven registry.
- * These tests lock the ORDER (Mission Control first), the id set, and that each
+ * These tests lock the ORDER (Mission Control last, below Memory — 0.11.15),
+ * the id set, and that each
  * entry's `render` still threads the bespoke `isActive` / click wiring through
  * to its live component.
  */
@@ -33,13 +34,12 @@ const propsOf = (id: string, ctx: SiderNavContext): Record<string, unknown> => {
 };
 
 describe('SIDER_NAV_ITEMS registry (#118)', () => {
-  it('lists Mission Control first', () => {
-    expect(SIDER_NAV_ITEMS[0].id).toBe('mission-control');
+  it('lists Mission Control last (below Memory, 0.11.15)', () => {
+    expect(SIDER_NAV_ITEMS[SIDER_NAV_ITEMS.length - 1].id).toBe('mission-control');
   });
 
   it('has the expected entries in order', () => {
     expect(SIDER_NAV_ITEMS.map((i) => i.id)).toEqual([
-      'mission-control',
       'sessions',
       'search',
       'projects',
@@ -48,6 +48,7 @@ describe('SIDER_NAV_ITEMS registry (#118)', () => {
       'scheduled',
       'teams',
       'memory',
+      'mission-control',
     ]);
   });
 

--- a/tests/unit/renderer/services/FileService.classification.test.ts
+++ b/tests/unit/renderer/services/FileService.classification.test.ts
@@ -95,9 +95,17 @@ describe('FileService classification (#655)', () => {
   });
 
   it('isLikelyTextFile excludes genuine binaries (images + office docs)', () => {
-    for (const name of ['logo.png', 'photo.jpeg', 'diagram.svg']) expect(isLikelyTextFile(name)).toBe(false);
+    for (const name of ['logo.png', 'photo.jpeg']) expect(isLikelyTextFile(name)).toBe(false);
     for (const name of ['report.docx', 'q3.xlsx', 'deck.pptx', 'invoice.pdf'])
       expect(isLikelyTextFile(name)).toBe(false);
+  });
+
+  it('isLikelyTextFile treats SVG as text-diffable despite isImageFile matching it', () => {
+    // 0.11.15 regression fix: SVG is XML text — the Workspace diff viewer must be
+    // able to expand and diff it, even though the attach path classifies it as an
+    // image (#655).
+    expect(isImageFile('diagram.svg')).toBe(true);
+    expect(isLikelyTextFile('diagram.svg')).toBe(true);
   });
 
   it('isSupportedFile stays accept-all (upload acceptance is NOT gated by type)', () => {


### PR DESCRIPTION
## What

Repairs the 8 unit-test failures (5 files) that exist on a clean `main` checkout, so PRs stop failing CI on inherited breakage (e.g. PR #726, ubuntu shard 1/4, failed on `FileService.classification.test.ts:98` without touching that file).

## Root cause (one commit, five stale test pins)

Commit `7729345ab` ("fix: resolve 0.11.14 regressions for 0.11.15") deliberately changed five behaviors — each one listed in its own commit message — but never updated the tests that pin them. Every failure below is the test lagging the intended product change, so the fix in each case is to align the test with the shipped intent. No product code is touched and no test is skipped or weakened.

| Failing test | Deliberate 0.11.15 change | Fix |
|---|---|---|
| `tests/unit/renderer/services/FileService.classification.test.ts` — `isLikelyTextFile excludes genuine binaries` (`diagram.svg` expected `false`, got `true`) | "files: SVG is text-diffable in the Workspace diff viewer" — `isLikelyTextFile` gained an explicit `.svg -> true` case | Moved `.svg` out of the genuine-binaries list; added a dedicated test asserting SVG is image-classified for attach yet text-diffable |
| `tests/unit/renderer/components/layout/navItems.dom.test.tsx` — 2 tests (`mission-control` expected first) | "ui: Mission Control sits below Memory in the sidebar" — registry reordered, Mission Control now last | Updated expected order; "first" assertion now pins Mission Control last |
| `tests/unit/chatLayoutHooks.dom.test.ts` — `stepsRailMode defaults EXPANDED on mobile too` | "workflow: never overlay chat with the Steps rail on a narrow viewport" (#593) — mobile now defaults collapsed even in steps-rail mode | Test now asserts COLLAPSED on mobile; desktop-expanded test unchanged |
| `tests/unit/autoUpdaterServiceInstallGuard.test.ts` (3 tests) + `tests/unit/autoUpdaterServiceQuiesce.test.ts` (1 test) — expected `quitAndInstall(true, false)` | "auto-update on quit: relaunch after install, matching the Install-and-restart promise" (#651) — now `quitAndInstall(true, true)` | Updated the four assertions and comments to the install-and-relaunch contract |
| `tests/unit/WCoreManagerEventBus.test.ts` — yoloMode escalation expected `resumeApproval(tok, false)` + loud `mainError` | "approvals: restore auto-approve for non-interactive yolo/cron sessions" — yoloMode now `resumeApproval(true)` and logs via `mainLog` | Test now asserts auto-approve + recorded `mainLog` line; still asserts no confirmation card is synthesized |

## Verification

- `bunx vitest run` — full unit suite green locally (was: 8 failed / 12306 passed; the 8 were the only failures on clean main)
- `bun run typecheck` (tsc --noEmit) — 0 errors
- `bun run lint` — 0 errors
- `bunx oxfmt --check` on the six touched files — clean

No product-decision items surfaced: all eight failures share the single root cause above.

## Flake note (observed, not fixed here)

Under heavy CPU contention (two full suites running concurrently), `tests/unit/renderer/guidModelSelector.dom.test.tsx` (audit C4: `setCurrentModel` called 2x instead of 1x) and `tests/unit/ChannelModalRegisteredChannels.dom.test.tsx` (S17 roster) each flaked once. Both pass 5/5 solo and pass in the final full run, so they are timing-sensitive rather than rot; flagging in case they ever surface on a loaded CI runner.
