### PR TITLE
fix(ijfw): scan project workspaces at launch instead of cwd '/' (#716)

### DIFF
--- a/src/process/services/ijfwSystemService.ts
+++ b/src/process/services/ijfwSystemService.ts
@@ -261,8 +261,8 @@ function mapToPreludeStatus(status: IjfwLifecycleStatus): PreludeStatus {
 // Hard guard: refuse any path that is the filesystem root, the user's bare
 // HOME directory, or a well-known system path. The empty list is a safe
 // no-op for preludeManager (it just won't manage any files this session).
-// Wave 6.4 will wire the recent-workspaces store so users see managed files
-// for every tracked project, not just whatever cwd happens to be.
+// #716 wired the persisted project workspaces as the primary source, so a GUI
+// launch (cwd `/`) still scans every tracked project instead of nothing.
 const UNSAFE_PROJECT_ROOTS: readonly string[] = [
   '/',
   '/etc',
@@ -302,24 +302,50 @@ function isUnsafeProjectRoot(dir: string): boolean {
   return false;
 }
 
-export function getActiveProjectDirs(): string[] {
-  // Wave 1 baseline: only the current working directory. Wave 6.4 will hook
-  // into the recent-workspaces store. We never inject markers into foreign
-  // files, so this is safe even if the cwd is unrelated (preludeManager
+export async function getActiveProjectDirs(): Promise<string[]> {
+  const dirs: string[] = [];
+  const push = (dir: string) => {
+    if (!dir || dirs.includes(dir) || isUnsafeProjectRoot(dir)) return;
+    dirs.push(dir);
+  };
+
+  // #716: a macOS GUI launch (Dock/Finder/Spotlight) inherits cwd `/` from
+  // LaunchServices, so the cwd alone can NEVER seed the startup scan - the
+  // unsafe-root guard below refused it on every launch and the scan silently
+  // never ran. The persisted project workspaces are the real source of truth
+  // and are available at bootstrap time, so read them first. Imported lazily
+  // so this module stays loadable in unit tests that don't exercise the DB.
+  try {
+    const { SqliteProjectRepository } = await import('@process/services/database/SqliteProjectRepository');
+    const projects = await new SqliteProjectRepository().listProjects();
+    for (const project of projects) {
+      const workspace = typeof project.workspace === 'string' ? project.workspace.trim() : '';
+      if (workspace) push(workspace);
+    }
+  } catch (err) {
+    log.warn('[ijfw] failed to read project workspaces - falling back to cwd', { err });
+  }
+
+  // Terminal launches still contribute their cwd. We never inject markers into
+  // foreign files, so this is safe even if the cwd is unrelated (preludeManager
   // returns early for files without the IJFW-PRELUDE-START sentinel) -
   // BUT discoverTargets() still has to walk the tree before that filter runs,
-  // so we must never hand it `/` or `$HOME`. See Gemini B2.
+  // so we must never hand it `/` or `$HOME`. See Gemini B2. An unsafe cwd is
+  // the EXPECTED state for GUI launches, so it is skipped quietly; we only log
+  // when it leaves nothing at all to scan (#716: no open workspace yet - the
+  // next syncPrelude after one exists picks it up).
   const cwd = process.cwd();
-  if (isUnsafeProjectRoot(cwd)) {
-    log.warn('[ijfw] cwd is unsafe project root - refusing to scan', { cwd });
-    return [];
+  if (!isUnsafeProjectRoot(cwd)) {
+    push(cwd);
+  } else if (dirs.length === 0) {
+    log.info('[ijfw] no project workspace and cwd is unsafe - skipping prelude scan', { cwd });
   }
-  return [cwd];
+  return dirs;
 }
 
 async function syncPrelude(status: IjfwLifecycleStatus): Promise<void> {
   try {
-    const targets = await discoverTargets(getActiveProjectDirs());
+    const targets = await discoverTargets(await getActiveProjectDirs());
     await applyPreludeForStatus(mapToPreludeStatus(status), targets);
   } catch (err) {
     log.warn('[ijfw] prelude sync failed', { status, err });

--- a/tests/unit/process/services/ijfwSystemService.applyPendingUpgrade.test.ts
+++ b/tests/unit/process/services/ijfwSystemService.applyPendingUpgrade.test.ts
@@ -42,6 +42,16 @@ vi.mock('@process/services/ijfw/preludeManager', () => ({
   discoverTargets: (dirs: unknown) => discoverTargetsSpy(dirs),
 }));
 
+// #716: getActiveProjectDirs lazily reads persisted project workspaces.
+// Mocked so unit tests never open a real SQLite database.
+vi.mock('@process/services/database/SqliteProjectRepository', () => ({
+  SqliteProjectRepository: class {
+    listProjects() {
+      return Promise.resolve([]);
+    }
+  },
+}));
+
 const mcpShutdownSpy = vi.fn().mockResolvedValue(undefined);
 const mcpWaitSpy = vi.fn().mockResolvedValue(true);
 vi.mock('@process/services/ijfw/ijfwMcpClient', () => ({

--- a/tests/unit/process/services/ijfwSystemService.bootstrap.test.ts
+++ b/tests/unit/process/services/ijfwSystemService.bootstrap.test.ts
@@ -51,6 +51,16 @@ vi.mock('@process/services/ijfw/preludeManager', () => ({
   discoverTargets: (dirs: unknown) => discoverTargetsSpy(dirs),
 }));
 
+// #716: getActiveProjectDirs lazily reads persisted project workspaces.
+// Mocked so unit tests never open a real SQLite database.
+vi.mock('@process/services/database/SqliteProjectRepository', () => ({
+  SqliteProjectRepository: class {
+    listProjects() {
+      return Promise.resolve([]);
+    }
+  },
+}));
+
 const refreshAllSpy = vi.fn().mockResolvedValue(undefined);
 vi.mock('@process/agent/AgentRegistry', () => ({
   agentRegistry: {

--- a/tests/unit/process/services/ijfwSystemService.healthWatcher.test.ts
+++ b/tests/unit/process/services/ijfwSystemService.healthWatcher.test.ts
@@ -54,6 +54,16 @@ vi.mock('@process/services/ijfw/preludeManager', () => ({
   discoverTargets: (dirs: unknown) => discoverTargetsSpy(dirs),
 }));
 
+// #716: getActiveProjectDirs lazily reads persisted project workspaces.
+// Mocked so unit tests never open a real SQLite database.
+vi.mock('@process/services/database/SqliteProjectRepository', () => ({
+  SqliteProjectRepository: class {
+    listProjects() {
+      return Promise.resolve([]);
+    }
+  },
+}));
+
 const mcpShutdownSpy = vi.fn().mockResolvedValue(undefined);
 vi.mock('@process/services/ijfw/ijfwMcpClient', () => ({
   ijfwMcpClient: {

--- a/tests/unit/process/services/ijfwSystemService.healthWatcher.test.ts
+++ b/tests/unit/process/services/ijfwSystemService.healthWatcher.test.ts
@@ -112,7 +112,7 @@ describe('ijfwSystemService.startHealthWatcher', () => {
     lastWatcherCallback!('rename', 'mcp-server');
     for (let i = 0; i < 5; i++) await flush();
     expect(emitSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ status: 'not_installed', reason: 'install_removed' }),
+      expect.objectContaining({ status: 'not_installed', reason: 'install_removed' })
     );
     expect(mcpShutdownSpy).toHaveBeenCalled();
     dispose();
@@ -126,7 +126,7 @@ describe('ijfwSystemService.startHealthWatcher', () => {
     lastWatcherCallback!('rename', 'mcp-server');
     for (let i = 0; i < 5; i++) await flush();
     expect(
-      emitSpy.mock.calls.filter((c) => (c[0] as { status: string }).status === 'not_installed').length,
+      emitSpy.mock.calls.filter((c) => (c[0] as { status: string }).status === 'not_installed').length
     ).toBeLessThanOrEqual(1);
     dispose();
   });

--- a/tests/unit/process/services/ijfwSystemService.test.ts
+++ b/tests/unit/process/services/ijfwSystemService.test.ts
@@ -16,6 +16,18 @@ vi.mock('electron', () => ({
   },
 }));
 
+// #716: getActiveProjectDirs reads persisted project workspaces (lazily) so a
+// GUI launch with cwd '/' still scans tracked projects. Mocked so unit tests
+// never touch a real SQLite database.
+const listProjectsSpy = vi.fn().mockResolvedValue([]);
+vi.mock('@process/services/database/SqliteProjectRepository', () => ({
+  SqliteProjectRepository: class {
+    listProjects() {
+      return listProjectsSpy();
+    }
+  },
+}));
+
 // eslint-disable-next-line import/first
 import { ijfwSystemService, getActiveProjectDirs } from '@process/services/ijfwSystemService';
 
@@ -56,6 +68,7 @@ describe('getActiveProjectDirs - Gemini B2 unsafe-root guard', () => {
 
   beforeEach(() => {
     vi.spyOn(process, 'cwd');
+    listProjectsSpy.mockReset().mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -69,26 +82,79 @@ describe('getActiveProjectDirs - Gemini B2 unsafe-root guard', () => {
     }
   });
 
-  it('returns [] when cwd is "/" (macOS GUI Dock launch)', () => {
+  it('returns [] when cwd is "/" (macOS GUI Dock launch) and no projects exist', async () => {
     (process.cwd as ReturnType<typeof vi.fn>).mockReturnValue('/');
-    expect(getActiveProjectDirs()).toEqual([]);
+    await expect(getActiveProjectDirs()).resolves.toEqual([]);
   });
 
-  it('returns [] when cwd is the bare HOME directory', () => {
+  it('returns [] when cwd is the bare HOME directory', async () => {
     process.env.HOME = '/Users/test-user';
     (process.cwd as ReturnType<typeof vi.fn>).mockReturnValue('/Users/test-user');
-    expect(getActiveProjectDirs()).toEqual([]);
+    await expect(getActiveProjectDirs()).resolves.toEqual([]);
   });
 
-  it('returns [] for system paths like /etc, /var, /System', () => {
+  it('returns [] for system paths like /etc, /var, /System', async () => {
     for (const sys of ['/etc', '/var', '/System', '/Library', '/Applications']) {
       (process.cwd as ReturnType<typeof vi.fn>).mockReturnValue(sys);
-      expect(getActiveProjectDirs()).toEqual([]);
+      await expect(getActiveProjectDirs()).resolves.toEqual([]);
     }
   });
 
-  it('returns [cwd] for a normal project directory', () => {
+  it('returns [cwd] for a normal project directory', async () => {
     (process.cwd as ReturnType<typeof vi.fn>).mockReturnValue('/Users/test-user/dev/myproject');
-    expect(getActiveProjectDirs()).toEqual(['/Users/test-user/dev/myproject']);
+    await expect(getActiveProjectDirs()).resolves.toEqual(['/Users/test-user/dev/myproject']);
+  });
+});
+
+describe('getActiveProjectDirs - #716 project workspaces on GUI launch', () => {
+  const originalHome = process.env.HOME;
+
+  beforeEach(() => {
+    vi.spyOn(process, 'cwd');
+    listProjectsSpy.mockReset().mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env.HOME = originalHome;
+  });
+
+  it('returns project workspaces when cwd is "/" (macOS GUI Dock launch)', async () => {
+    (process.cwd as ReturnType<typeof vi.fn>).mockReturnValue('/');
+    listProjectsSpy.mockResolvedValue([
+      { id: 'a', name: 'A', workspace: '/Users/test-user/WaylandProjects/alpha' },
+      { id: 'b', name: 'B', workspace: '/Users/test-user/WaylandProjects/beta' },
+    ]);
+    await expect(getActiveProjectDirs()).resolves.toEqual([
+      '/Users/test-user/WaylandProjects/alpha',
+      '/Users/test-user/WaylandProjects/beta',
+    ]);
+  });
+
+  it('skips projects without a workspace and unsafe workspace values', async () => {
+    process.env.HOME = '/Users/test-user';
+    (process.cwd as ReturnType<typeof vi.fn>).mockReturnValue('/');
+    listProjectsSpy.mockResolvedValue([
+      { id: 'a', name: 'A' },
+      { id: 'b', name: 'B', workspace: '  ' },
+      { id: 'c', name: 'C', workspace: '/' },
+      { id: 'd', name: 'D', workspace: '/Users/test-user' },
+      { id: 'e', name: 'E', workspace: '/Users/test-user/dev/ok' },
+    ]);
+    await expect(getActiveProjectDirs()).resolves.toEqual(['/Users/test-user/dev/ok']);
+  });
+
+  it('deduplicates a cwd that is also a project workspace', async () => {
+    (process.cwd as ReturnType<typeof vi.fn>).mockReturnValue('/Users/test-user/dev/myproject');
+    listProjectsSpy.mockResolvedValue([
+      { id: 'a', name: 'A', workspace: '/Users/test-user/dev/myproject' },
+    ]);
+    await expect(getActiveProjectDirs()).resolves.toEqual(['/Users/test-user/dev/myproject']);
+  });
+
+  it('falls back to a safe cwd when the project store read fails', async () => {
+    (process.cwd as ReturnType<typeof vi.fn>).mockReturnValue('/Users/test-user/dev/myproject');
+    listProjectsSpy.mockRejectedValue(new Error('db not ready'));
+    await expect(getActiveProjectDirs()).resolves.toEqual(['/Users/test-user/dev/myproject']);
   });
 });

--- a/tests/unit/process/services/ijfwSystemService.test.ts
+++ b/tests/unit/process/services/ijfwSystemService.test.ts
@@ -146,9 +146,7 @@ describe('getActiveProjectDirs - #716 project workspaces on GUI launch', () => {
 
   it('deduplicates a cwd that is also a project workspace', async () => {
     (process.cwd as ReturnType<typeof vi.fn>).mockReturnValue('/Users/test-user/dev/myproject');
-    listProjectsSpy.mockResolvedValue([
-      { id: 'a', name: 'A', workspace: '/Users/test-user/dev/myproject' },
-    ]);
+    listProjectsSpy.mockResolvedValue([{ id: 'a', name: 'A', workspace: '/Users/test-user/dev/myproject' }]);
     await expect(getActiveProjectDirs()).resolves.toEqual(['/Users/test-user/dev/myproject']);
   });
 


### PR DESCRIPTION
GUI launches (Dock/Finder/Spotlight) inherit cwd '/' from LaunchServices,
so getActiveProjectDirs() fed '/' to the unsafe-root guard on every boot
and the ijfw startup prelude scan silently never ran.

Read the persisted project workspaces (SqliteProjectRepository, lazily
imported) as the primary source, keep a safe cwd for terminal launches,
dedupe, and drop the per-launch warn: an unsafe cwd is the expected GUI
state, so it is skipped quietly and only logged (info) when nothing is
scannable at all.
