### PR TITLE
chore: bump to 0.11.17, bundle wayland-core v0.12.24

### DIFF
--- a/installer/scripts/postinstall.mjs
+++ b/installer/scripts/postinstall.mjs
@@ -17,7 +17,7 @@ import { fileURLToPath } from 'node:url';
 
 // Kept in lockstep with scripts/prepareWaylandCore.js DEFAULT_WCORE_VERSION by
 // scripts/stage-wcore-bump.mjs. Do not hand-edit; run that tool so both move.
-const WCORE_VERSION = 'v0.12.23';
+const WCORE_VERSION = 'v0.12.24';
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PAYLOAD = resolve(HERE, '..', 'payload');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Wayland",
-  "version": "0.11.16",
+  "version": "0.11.17",
   "description": "The local-first desktop AI agent that drives every AI CLI on your machine - Claude Code, Codex, Gemini and more, on your keys.",
   "keywords": [],
   "license": "AGPL-3.0-or-later",

--- a/scripts/bundled-wcore-shasums.json
+++ b/scripts/bundled-wcore-shasums.json
@@ -1,5 +1,13 @@
 {
   "_comment": "Authoritative SHA-256 checksums for bundled wayland-core release archives (the downloaded .tar.gz / .zip assets), keyed by release tag then asset filename. Mirrors scripts/bundled-bun-shasums.json. Source of truth: the SHASUMS published alongside each signed FerroxLabs/wayland-core release. The downloaded archive is verified against this file BEFORE it is extracted, copied, or executed. Update this file in lockstep with DEFAULT_WCORE_VERSION in scripts/prepareWaylandCore.js and regenerate on every engine version bump.",
+  "v0.12.24": {
+    "wayland-core-v0.12.24-aarch64-apple-darwin.tar.gz": "sha256:7b13153f16b403fea2743462a0fa7f3071715eb23be9ffd6972d545cb281f98b",
+    "wayland-core-v0.12.24-x86_64-apple-darwin.tar.gz": "sha256:b880010da0375bd55e86e867e61d09398735fa3a694c114d7044fb042aad4176",
+    "wayland-core-v0.12.24-aarch64-unknown-linux-gnu.tar.gz": "sha256:046c33c07784525b09e1f9a9fd658354fd7ee7c2e0a8071a0cc3a84d2d57b436",
+    "wayland-core-v0.12.24-x86_64-unknown-linux-gnu.tar.gz": "sha256:678f3c5a32efabc760bafec46c8ce320c20986bd55ea7cdb88b4ce999efc970b",
+    "wayland-core-v0.12.24-aarch64-pc-windows-msvc.zip": "sha256:d2f83d9a36a6d904ba27f507b11a472c67c821d2a46624fc8b831840f5256513",
+    "wayland-core-v0.12.24-x86_64-pc-windows-msvc.zip": "sha256:55df584ac4f3bc1c3aacdae2843c13bd7e1f9b142e9edfa21ecce106fc48a7e4"
+  },
   "v0.12.23": {
     "wayland-core-v0.12.23-aarch64-apple-darwin.tar.gz": "sha256:d655dde863946ec61fbda0050897464703132bc3e155ac4dc4f5347263d6b855",
     "wayland-core-v0.12.23-x86_64-apple-darwin.tar.gz": "sha256:b5d9f904a3eb927d6db2eff6e1eb81e0b2ee7d482fcddb00364e8d945c7ebe18",

--- a/scripts/prepareWaylandCore.js
+++ b/scripts/prepareWaylandCore.js
@@ -184,7 +184,7 @@ function verifyArchiveChecksum(archivePath, expectedHex, assetName, tag) {
 // FerroxLabs/wayland-core; Desktop integrates against a specific tag rather
 // than tracking `latest` so version drift can't sneak in via a release made
 // while a CI build is mid-flight. Override with WCORE_VERSION=... when bumping.
-const DEFAULT_WCORE_VERSION = 'v0.12.23';
+const DEFAULT_WCORE_VERSION = 'v0.12.24';
 
 function getVersion() {
   return (process.env.WCORE_VERSION || DEFAULT_WCORE_VERSION).trim();


### PR DESCRIPTION
Desktop 0.11.17 bundling the token-efficiency engine wayland-core v0.12.24.

Engine (v0.12.24, SHA-256 verified via stage-wcore-bump): CORE-1/2/4/5, tool catalog fold (−86.2% tools bytes), Anthropic cache breakpoints. Measured 1.18× Direct cost (near parity), down from 11.99×.

Also in this cut (already merged to main): skill-scan progress+batch+timeout (#732), cost meter delta fix (#724), engine-credential vault (#725), skillguard string-tags (#726).

4-file engine bump (package.json, postinstall.mjs, bundled-wcore-shasums.json, prepareWaylandCore.js). Gates: tsc clean, lint 0 errors, 12,351 tests pass. prepareWaylandCore end-to-end verify passed (downloaded + SHA-checked v0.12.24). Packaged-artifact live-verify before tag.