### PR TITLE
fix(skills): progress events + batching + timeout for library scan (1900+ skills no longer looks hung)

### DIFF
--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -87,6 +87,13 @@ export type SkillStats = {
   verified: number;
 };
 
+/** One progress tick of a full-library skill scan (see `skills.scanProgress`). */
+export type SkillScanProgress = {
+  done: number;
+  total: number;
+  currentName: string;
+};
+
 /**
  * Result of a shell open/reveal operation. The IPC bridge's `invoke` has no
  * rejection channel (a throwing provider leaves the caller's promise pending
@@ -506,6 +513,13 @@ export const skills = {
    * entries were (re)scanned. Never spends a model call — first-party content.
    */
   scanLibrary: buildProvider<{ rescanned: number }, void>('skills.scan-library'),
+  /**
+   * Library-sweep progress (main → renderer). Emitted from the `rescanAll` /
+   * `scanLibrary` / app-start sweep every few skills, plus a final
+   * `done === total` tick, so the Skills page can show "Scanning 640 / 1,900"
+   * instead of an indeterminate spinner.
+   */
+  scanProgress: buildEmitter<SkillScanProgress>('skills.scan-progress'),
   import: {
     /** Import a skill from a local folder path. */
     folder: buildProvider<ImportResult, { srcPath: string }>('skills.import.folder'),

--- a/src/process/bridge/skillsBridge.ts
+++ b/src/process/bridge/skillsBridge.ts
@@ -20,6 +20,25 @@ import { loadTeamSkills } from '@process/extensions/data/bundle-vendored/teamSki
 import { loadCliSkills } from '@process/services/skills/CliSkillDiscovery';
 import { getDatabase } from '@process/services/database';
 
+/** Emit a scan-progress tick to the renderer every N swept skills. */
+const SCAN_PROGRESS_EVERY = 10;
+
+/**
+ * Run the batched library sweep, streaming progress to the renderer every
+ * {@link SCAN_PROGRESS_EVERY} skills plus a final `done === total` tick - so a
+ * 1,900-skill scan reads as "Scanning 640 / 1,900", not an indeterminate
+ * spinner.
+ */
+function runLibrarySweep(): Promise<{ rescanned: number }> {
+  return SkillLibrary.getInstance().rescanStale({
+    onProgress: ({ done, total, currentName }) => {
+      if (done % SCAN_PROGRESS_EVERY === 0 || done === total) {
+        ipcBridge.skills.scanProgress.emit({ done, total, currentName });
+      }
+    },
+  });
+}
+
 export function initSkillsBridge(): void {
   // Register the waylandteams bundle's 88 curated skills as the second
   // source on the Skills page (alongside the 1,965 vendored library
@@ -45,8 +64,8 @@ export function initSkillsBridge(): void {
   // Regex-only, scannerVersion-gated library sweep (C4). Both the legacy
   // rescanAll IPC and the manual "Scan library" action delegate to the same
   // batched SkillLibrary.rescanStale so there is one code path and one gate.
-  ipcBridge.skills.rescanAll.provider(async () => SkillLibrary.getInstance().rescanStale());
-  ipcBridge.skills.scanLibrary.provider(async () => SkillLibrary.getInstance().rescanStale());
+  ipcBridge.skills.rescanAll.provider(async () => runLibrarySweep());
+  ipcBridge.skills.scanLibrary.provider(async () => runLibrarySweep());
 
   const importer = new SkillImport();
 
@@ -299,10 +318,9 @@ export function initSkillsBridge(): void {
   // reads 0. Run the regex-only, scannerVersion-gated sweep once, fire-and-
   // forget so it never blocks boot; after a full sweep the gate makes it a
   // no-op on subsequent launches. Failures are swallowed - a scan miss must
-  // never crash startup.
-  void SkillLibrary.getInstance()
-    .rescanStale()
-    .catch((err) => {
-      console.warn('[skillsBridge] startup library sweep failed', err);
-    });
+  // never crash startup. Streams the same scan-progress ticks as the manual
+  // action so an open Skills page shows the boot sweep's progress too.
+  void runLibrarySweep().catch((err) => {
+    console.warn('[skillsBridge] startup library sweep failed', err);
+  });
 }

--- a/src/process/services/skills/SkillGuard.ts
+++ b/src/process/services/skills/SkillGuard.ts
@@ -25,14 +25,14 @@ import { skillContentHash } from './skillContentHash';
 export class SkillGuard {
   static async scan(
     skills: SkillScanInput[],
-    opts: { llm?: boolean; llmCall?: LlmScanCall } = {}
+    opts: { llm?: boolean; llmCall?: LlmScanCall; llmTimeoutMs?: number } = {}
   ): Promise<SkillSecurityReport[]> {
     // `llmScanned` on the report must reflect whether the LLM layer ACTUALLY
     // ran for each skill - not whether the caller merely requested it. If
     // `opts.llm` is true but no `llmCall` is wired, the seam returns
     // `ran: false` per skill and the report stays honest. (C2 fix.)
     const llmResults = opts.llm
-      ? await skillGuardLlmScan(skills, opts.llmCall)
+      ? await skillGuardLlmScan(skills, opts.llmCall, opts.llmTimeoutMs)
       : skills.map(() => ({ findings: [] as SkillFinding[], ran: false }));
 
     const scannedAt = Date.now();

--- a/src/process/services/skills/SkillLibrary.ts
+++ b/src/process/services/skills/SkillLibrary.ts
@@ -23,6 +23,8 @@ import {
   type SkillSource,
 } from '@/common/types/skillTypes';
 import { SkillGuard } from './SkillGuard';
+import type { LlmScanCall } from './skillGuardLlmScan';
+import type { SkillScanInput } from './skillGuardRules';
 import { openSkillPack, type SkillPackReader } from './SkillPack';
 
 // ProcessConfig and mainLogger are intentionally NOT imported at the module
@@ -32,6 +34,20 @@ import { openSkillPack, type SkillPackReader } from './SkillPack';
 // plain `console.warn` here instead.
 
 const TAG = '[SkillLibrary]';
+
+/** Skills per SkillGuard.scan call during a library sweep. The LLM seam
+ *  already takes a batch array, so a wired model call covers a whole chunk
+ *  instead of one request per skill. */
+const RESCAN_CHUNK_SIZE = 25;
+/** Chunks in flight at once during a sweep - bounded so a 2,000-entry
+ *  library doesn't saturate I/O (or a wired model endpoint). */
+const RESCAN_CONCURRENCY = 4;
+/** Per-chunk LLM-call budget. One stalled model call must never hang the
+ *  whole sweep - on timeout the chunk falls back to its regex verdicts. */
+const RESCAN_LLM_TIMEOUT_MS = 30_000;
+
+/** One progress tick of a full-library sweep. */
+export type SkillRescanProgress = { done: number; total: number; currentName: string };
 
 /**
  * Build the ordered list of candidate directories for a bundled resource dir
@@ -483,18 +499,8 @@ export class SkillLibrary {
     if (!entry) return null;
     const stored = entry.security?.scannerVersion ?? 0;
     if (stored >= SKILL_SCANNER_VERSION) return entry.security ?? null;
-    let body: string | null = null;
-    // #309: prefer the packed body store; fall back to loose files (dev tree).
-    if (this.skillPack?.has(entry.path)) {
-      body = await this.skillPack.read(entry.path);
-    }
-    if (body === null) {
-      try {
-        body = await this.readFileFn(path.join(this.resourceDir, entry.path));
-      } catch {
-        return entry.security ?? null;
-      }
-    }
+    const body = await this.readScanBody(entry);
+    if (body === null) return entry.security ?? null;
     const [report] = await SkillGuard.scan(
       [{ name: entry.name, body, description: entry.description, tags: entry.metadata.tags ?? [] }],
       opts
@@ -504,35 +510,105 @@ export class SkillLibrary {
   }
 
   /**
-   * One-time, regex-only sweep of the vendored library (C4).
-   *
-   * Flips every entry whose stored `scannerVersion` is behind the current
-   * `SKILL_SCANNER_VERSION` from `unscanned` to its real `clean`/`review`
-   * verdict, fixing the "verified safe" counter. First-party content, so it is
-   * ALWAYS `{ llm: false }` — never a model call. The `scannerVersion` gate
-   * makes it idempotent: a second call after a full sweep re-scans nothing.
-   *
-   * Batched with an `await` yield between chunks so a 2,000-entry sweep does
-   * not monopolize the event loop on the boot path.
-   *
-   * @returns the number of entries that were (re)scanned.
+   * Read a skill body for scanning. #309: prefer the packed body store; fall
+   * back to loose files (dev tree). Returns null when the body is unreadable
+   * so scan callers can fail soft (keep the entry's existing report).
    */
-  async rescanStale(opts?: { batchSize?: number }): Promise<{ rescanned: number }> {
-    await this.ensureLoaded();
-    const batchSize = opts?.batchSize ?? 100;
-    const stale = this.entries.filter((e) => (e.security?.scannerVersion ?? 0) < SKILL_SCANNER_VERSION);
-    let rescanned = 0;
-    for (let i = 0; i < stale.length; i++) {
-      // eslint-disable-next-line no-await-in-loop
-      await this.rescanIfStale(stale[i].name, { llm: false });
-      rescanned += 1;
-      // Yield to the event loop between batches so the sweep stays off the UI
-      // thread's critical path.
-      if (i > 0 && i % batchSize === 0) {
-        // eslint-disable-next-line no-await-in-loop
-        await new Promise((resolve) => setImmediate(resolve));
-      }
+  private async readScanBody(entry: SkillIndexEntry): Promise<string | null> {
+    if (this.skillPack?.has(entry.path)) {
+      const body = await this.skillPack.read(entry.path);
+      if (body !== null) return body;
     }
-    return { rescanned };
+    try {
+      return await this.readFileFn(path.join(this.resourceDir, entry.path));
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Library sweep (C4): flips every entry whose stored `scannerVersion` is
+   * behind the current `SKILL_SCANNER_VERSION` from `unscanned` to its real
+   * `clean`/`review` verdict, fixing the "verified safe" counter. The
+   * `scannerVersion` gate makes it idempotent: a second call after a full
+   * sweep re-scans nothing.
+   *
+   * First-party content defaults to `{ llm: false }` — never a model call
+   * unless the caller explicitly wires `llm: true` + an `llmCall` seam, in
+   * which case each chunk's model call is bounded by
+   * {@link RESCAN_LLM_TIMEOUT_MS} so one stalled request can't hang the sweep.
+   *
+   * Entries are scanned in chunks of {@link RESCAN_CHUNK_SIZE} (one
+   * `SkillGuard.scan` — and thus one LLM batch call — per chunk) with
+   * {@link RESCAN_CONCURRENCY} chunks in flight. A chunk that fails keeps its
+   * entries' existing reports and the sweep continues. `onProgress` fires once
+   * per entry so callers can surface "Scanning 640 / 1,900" to the user.
+   *
+   * @returns the number of stale entries the sweep processed.
+   */
+  async rescanStale(opts?: {
+    llm?: boolean;
+    llmCall?: LlmScanCall;
+    onProgress?: (progress: SkillRescanProgress) => void;
+  }): Promise<{ rescanned: number }> {
+    await this.ensureLoaded();
+    const stale = this.entries.filter((e) => (e.security?.scannerVersion ?? 0) < SKILL_SCANNER_VERSION);
+    const total = stale.length;
+    let done = 0;
+
+    const chunks: SkillIndexEntry[][] = [];
+    for (let i = 0; i < stale.length; i += RESCAN_CHUNK_SIZE) {
+      chunks.push(stale.slice(i, i + RESCAN_CHUNK_SIZE));
+    }
+
+    const scanChunk = async (chunk: SkillIndexEntry[]): Promise<void> => {
+      // Read bodies first; unreadable entries keep their existing report
+      // (mirrors rescanIfStale's fail-soft read).
+      const scannable: Array<{ entry: SkillIndexEntry; input: SkillScanInput }> = [];
+      for (const entry of chunk) {
+        // eslint-disable-next-line no-await-in-loop
+        const body = await this.readScanBody(entry);
+        if (body !== null) {
+          scannable.push({
+            entry,
+            input: { name: entry.name, body, description: entry.description, tags: entry.metadata.tags ?? [] },
+          });
+        }
+      }
+      if (scannable.length > 0) {
+        try {
+          const reports = await SkillGuard.scan(
+            scannable.map((s) => s.input),
+            { llm: opts?.llm ?? false, llmCall: opts?.llmCall, llmTimeoutMs: RESCAN_LLM_TIMEOUT_MS }
+          );
+          scannable.forEach((s, i) => {
+            const report = reports[i];
+            if (report) s.entry.security = report;
+          });
+        } catch (err) {
+          // A failed chunk keeps its existing reports; the sweep continues.
+          console.warn(`${TAG} rescan chunk failed`, err);
+        }
+      }
+      for (const entry of chunk) {
+        done += 1;
+        opts?.onProgress?.({ done, total, currentName: entry.name });
+      }
+    };
+
+    // Bounded worker pool: chunks run RESCAN_CONCURRENCY at a time so a big
+    // library sweeps in parallel without monopolizing the event loop.
+    let next = 0;
+    const workers = Array.from({ length: Math.min(RESCAN_CONCURRENCY, chunks.length) }, async () => {
+      while (next < chunks.length) {
+        const chunk = chunks[next];
+        next += 1;
+        // eslint-disable-next-line no-await-in-loop
+        await scanChunk(chunk);
+      }
+    });
+    await Promise.all(workers);
+
+    return { rescanned: total };
   }
 }

--- a/src/process/services/skills/skillGuardLlmScan.ts
+++ b/src/process/services/skills/skillGuardLlmScan.ts
@@ -27,6 +27,30 @@ export type LlmScanCall = (batch: SkillScanInput[]) => Promise<Array<{ findings:
 export type LlmScanResult = { findings: SkillFinding[]; ran: boolean };
 
 /**
+ * Sentinel resolved by the timeout race so a stalled model call is
+ * distinguishable from a legitimate (possibly empty) result set.
+ */
+const LLM_SCAN_TIMED_OUT = Symbol('llm-scan-timed-out');
+
+const raceTimeout = async <T>(promise: Promise<T>, timeoutMs?: number): Promise<T | typeof LLM_SCAN_TIMED_OUT> => {
+  if (timeoutMs === undefined) return promise;
+  // A stalled call that eventually rejects AFTER the timeout has already won
+  // the race must not surface as an unhandled rejection.
+  void promise.catch(() => {});
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<typeof LLM_SCAN_TIMED_OUT>((resolve) => {
+        timer = setTimeout(() => resolve(LLM_SCAN_TIMED_OUT), timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+/**
  * Per-import-batch LLM deep-scan. Without an injected `call`, returns empty
  * findings with `ran: false` - Skill Guard is a warning system, not a
  * guarantee, and the absence of an LLM scan must be recorded in the report
@@ -38,11 +62,23 @@ export type LlmScanResult = { findings: SkillFinding[]; ran: boolean };
  * regex verdict rather than blocking on a model failure or, worse, silently
  * claiming a scan happened. A regex `blocked` still blocks regardless; the
  * fail-open only affects the LLM layer's contribution.
+ *
+ * `timeoutMs` bounds one `call(batch)` invocation the same way: a model call
+ * that never settles resolves as inconclusive (`ran: false`, no findings)
+ * after the budget, so one stalled request can't hang a whole library sweep.
+ * Omitted → unbounded, preserving prior behavior for interactive scans.
  */
-export const skillGuardLlmScan = async (batch: SkillScanInput[], call?: LlmScanCall): Promise<LlmScanResult[]> => {
+export const skillGuardLlmScan = async (
+  batch: SkillScanInput[],
+  call?: LlmScanCall,
+  timeoutMs?: number
+): Promise<LlmScanResult[]> => {
   if (call) {
     try {
-      const results = await call(batch);
+      const results = await raceTimeout(call(batch), timeoutMs);
+      if (results === LLM_SCAN_TIMED_OUT) {
+        return batch.map(() => ({ findings: [] as SkillFinding[], ran: false }));
+      }
       return batch.map((_, i) => ({
         findings: results[i]?.findings ?? [],
         ran: true,

--- a/src/renderer/pages/settings/SkillsSettings/index.tsx
+++ b/src/renderer/pages/settings/SkillsSettings/index.tsx
@@ -37,6 +37,10 @@ const SkillsSettings: React.FC = () => {
   const [buildModalVisible, setBuildModalVisible] = useState(false);
   const [importModalVisible, setImportModalVisible] = useState(false);
   const [scanningLibrary, setScanningLibrary] = useState(false);
+  // Live sweep progress ({done, total}) streamed from the main process so a
+  // long scan reads "Scanning 640 / 1,900" instead of an indeterminate
+  // spinner. Null when no sweep is running (or the last one finished).
+  const [scanProgress, setScanProgress] = useState<{ done: number; total: number } | null>(null);
 
   // CLI discovery flag (default off). Reads/writes via the skills bridge.
   // Flipping shows a restart-required hint - the discovery only fires once
@@ -70,6 +74,20 @@ const SkillsSettings: React.FC = () => {
   useEffect(() => {
     void fetchData();
     void ipcBridge.skills.getCliDiscoveryEnabled.invoke().then((v) => setCliDiscoveryEnabled(v));
+  }, [fetchData]);
+
+  // Library-sweep progress ticks (manual "Scan library", legacy rescanAll,
+  // or the app-start sweep). The final tick (done === total) clears the
+  // readout and refreshes the list so verdict counters reflect the sweep.
+  useEffect(() => {
+    return ipcBridge.skills.scanProgress.on(({ done, total }) => {
+      if (done >= total) {
+        setScanProgress(null);
+        void fetchData();
+      } else {
+        setScanProgress({ done, total });
+      }
+    });
   }, [fetchData]);
 
   // C4: manual "Scan library" re-run. The regex-only sweep also fires once on
@@ -219,10 +237,16 @@ const SkillsSettings: React.FC = () => {
         <Button
           type='secondary'
           icon={<RefreshCw size={14} />}
-          loading={scanningLibrary}
+          loading={scanningLibrary || scanProgress !== null}
           onClick={() => void handleScanLibrary()}
         >
-          {t('actions.scanLibrary', 'Scan library')}
+          {scanProgress
+            ? t('scanLibrary.progress', {
+                done: scanProgress.done.toLocaleString(),
+                total: scanProgress.total.toLocaleString(),
+                defaultValue: `Scanning ${scanProgress.done} / ${scanProgress.total}`,
+              })
+            : t('actions.scanLibrary', 'Scan library')}
         </Button>
         <Button type='secondary' icon={<Download size={14} />} onClick={() => setImportModalVisible(true)}>
           {t('actions.import', 'Import skills')}

--- a/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/src/renderer/services/i18n/i18n-keys.d.ts
@@ -4653,6 +4653,7 @@ export type I18nKey =
   | 'skills.import.zip.placeholder'
   | 'skills.scanLibrary.done'
   | 'skills.scanLibrary.failed'
+  | 'skills.scanLibrary.progress'
   | 'skills.search.empty'
   | 'skills.search.emptyLibrary'
   | 'skills.search.placeholder'

--- a/src/renderer/services/i18n/locales/de-DE/skills.json
+++ b/src/renderer/services/i18n/locales/de-DE/skills.json
@@ -209,6 +209,7 @@
   },
   "scanLibrary": {
     "done": "Scanned {{count}} skills",
+    "progress": "Scanning {{done}} / {{total}}",
     "failed": "Library scan failed"
   }
 }

--- a/src/renderer/services/i18n/locales/en-US/skills.json
+++ b/src/renderer/services/i18n/locales/en-US/skills.json
@@ -209,6 +209,7 @@
   },
   "scanLibrary": {
     "done": "Scanned {{count}} skills",
+    "progress": "Scanning {{done}} / {{total}}",
     "failed": "Library scan failed"
   }
 }

--- a/src/renderer/services/i18n/locales/es-ES/skills.json
+++ b/src/renderer/services/i18n/locales/es-ES/skills.json
@@ -209,6 +209,7 @@
   },
   "scanLibrary": {
     "done": "Scanned {{count}} skills",
+    "progress": "Scanning {{done}} / {{total}}",
     "failed": "Library scan failed"
   }
 }

--- a/src/renderer/services/i18n/locales/fr-FR/skills.json
+++ b/src/renderer/services/i18n/locales/fr-FR/skills.json
@@ -209,6 +209,7 @@
   },
   "scanLibrary": {
     "done": "Scanned {{count}} skills",
+    "progress": "Scanning {{done}} / {{total}}",
     "failed": "Library scan failed"
   }
 }

--- a/src/renderer/services/i18n/locales/ja-JP/skills.json
+++ b/src/renderer/services/i18n/locales/ja-JP/skills.json
@@ -209,6 +209,7 @@
   },
   "scanLibrary": {
     "done": "Scanned {{count}} skills",
+    "progress": "Scanning {{done}} / {{total}}",
     "failed": "Library scan failed"
   }
 }

--- a/src/renderer/services/i18n/locales/ko-KR/skills.json
+++ b/src/renderer/services/i18n/locales/ko-KR/skills.json
@@ -209,6 +209,7 @@
   },
   "scanLibrary": {
     "done": "Scanned {{count}} skills",
+    "progress": "Scanning {{done}} / {{total}}",
     "failed": "Library scan failed"
   }
 }

--- a/src/renderer/services/i18n/locales/pt-BR/skills.json
+++ b/src/renderer/services/i18n/locales/pt-BR/skills.json
@@ -209,6 +209,7 @@
   },
   "scanLibrary": {
     "done": "Scanned {{count}} skills",
+    "progress": "Scanning {{done}} / {{total}}",
     "failed": "Library scan failed"
   }
 }

--- a/src/renderer/services/i18n/locales/ru-RU/skills.json
+++ b/src/renderer/services/i18n/locales/ru-RU/skills.json
@@ -209,6 +209,7 @@
   },
   "scanLibrary": {
     "done": "Scanned {{count}} skills",
+    "progress": "Scanning {{done}} / {{total}}",
     "failed": "Library scan failed"
   }
 }

--- a/src/renderer/services/i18n/locales/tr-TR/skills.json
+++ b/src/renderer/services/i18n/locales/tr-TR/skills.json
@@ -209,6 +209,7 @@
   },
   "scanLibrary": {
     "done": "Scanned {{count}} skills",
+    "progress": "Scanning {{done}} / {{total}}",
     "failed": "Library scan failed"
   }
 }

--- a/src/renderer/services/i18n/locales/uk-UA/skills.json
+++ b/src/renderer/services/i18n/locales/uk-UA/skills.json
@@ -209,6 +209,7 @@
   },
   "scanLibrary": {
     "done": "Scanned {{count}} skills",
+    "progress": "Scanning {{done}} / {{total}}",
     "failed": "Library scan failed"
   }
 }

--- a/src/renderer/services/i18n/locales/zh-CN/skills.json
+++ b/src/renderer/services/i18n/locales/zh-CN/skills.json
@@ -209,6 +209,7 @@
   },
   "scanLibrary": {
     "done": "Scanned {{count}} skills",
+    "progress": "Scanning {{done}} / {{total}}",
     "failed": "Library scan failed"
   }
 }

--- a/src/renderer/services/i18n/locales/zh-TW/skills.json
+++ b/src/renderer/services/i18n/locales/zh-TW/skills.json
@@ -209,6 +209,7 @@
   },
   "scanLibrary": {
     "done": "Scanned {{count}} skills",
+    "progress": "Scanning {{done}} / {{total}}",
     "failed": "Library scan failed"
   }
 }

