### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default reviewers for everything in app.
+# Refine to teams/paths as the project grows, e.g. `/src/ @FerroxLabs/core`.
+* @FerroxLabs


### PR DESCRIPTION
Governance starter scaffolded via `ratchet govern app --scaffold`:

- **CODEOWNERS** — default reviewer `@FerroxLabs`; refine per-path as the tree grows

Starter with TODOs — review ownership before merge.