### PR TITLE
fix(scroll): future-proof nested-scroller detection via composedPath (#777)

### DIFF
--- a/src/renderer/pages/conversation/Messages/useAutoScroll.ts
+++ b/src/renderer/pages/conversation/Messages/useAutoScroll.ts
@@ -229,8 +229,25 @@ export function useAutoScroll({ messages, itemCount, conversationId }: UseAutoSc
       accumIntentUntilRef.current = now + USER_SCROLL_INTENT_MS;
     };
 
+    // #777: start the ancestor walk from the composed-path origin rather than
+    // e.target. Agent markdown renders inside an OPEN shadow root (ShadowView),
+    // so for the most common scroll surface e.target is retargeted to the host
+    // while composedPath()[0] is the real inner element - they already differ.
+    // The result stays identical today only by two invariants, not by equality:
+    //   1. gestureTargetsMainScroller walks via parentNode, which does not cross
+    //      shadow boundaries (it stops at the ShadowRoot), so it never inspects
+    //      the host from inside; and
+    //   2. ShadowView's shadow tree has no vertical scroller (pre/katex/tables
+    //      are overflow-x only), so no `scrollTop > 0` node exists to consume the
+    //      gesture there.
+    // If a vertical `overflow-y` scroller is ever added inside ShadowView, this
+    // walk will (correctly) treat a gesture it consumes as child-targeted. Called
+    // synchronously during dispatch, so composedPath() is populated; `?? e.target`
+    // guards the post-dispatch empty-array case defensively.
+    const eventOrigin = (e: Event): EventTarget | null => e.composedPath()[0] ?? e.target;
+
     const onWheel = (e: WheelEvent) => {
-      if (e.deltaY < 0) markIntent(gestureTargetsMainScroller(e.target));
+      if (e.deltaY < 0) markIntent(gestureTargetsMainScroller(eventOrigin(e)));
     };
 
     let lastTouchY: number | null = null;
@@ -247,7 +264,7 @@ export function useAutoScroll({ messages, itemCount, conversationId }: UseAutoSc
       // the content scrolls up - the user is reading back through history.
       // Same accumulation rule as wheel: a drag over a mid-scroll nested
       // child does not arm the travel accumulator.
-      if (y - lastTouchY > 0) markIntent(gestureTargetsMainScroller(e.target));
+      if (y - lastTouchY > 0) markIntent(gestureTargetsMainScroller(eventOrigin(e)));
       lastTouchY = y;
     };
 


### PR DESCRIPTION
## Summary

#777 mitigation **#3** — the only tightening Overwatch greenlit (mechanism investigation on #777).

Starts `gestureTargetsMainScroller`'s ancestor walk from `e.composedPath()[0]` instead of `e.target` in the wheel/touch intent listeners. Agent markdown renders inside an **open shadow root** (`ShadowView`), so for the most common scroll surface `e.target` is retargeted to the host while `composedPath()[0]` is the real inner element — they already differ. The detection result stays identical **today** by two invariants (not by equality): `parentNode` doesn't cross shadow boundaries, and the shadow tree has no vertical (`overflow-y`) scroller. This future-proofs the nested-scroller detection if a vertical scroller is ever added inside `ShadowView`.

**Not** the residue's real fix. The false-latch residue (#777) is held pending a physical-trackpad repro — mitigation #1 risks re-opening #479/#700 in the app's most regression-prone code and is only justified once a human repro confirms the residue actually fires; mitigation #2 is rejected (it breaks the #479 single-wheel-up latch test).

## Verification

- `tests/unit/useAutoScroll.dom.test.ts` — 29/29 pass (includes the #479/#700 guards); the wheel path is exercised so the new code runs. Full unit suite green (land gate). Typecheck + oxfmt clean.
- Adversarial review: **CLEAN** — confirmed behavior-identical against the `ShadowView` CSS invariant, strictly confined to the walk's start node, no interaction with the intent-window/accumulator/#479 guard.

Refs #777.