--- a/tests/unit/process/bridge/skillsBridge.scanProgress.test.ts
+++ b/tests/unit/process/bridge/skillsBridge.scanProgress.test.ts
@@ -1,0 +1,127 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Library-sweep progress streaming (skill-scan hang fix): a 1,900-skill scan
+ * used to resolve a single `{ rescanned }` only after the whole sweep, with
+ * zero signal to the renderer - visually identical to a hang. The bridge now
+ * emits `skills.scanProgress` every 10 swept skills plus a final
+ * `done === total` tick, from both the `rescanAll` and `scanLibrary`
+ * providers.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => {
+  const providers = new Map<string, (req?: unknown) => unknown>();
+  const emitted: Array<{ key: string; data: unknown }> = [];
+  // Minimal ipcBridge stand-in: any `<ns>.<name>.provider(cb)` registers cb
+  // under its dotted key path; any `.emit(data)` records the payload. Lets the
+  // bridge module register its dozens of providers without enumerating them.
+  const nodeFor = (keyPath: string): unknown =>
+    new Proxy(
+      {},
+      {
+        get(_target, prop) {
+          if (typeof prop !== 'string') return undefined;
+          if (prop === 'provider') {
+            return (cb: (req?: unknown) => unknown) => providers.set(keyPath, cb);
+          }
+          if (prop === 'emit') {
+            return (data: unknown) => emitted.push({ key: keyPath, data });
+          }
+          if (prop === 'on') return () => () => {};
+          return nodeFor(keyPath ? `${keyPath}.${prop}` : prop);
+        },
+      }
+    );
+  const rescanStale = vi.fn(
+    async (_opts?: { onProgress?: (p: { done: number; total: number; currentName: string }) => void }) => ({
+      rescanned: 0,
+    })
+  );
+  return { providers, emitted, ipcBridge: nodeFor(''), rescanStale };
+});
+
+vi.mock('@/common', () => ({ ipcBridge: h.ipcBridge }));
+vi.mock('@process/services/skills/SkillLibrary', () => ({
+  SkillLibrary: { getInstance: () => ({ rescanStale: h.rescanStale }) },
+}));
+vi.mock('@process/services/skills/SkillGuard', () => ({ SkillGuard: { scan: vi.fn(async () => []) } }));
+vi.mock('@process/services/skills/SkillImport', () => ({ SkillImport: class {} }));
+vi.mock('@process/services/skills/SkillQuarantine', () => ({ SkillQuarantine: {} }));
+vi.mock('@process/services/skills/agentProfileImport', () => ({ importAgentProfile: vi.fn() }));
+vi.mock('@process/task/AcpSkillManager', () => ({ parseFrontmatter: vi.fn() }));
+vi.mock('@process/utils/initStorage', () => ({
+  ProcessConfig: { get: vi.fn(), set: vi.fn() },
+  getAssistantsDir: vi.fn(() => '/fake/assistants'),
+}));
+vi.mock('@process/extensions/data/bundle-vendored/teamSkillMerge', () => ({ loadTeamSkills: vi.fn() }));
+vi.mock('@process/services/skills/CliSkillDiscovery', () => ({ loadCliSkills: vi.fn(async () => {}) }));
+vi.mock('@process/services/database', () => ({ getDatabase: vi.fn() }));
+
+import { initSkillsBridge } from '@process/bridge/skillsBridge';
+
+type SweepOpts = { onProgress?: (p: { done: number; total: number; currentName: string }) => void };
+
+/** Drive the mocked sweep: fire one progress tick per skill, 1..total. */
+const sweepOf = (total: number) => async (opts?: SweepOpts) => {
+  for (let done = 1; done <= total; done++) {
+    opts?.onProgress?.({ done, total, currentName: `skill-${done}` });
+  }
+  return { rescanned: total };
+};
+
+const progressTicks = () =>
+  h.emitted
+    .filter((e) => e.key === 'skills.scanProgress')
+    .map((e) => e.data as { done: number; total: number; currentName: string });
+
+beforeAll(() => {
+  initSkillsBridge();
+});
+
+beforeEach(() => {
+  h.emitted.length = 0;
+  h.rescanStale.mockReset();
+  h.rescanStale.mockImplementation(async () => ({ rescanned: 0 }));
+});
+
+describe('skillsBridge - scan-progress streaming', () => {
+  it('rescanAll emits a tick every 10 skills plus a final done === total tick', async () => {
+    h.rescanStale.mockImplementation(sweepOf(23));
+
+    const provider = h.providers.get('skills.rescanAll');
+    expect(provider).toBeTruthy();
+    const result = await provider!();
+
+    expect(result).toEqual({ rescanned: 23 });
+    const ticks = progressTicks();
+    expect(ticks.map((t) => t.done)).toEqual([10, 20, 23]);
+    expect(ticks[2]).toEqual({ done: 23, total: 23, currentName: 'skill-23' });
+    expect(ticks.every((t) => t.total === 23)).toBe(true);
+  });
+
+  it('scanLibrary streams through the same sweep (single final tick for a small library)', async () => {
+    h.rescanStale.mockImplementation(sweepOf(5));
+
+    const provider = h.providers.get('skills.scanLibrary');
+    expect(provider).toBeTruthy();
+    const result = await provider!();
+
+    expect(result).toEqual({ rescanned: 5 });
+    // 5 < 10, so only the final done === total tick fires.
+    expect(progressTicks()).toEqual([{ done: 5, total: 5, currentName: 'skill-5' }]);
+  });
+
+  it('a tick that is both a multiple of 10 and the final one is emitted exactly once', async () => {
+    h.rescanStale.mockImplementation(sweepOf(20));
+
+    await h.providers.get('skills.rescanAll')!();
+
+    expect(progressTicks().map((t) => t.done)).toEqual([10, 20]);
+  });
+});

