### PR TITLE
test(e2e): realign team-create spec to v0.6.2.1 UI + reachability (#780)

### DIFF
--- a/tests/e2e/specs/team-create.e2e.ts
+++ b/tests/e2e/specs/team-create.e2e.ts
@@ -1,10 +1,27 @@
 /**
  * E2E Scenario 1: Create a team from the sidebar.
  *
- * Flow: sidebar "+" button -> Create Team modal -> fill form -> create -> verify navigation
+ * Flow: sidebar inline "+ Create team" button -> Create Team modal -> fill form
+ * -> create -> verify navigation.
+ *
+ * Selectors + reachability track the v0.6.2.1 UI (#780):
+ *  - The create affordance is the bottom-of-list inline button
+ *    `data-testid="sider-team-create-inline"` (TeamSiderSection.tsx). It is the
+ *    ONLY mount point for TeamCreateModal, and it renders only inside
+ *    SiderTeamsSection, which (a) returns null when the user has zero teams and
+ *    (b) lives in an accordion that is COLLAPSED by default. So the spec seeds a
+ *    team via the bridge and expands the Teams accordion before the button is
+ *    reachable — otherwise every test would hang on a button that isn't in the DOM.
+ *  - The modal is the custom WaylandModal (`.team-create-modal`) with a heading
+ *    instead of `.arco-modal-title`; the leader select and agent options carry
+ *    stable testids (`team-create-leader-select`, `team-create-agent-option-*`),
+ *    and options portal to document.body (WaylandSelect getPopupContainer).
+ *  - The confirm button is NO LONGER disabled on an empty form — TeamCreateModal
+ *    validates on click and warns — so the spec asserts enabled + submit behavior
+ *    rather than a disabled state.
  */
-import { test, expect } from '../fixtures';
-import { TEAM_SUPPORTED_BACKENDS } from '../helpers';
+import { test, expect, type Page } from '../fixtures';
+import { invokeBridge, TEAM_SUPPORTED_BACKENDS } from '../helpers';
 
 /**
  * UI label patterns for each backend. Used to match the agent option in the
@@ -16,68 +33,132 @@ const BACKEND_UI_PATTERN: Record<string, RegExp> = {
   gemini: /Gemini/i,
 };
 
+/** Prefixes for every team this spec may create, so cleanup can find them all. */
+const NAME_PREFIXES = ['E2E TeamCreate Seed', 'E2E Test Team', 'E2E Team ('];
+
+type TeamRow = { id: string; name: string };
+
+/** Remove every team this spec created/seeded, matched by name prefix. */
+async function cleanupSpecTeams(page: Page): Promise<void> {
+  const teams = await invokeBridge<TeamRow[]>(page, 'team.list', { userId: 'system_default_user' }).catch(
+    () => [] as TeamRow[]
+  );
+  await Promise.all(
+    teams
+      .filter((team) => NAME_PREFIXES.some((p) => team.name.startsWith(p)))
+      .map((team) => invokeBridge(page, 'team.remove', { id: team.id }).catch(() => undefined))
+  );
+}
+
+/**
+ * Seed one team (so SiderTeamsSection renders) and expand the Teams accordion
+ * (collapsed by default), leaving the inline create button reachable.
+ */
+async function primeSiderCreateAffordance(page: Page): Promise<void> {
+  const seeded = await invokeBridge<{ id?: string; __bridgeError?: boolean } | null>(page, 'team.create', {
+    userId: 'system_default_user',
+    name: `E2E TeamCreate Seed ${Date.now()}`,
+    workspace: '',
+    workspaceMode: 'shared',
+    agents: [
+      {
+        slotId: '',
+        conversationId: '',
+        role: 'leader',
+        agentType: 'wayland-core',
+        agentName: 'Leader',
+        conversationType: 'acp',
+        status: 'pending',
+      },
+    ],
+  }).catch(() => null);
+
+  // If seeding fails (e.g. no engine available), skip cleanly instead of hanging
+  // 15s on a section that will never render — mirrors team-modal-lifecycle.
+  if (!seeded?.id || seeded.__bridgeError) {
+    test.skip(true, 'team.create seed returned no team id (no usable leader backend)');
+    return;
+  }
+
+  // The Teams accordion section appears once ≥1 team exists.
+  const section = page.getByTestId('sider-teams-section');
+  await expect(section).toBeVisible({ timeout: 15000 });
+
+  // Expand it if collapsed (default). The header is a role=button with
+  // aria-expanded reflecting open state (SiderAccordionShell).
+  const header = section.locator('[role="button"]').first();
+  if ((await header.getAttribute('aria-expanded')) !== 'true') {
+    await header.click();
+  }
+
+  await expect(page.getByTestId('sider-team-create-inline')).toBeVisible({ timeout: 10000 });
+}
+
+/** The inline "+ Create team" button at the bottom of the sidebar team list. */
+function createButton(page: Page) {
+  return page.getByTestId('sider-team-create-inline');
+}
+
+/** The Create Team modal (custom WaylandModal, class passed through to Arco). */
+function createModal(page: Page) {
+  return page.locator('.team-create-modal');
+}
+
 test.describe('Team Create', () => {
-  test('sidebar shows team section with create button', async ({ page }) => {
-    // Wait for sidebar to render - no fixed timeout, listen for element
-    const teamSection = page.locator('text=Teams').or(page.locator('text=团队'));
-    await expect(teamSection.first()).toBeVisible({ timeout: 15000 });
-
-    // Screenshot: initial state
-    await page.screenshot({ path: 'tests/e2e/results/team-01-initial.png' });
-
-    // Verify the "+" create button exists next to the Teams title
-    const createBtn = page.locator('.h-20px.w-20px.rd-4px').first();
-    await expect(createBtn).toBeVisible();
+  test.beforeEach(async ({ page }) => {
+    await cleanupSpecTeams(page);
+    await primeSiderCreateAffordance(page);
   });
 
-  test('clicking + opens create team modal', async ({ page }) => {
-    // Wait for create button to be ready before clicking
-    const createBtn = page.locator('.h-20px.w-20px.rd-4px').first();
-    await expect(createBtn).toBeVisible({ timeout: 10000 });
-    await createBtn.click();
+  test.afterEach(async ({ page }) => {
+    await cleanupSpecTeams(page);
+  });
+
+  test('sidebar shows inline create-team button', async ({ page }) => {
+    await page.screenshot({ path: 'tests/e2e/results/team-01-initial.png' });
+    await expect(createButton(page)).toBeVisible();
+  });
+
+  test('clicking create opens the team modal', async ({ page }) => {
+    await createButton(page).click();
 
     // Screenshot: modal open
     await page.screenshot({ path: 'tests/e2e/results/team-02-modal.png' });
 
-    // Verify Modal is visible with "Create Team" title
-    const modalTitle = page.locator('.arco-modal-title').filter({ hasText: /Create Team|创建团队/ });
-    await expect(modalTitle).toBeVisible({ timeout: 5000 });
+    // Modal is visible with a "Create Team" heading
+    const modal = createModal(page);
+    await expect(modal).toBeVisible({ timeout: 5000 });
+    await expect(modal.getByRole('heading', { name: /Create Team|创建团队/ })).toBeVisible();
 
-    // Verify Team name input exists
-    const nameInput = page.locator('.arco-modal input').first();
+    // Team name input exists
+    const nameInput = modal.locator('input').first();
     await expect(nameInput).toBeVisible();
 
-    // Verify Dispatch Agent select exists
-    const agentSelect = page.locator('.arco-modal .arco-select').first();
-    await expect(agentSelect).toBeVisible();
+    // Team leader select exists
+    await expect(page.getByTestId('team-create-leader-select')).toBeVisible();
 
-    // Verify Create button exists but is disabled (form not filled)
-    const confirmBtn = page.locator('.arco-modal .arco-btn-primary');
+    // Confirm button exists and is ENABLED (validation happens on click now, so
+    // it is not disabled on an empty form — see TeamCreateModal.handleCreate).
+    const confirmBtn = modal.getByRole('button', { name: /Create Team|创建团队/ });
     await expect(confirmBtn).toBeVisible();
-    await expect(confirmBtn).toBeDisabled();
+    await expect(confirmBtn).toBeEnabled();
 
-    // Close modal and wait for it to disappear
-    await page.locator('.arco-modal .arco-modal-close-icon').click();
-    await expect(page.locator('.arco-modal')).toBeHidden({ timeout: 5000 });
+    // Close the modal (Arco WaylandModal closes on Escape).
+    await page.keyboard.press('Escape');
+    await expect(modal).toBeHidden({ timeout: 5000 });
   });
 
   test('can fill form and create team', async ({ page }) => {
-    // Wait for create button to be ready before clicking
-    const createBtn = page.locator('.h-20px.w-20px.rd-4px').first();
-    await expect(createBtn).toBeVisible({ timeout: 10000 });
-    await createBtn.click();
+    await createButton(page).click();
 
-    // Wait for modal to appear
-    const modalTitle = page.locator('.arco-modal-title').filter({ hasText: /Create Team|创建团队/ });
-    await expect(modalTitle).toBeVisible({ timeout: 5000 });
+    const modal = createModal(page);
+    await expect(modal).toBeVisible({ timeout: 5000 });
 
     // Fill team name
-    const nameInput = page.locator('.arco-modal input').first();
-    await nameInput.fill('E2E Test Team');
+    await modal.locator('input').first().fill('E2E Test Team');
 
-    // Open Agent select dropdown and wait for options to appear
-    const agentSelect = page.locator('.arco-modal .arco-select').first();
-    await agentSelect.click();
+    // Open leader select and wait for options (rendered in an Arco portal)
+    await page.getByTestId('team-create-leader-select').click();
     const firstOption = page.locator('.arco-select-option').first();
     await firstOption.waitFor({ state: 'visible', timeout: 5000 }).catch(() => {});
 
@@ -89,8 +170,7 @@ test.describe('Team Create', () => {
     if (hasOption) {
       await firstOption.click();
 
-      // Wait for select value to reflect the chosen option (Create btn becomes enabled)
-      const confirmBtn = page.locator('.arco-modal .arco-btn-primary');
+      const confirmBtn = modal.getByRole('button', { name: /Create Team|创建团队/ });
       await expect(confirmBtn).toBeEnabled({ timeout: 5000 });
 
       // Screenshot: form filled
@@ -104,8 +184,7 @@ test.describe('Team Create', () => {
       await page.screenshot({ path: 'tests/e2e/results/team-05-created.png' });
 
       // Verify team name appears in sidebar
-      const teamName = page.locator('text=E2E Test Team');
-      await expect(teamName.first()).toBeVisible({ timeout: 10000 });
+      await expect(page.locator('text=E2E Test Team').first()).toBeVisible({ timeout: 10000 });
     } else {
       // No supported agents installed - screenshot and skip
       await page.screenshot({ path: 'tests/e2e/results/team-03-no-agents.png' });
@@ -121,27 +200,21 @@ test.describe('Team Create', () => {
  * was created. Skips gracefully if the agent is not installed.
  */
 async function createTeamWithAgent(
-  page: import('@playwright/test').Page,
+  page: Page,
   teamName: string,
   agentTextPattern: RegExp,
   screenshotPrefix: string
 ): Promise<void> {
-  // Wait for create button to be ready (sidebar may still be loading after previous test)
-  const createBtn = page.locator('.h-20px.w-20px.rd-4px').first();
-  await expect(createBtn).toBeVisible({ timeout: 10000 });
-  await createBtn.click();
+  await createButton(page).click();
 
-  // Wait for modal to appear
-  const modalTitle = page.locator('.arco-modal-title').filter({ hasText: /Create Team|创建团队/ });
-  await expect(modalTitle).toBeVisible({ timeout: 5000 });
+  const modal = createModal(page);
+  await expect(modal).toBeVisible({ timeout: 5000 });
 
   // Fill team name
-  const nameInput = page.locator('.arco-modal input').first();
-  await nameInput.fill(teamName);
+  await modal.locator('input').first().fill(teamName);
 
-  // Open agent select dropdown and wait for options
-  const agentSelect = page.locator('.arco-modal .arco-select').first();
-  await agentSelect.click();
+  // Open leader select and wait for options
+  await page.getByTestId('team-create-leader-select').click();
   await page
     .locator('.arco-select-option')
     .first()
@@ -157,8 +230,8 @@ async function createTeamWithAgent(
   if (!optionVisible) {
     // Agent not installed - close dropdown then modal, skip test
     await page.keyboard.press('Escape');
-    await page.locator('.arco-modal .arco-modal-close-icon').click({ force: true });
-    await expect(page.locator('.arco-modal')).toBeHidden({ timeout: 5000 });
+    await page.keyboard.press('Escape');
+    await expect(modal).toBeHidden({ timeout: 5000 });
     console.log(`[E2E] Agent matching ${agentTextPattern} not found - skipping`);
     test.skip();
     return;
@@ -166,8 +239,8 @@ async function createTeamWithAgent(
 
   await matchingOption.click();
 
-  // Wait for Create button to become enabled (select value applied)
-  const confirmBtn = page.locator('.arco-modal .arco-btn-primary');
+  // Confirm button is enabled (validation is on-click, not a disabled state)
+  const confirmBtn = modal.getByRole('button', { name: /Create Team|创建团队/ });
   await expect(confirmBtn).toBeEnabled({ timeout: 5000 });
 
   await page.screenshot({ path: `tests/e2e/results/${screenshotPrefix}-filled.png` });
@@ -179,11 +252,19 @@ async function createTeamWithAgent(
   await page.screenshot({ path: `tests/e2e/results/${screenshotPrefix}-created.png` });
 
   // Verify team name appears in sidebar
-  const teamNameLocator = page.locator(`text=${teamName}`);
-  await expect(teamNameLocator.first()).toBeVisible({ timeout: 10000 });
+  await expect(page.locator(`text=${teamName}`).first()).toBeVisible({ timeout: 10000 });
 }
 
 test.describe('Team Create - whitelisted leader types', () => {
+  test.beforeEach(async ({ page }) => {
+    await cleanupSpecTeams(page);
+    await primeSiderCreateAffordance(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await cleanupSpecTeams(page);
+  });
+
   for (const backend of TEAM_SUPPORTED_BACKENDS) {
     const pattern = BACKEND_UI_PATTERN[backend] ?? new RegExp(backend, 'i');
     test(`create E2E Team (${backend})`, async ({ page }) => {


### PR DESCRIPTION
The spec targeted pre-v0.6.2.1 UI and failed 5/6 in isolation on stale
selectors AND stale reachability assumptions:

Selectors:
- create affordance is the inline bottom-of-list button
  data-testid="sider-team-create-inline" (was the `+` icon matched by
  .h-20px.w-20px.rd-4px, since removed)
- modal is the custom WaylandModal (.team-create-modal) with a heading
  instead of .arco-modal-title; leader select and agent options carry
  stable testids (team-create-leader-select, team-create-agent-option-*);
  options portal to document.body
- confirm button is no longer disabled on an empty form — TeamCreateModal
  validates on click and warns — so the spec asserts enabled + submit

Reachability (found in adversarial review):
- TeamCreateModal's only mount point is the inline button in
  TeamSiderSection, which renders only inside SiderTeamsSection. That
  section returns null with zero teams (SiderTeamsSection.tsx:80) and
  lives in an accordion that is collapsed by default
  (useSiderAccordionState DEFAULT_STATE.teams=false). So the button is
  absent in a clean state and the old spec would hang.
- beforeEach now seeds a team via the bridge and expands the Teams
  accordion (aria-expanded toggle) so the button is reachable; afterEach
  cleans up every team this spec seeds/creates by name prefix.

Selectors + gating verified against current components; spec compiles and
lists all 6 tests. Live e2e not re-run locally (shares app state with a
concurrent team e2e in another session); this spec is not in any CI/land
gate.
