### PR TITLE
fix(models): exclude family-named embedding models from chat selection

### DIFF
--- a/src/common/utils/modelCapabilities.ts
+++ b/src/common/utils/modelCapabilities.ts
@@ -20,6 +20,18 @@ import { isFluxModelId } from '@/common/config/flux';
 const FLUX_IMAGE_MODEL = /flux(?:[.-]?\d|-(?:dev|schnell|pro|kontext|realism|lora))/i;
 
 /**
+ * Embedding / retrieval model families. Many are NOT named with the literal
+ * `embed` (`bge-m3`, `gte-large`, `e5-mistral`, `voyage-3`, …), so the known
+ * families are matched by name. Exported so other classifiers (e.g. the
+ * models.dev catalog assembler) stay consistent with this one. See #740.
+ */
+export const EMBEDDING_MODEL =
+  /(?:^text-|embed|bge-|e5-|LLM2Vec|retrieval|uae-|gte-|jina-clip|jina-embeddings|voyage-)/i;
+
+/** Reranker / retriever models (cross-encoders) - never chat models. */
+const RERANK_MODEL = /(?:rerank|re-rank|re-ranker|re-ranking|retrieval|retriever)/i;
+
+/**
  * Capability matching regex patterns
  */
 export const CAPABILITY_PATTERNS: Record<ModelType, RegExp> = {
@@ -32,10 +44,15 @@ export const CAPABILITY_PATTERNS: Record<ModelType, RegExp> = {
   ),
   web_search: /search|perplexity/i,
   reasoning: /o1-|reasoning|think/i,
-  embedding: /(?:^text-|embed|bge-|e5-|LLM2Vec|retrieval|uae-|gte-|jina-clip|jina-embeddings|voyage-)/i,
-  rerank: /(?:rerank|re-rank|re-ranker|re-ranking|retrieval|retriever)/i,
+  embedding: EMBEDDING_MODEL,
+  rerank: RERANK_MODEL,
+  // Must be a SUPERSET of embedding + rerank so a non-chat model (e.g.
+  // `bge-m3:latest`) is filtered OUT of the primary / workflow model picker
+  // instead of being offered for chat and failing with a provider 400
+  // ("does not support chat"). The bare `embed`/`rerank` literals alone missed
+  // family-named embeddings like bge-/gte-/e5-/voyage-, which is #740's bug.
   excludeFromPrimary: new RegExp(
-    `dall-e|${FLUX_IMAGE_MODEL.source}|stable-diffusion|midjourney|flash-image|image|embed|rerank`,
+    `dall-e|${FLUX_IMAGE_MODEL.source}|stable-diffusion|midjourney|flash-image|image|${EMBEDDING_MODEL.source}|${RERANK_MODEL.source}`,
     'i'
   ),
 };

--- a/src/process/providers/catalog/CatalogAssembler.ts
+++ b/src/process/providers/catalog/CatalogAssembler.ts
@@ -34,6 +34,7 @@ import type { CatalogSource } from '../sources/CatalogSource';
 import type { ModelsDevModel, ModelsDevRegistry } from '../enrichment/modelsDevSchema';
 import type { CatalogModel, ModelKind, ProviderId, RawModel, UsageTag } from '../types';
 import { ModelDisplayNames } from './ModelDisplayNames';