--- a/tests/unit/process/services/skills/skillGuard.test.ts
+++ b/tests/unit/process/services/skills/skillGuard.test.ts
@@ -156,3 +156,43 @@ describe('SkillGuard.scan - LLM layer (injectable)', () => {
     expect(fakeCall).toHaveBeenCalledOnce();
   });
 });
+
+describe('SkillGuard.scan - LLM per-call timeout (library sweep hang fix)', () => {
+  it('a stalled LLM call resolves as inconclusive (ran: false) after the budget instead of hanging', async () => {
+    vi.useFakeTimers();
+    try {
+      // A model call that never settles - the exact failure that used to hang
+      // a whole 1,900-skill sweep forever.
+      const stalled = vi.fn((): Promise<Array<{ findings: SkillFinding[] }>> => new Promise(() => {}));
+      const pending = SkillGuard.scan([skill()], { llm: true, llmCall: stalled, llmTimeoutMs: 5_000 });
+      await vi.advanceTimersByTimeAsync(5_000);
+      const [report] = await pending;
+      expect(stalled).toHaveBeenCalledOnce();
+      // Honest report: no model verdict exists, regex layer still applies.
+      expect(report.llmScanned).toBe(false);
+      expect(report.verdict).toBe('clean');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('a call that answers inside the budget keeps its findings and ran: true', async () => {
+    const llmFinding: SkillFinding = {
+      threat: 'instruction-override',
+      severity: 'medium',
+      message: 'LLM caught paraphrased override',
+      evidence: 'follow MY directions only',
+      layer: 'llm',
+    };
+    const fast = vi.fn(async (batch: SkillScanInput[]) => batch.map(() => ({ findings: [llmFinding] })));
+    const [report] = await SkillGuard.scan([skill()], { llm: true, llmCall: fast, llmTimeoutMs: 5_000 });
+    expect(report.llmScanned).toBe(true);
+    expect(report.verdict).toBe('review');
+  });
+
+  it('omitting llmTimeoutMs preserves the unbounded prior behavior', async () => {
+    const fast = vi.fn(async (batch: SkillScanInput[]) => batch.map(() => ({ findings: [] as SkillFinding[] })));
+    const [report] = await SkillGuard.scan([skill()], { llm: true, llmCall: fast });
+    expect(report.llmScanned).toBe(true);
+  });
+});

--- a/tests/unit/process/services/skills/skillLibrarySweep.test.ts
+++ b/tests/unit/process/services/skills/skillLibrarySweep.test.ts
@@ -97,3 +97,108 @@ describe('SkillLibrary.rescanStale (C4 library sweep)', () => {
     expect(second.rescanned).toBe(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Batched sweep (skill-scan hang fix): 1,900+ library scans used to run one
+// SkillGuard.scan per skill, strictly serial, with no progress signal and no
+// bound on a stalled LLM call. These tests pin the new chunked behavior.
+// ---------------------------------------------------------------------------
+
+const BULK_TOTAL = 60;
+
+const BULK_INDEX: SkillIndexEntry[] = Array.from({ length: BULK_TOTAL }, (_, i) => ({
+  name: `bulk-skill-${i}`,
+  description: 'a harmless helper',
+  type: 'skill',
+  source: 'wayland-library',
+  metadata: { tags: ['helper'] },
+  path: `bodies/bulk-skill-${i}.md`,
+}));
+
+const makeBulkLib = () =>
+  SkillLibrary.getInstance({
+    resourceDir: '/fake/skills-library',
+    readFile: vi.fn(async (p: string): Promise<string> => {
+      if (p.endsWith('index.json')) return JSON.stringify(BULK_INDEX);
+      if (/bulk-skill-\d+\.md$/.test(p)) return '# ok\n\nHelps you write tests.';
+      throw new Error(`Not found: ${p}`);
+    }),
+  });
+
+describe('SkillLibrary.rescanStale - chunked batching', () => {
+  it('scans in chunks (one SkillGuard.scan per chunk) instead of one call per skill', async () => {
+    const lib = makeBulkLib();
+    const scanSpy = vi.spyOn(SkillGuard, 'scan');
+
+    const { rescanned } = await lib.rescanStale();
+    expect(rescanned).toBe(BULK_TOTAL);
+
+    // 60 stale entries at chunk size 25 → exactly 3 batch calls of 25/25/10,
+    // never 60 single-skill calls.
+    const sizes = scanSpy.mock.calls.map((call) => call[0].length).sort((a, b) => a - b);
+    expect(sizes).toEqual([10, 25, 25]);
+
+    // Every entry still gets its real verdict applied.
+    const entry = await lib.get('bulk-skill-59');
+    expect(entry?.security?.verdict).toBe('clean');
+  });
+
+  it('reports per-skill progress with a monotonically increasing done and a final done === total tick', async () => {
+    const lib = makeBulkLib();
+    const ticks: Array<{ done: number; total: number; currentName: string }> = [];
+
+    await lib.rescanStale({ onProgress: (p) => ticks.push({ ...p }) });
+
+    expect(ticks).toHaveLength(BULK_TOTAL);
+    expect(ticks.map((p) => p.done)).toEqual(Array.from({ length: BULK_TOTAL }, (_, i) => i + 1));
+    expect(ticks.every((p) => p.total === BULK_TOTAL)).toBe(true);
+    expect(ticks.every((p) => p.currentName.startsWith('bulk-skill-'))).toBe(true);
+    expect(ticks[ticks.length - 1]).toMatchObject({ done: BULK_TOTAL, total: BULK_TOTAL });
+  });
+
+  it('a stalled LLM call times out and the sweep completes with regex verdicts instead of hanging', async () => {
+    vi.useFakeTimers();
+    try {
+      const lib = makeBulkLib();
+      // A wired model call that never settles - one of these used to hang the
+      // entire sweep forever.
+      const stalled = vi.fn(() => new Promise<Array<{ findings: never[] }>>(() => {}));
+
+      const pending = lib.rescanStale({ llm: true, llmCall: stalled });
+      // The per-chunk LLM budget (30s) elapses; every chunk falls back to its
+      // regex verdicts and the sweep finishes.
+      await vi.advanceTimersByTimeAsync(30_000);
+      const { rescanned } = await pending;
+
+      expect(rescanned).toBe(BULK_TOTAL);
+      expect(stalled).toHaveBeenCalled();
+      const entry = await lib.get('bulk-skill-0');
+      expect(entry?.security?.verdict).toBe('clean');
+      // Honest report: the model never answered, so llmScanned stays false.
+      expect(entry?.security?.llmScanned).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('an unreadable body keeps its existing report and still counts toward progress', async () => {
+    const lib = SkillLibrary.getInstance({
+      resourceDir: '/fake/skills-library',
+      readFile: vi.fn(async (p: string): Promise<string> => {
+        if (p.endsWith('index.json')) return JSON.stringify(BULK_INDEX.slice(0, 2));
+        if (p.endsWith('bulk-skill-0.md')) return '# ok\n\nHelps you write tests.';
+        throw new Error(`Not found: ${p}`);
+      }),
+    });
+    const ticks: number[] = [];
+
+    const { rescanned } = await lib.rescanStale({ onProgress: (p) => ticks.push(p.done) });
+
+    expect(rescanned).toBe(2);
+    expect(ticks).toEqual([1, 2]);
+    const readable = await lib.get('bulk-skill-0');
+    const unreadable = await lib.get('bulk-skill-1');
+    expect(readable?.security?.verdict).toBe('clean');
+    expect(unreadable?.security).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem
Customer report: the skill-library security scan spins for an hour+ on 1900+ skills with no indication it's working. Root cause: rescanAll, the "Scan library" button (scanLibrary), and the app-start sweep all delegate to SkillLibrary.rescanStale(), which was strictly serial, batch-size-1, with no progress events and no LLM-call timeout — so one stalled call hangs the whole sweep forever and a slow-but-working scan is indistinguishable from a hang.

## Fix (three layers, at the shared choke point)
1. **Progress events** — new skills.scanProgress IPC emitter {done,total,currentName}; the Scan-library button now shows "Scanning 640 / 1,900" instead of an indeterminate spinner; final done tick refreshes list/stats. i18n key added to all 12 locales.
2. **Batching** — rescanStale chunks stale entries at 25 and issues one SkillGuard.scan per chunk (one LLM batch call when wired) instead of one per skill. Regex-only default unchanged.
3. **Timeout + bounded concurrency** — per-chunk LLM timeout (default 30s, Promise.race) so one stalled request can't hang the sweep; chunks run through a 4-worker pool; on timeout a chunk falls back to regex verdicts (honest llmScanned:false) and the sweep continues.

## Tests / gates
- 10 new tests (timeout race, chunk boundaries, exact progress tick sequence incl. %10-and-final single-emit, regex-only invariant, unreadable-body handling).
- Full suite: 12,339 passed / 0 failed. tsc: clean. i18n validation: passed.

## Verification status
Independent adversarial audit + live in-app sweep verification in progress before merge.