### PR TITLE
fix(updater): explain Windows silent-noop update failures (UAC) (#492)

### DIFF
--- a/src/process/services/autoUpdaterService.ts
+++ b/src/process/services/autoUpdaterService.ts
@@ -747,8 +747,18 @@ class AutoUpdaterService extends EventEmitter {
         ? `${subject} can't be installed because Wayland is running from outside your Applications folder ` +
           `(macOS blocks in-place updates from temporary or read-only locations). Move Wayland to ` +
           `/Applications, reopen it, and try again.`
-        : `${subject} was downloaded but couldn't be installed automatically (the app is still running the ` +
-          `previous version). Please download and install it manually from the Releases page.`;
+        : process.platform === 'win32'
+          ? // Windows installs are per-machine (UPD-04), so applying an update
+            // writes to %ProgramFiles% and needs administrator approval; the most
+            // common cause of a silent no-op is an elevation (UAC) prompt that was
+            // declined, dismissed, or never completed (#492).
+            `${subject} was downloaded but couldn't be installed automatically (the app is still running the ` +
+            `previous version). Wayland is installed for all users, so updating needs administrator approval — ` +
+            `this usually means the elevation (UAC) prompt was declined or couldn't be completed. Please ` +
+            `download the installer manually from the Releases page and approve the administrator prompt ` +
+            `when it appears.`
+          : `${subject} was downloaded but couldn't be installed automatically (the app is still running the ` +
+            `previous version). Please download and install it manually from the Releases page.`;
     this.broadcastStatus({ status: 'install-failed', reason, version, error: message });
   }
 

--- a/tests/unit/autoUpdaterServiceInstallGuard.test.ts
+++ b/tests/unit/autoUpdaterServiceInstallGuard.test.ts
@@ -136,6 +136,19 @@ describe('autoUpdaterService install guard (#286)', () => {
     expect(s.error).toMatch(/manually/i);
   });
 
+  it('Windows silent-noop failure names the actual blocker: administrator approval (#492)', () => {
+    setPlatform('win32');
+    fs.writeFileSync(markerPath(), JSON.stringify({ version: '2.0.0', attemptedAt: 1 }));
+    (app.getVersion as ReturnType<typeof vi.fn>).mockReturnValue('1.0.0');
+
+    service.reconcilePendingInstall();
+
+    const s = lastStatus();
+    expect(s.status).toBe('install-failed');
+    expect(s.reason).toBe('silent-noop');
+    expect(s.error).toMatch(/administrator/i);
+  });
+
   it('suppresses a re-offer of the version whose install silently failed', () => {
     fs.writeFileSync(markerPath(), JSON.stringify({ version: '2.0.0', attemptedAt: 1 }));
     service.reconcilePendingInstall();


### PR DESCRIPTION
On Windows the app is installed perMachine (UPD-04 tamper-hardening), so
applying an update writes to %ProgramFiles% and requires UAC elevation.
When the apply silently no-ops (version never advances), the reconciler
only said 'download manually' with no explanation, leaving users confused
about why updates never land (#492).

The silent-noop failure message on win32 now explains that updating needs
administrator approval and that a declined/incomplete UAC prompt is the
usual cause, and directs the user to run the Releases installer and
approve the elevation prompt.

Deliberately NOT changed after adversarial review of the vendored
electron-updater (6.x) sources: flipping quitAndInstall to non-silent on
Windows does not help — the EACCES happens at CreateProcess against the
admin-manifest installer before NSIS parses /S, electron-updater already
retries via elevate.exe (UAC) on EACCES in silent mode, and non-silent
would regress admin users from one-consent silent updates to the full
assisted wizard (oneClick: false). The structural fix (perMachine: false,
issue option 1) reverses the recorded UPD-04 tradeoff and is escalated
for a human decision.
