### PR TITLE
fix(team): raise + make configurable the Teams inactivity watchdog (#747)

### DIFF
--- a/src/process/team/TeamSessionService.ts
+++ b/src/process/team/TeamSessionService.ts
@@ -64,8 +64,8 @@ export class TeamSessionService {
     this.eventLogger = new EventLogger(repo);
     // P2 - one Watchdog per process (TeamSessionService is constructed once at
     // boot in initBridge). Sweep every 60s, matching TeammateManager's
-    // WAKE_TIMEOUT_MS; the lease TTL is 3x that, so a lapsed lease is reclaimed
-    // within one TTL window after the owner dies. Stopped in stopAllSessions.
+    // LEASE_RENEW_THROTTLE_MS; the lease TTL is 3x that, so a lapsed lease is
+    // reclaimed within one TTL window after the owner dies. Stopped in stopAllSessions.
     // checkUnblocks is roster-agnostic (it derives the team from the task), so a
     // bare TaskManager over the repo is enough to release dependents when the
     // Watchdog completes-through a verify-orphan.

--- a/src/process/team/TeammateManager.ts
+++ b/src/process/team/TeammateManager.ts
@@ -143,13 +143,46 @@ export class TeammateManager extends EventEmitter {
    */
   private readonly tokenUsageBaselines = new Map<string, UsageSnapshot>();
 
-  /** Maximum time (ms) to wait for a turnCompleted event before force-releasing a wake */
-  private static readonly WAKE_TIMEOUT_MS = 60 * 1000;
+  /**
+   * Lease-renew throttle (ms): maybeRenewLease writes the persisted lease at
+   * most once per this window. MUST stay well under LEASE_TTL_MS (180s) so a
+   * live owner's lease never lapses between renewals and the out-of-process
+   * Watchdog can't falsely reclaim its task. Deliberately distinct from the
+   * inactivity watchdog below - conflating them is why #747 bit.
+   */
+  private static readonly LEASE_RENEW_THROTTLE_MS = 60 * 1000;
+
+  /**
+   * Default inactivity-watchdog budget (ms): if a teammate streams NO activity
+   * (text, tool call, or thought) for this long, the leader is told it may be
+   * stalled. Raised from 60s (#747): a single silent tool/test run or slow
+   * first-token latency routinely exceeds a minute, which falsely flagged live,
+   * still-working teammates (and the leader itself) as "failed" and derailed
+   * runs. 180s aligns with LEASE_TTL_MS so the in-memory watchdog and the
+   * persisted-lease Watchdog surface a genuine stall at the same horizon.
+   * Override with env WAYLAND_TEAM_WAKE_TIMEOUT_MS (floored at 30s to reject
+   * garbage / a value low enough to re-introduce the false positives).
+   */
+  private static readonly DEFAULT_INACTIVITY_TIMEOUT_MS = 3 * 60 * 1000;
+
+  private static resolveInactivityTimeoutMs(): number {
+    const raw = process.env.WAYLAND_TEAM_WAKE_TIMEOUT_MS;
+    if (!raw) return TeammateManager.DEFAULT_INACTIVITY_TIMEOUT_MS;
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed) || parsed < 30_000) return TeammateManager.DEFAULT_INACTIVITY_TIMEOUT_MS;
+    // Clamp to the 32-bit setTimeout ceiling: a larger delay overflows and fires
+    // after ~1ms, which would flag every teammate failed immediately - the exact
+    // opposite of a long timeout. 2^31-1 ms is ~24.8 days, far past any real use.
+    return Math.min(parsed, 2_147_483_647);
+  }
+
+  /** Resolved once per manager: the inactivity-watchdog budget for this team. */
+  private readonly inactivityTimeoutMs = TeammateManager.resolveInactivityTimeoutMs();
 
   /**
    * P2 - the persisted lease ({@link LEASE_TTL_MS}, shared with TaskManager) is
    * stamped at wake start, RENEWED on streaming activity (throttled to once per
-   * WAKE_TIMEOUT_MS, see {@link maybeRenewLease}) REGARDLESS of in-memory status,
+   * LEASE_RENEW_THROTTLE_MS, see {@link maybeRenewLease}) REGARDLESS of in-memory status,
    * and renewed again at turn completion - so a still-alive turn keeps its lease
    * fresh even after a soft `failed` flip (inactivity/429 that did not kill the
    * process) and is never falsely reclaimed. The lease only lapses when the owner
@@ -460,7 +493,7 @@ export class TeammateManager extends EventEmitter {
 
       // Arm the inactivity watchdog. Any streaming output from this agent
       // resets it via handleResponseStream → resetWakeTimeout. It only fires
-      // when the agent has been silent for WAKE_TIMEOUT_MS with no finish event.
+      // when the agent has been silent for inactivityTimeoutMs with no finish event.
       this.resetWakeTimeout(slotId);
 
       // W1e: log the successful wake (post-sendMessage, before turn completes).
@@ -672,8 +705,8 @@ export class TeammateManager extends EventEmitter {
 
   /**
    * P2 - renew the persisted lease on streaming activity, at most once per
-   * WAKE_TIMEOUT_MS to avoid spamming the DB. Without this the persisted lease
-   * would only refresh at wake start / turn end, so a turn that streams for
+   * LEASE_RENEW_THROTTLE_MS to avoid spamming the DB. Without this the persisted
+   * lease would only refresh at wake start / turn end, so a turn that streams for
    * longer than LEASE_TTL_MS would let its lease lapse and be falsely reclaimed
    * while still alive.
    */
@@ -681,7 +714,7 @@ export class TeammateManager extends EventEmitter {
     if (!this.taskRepo) return;
     const now = Date.now();
     const last = this.lastLeaseRenewMs.get(slotId) ?? 0;
-    if (now - last < TeammateManager.WAKE_TIMEOUT_MS) return;
+    if (now - last < TeammateManager.LEASE_RENEW_THROTTLE_MS) return;
     this.lastLeaseRenewMs.set(slotId, now);
     void this.stampTaskLease(slotId, now);
   }
@@ -690,8 +723,8 @@ export class TeammateManager extends EventEmitter {
    * (Re)arm the inactivity watchdog for an agent's current wake.
    * Fired from wake() after dispatching the prompt, and from handleResponseStream
    * whenever fresh streaming activity arrives. When it finally fires (agent silent
-   * for WAKE_TIMEOUT_MS), escalates to handleInactivityTimeout so the leader learns
-   * about the stall instead of the agent dropping silently to idle.
+   * for inactivityTimeoutMs), escalates to handleInactivityTimeout so the leader
+   * learns about the stall instead of the agent dropping silently to idle.
    */
   private resetWakeTimeout(slotId: string): void {
     const existing = this.wakeTimeouts.get(slotId);
@@ -703,23 +736,24 @@ export class TeammateManager extends EventEmitter {
       if (currentAgent?.status === 'active') {
         void this.handleInactivityTimeout(currentAgent);
       }
-    }, TeammateManager.WAKE_TIMEOUT_MS);
+    }, this.inactivityTimeoutMs);
     this.wakeTimeouts.set(slotId, timeoutHandle);
   }
 
   /**
-   * A teammate went silent for WAKE_TIMEOUT_MS with no streaming activity and no
-   * finish event. Treat it as a soft failure: mark the agent 'failed' (not 'idle',
-   * which hides the problem), write an explanatory message into the leader's mailbox,
-   * and wake the leader so it can decide the next move (retry, replace, escalate).
+   * A teammate went silent for inactivityTimeoutMs with no streaming activity and
+   * no finish event. Treat it as a soft failure: mark the agent 'failed' (not
+   * 'idle', which hides the problem), write an explanatory message into the
+   * leader's mailbox, and wake the leader so it can decide the next move (retry,
+   * replace, escalate).
    *
    * Previously the timeout just setStatus(slotId, 'idle'), which left the leader
    * unaware - it would eventually re-wake on some other signal and guess that
    * the teammate was "idle-spinning" with no concrete evidence.
    */
   private async handleInactivityTimeout(agent: TeamAgent): Promise<void> {
-    const timeoutSeconds = Math.floor(TeammateManager.WAKE_TIMEOUT_MS / 1000);
-    const reason = `stopped responding after ${timeoutSeconds}s without sending any update`;
+    const timeoutSeconds = Math.floor(this.inactivityTimeoutMs / 1000);
+    const reason = `has not streamed any update in ${timeoutSeconds}s and may be stalled`;
 
     console.warn(`[TeammateManager] ${agent.agentName} (${agent.slotId}) ${reason}`);
     this.setStatus(agent.slotId, 'failed', reason);

--- a/src/process/team/types.ts
+++ b/src/process/team/types.ts
@@ -62,8 +62,9 @@ export const DEFAULT_RETRY_BUDGET = 3;
  * Task lease TTL (ms). Single source of truth for both the executor
  * (TeammateManager stamps/renews lease_expires_at = now + LEASE_TTL_MS) and the
  * point where a task transitions to `in_progress` (TaskManager stamps it too).
- * 3x the 60s wake timeout: a live turn renews well inside this window; only a
- * genuinely dead owner lets it lapse, which is when the Watchdog reclaims.
+ * 3x the 60s lease-renew throttle (TeammateManager.LEASE_RENEW_THROTTLE_MS): a
+ * live turn renews well inside this window; only a genuinely dead owner lets it
+ * lapse, which is when the Watchdog reclaims.
  */
 export const LEASE_TTL_MS = 3 * 60 * 1000;
 

--- a/tests/unit/team-TeammateManager.test.ts
+++ b/tests/unit/team-TeammateManager.test.ts
@@ -521,7 +521,7 @@ describe('TeammateManager', () => {
       mgr.dispose();
     });
 
-    it('marks a silent leader as failed after the 60s inactivity watchdog fires', async () => {
+    it('marks a silent leader as failed after the inactivity watchdog fires', async () => {
       vi.useFakeTimers();
       try {
         // Lead is the only agent - timeout escalates to 'failed' but has nobody to notify.
@@ -535,7 +535,7 @@ describe('TeammateManager', () => {
         await mgr.wake('slot-1');
         expect(mgr.getAgents().find((a) => a.slotId === 'slot-1')?.status).toBe('active');
 
-        await vi.advanceTimersByTimeAsync(61_000);
+        await vi.advanceTimersByTimeAsync(181_000);
 
         // Previously the watchdog dropped the agent to 'idle' (hiding the stall).
         // It now marks the agent 'failed' so the team surface reflects the problem.
@@ -692,7 +692,7 @@ describe('TeammateManager', () => {
   // -------------------------------------------------------------------------
 
   describe('wake inactivity watchdog', () => {
-    it('notifies the leader when a teammate goes silent past the 60s watchdog', async () => {
+    it('notifies the leader when a teammate goes silent past the inactivity watchdog', async () => {
       vi.useFakeTimers();
       try {
         const leadAgent = makeAgent({
@@ -719,8 +719,8 @@ describe('TeammateManager', () => {
         await mgr.wake('slot-member');
         expect(mgr.getAgents().find((a) => a.slotId === 'slot-member')?.status).toBe('active');
 
-        // No stream activity arrives - push past the watchdog deadline.
-        await vi.advanceTimersByTimeAsync(61_000);
+        // No stream activity arrives - push past the 180s watchdog deadline (#747).
+        await vi.advanceTimersByTimeAsync(181_000);
 
         // Teammate is escalated to 'failed' (not silently dropped to 'idle').
         expect(mgr.getAgents().find((a) => a.slotId === 'slot-member')?.status).toBe('failed');
@@ -783,13 +783,125 @@ describe('TeammateManager', () => {
           });
         }
 
-        // Still within 60s of the last heartbeat - watchdog must NOT have fired.
+        // Still within the inactivity budget of the last heartbeat - watchdog must NOT have fired.
         expect(mgr.getAgents().find((a) => a.slotId === 'slot-member')?.status).toBe('active');
         expect(mailbox.write).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'idle_notification' }));
 
         mgr.dispose();
       } finally {
         vi.useRealTimers();
+      }
+    });
+
+    // #747 regression: a teammate silent for 61s (past the OLD 60s watchdog, but
+    // within the raised 180s default) must NOT be flagged failed. A single silent
+    // tool/test run or slow first-token latency routinely exceeds a minute.
+    it('#747: does NOT flag a teammate failed at 61s of silence (raised default)', async () => {
+      vi.useFakeTimers();
+      try {
+        const leadAgent = makeAgent({
+          slotId: 'slot-lead',
+          conversationId: 'conv-lead',
+          role: 'leader',
+          status: 'idle',
+        });
+        const teammate = makeAgent({
+          slotId: 'slot-member',
+          conversationId: 'conv-member',
+          role: 'teammate',
+          status: 'idle',
+          agentName: 'Codex',
+        });
+        const mockSendMessage = vi.fn().mockResolvedValue(undefined);
+        const { mgr, mailbox, workerTaskManager } = makeTeammateManager([leadAgent, teammate]);
+        vi.mocked(workerTaskManager.getOrBuildTask).mockResolvedValue({ sendMessage: mockSendMessage } as never);
+
+        await mgr.wake('slot-member');
+        // Past the old 60s watchdog, but well under the 180s default.
+        await vi.advanceTimersByTimeAsync(61_000);
+
+        expect(mgr.getAgents().find((a) => a.slotId === 'slot-member')?.status).toBe('active');
+        expect(mailbox.write).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'idle_notification' }));
+
+        mgr.dispose();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    // #747: the inactivity budget is env-configurable for slower models / longer
+    // tool runs. Resolved once at construction from WAYLAND_TEAM_WAKE_TIMEOUT_MS.
+    it('#747: honors WAYLAND_TEAM_WAKE_TIMEOUT_MS override', async () => {
+      vi.stubEnv('WAYLAND_TEAM_WAKE_TIMEOUT_MS', '90000');
+      vi.useFakeTimers();
+      try {
+        const leadAgent = makeAgent({
+          slotId: 'slot-lead',
+          conversationId: 'conv-lead',
+          role: 'leader',
+          status: 'idle',
+        });
+        const teammate = makeAgent({
+          slotId: 'slot-member',
+          conversationId: 'conv-member',
+          role: 'teammate',
+          status: 'idle',
+          agentName: 'Codex',
+        });
+        const mockSendMessage = vi.fn().mockResolvedValue(undefined);
+        const { mgr, workerTaskManager } = makeTeammateManager([leadAgent, teammate]);
+        vi.mocked(workerTaskManager.getOrBuildTask).mockResolvedValue({ sendMessage: mockSendMessage } as never);
+
+        await mgr.wake('slot-member');
+
+        // At 80s: under the 90s override -> still active (would have failed at the 60s old default).
+        await vi.advanceTimersByTimeAsync(80_000);
+        expect(mgr.getAgents().find((a) => a.slotId === 'slot-member')?.status).toBe('active');
+
+        // Past 90s -> now flagged.
+        await vi.advanceTimersByTimeAsync(11_000);
+        expect(mgr.getAgents().find((a) => a.slotId === 'slot-member')?.status).toBe('failed');
+
+        mgr.dispose();
+      } finally {
+        vi.useRealTimers();
+        vi.unstubAllEnvs();
+      }
+    });
+
+    // #747: an absurd override above the 32-bit setTimeout ceiling must be clamped,
+    // not overflow-and-fire after ~1ms (which would flag every teammate instantly).
+    it('#747: clamps an overflow WAYLAND_TEAM_WAKE_TIMEOUT_MS instead of firing immediately', async () => {
+      vi.stubEnv('WAYLAND_TEAM_WAKE_TIMEOUT_MS', '9999999999'); // ~115 days, past 2^31-1 ms
+      vi.useFakeTimers();
+      try {
+        const leadAgent = makeAgent({
+          slotId: 'slot-lead',
+          conversationId: 'conv-lead',
+          role: 'leader',
+          status: 'idle',
+        });
+        const teammate = makeAgent({
+          slotId: 'slot-member',
+          conversationId: 'conv-member',
+          role: 'teammate',
+          status: 'idle',
+          agentName: 'Codex',
+        });
+        const mockSendMessage = vi.fn().mockResolvedValue(undefined);
+        const { mgr, workerTaskManager } = makeTeammateManager([leadAgent, teammate]);
+        vi.mocked(workerTaskManager.getOrBuildTask).mockResolvedValue({ sendMessage: mockSendMessage } as never);
+
+        await mgr.wake('slot-member');
+        // Pre-clamp this would have overflowed and fired ~immediately. Advance a
+        // generous window; the teammate must still be active (clamped to ~24.8 days).
+        await vi.advanceTimersByTimeAsync(600_000);
+        expect(mgr.getAgents().find((a) => a.slotId === 'slot-member')?.status).toBe('active');
+
+        mgr.dispose();
+      } finally {
+        vi.useRealTimers();
+        vi.unstubAllEnvs();
       }
     });
   });


### PR DESCRIPTION
## Summary

Fixes #747 — the Teams inactivity watchdog fired at a hardcoded **60s** of no streamed activity, falsely marking live, still-working teammates (and the leader) as **"failed"** and derailing runs. A single silent tool/test run or slow first-token latency routinely exceeds a minute; the reporter saw this fire 17 times in one 2.5h session (including the leader 4×) with zero real crashes.

## The subtle part

`WAKE_TIMEOUT_MS = 60_000` did **double duty**: it was the inactivity-watchdog deadline **and** the `maybeRenewLease` throttle. That throttle **must stay under `LEASE_TTL_MS` (180s)** or the out-of-process Watchdog reclaims a live owner's task. Naively bumping the constant would have silently broken lease correctness. So the two concerns are split:

- **`LEASE_RENEW_THROTTLE_MS`** stays **60s** (lease-renew cadence, safely `< LEASE_TTL_MS`).
- **`inactivityTimeoutMs`** is new: default **180s** (aligned with `LEASE_TTL_MS` so the in-memory watchdog and the persisted-lease Watchdog surface a genuine stall at the same horizon), env-overridable via **`WAYLAND_TEAM_WAKE_TIMEOUT_MS`** (floored at 30s, clamped at the 32-bit `setTimeout` ceiling so an absurd value can't overflow-and-fire immediately).

The heartbeat already resets on any streamed activity (text/tool/thought); this change targets genuinely silent stretches. The leader-notification wording is softened to "may be stalled" (non-terminal), matching the soft-fail semantics.

Out of scope (kept surgical): a distinct non-terminal status enum for "possibly stalled" — the timeout raise + configurability removes the false-positive frequency the issue is about.

## Verification

- 76 unit tests: #747 regression (61s no longer fails), env-override, overflow-clamp; existing watchdog tests bumped 60→180s. Full suite green (land gate). Typecheck + oxfmt clean.
- Adversarial review: **non-blocking** — confirmed the lease invariant is preserved and the split routed all three original sites correctly; reviewer empirically confirmed the regression tests fail on pre-fix code. Two LOW nits (overflow clamp, stale `types.ts` comment) fixed.

Fixes #747.
