### PR TITLE
fix(tabs): navigate on close-left/right when the active tab is closed (#762)

### DIFF
--- a/src/renderer/pages/conversation/components/ConversationTabs.tsx
+++ b/src/renderer/pages/conversation/components/ConversationTabs.tsx
@@ -507,12 +507,27 @@ const ConversationTabs: React.FC = () => {
                 closeAllTabs();
                 void navigate('/guid');
                 break;
-              case 'close-left':
+              case 'close-left': {
                 closeTabsToLeft(tabId);
+                // #762 (sibling of #678): the context switches activeTabId to the
+                // anchor tab when the active tab is inside the closed range, but the
+                // router keeps rendering the closed chat unless we navigate too.
+                // Only navigate when the active tab was actually closed (to the
+                // left of the anchor); leave an unaffected active tab in place.
+                const activeIndexLeft = openTabs.findIndex((tab) => tab.id === activeTabId);
+                if (activeIndexLeft > -1 && activeIndexLeft < tabIndex) {
+                  void navigate(`/conversation/${tabId}`);
+                }
                 break;
-              case 'close-right':
+              }
+              case 'close-right': {
                 closeTabsToRight(tabId);
+                const activeIndexRight = openTabs.findIndex((tab) => tab.id === activeTabId);
+                if (activeIndexRight > -1 && activeIndexRight > tabIndex) {
+                  void navigate(`/conversation/${tabId}`);
+                }
                 break;
+              }
               case 'close-others':
                 closeOtherTabs(tabId);
                 void navigate(`/conversation/${tabId}`);
@@ -541,6 +556,7 @@ const ConversationTabs: React.FC = () => {
     },
     [
       openTabs,
+      activeTabId,
       closeAllTabs,
       closeTabsToLeft,
       closeTabsToRight,

--- a/tests/unit/renderer/conversationTabsClose.dom.test.tsx
+++ b/tests/unit/renderer/conversationTabsClose.dom.test.tsx
@@ -58,6 +58,7 @@ import { ConversationTabsProvider } from '../../../src/renderer/pages/conversati
 
 const TAB_A = { id: 'conv-a', name: 'Chat A', workspace: '/ws/a', type: 'gemini' as const };
 const TAB_B = { id: 'conv-b', name: 'Chat B', workspace: '/ws/b', type: 'gemini' as const };
+const TAB_C = { id: 'conv-c', name: 'Chat C', workspace: '/ws/c', type: 'gemini' as const };
 
 const ConversationContent: React.FC = () => {
   const { id } = useParams();
@@ -87,6 +88,14 @@ const closeButtonOfTab = (tabName: string) => {
   const tab = tabLabel.closest('.group\\/tab') as HTMLElement;
   expect(tab).not.toBeNull();
   return within(tab).getByTestId('icon-X');
+};
+
+/** The tab element (the context-menu target). */
+const tabElement = (tabName: string) => {
+  const tabLabel = screen.getByText(tabName);
+  const tab = tabLabel.closest('.group\\/tab') as HTMLElement;
+  expect(tab).not.toBeNull();
+  return tab;
 };
 
 describe('ConversationTabs close (#678)', () => {
@@ -131,5 +140,67 @@ describe('ConversationTabs close (#678)', () => {
     // Closed tab is gone; the active conversation stays on screen.
     expect(screen.queryByText('Chat A')).not.toBeInTheDocument();
     expect(screen.getByTestId('conversation-content')).toHaveTextContent('content-of-conv-b');
+  });
+});
+
+describe('ConversationTabs bulk close (#762)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it('close-tabs-to-left navigates to the anchor when the active tab is in the closed range', async () => {
+    seedTabs([TAB_A, TAB_B, TAB_C], TAB_A.id); // active A is left of the anchor C
+    renderTabsApp(TAB_A.id);
+    expect(screen.getByTestId('conversation-content')).toHaveTextContent('content-of-conv-a');
+
+    // Right-click tab C, choose "close left" (closes A and B; active A was in range).
+    fireEvent.contextMenu(tabElement('Chat C'));
+    fireEvent.click(await screen.findByText('conversation.tabs.closeLeft'));
+
+    expect(screen.queryByText('Chat A')).not.toBeInTheDocument();
+    expect(screen.queryByText('Chat B')).not.toBeInTheDocument();
+    // Content followed to the surviving anchor tab - not stale on the closed conv-a.
+    expect(screen.getByTestId('conversation-content')).toHaveTextContent('content-of-conv-c');
+  });
+
+  it('close-tabs-to-right navigates to the anchor when the active tab is in the closed range', async () => {
+    seedTabs([TAB_A, TAB_B, TAB_C], TAB_C.id); // active C is right of the anchor A
+    renderTabsApp(TAB_C.id);
+    expect(screen.getByTestId('conversation-content')).toHaveTextContent('content-of-conv-c');
+
+    fireEvent.contextMenu(tabElement('Chat A'));
+    fireEvent.click(await screen.findByText('conversation.tabs.closeRight'));
+
+    expect(screen.queryByText('Chat B')).not.toBeInTheDocument();
+    expect(screen.queryByText('Chat C')).not.toBeInTheDocument();
+    expect(screen.getByTestId('conversation-content')).toHaveTextContent('content-of-conv-a');
+  });
+
+  it('close-tabs-to-left leaves an unaffected active tab in place', async () => {
+    seedTabs([TAB_A, TAB_B, TAB_C], TAB_C.id); // active C is the anchor - not in the closed range
+    renderTabsApp(TAB_C.id);
+
+    fireEvent.contextMenu(tabElement('Chat C'));
+    fireEvent.click(await screen.findByText('conversation.tabs.closeLeft'));
+
+    // A and B closed, but the active tab C was not in range - content unchanged.
+    expect(screen.queryByText('Chat A')).not.toBeInTheDocument();
+    expect(screen.getByTestId('conversation-content')).toHaveTextContent('content-of-conv-c');
+  });
+
+  it('close-tabs-to-left with a mid-strip anchor leaves an active tab to its right in place', async () => {
+    // [A, B, C, D], active D, close-left on B -> closes A only; D is right of B,
+    // NOT in the closed range, so content must stay on D.
+    const TAB_D = { id: 'conv-d', name: 'Chat D', workspace: '/ws/d', type: 'gemini' as const };
+    seedTabs([TAB_A, TAB_B, TAB_C, TAB_D], TAB_D.id);
+    renderTabsApp(TAB_D.id);
+
+    fireEvent.contextMenu(tabElement('Chat B'));
+    fireEvent.click(await screen.findByText('conversation.tabs.closeLeft'));
+
+    expect(screen.queryByText('Chat A')).not.toBeInTheDocument();
+    expect(screen.getByText('Chat B')).toBeInTheDocument();
+    expect(screen.getByTestId('conversation-content')).toHaveTextContent('content-of-conv-d');
   });
 });


### PR DESCRIPTION
## Summary

Fixes #762 (sibling of #678) — the tab context-menu actions **"Close tabs to the left"** and **"Close tabs to the right"** updated `activeTabId` in the tabs context but didn't navigate the router. When the active tab falls inside the closed range, the context switches `activeTabId` to the anchor tab while the route keeps rendering the just-closed conversation — the tab strip and the content panel desync (tab gone, stale content on screen).

## Fix

Mirror the #678 fix already applied to single-close and "close others": after `closeTabsToLeft`/`closeTabsToRight`, navigate to the anchor tab — but **only when the active tab was actually in the closed range** (`activeIndex < tabIndex` for left, `> tabIndex` for right). This matches the exact condition under which the context switches `activeTabId`, so an unaffected active tab is left in place (no spurious navigation). `activeTabId` added to the memo deps.

The asymmetry with "close others"/"close all" (which navigate unconditionally) is intentional: those switch `activeTabId` unconditionally in the context, left/right only conditionally.

## Verification

- 7 dom tests in `conversationTabsClose.dom.test.tsx`: both directions navigate when the active tab is in-range; an unaffected active tab (anchor, and far-side in a 4-tab strip) stays; alongside the existing #678 cases. Content is route-driven and the tab strip context-driven, so the tests genuinely assert the router followed.
- Adversarial review: **CLEAN** — reviewer confirmed the range predicate matches the context's switch logic exactly (edge cases: active===anchor, active-not-in-list, context early-returns all resolve correctly), the tests fail on pre-fix code, and the Arco context-menu trigger is not flaky. Full suite green (land gate); typecheck + oxfmt clean.

Fixes #762.