+import { EMBEDDING_MODEL } from '@/common/utils/modelCapabilities';
 
 /**
  * Maps our `ProviderId` to the provider key models.dev uses in its registry.
@@ -176,8 +177,7 @@ function findModelsDevModel(raw: RawModel, registry: ModelsDevRegistry): ModelsD
  *
  * `modalities.output` carries `image`/`audio` for those model kinds. Embedding
  * models are NOT distinguishable by modality - they declare a `text` output
- * like a chat model - so they are detected by name (`family`/`id` containing
- * `embed`). Everything else is `text`.
+ * like a chat model - so they are detected by name. Everything else is `text`.
  */
 function deriveKind(model: ModelsDevModel): ModelKind {
   const output = model.modalities?.output ?? [];
@@ -187,10 +187,15 @@ function deriveKind(model: ModelsDevModel): ModelKind {
   return 'text';
 }
 
-/** True when a model's name/family/id reads like an embedding model. */
+/**
+ * True when a model's name/family/id reads like an embedding/retrieval model.
+ * Reuses the shared {@link EMBEDDING_MODEL} pattern so this catalog stays
+ * consistent with the capability picker - many embeddings (`bge-m3`, `gte-*`,
+ * `e5-*`) are not named with the literal `embed`. See #740.
+ */
 function looksLikeEmbedding(model: ModelsDevModel): boolean {
   const haystack = `${model.family ?? ''} ${model.id}`.toLowerCase();
-  return haystack.includes('embed');
+  return EMBEDDING_MODEL.test(haystack);
 }
 
 /**

--- a/tests/unit/common/modelCapabilities.embedding.test.ts
+++ b/tests/unit/common/modelCapabilities.embedding.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { hasSpecificModelCapability } from '@/common/utils/modelCapabilities';
+import type { IProvider } from '@/common/config/storage';
+
+// Regression for #740: embedding/retrieval models whose ids are NOT named with
+// the literal "embed" (bge-m3, gte-large, e5-mistral, voyage-3, …) were not
+// excluded from the primary/workflow model picker. They then got selected for a
+// chat turn and failed with a provider 400 ("<model> does not support chat"),
+// while the Workflow view still showed a green "Complete". The excludeFromPrimary
+// pattern must be a superset of the embedding + rerank families.
+const provider = { platform: 'ollama' } as unknown as IProvider;
+
+describe('hasSpecificModelCapability - embedding/retrieval exclusion (#740)', () => {
+  const embeddingIds = [
+    'bge-m3:latest', // the reported model
+    'bge-large-en-v1.5',
+    'gte-large',
+    'e5-mistral-7b-instruct',
+    'voyage-3',
+    'jina-embeddings-v3',
+    'nomic-embed-text', // already matched via "embed" - kept as a guard
+  ];
+
+  for (const id of embeddingIds) {
+    it(`${id} IS excluded from the primary picker`, () => {
+      expect(hasSpecificModelCapability(provider, id, 'excludeFromPrimary')).toBe(true);
+    });
+
+    it(`${id} is classified as an embedding model`, () => {
+      expect(hasSpecificModelCapability(provider, id, 'embedding')).toBe(true);
+    });
+  }
+
+  it('a reranker (cross-encoder) is excluded from the primary picker', () => {
+    expect(hasSpecificModelCapability(provider, 'bge-reranker-v2-m3', 'excludeFromPrimary')).toBe(true);
+  });
+
+  // Guard against over-exclusion: real chat models must NOT be filtered out.
+  // excludeFromPrimary returns `undefined` (no rule) for a normal chat model,
+  // which the picker treats as "not excluded" - so assert it is never `true`.
+  const chatIds = [
+    'gpt-4o',
+    'claude-3-5-sonnet',
+    'llama3.1:8b',
+    'qwen2.5-coder:7b',
+    'deepseek-chat',
+    'gemini-2.0-flash',
+    'mistral-large-latest',
+  ];
+
+  for (const id of chatIds) {
+    it(`${id} is NOT excluded from the primary picker`, () => {
+      expect(hasSpecificModelCapability(provider, id, 'excludeFromPrimary')).not.toBe(true);
+    });
+  }
+});

--- a/tests/unit/process/providers/catalogAssembler.test.ts
+++ b/tests/unit/process/providers/catalogAssembler.test.ts
@@ -99,6 +99,22 @@ function buildRegistry(): ModelsDevRegistry {
         }),
       },
     },
+    // A family-named embedding model that is NOT called "embed" (#740). It
+    // declares a `text` output like a chat model, so kind must come from the
+    // name pattern, not the modality.
+    ollama: {
+      id: 'ollama',
+      name: 'Ollama',
+      env: [],
+      models: {
+        'bge-m3': devModel({
+          id: 'bge-m3',
+          name: 'BGE M3',
+          family: 'bge-m3',
+          modalities: { input: ['text'], output: ['text'] },
+        }),
+      },
+    },
   };
 }
 
@@ -173,6 +189,16 @@ describe('CatalogAssembler', () => {
     const source = fixedSource('api', 'openai', [{ id: 'text-embedding-3-large', providerId: 'openai' }]);
     const { models: catalog } = await assembler.assemble([source], buildRegistry());
     expect(catalog[0].kind).toBe('embedding');
+  });
+
+  // #740: family-named embeddings (bge-m3, gte-*, e5-*) lack the literal "embed"
+  // but must still classify as embedding, not chat.
+  it('derives kind=embedding for a family-named embedding model (bge-m3)', async () => {
+    const source = fixedSource('api', 'ollama', [{ id: 'bge-m3', providerId: 'ollama' }]);
+    const { models: catalog } = await assembler.assemble([source], buildRegistry());
+    expect(catalog[0].kind).toBe('embedding');
+    expect(catalog[0].tags).toContain('embeddings');
+    expect(catalog[0].tags).not.toContain('chat');
   });
 
   it('skips a source that throws without aborting the rest of the assemble', async () => {

--- a/tests/unit/renderer/guidModelUtils.embedding.test.ts
+++ b/tests/unit/renderer/guidModelUtils.embedding.test.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getAvailableModels } from '@renderer/pages/guid/utils/modelUtils';
+import type { IProvider } from '@/common/config/storage';
+
+// End-to-end regression for #740: the primary model picker (getAvailableModels)
+// must drop embedding/retrieval models so they can never be selected for a chat
+// or workflow turn. Before the fix, `bge-m3:latest` passed the filter (its
+// excludeFromPrimary capability was `undefined`, not `true`) and was offered
+// alongside real chat models.
+describe('getAvailableModels - embedding models excluded (#740)', () => {
+  it('drops bge-m3 while keeping the chat model', () => {
+    const provider = {
+      id: 'ollama-740-a',
+      platform: 'ollama',
+      model: ['bge-m3:latest', 'llama3.1:8b'],
+    } as unknown as IProvider;
+
+    expect(getAvailableModels(provider)).toEqual(['llama3.1:8b']);
+  });
+
+  it('drops a range of family-named embedding models', () => {
+    const provider = {
+      id: 'ollama-740-b',
+      platform: 'ollama',
+      model: ['gte-large', 'e5-mistral-7b-instruct', 'voyage-3', 'qwen2.5-coder:7b'],
+    } as unknown as IProvider;
+
+    expect(getAvailableModels(provider)).toEqual(['qwen2.5-coder:7b']);
+  });
+});


### PR DESCRIPTION
Embedding/retrieval models whose ids are not spelled with the literal
'embed' (bge-m3, gte-large, e5-mistral, voyage-3, ...) were offered in
the primary/workflow model picker: excludeFromPrimary only matched
'embed'/'rerank'/'image', so their capability came back undefined and
the picker included them. Selecting one for a workflow turn then failed
with a provider 400 ('does not support chat') while the Workflow view
still showed a green Complete.

Make excludeFromPrimary a superset of the embedding + rerank family
patterns (extracted to a shared, exported EMBEDDING_MODEL regex), and
reuse that same pattern in the models.dev CatalogAssembler so the
catalog kind/tags stay consistent with the picker. Fixes the selection
root cause in #740; the 'workflow shows complete despite failures'
presentation is tracked separately.
