### PR TITLE
fix(memory): contain detail-panel render errors with error boundaries

### DIFF
--- a/src/renderer/components/ErrorBoundary.tsx
+++ b/src/renderer/components/ErrorBoundary.tsx
@@ -12,6 +12,13 @@ type State = { error: Error | null };
 type Props = {
   children: React.ReactNode;
   fallback?: (error: Error, reset: () => void) => React.ReactNode;
+  /**
+   * When the boundary is showing a fallback and any value in this array changes
+   * (shallow compare), the error state is cleared and the children are
+   * re-rendered. Lets a caller auto-recover on a relevant change (e.g. the user
+   * selecting a different item) without remounting the children on every render.
+   */
+  resetKeys?: ReadonlyArray<unknown>;
 };
 
 export class ErrorBoundary extends React.Component<Props, State> {
@@ -23,6 +30,17 @@ export class ErrorBoundary extends React.Component<Props, State> {
 
   componentDidCatch(error: Error, info: React.ErrorInfo) {
     log.error('[ErrorBoundary]', error, info.componentStack);
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    // Only relevant while a fallback is showing: if the caller's reset keys
+    // changed, clear the error so the (now hopefully healthy) children render.
+    if (!this.state.error) return;
+    const prev = prevProps.resetKeys;
+    const next = this.props.resetKeys;
+    if (next && (!prev || prev.length !== next.length || next.some((k, i) => !Object.is(k, prev[i])))) {
+      this.reset();
+    }
   }
 
   reset = () => this.setState({ error: null });

--- a/src/renderer/components/layout/Router.tsx
+++ b/src/renderer/components/layout/Router.tsx
@@ -199,7 +199,10 @@ const PanelRoute: React.FC<{ layout: React.ReactElement }> = ({ layout }) => {
             <Route path='/projects' element={withRouteFallback(ProjectsListPage)} />
             <Route path='/conversations' element={withRouteFallback(ConversationsListPage)} />
             <Route path='/project/:projectId' element={withRouteFallback(ProjectWorkspacePage)} />
-            <Route path='/memory' element={withRouteFallback(MemoryPage)} />
+            {/* #792: a render error in the memory subtree must not bubble to the
+              app-root boundary and blank the whole app. Mirror /conversation's
+              route-level boundary so a memory crash is contained to the page. */}
+            <Route path='/memory' element={<ErrorBoundary>{withRouteFallback(MemoryPage)}</ErrorBoundary>} />
             <Route path='/wiki' element={withRouteFallback(WikiHomePage)} />
             <Route path='/wiki/:slug' element={withRouteFallback(WikiDetailPage)} />
           </Route>

--- a/src/renderer/pages/memory/state-branches/FullPanelShell.tsx
+++ b/src/renderer/pages/memory/state-branches/FullPanelShell.tsx
@@ -36,6 +36,7 @@ import { formatModifierShortcut } from '@/renderer/utils/platform';
 import { memory as memoryBridge, ijfw as ijfwBridge } from '@/common/adapter/ipcBridge';
 import type { IjfwStatusPayload, IjfwLifecycleStatus } from '@/common/adapter/ipcBridge';
 import IjfwSetupStatus from '@/renderer/pages/settings/components/IjfwSetupStatus';
+import { ErrorBoundary } from '@/renderer/components/ErrorBoundary';
 import type { LastDream, ListFilter, MemoryEntry, MemoryType } from '@/common/types/memory';
 import { useTranslation } from 'react-i18next';
 import MemoryList from '../components/MemoryList';
@@ -605,17 +606,24 @@ const FullPanelShell: React.FC = () => {
               />
             </div>
 
-            {/* Right drawer - push-content, 480px */}
-            <RightDrawer
-              entry={selected}
-              promotionThreshold={promotionThreshold}
-              onClose={clearSelection}
-              onPromote={handlePromote}
-              onOpenSource={handleOpenSource}
-              onCopy={handleCopy}
-              onEdit={handleEdit}
-              onDelete={handleDelete}
-            />
+            {/* Right drawer - push-content, 480px.
+              #792: contain a detail-panel render error (the #751 class) to the
+              drawer so the list stays usable. resetKeys (not a React key) clears
+              the fallback when the user picks another entry, so switching rows
+              recovers from a crash tied to one entry's data - without remounting
+              the drawer on open/close, which would break its width transition. */}
+            <ErrorBoundary resetKeys={[selectedId]}>
+              <RightDrawer
+                entry={selected}
+                promotionThreshold={promotionThreshold}
+                onClose={clearSelection}
+                onPromote={handlePromote}
+                onOpenSource={handleOpenSource}
+                onCopy={handleCopy}
+                onEdit={handleEdit}
+                onDelete={handleDelete}
+              />
+            </ErrorBoundary>
           </>
         )}
       </div>

--- a/tests/unit/renderer/components/ErrorBoundary.dom.test.tsx
+++ b/tests/unit/renderer/components/ErrorBoundary.dom.test.tsx
@@ -89,4 +89,57 @@ describe('ErrorBoundary', () => {
 
     expect(screen.getByText('recovered content')).toBeInTheDocument();
   });
+
+  // #792: resetKeys lets a host auto-recover the boundary when a relevant value
+  // changes (e.g. selecting a different memory entry), without remounting the
+  // children on every render.
+  it('auto-resets when a resetKeys value changes', () => {
+    let shouldThrow = true;
+    const Conditional: React.FC = () => {
+      if (shouldThrow) throw new Error('entry A crashes');
+      return <div>healthy entry</div>;
+    };
+
+    const { rerender } = render(
+      <ErrorBoundary resetKeys={['A']}>
+        <Conditional />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('An unexpected error occurred.')).toBeInTheDocument();
+
+    // The relevant selection changed AND the new render is healthy → recover.
+    shouldThrow = false;
+    rerender(
+      <ErrorBoundary resetKeys={['B']}>
+        <Conditional />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('healthy entry')).toBeInTheDocument();
+  });
+
+  it('does NOT reset while resetKeys are unchanged (a re-render is not a reset)', () => {
+    let shouldThrow = true;
+    const Conditional: React.FC = () => {
+      if (shouldThrow) throw new Error('still crashing');
+      return <div>should not appear yet</div>;
+    };
+
+    const { rerender } = render(
+      <ErrorBoundary resetKeys={['A']}>
+        <Conditional />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('An unexpected error occurred.')).toBeInTheDocument();
+
+    // Same reset key on a re-render must not clear the fallback, even if the
+    // child would now render cleanly - the caller hasn't signalled a change.
+    shouldThrow = false;
+    rerender(
+      <ErrorBoundary resetKeys={['A']}>
+        <Conditional />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('An unexpected error occurred.')).toBeInTheDocument();
+    expect(screen.queryByText('should not appear yet')).toBeNull();
+  });
 });

