### PR TITLE
test: give the #721 garbage-child settle loop a 30s budget

### DIFF
--- a/tests/unit/process/services/ijfwSystemService.applyPendingUpgrade.test.ts
+++ b/tests/unit/process/services/ijfwSystemService.applyPendingUpgrade.test.ts
@@ -329,7 +329,10 @@ describe('ijfwSystemService.applyPendingUpgrade', () => {
     } finally {
       vi.useRealTimers();
     }
-  });
+    // The settle loop interleaves up to 200 rounds of real macrotask flushes
+    // with fake-clock advances; on loaded CI shards that legitimately exceeds
+    // the default 10s wall budget (observed flaking PR merge runs).
+  }, 30_000);
 
   it('Checkpoint B B2: acquires installLock and short-circuits when one is already held', async () => {
     // Pre-seed a lockfile that matches the current host+boot and points at the


### PR DESCRIPTION
## Summary
- \`applyPendingUpgrade.test.ts\` "#721: spawn-test settles false via its 5s timeout" times out at vitest's default 10s wall budget on loaded CI shards, failing otherwise-green PR merge runs (observed on #764 windows shard and #770 ubuntu shard).
- The test already fake-times the 5s verify timer; the wall cost comes from its settle loop of up to 200 rounds of real macrotask flushes + real fs. Give that one test a 30s budget.

Test-only change; no production code touched.