### PR TITLE
fix(memory): wrap score-tooltip icon so hover can't blank the app (#751)

### DIFF
--- a/src/renderer/pages/memory/components/Inspector.tsx
+++ b/src/renderer/pages/memory/components/Inspector.tsx
@@ -73,13 +73,7 @@ const scoreBarClass = (score: number, threshold: number): string => {
 function EmptyState(): React.ReactElement {
   return (
     <div className={styles.empty} data-testid='inspector-empty'>
-      <FileCode
-        className={styles.emptyIcon}
-        theme='outline'
-        size='32'
-        aria-hidden
-        data-testid='inspector-empty-icon'
-      />
+      <FileCode className={styles.emptyIcon} theme='outline' size='32' aria-hidden data-testid='inspector-empty-icon' />
       <span>Select a memory to inspect it</span>
       <div className={styles.emptyHint}>
         <span className={styles.kbdChip}>↑/↓ navigate</span>
@@ -122,7 +116,7 @@ const Inspector: React.FC<InspectorProps> = ({
       onCopy?.(text);
       // Parent onCopy shows its own toast - do not add a second one here.
     },
-    [onCopy],
+    [onCopy]
   );
 
   if (entry === null) {
@@ -224,12 +218,11 @@ const Inspector: React.FC<InspectorProps> = ({
             Promotion score {entry.promotionScore}/100 - auto-promotes at {promotionThreshold}
           </span>
           <Tooltip content={SCORE_TOOLTIP} position='top'>
-            <Help
-              theme='outline'
-              size='13'
-              style={{ cursor: 'help', opacity: 0.6 }}
-              aria-label='Score formula'
-            />
+            {/* #751: wrap so Arco gets a real DOM node - @icon-park icons don't
+                forwardRef, and an unwrapped trigger crashes on hover positioning. */}
+            <span style={{ display: 'inline-flex' }}>
+              <Help theme='outline' size='13' style={{ cursor: 'help', opacity: 0.6 }} aria-label='Score formula' />
+            </span>
           </Tooltip>
         </div>
         <div className={styles.scoreBar} data-testid='inspector-score-bar'>
@@ -255,11 +248,7 @@ const Inspector: React.FC<InspectorProps> = ({
         <div className={styles.section} data-testid='inspector-section-why'>
           <h3 className={styles.sectionLabel}>Why</h3>
           <div className={styles.sectionContent}>
-            {entry.why ? (
-              <p>{entry.why}</p>
-            ) : (
-              <span className={styles.sectionAbsent}>No "Why" recorded</span>
-            )}
+            {entry.why ? <p>{entry.why}</p> : <span className={styles.sectionAbsent}>No "Why" recorded</span>}
           </div>
         </div>
 

--- a/src/renderer/pages/memory/components/RightDrawer.tsx
+++ b/src/renderer/pages/memory/components/RightDrawer.tsx
@@ -376,12 +376,18 @@ const RightDrawer: React.FC<RightDrawerProps> = ({
                 {t('archive.drawer.autoPromotesAt', 'auto-promotes at {{n}}', { n: promotionThreshold })}
               </span>
               <Tooltip content={SCORE_TOOLTIP} position='top'>
-                <Help
-                  theme='outline'
-                  size='13'
-                  style={{ cursor: 'help', opacity: 0.6 }}
-                  aria-label={t('archive.drawer.scoreFormula', 'Score formula')}
-                />
+                {/* #751: wrap the icon so Arco gets a real DOM node. @icon-park
+                    icons don't forwardRef, so an unwrapped trigger yields a null
+                    getRootDOMNode/findDOMNode and Arco crashes while positioning
+                    on hover - which blanked the whole app (no error boundary). */}
+                <span style={{ display: 'inline-flex' }}>
+                  <Help
+                    theme='outline'
+                    size='13'
+                    style={{ cursor: 'help', opacity: 0.6 }}
+                    aria-label={t('archive.drawer.scoreFormula', 'Score formula')}
+                  />
+                </span>
               </Tooltip>
             </div>
             <div className={styles.scoreTrack} data-testid='drawer-score-track'>

--- a/tests/unit/renderer/pages/memory/Inspector.dom.test.tsx
+++ b/tests/unit/renderer/pages/memory/Inspector.dom.test.tsx
@@ -100,6 +100,16 @@ describe('Inspector', () => {
     expect(screen.getByTestId('inspector-section-howto')).toBeTruthy();
   });
 
+  // #751: @icon-park icons don't forwardRef, so an unwrapped Arco <Tooltip>
+  // trigger yields a null DOM node and crashes on hover positioning. The score
+  // help icon must be wrapped in a host element.
+  it('#751: wraps the score help icon in a span so the tooltip cannot crash on hover', () => {
+    render(<Inspector {...defaultProps()} />);
+    const wrapper = screen.getByTestId('icon-help').parentElement;
+    expect(wrapper?.tagName).toBe('SPAN');
+    expect(wrapper?.style.display).toBe('inline-flex');
+  });
+
   it('renders the empty state when entry is null', () => {
     render(<Inspector {...defaultProps({ entry: null })} />);
     expect(screen.getByTestId('inspector-empty')).toBeTruthy();
@@ -203,9 +213,7 @@ describe('Inspector', () => {
     const btn = screen.getByTestId('inspector-promote-btn');
     expect(btn.textContent).toContain('✓');
     // Arco Button disabled sets aria-disabled or the DOM disabled attribute
-    expect(btn.getAttribute('disabled') !== null || btn.getAttribute('aria-disabled') === 'true').toBe(
-      true,
-    );
+    expect(btn.getAttribute('disabled') !== null || btn.getAttribute('aria-disabled') === 'true').toBe(true);
   });
 
   // ----- H6: no double toast on source path copy -----

--- a/tests/unit/renderer/pages/memory/RightDrawer.dom.test.tsx
+++ b/tests/unit/renderer/pages/memory/RightDrawer.dom.test.tsx
@@ -126,6 +126,16 @@ describe('RightDrawer', () => {
     expect(screen.getByTestId('drawer-score-fill')).toBeTruthy();
   });
 
+  // #751: @icon-park icons don't forwardRef, so an unwrapped Arco <Tooltip>
+  // trigger yields a null DOM node and crashes on hover positioning - which
+  // blanked the whole app. The score help icon must sit inside a host element.
+  it('#751: wraps the score help icon in a span so the tooltip cannot crash on hover', () => {
+    render(<RightDrawer entry={MOCK_ENTRY} onClose={vi.fn()} />);
+    const wrapper = screen.getByTestId('icon-help').parentElement;
+    expect(wrapper?.tagName).toBe('SPAN');
+    expect(wrapper?.style.display).toBe('inline-flex');
+  });
+
   it('shows source path (Q5 acceptance)', () => {
     render(<RightDrawer entry={MOCK_ENTRY} onClose={vi.fn()} />);
     const sourcePath = screen.getByTestId('drawer-source-path');

--- a/tests/unit/renderer/scoreTooltipHover.dom.test.tsx
+++ b/tests/unit/renderer/scoreTooltipHover.dom.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Regression for #751: hovering the promotion-score (?) help icon in the Memory
+ * Archive detail panel blanked the whole app. The icon (@icon-park/react `Help`)
+ * does not forwardRef, so Arco's <Tooltip> received a null trigger ref and threw
+ * while positioning the popup on hover; with no error boundary over the memory
+ * page the whole tree unmounted. The fix wraps the trigger in a ref-forwarding
+ * host element (a span), matching the DesktopActionButton pattern.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Tooltip } from '@arco-design/web-react';
+import { Help } from '@icon-park/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+
+describe('promotion-score tooltip hover (#751)', () => {
+  it('does not throw when hovering an icon-park trigger wrapped for the tooltip', async () => {
+    render(
+      <Tooltip content='Score formula' position='top'>
+        <span style={{ display: 'inline-flex' }}>
+          <Help theme='outline' size='13' aria-label='Score formula' />
+        </span>
+      </Tooltip>
+    );
+
+    const trigger = screen.getByLabelText('Score formula').closest('span') as HTMLElement;
+    expect(trigger).not.toBeNull();
+
+    // Hovering must not throw / tear down the tree. Arco shows the popup on
+    // mouseEnter after a short delay; the content becomes reachable.
+    expect(() => {
+      fireEvent.mouseEnter(trigger);
+    }).not.toThrow();
+
+    await waitFor(() => expect(screen.getByText('Score formula')).toBeInTheDocument());
+    // The trigger icon is still mounted (the tree did not blank out).
+    expect(screen.getByLabelText('Score formula')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #751 — hovering the promotion-score **(?)** help icon in the Memory Archive detail side panel blanked the entire app (white screen, unusable until restart).

## Root cause (reproduced)

`@icon-park/react` icons do not `forwardRef`. An Arco `<Tooltip>` placed **directly** around `<Help>` can't get the trigger's DOM node — Arco logs `Element does not define getRootDOMNode ... React.findDOMNode ... element: null`, then throws `Cannot read properties of null (reading 'offsetParent')` while positioning the popup on hover. With no error boundary over the memory page, the whole React tree unmounts → blank screen.

## Fix

Wrap the tooltip trigger in a host `<span style={{display:'inline-flex'}}>` (the existing `DesktopActionButton` pattern) so Arco resolves a real DOM node. Applied to **both** `RightDrawer.tsx` (the Archive drawer) and `Inspector.tsx`, which share the identical unwrapped tooltip. No other `<Tooltip>`/`<Popover>` in the memory panels wraps a non-ref-forwarding icon (verified).

## Verification

- `scoreTooltipHover.dom.test.tsx`: hovers a wrapped trigger using the **real** icon-park `Help` (the component tests mock icons as spans, which can't reproduce the refless crash) — exercises the exact show/position path that threw.
- Structural guards in `RightDrawer.dom.test.tsx` / `Inspector.dom.test.tsx`: assert the score help is span-wrapped (`inline-flex`). Confirmed non-vacuous — removing the wrapper makes them fail (`DIV` vs `SPAN`).
- Adversarial review: **CLEAN** — reviewer independently reproduced the crash, confirmed the fix and completeness, and confirmed the structural tests distinguish fixed vs broken. Full suite green (land gate); typecheck clean.

> Note: the touched files were reformatted by `oxfmt` per the repo's touched-file format gate (origin/main's versions weren't oxfmt-clean); those hunks are cosmetic only.

Follow-up worth a separate issue: add an error boundary around the memory detail panel so a future single-component render error can't blank the whole app.

Fixes #751.