--- a/tests/unit/renderer/pages/memory/fullPanelShellErrorBoundary.dom.test.tsx
+++ b/tests/unit/renderer/pages/memory/fullPanelShellErrorBoundary.dom.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// @vitest-environment jsdom
+
+/**
+ * Regression for #792 (follow-up to #751): a render error inside the memory
+ * detail panel (RightDrawer / Inspector) must NOT take down the whole memory
+ * page. Before the fix there was no error boundary between RightDrawer and the
+ * app-root boundary, so any throw blanked the entire app. FullPanelShell now
+ * wraps RightDrawer in a keyed <ErrorBoundary>, so a detail-panel crash is
+ * contained: the memory list stays mounted and switching entries recovers.
+ *
+ * The real ErrorBoundary is intentionally NOT mocked here — it is the unit
+ * under test. Everything else FullPanelShell pulls in is stubbed to keep the
+ * render in jsdom and to give RightDrawer a controllable throw.
+ */
+
+import React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Controllable state read from inside hoisted mock factories --------------
+let drawerThrows = true;
+let mockSelectedId: string | null = 'entry-A';
+
+// --- Mocks -------------------------------------------------------------------
+vi.mock('@/common', () => ({
+  ipcBridge: { shell: { openFile: { invoke: vi.fn() } } },
+}));
+
+vi.mock('@/common/adapter/ipcBridge', () => {
+  const emitter = { on: vi.fn(() => vi.fn()) };
+  return {
+    memory: {
+      promote: { invoke: vi.fn() },
+      deleteEntry: { invoke: vi.fn() },
+      ingestFiles: { invoke: vi.fn() },
+      getPromotionCandidates: { invoke: vi.fn().mockResolvedValue({ threshold: 90 }) },
+      onIndexChanged: emitter,
+    },
+    ijfw: {
+      getStatus: { invoke: vi.fn().mockResolvedValue({ status: 'installed_current', cliCount: 0 }) },
+      onStatusChanged: emitter,
+    },
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    // Handles both t('key', 'default') and t('key', { defaultValue }).
+    t: (k: string, d?: string | { defaultValue?: string }) => (typeof d === 'string' ? d : (d?.defaultValue ?? k)),
+  }),
+}));
+
+vi.mock('@/renderer/utils/platform', () => ({ formatModifierShortcut: (k: string) => k }));
+
+vi.mock('@arco-design/web-react', () => ({
+  Button: (p: Record<string, unknown>) => <button {...p} />,
+  Input: (p: Record<string, unknown>) => <input {...p} />,
+  Message: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+  Modal: { confirm: vi.fn() },
+}));
+
+vi.mock('lucide-react', () => {
+  const Icon = () => <span />;
+  return {
+    Archive: Icon,
+    Search: Icon,
+    Import: Icon,
+    Settings2: Icon,
+    Plus: Icon,
+    ChevronDown: Icon,
+    ChevronRight: Icon,
+  };
+});
+
+// Hooks: return controlled state so the list branch (non-empty) renders.
+vi.mock('@renderer/pages/memory/hooks/useMemoryIndex', () => ({
+  useMemoryIndex: () => ({
+    stats: null,
+    entries: [{ id: 'entry-A', type: 'decision', summary: 's' }],
+    projects: [],
+    tags: [],
+    typeCounts: {},
+    total: 1,
+    isLoading: false,
+    error: null,
+    reload: vi.fn(),
+  }),
+}));
+vi.mock('@renderer/pages/memory/hooks/useSelectedEntry', () => ({
+  useSelectedEntry: () => ({
+    selectedId: mockSelectedId,
+    selected: mockSelectedId ? { id: mockSelectedId, type: 'decision', summary: 's', body: 'b' } : null,
+    selectEntry: vi.fn(),
+    clearSelection: vi.fn(),
+  }),
+}));
+
+// Child components stubbed to trivial markers. RightDrawer is the one that
+// throws — the exact failure mode #792 is about.
+vi.mock('@renderer/pages/memory/components/MemoryList', () => ({
+  default: () => <div data-testid='memory-list-stub' />,
+}));
+vi.mock('@renderer/pages/memory/components/RightDrawer', () => ({
+  default: () => {
+    if (drawerThrows) throw new Error('boom: detail panel render crash');
+    return <div data-testid='right-drawer-stub' />;
+  },
+}));
+vi.mock('@renderer/pages/memory/components/TopbarChips', () => ({ default: () => <div /> }));
+vi.mock('@renderer/pages/memory/components/StreakPill', () => ({ default: () => <div /> }));
+vi.mock('@renderer/pages/memory/components/ProjectDropdown', () => ({ default: () => <div /> }));
+vi.mock('@renderer/pages/memory/components/TimeDropdown', () => ({ default: () => <div /> }));
+vi.mock('@renderer/pages/memory/components/TypeDropdown', () => ({ default: () => <div /> }));
+vi.mock('@renderer/pages/memory/components/EmptyStateHero', () => ({ default: () => <div /> }));
+vi.mock('@renderer/pages/memory/components/MemoryStatusBar', () => ({ default: () => <div /> }));
+vi.mock('@renderer/pages/memory/components/ImportDrawer', () => ({ default: () => <div /> }));
+vi.mock('@renderer/pages/memory/components/ComposerModal', () => ({ default: () => <div /> }));
+vi.mock('@renderer/pages/memory/components/EntryEditorModal', () => ({ default: () => <div /> }));
+vi.mock('@/renderer/pages/settings/components/IjfwSetupStatus', () => ({ default: () => <div /> }));
+
+import FullPanelShell from '@renderer/pages/memory/state-branches/FullPanelShell';
+
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  drawerThrows = true;
+  mockSelectedId = 'entry-A';
+  // React logs caught render errors; the throw here is intentional, so keep the
+  // test output clean.
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  cleanup();
+  errorSpy.mockRestore();
+  vi.clearAllMocks();
+});
+
+describe('FullPanelShell detail-panel error boundary (#792)', () => {
+  it('contains a RightDrawer render crash: the list survives and a fallback shows', () => {
+    render(<FullPanelShell />);
+    // The memory list is still mounted — the crash did NOT unmount the page.
+    expect(screen.getByTestId('memory-list-stub')).toBeInTheDocument();
+    // The boundary rendered its fallback in place of the drawer.
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    // The crashing drawer content is NOT in the tree.
+    expect(screen.queryByTestId('right-drawer-stub')).toBeNull();
+  });
+
+  it('recovers when a different entry is selected (boundary is keyed on selectedId)', () => {
+    const { rerender } = render(<FullPanelShell />);
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+
+    // Simulate the user selecting a different, healthy entry: the id changes and
+    // the drawer no longer throws. The keyed boundary remounts and recovers.
+    drawerThrows = false;
+    mockSelectedId = 'entry-B';
+    rerender(<FullPanelShell />);
+
+    expect(screen.getByTestId('right-drawer-stub')).toBeInTheDocument();
+    expect(screen.queryByText('Something went wrong')).toBeNull();
+  });
+});

