### PR TITLE
fix/714

### DIFF
--- a/src/process/task/WCoreManager.ts
+++ b/src/process/task/WCoreManager.ts
@@ -177,7 +177,7 @@ export function dedupeThinkingDelta(prev: string, incoming: string): string {
  * debugging session needs; the full output still reaches the renderer via the
  * normal message stream.
  */
-const INFO_LOG_PREVIEW_MAX_CHARS = 400;
+export const INFO_LOG_PREVIEW_MAX_CHARS = 400;
 
 /**
  * Reduce a wcore `info` payload to something safe to persist to the on-disk
@@ -186,10 +186,22 @@ const INFO_LOG_PREVIEW_MAX_CHARS = 400;
  * runs FIRST so the redaction regexes never scan a multi-hundred-KB string; a
  * secret cut by the boundary either still matches (the prefixed-key regex
  * needs only 6 chars past the prefix) or has too little of it left to matter.
- * This is the desktop log-file surface; engine-side transports are #584.
+ * Non-string payloads (e.g. the `approval_required` diagnostic's structured
+ * data, whose engine-supplied `context` is free-form) are JSON-stringified so
+ * they stay readable AND pass through the same redaction. This is the desktop
+ * log-file surface; engine-side transports are #584.
  */
 export function toSafeInfoLogPreview(info: unknown): string {
-  const text = typeof info === 'string' ? info : String(info);
+  let text: string;
+  if (typeof info === 'string') {
+    text = info;
+  } else {
+    try {
+      text = JSON.stringify(info) ?? String(info);
+    } catch {
+      text = String(info); // circular/unserializable - type tag beats nothing
+    }
+  }
   const truncated =
     text.length > INFO_LOG_PREVIEW_MAX_CHARS
       ? `${text.slice(0, INFO_LOG_PREVIEW_MAX_CHARS)}… [+${text.length - INFO_LOG_PREVIEW_MAX_CHARS} chars truncated]`
@@ -1205,10 +1217,12 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
         // token: we can neither resume nor escalate, so surface a diagnostic.
         if (appr.reason && !isInfo) {
           if (autoMode && !appr.resumeToken) {
+            // Preview, not the raw payload: `context` is engine-supplied
+            // free-form text and this persists to the on-disk log (#714).
             mainError(
               '[WCoreManager]',
               `approval_required reason='${appr.reason}' in auto mode has no resume token and no HITL UI; turn may wedge`,
-              data.data
+              toSafeInfoLogPreview(data.data)
             );
           } else {
             mainLog(

--- a/src/process/task/WCoreManager.ts
+++ b/src/process/task/WCoreManager.ts
@@ -35,6 +35,7 @@ import { uuid } from '@/common/utils';
 import BaseAgentManager from './BaseAgentManager';
 import { IpcAgentEventEmitter } from './IpcAgentEventEmitter';
 import { mainError, mainLog, mainWarn } from '@process/utils/mainLogger';
+import { redactCommandSecrets } from '@/common/utils/redactCommandSecrets';
 import { hasCronCommands } from './CronCommandDetector';
 import { hasConciergeProposals } from './ConciergeProposeDetector';
 import { processCronInMessage } from './MessageMiddleware';
@@ -166,6 +167,34 @@ export function dedupeThinkingDelta(prev: string, incoming: string): string {
   const isRestate = common >= 10 || (prev.length > 0 && common >= prev.length * 0.5);
   if (isRestate) return incoming.length > prev.length ? incoming.slice(prev.length) : '';
   return incoming;
+}
+
+/**
+ * Cap for wcore `info` event text in the persistent log (#714). These events
+ * include full tool results ("[Grep success] <matched content>") — observed
+ * single entries up to ~600 KB — so the daily electron-log file was a plaintext
+ * copy of everything the agent read, API keys included. A short head is all a
+ * debugging session needs; the full output still reaches the renderer via the
+ * normal message stream.
+ */
+const INFO_LOG_PREVIEW_MAX_CHARS = 400;
+
+/**
+ * Reduce a wcore `info` payload to something safe to persist to the on-disk
+ * log (#714): truncate to a short preview, then mask recognizable secret
+ * shapes with the same redactor the activity timeline uses (#610). Truncation
+ * runs FIRST so the redaction regexes never scan a multi-hundred-KB string; a
+ * secret cut by the boundary either still matches (the prefixed-key regex
+ * needs only 6 chars past the prefix) or has too little of it left to matter.
+ * This is the desktop log-file surface; engine-side transports are #584.
+ */
+export function toSafeInfoLogPreview(info: unknown): string {
+  const text = typeof info === 'string' ? info : String(info);
+  const truncated =
+    text.length > INFO_LOG_PREVIEW_MAX_CHARS
+      ? `${text.slice(0, INFO_LOG_PREVIEW_MAX_CHARS)}… [+${text.length - INFO_LOG_PREVIEW_MAX_CHARS} chars truncated]`
+      : text;
+  return redactCommandSecrets(truncated);
 }
 
 export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
@@ -1076,10 +1105,12 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
         return;
       }
 
-      // Log info events from wcore (includes set_config/set_mode acknowledgments)
+      // Log info events from wcore (includes set_config/set_mode acknowledgments).
+      // These also carry full tool results, so persist only a truncated,
+      // secret-redacted preview — never the verbatim output (#714).
       if (data.type === 'info') {
         const elapsed = this._configSentAt ? ` (${Date.now() - this._configSentAt}ms since command)` : '';
-        mainLog('[WCoreManager]', `info: ${data.data}${elapsed}`);
+        mainLog('[WCoreManager]', `info: ${toSafeInfoLogPreview(data.data)}${elapsed}`);
       }
 
       // v0.9.4 - sub-agent activity events are system-level (empty msg_id) but

--- a/tests/unit/wcoreInfoLogPreview.test.ts
+++ b/tests/unit/wcoreInfoLogPreview.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { toSafeInfoLogPreview } from '@process/task/WCoreManager';
+
+// #714: wcore `info` events carry full tool results and were persisted
+// verbatim to the daily electron-log file — a Grep over an exported provider
+// settings page landed a live API-key object in plaintext on disk. The
+// preview must be short and secret-redacted before it reaches mainLog.
+describe('toSafeInfoLogPreview (#714 persistent-log tool output)', () => {
+  it('passes short, secret-free info lines through unchanged', () => {
+    expect(toSafeInfoLogPreview('set_mode acknowledged: auto_edit')).toBe('set_mode acknowledged: auto_edit');
+  });
+
+  it('truncates long tool output to a preview with a truncation marker', () => {
+    const out = toSafeInfoLogPreview(`[Grep success] ${'x'.repeat(50_000)}`);
+    expect(out.length).toBeLessThan(500);
+    expect(out).toContain('[Grep success]');
+    expect(out).toMatch(/\[\+\d+ chars truncated\]$/);
+  });
+
+  it('redacts prefixed provider API keys in the preview', () => {
+    const out = toSafeInfoLogPreview(
+      '[Grep success] settings.html:17: "api_key":{"label":"sk-or-v1-abcdef0123456789abcdef0123456789"}'
+    );
+    expect(out).not.toContain('sk-or-v1-abcdef0123456789abcdef0123456789');
+    expect(out).toContain('[Grep success]');
+  });
+
+  it('redacts Bearer tokens and KEY=value pairs', () => {
+    const out = toSafeInfoLogPreview(
+      '[Read success] Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.payload OPENROUTER_API_KEY=sk-or-v1-deadbeef1234'
+    );
+    expect(out).not.toContain('eyJhbGciOiJIUzI1NiJ9.payload');
+    expect(out).not.toContain('sk-or-v1-deadbeef1234');
+  });
+
+  it('redacts a secret that sits inside the truncated window', () => {
+    const secret = 'sk-or-v1-abcdef0123456789abcdef0123456789';
+    const out = toSafeInfoLogPreview(`[Grep success] "label":"${secret}" ${'y'.repeat(10_000)}`);
+    expect(out).not.toContain(secret);
+    expect(out).toMatch(/\[\+\d+ chars truncated\]$/);
+  });
+
+  it('stringifies non-string payloads instead of throwing', () => {
+    expect(toSafeInfoLogPreview(undefined)).toBe('undefined');
+    expect(toSafeInfoLogPreview(42)).toBe('42');
+  });
+});

--- a/tests/unit/wcoreInfoLogPreview.test.ts
+++ b/tests/unit/wcoreInfoLogPreview.test.ts
@@ -5,7 +5,14 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { toSafeInfoLogPreview } from '@process/task/WCoreManager';
+import { INFO_LOG_PREVIEW_MAX_CHARS, toSafeInfoLogPreview } from '@process/task/WCoreManager';
+
+/** Assert no usable fragment of `secret` (any 10-char run) survives in `out`. */
+function expectNoUsableFragment(out: string, secret: string): void {
+  for (let i = 0; i + 10 <= secret.length; i++) {
+    expect(out).not.toContain(secret.slice(i, i + 10));
+  }
+}
 
 // #714: wcore `info` events carry full tool results and were persisted
 // verbatim to the daily electron-log file — a Grep over an exported provider
@@ -46,8 +53,35 @@ describe('toSafeInfoLogPreview (#714 persistent-log tool output)', () => {
     expect(out).toMatch(/\[\+\d+ chars truncated\]$/);
   });
 
-  it('stringifies non-string payloads instead of throwing', () => {
+  it('leaves no usable fragment when truncation cuts mid-secret', () => {
+    const secret = 'sk-or-v1-abcdef0123456789abcdef0123456789';
+    // A key in real tool output sits after a delimiter (quote/space/colon) —
+    // the redactor's `\b` needs one — so pad up to a space and let the CUT
+    // land mid-secret. Cut 5 chars in: too little survives to be a credential
+    // or to match the redactor — the fragment check guards this boundary.
+    const pad = (chars: number) => `${'x'.repeat(INFO_LOG_PREVIEW_MAX_CHARS - chars - 1)} ${secret}`;
+    expectNoUsableFragment(toSafeInfoLogPreview(pad(5)), secret);
+    // Cut 20 chars in: enough of the prefixed key survives that the redactor
+    // itself must catch and mask it.
+    expectNoUsableFragment(toSafeInfoLogPreview(pad(20)), secret);
+  });
+
+  it('JSON-stringifies structured payloads and redacts secrets inside them', () => {
+    // The approval_required diagnostic passes its structured payload through
+    // the same preview (#714) — engine-supplied `context` is free-form text.
+    const out = toSafeInfoLogPreview({
+      reason: 'exec',
+      context: 'run with Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.secretpayload',
+    });
+    expect(out).toContain('"reason":"exec"');
+    expect(out).not.toContain('eyJhbGciOiJIUzI1NiJ9.secretpayload');
+  });
+
+  it('stringifies non-JSON payloads instead of throwing', () => {
     expect(toSafeInfoLogPreview(undefined)).toBe('undefined');
     expect(toSafeInfoLogPreview(42)).toBe('42');
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(toSafeInfoLogPreview(circular)).toBe('[object Object]');
   });
 });


### PR DESCRIPTION
- **fix(logging): redact tool outputs in persistent logs (#714)**
- **fix(logging): route approval diagnostic through log preview (#714)**