--- a/tests/unit/renderer/pages/memory/fullPanelShellErrorBoundary.dom.test.tsx
+++ b/tests/unit/renderer/pages/memory/fullPanelShellErrorBoundary.dom.test.tsx
@@ -11,8 +11,10 @@
  * detail panel (RightDrawer / Inspector) must NOT take down the whole memory
  * page. Before the fix there was no error boundary between RightDrawer and the
  * app-root boundary, so any throw blanked the entire app. FullPanelShell now
- * wraps RightDrawer in a keyed <ErrorBoundary>, so a detail-panel crash is
- * contained: the memory list stays mounted and switching entries recovers.
+ * wraps RightDrawer in an <ErrorBoundary resetKeys={[selectedId]}> - a
+ * resetKeys-based recovery (NOT a React key, which would remount the drawer and
+ * break its width transition), so a detail-panel crash is contained: the memory
+ * list stays mounted and selecting another entry clears the fallback.
  *
  * The real ErrorBoundary is intentionally NOT mocked here — it is the unit
  * under test. Everything else FullPanelShell pulls in is stubbed to keep the
@@ -153,12 +155,13 @@ describe('FullPanelShell detail-panel error boundary (#792)', () => {
     expect(screen.queryByTestId('right-drawer-stub')).toBeNull();
   });
 
-  it('recovers when a different entry is selected (boundary is keyed on selectedId)', () => {
+  it('recovers when a different entry is selected (boundary resetKeys on selectedId)', () => {
     const { rerender } = render(<FullPanelShell />);
     expect(screen.getByText('Something went wrong')).toBeInTheDocument();
 
     // Simulate the user selecting a different, healthy entry: the id changes and
-    // the drawer no longer throws. The keyed boundary remounts and recovers.
+    // the drawer no longer throws. selectedId is the boundary's resetKey, so the
+    // fallback clears and the healthy drawer renders (no remount of the drawer).
     drawerThrows = false;
     mockSelectedId = 'entry-B';
     rerender(<FullPanelShell />);


### PR DESCRIPTION
## What & why

Closes #792 (follow-up to #751).

A render error anywhere in the Memory pages had **no error boundary** between it and the app-root boundary in `main.tsx`. So a single component throw — e.g. #751's Arco `<Tooltip>` over a non-ref-forwarding `@icon-park` icon on hover — unmounted the **entire** app (blank white screen, restart required). #751 fixed that specific crash, but the blast-radius amplifier remained: the next unrelated render bug in the memory subtree would blank the app again.

## Fix

Two small, complementary boundaries (both reuse the existing shared `ErrorBoundary`):

1. **Route-level** boundary on `/memory` in `Router.tsx`, mirroring the existing `/conversation/:id` wrapping. Contains any memory-page render error to the page — the sider/nav survive instead of the whole app blanking.
2. **Localized** boundary around the `RightDrawer` detail panel in `FullPanelShell.tsx`, so a detail-panel crash (the #751 class) is contained to the drawer while the **memory list stays usable**.

The drawer boundary recovers when the user selects a different entry. It uses a **new optional `resetKeys` prop** on `ErrorBoundary` (the react-error-boundary pattern) rather than a React `key` — a `key` would remount `RightDrawer` on every open/close and break its `transition: width 0.22s` slide animation. `resetKeys` clears the fallback on entry change **without** remounting on the happy path.

`resetKeys` is opt-in and shallow-compared (`Object.is` per element, only while a fallback is showing); the app-root, `/conversation`, and PreviewPanel usages don't pass it, so their behavior is unchanged.

## Tests (reproduce-first)

- `ErrorBoundary.dom.test.tsx`: `resetKeys` auto-resets on change; does **not** reset while unchanged (guards against reference-equality / always-reset regressions).
- `fullPanelShellErrorBoundary.dom.test.tsx`: a `RightDrawer` render crash keeps the memory list mounted + shows a fallback; selecting another entry recovers. Verified these fail when the boundary is reverted (throw propagates / fallback sticks).

Full suite green post-rebase (12510 passed). Adversarial review: NON-BLOCKING.

Note: touching these files reformats a few pre-existing lines via oxfmt (repo main isn't fully oxfmt-clean).
