### PR TITLE
fix(team): deliver leader mailbox messages that arrive during its wake

### DIFF
--- a/src/process/team/TeammateManager.ts
+++ b/src/process/team/TeammateManager.ts
@@ -871,6 +871,36 @@ export class TeammateManager extends EventEmitter {
           err instanceof Error ? err.message : String(err)
         );
       }
+    } else {
+      // #786: the leader has the SAME mid-wake delivery race as members - a
+      // message written to the leader's mailbox while its wake is in flight is
+      // skipped by the activeWakes guard (e.g. a user follow-up sent during the
+      // leader's long first-spawn turn). The member drain above intentionally
+      // excludes the leader because an unconditional re-wake would re-introduce
+      // the notification-per-turn churn that maybeWakeLeaderWhenAllIdle exists to
+      // prevent. So drain the leader's own unread mailbox here, but re-wake ONLY
+      // when it holds real content (a user follow-up or a member report) - never
+      // for idle_notifications alone. Otherwise a leader message can rot when no
+      // member finishes a turn afterward (or there are no members at all) to
+      // trip maybeWakeLeaderWhenAllIdle. wake() drains ALL unread atomically
+      // (readUnreadAndMark), so any idle_notifications ride along on that wake.
+      try {
+        const pending = await this.mailbox.peekUnread(this.teamId, agent.slotId);
+        const actionable = pending.filter((m) => m.type !== 'idle_notification');
+        if (actionable.length > 0) {
+          console.log(
+            `[TeammateManager] finalizeTurn(leader ${agent.agentName}): ${actionable.length} actionable unread message(s) arrived mid-turn, re-waking`
+          );
+          void this.wake(agent.slotId).catch((err) => {
+            console.error(`[TeammateManager] finalizeTurn leader re-wake(${agent.slotId}) failed:`, err);
+          });
+        }
+      } catch (err) {
+        console.warn(
+          `[TeammateManager] finalizeTurn(leader ${agent.slotId}) unread-mailbox check failed:`,
+          err instanceof Error ? err.message : String(err)
+        );
+      }
     }
   }
 

--- a/tests/unit/team-TeammateManager.test.ts
+++ b/tests/unit/team-TeammateManager.test.ts
@@ -1401,6 +1401,91 @@ describe('TeammateManager', () => {
       expect(workerTaskManager.getOrBuildTask).not.toHaveBeenCalledWith('conv-member');
       mgr.dispose();
     });
+
+    // #786 regression: the LEADER has the same mid-wake race as a member. A
+    // message written to the leader's mailbox while its wake is in flight (e.g.
+    // a user follow-up during the leader's long first-spawn turn) is skipped by
+    // activeWakes. Since the member re-wake above excludes the leader (to avoid
+    // idle-notification churn), finalizeTurn must drain the leader's own mailbox
+    // and re-wake it - but ONLY for actionable (non-idle_notification) content.
+    it('re-wakes the leader when an actionable message is unread at turn end (#786)', async () => {
+      const leadAgent = makeAgent({
+        slotId: 'slot-lead',
+        conversationId: 'conv-lead',
+        role: 'leader',
+        status: 'active',
+        agentName: 'Leader',
+      });
+      // Solo leader (no members) - maybeWakeLeaderWhenAllIdle can never fire, so
+      // without the leader drain this message would rot forever.
+      const { mgr, mailbox: mbox, workerTaskManager } = makeTeammateManager([leadAgent]);
+
+      vi.mocked(mbox.peekUnread).mockResolvedValue([
+        {
+          id: 'msg-user',
+          teamId: 'team-1',
+          toAgentId: 'slot-lead',
+          fromAgentId: 'user',
+          content: 'Actually, also add tests.',
+          type: 'message',
+          read: false,
+          createdAt: Date.now(),
+        },
+      ] as never);
+
+      teamEventBus.emit('responseStream', {
+        type: 'finish',
+        conversation_id: 'conv-lead',
+        msg_id: 'm1',
+        data: null,
+      });
+
+      // The leader is re-woken to drain the unread follow-up.
+      await vi.waitFor(() => expect(workerTaskManager.getOrBuildTask).toHaveBeenCalledWith('conv-lead'), {
+        timeout: 2000,
+      });
+      mgr.dispose();
+    });
+
+    it('does NOT re-wake the leader when only idle_notifications are unread (no churn) (#786)', async () => {
+      const leadAgent = makeAgent({
+        slotId: 'slot-lead',
+        conversationId: 'conv-lead',
+        role: 'leader',
+        status: 'active',
+        agentName: 'Leader',
+      });
+      const { mgr, mailbox: mbox, workerTaskManager } = makeTeammateManager([leadAgent]);
+
+      vi.mocked(mbox.peekUnread).mockResolvedValue([
+        {
+          id: 'msg-idle',
+          teamId: 'team-1',
+          toAgentId: 'slot-lead',
+          fromAgentId: 'slot-member',
+          content: 'Turn completed',
+          type: 'idle_notification',
+          read: false,
+          createdAt: Date.now(),
+        },
+      ] as never);
+
+      teamEventBus.emit('responseStream', {
+        type: 'finish',
+        conversation_id: 'conv-lead',
+        msg_id: 'm1',
+        data: null,
+      });
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      // The leader mailbox WAS drained (peeked), but a pure idle_notification set
+      // must not trigger a re-wake - that would re-introduce the churn the
+      // maybeWakeLeaderWhenAllIdle gate exists to prevent.
+      expect(mbox.peekUnread).toHaveBeenCalledWith('team-1', 'slot-lead');
+      expect(workerTaskManager.getOrBuildTask).not.toHaveBeenCalledWith('conv-lead');
+      mgr.dispose();
+    });
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## What & why

Closes #786 (follow-up to #781).

`TeammateManager.finalizeTurn` runs when an agent's turn completes. #781 added, **for members only**, a drain: `peekUnread` the agent's mailbox and re-`wake()` it if anything is unread — so a message that arrived while the agent's wake was in flight (skipped by the `activeWakes` guard) isn't lost. The **leader** was intentionally excluded because its delivery is gated by `maybeWakeLeaderWhenAllIdle` (fires only when *all* non-leader agents are settled) to avoid a leader turn per idle-notification.

But the leader has the **same mid-wake race**: a message written to its mailbox during its in-flight wake (e.g. a user follow-up sent during the leader's long first-spawn turn) is skipped by `activeWakes`, and if no member finishes a turn afterward — or there are no members at all (`nonLeadAgents.length === 0`) — `maybeWakeLeaderWhenAllIdle` never fires and the message **rots**.

## Fix

Drain the leader's own mailbox in `finalizeTurn` too, but re-wake **only when it holds non-`idle_notification` content** (a user follow-up, a member `team_send_message` report, or a crash testament). Pure `idle_notification`s ride along on the next real wake, so the notification-per-turn churn the gate exists to prevent is not re-introduced. `wake()` drains atomically via `readUnreadAndMark`, so there's no double-delivery and no infinite loop (the actionable message is marked read on the re-wake, so the next turn's peek doesn't see it again).

## Tests (reproduce-first)

`tests/unit/team-TeammateManager.test.ts`:
- re-wakes the leader when an actionable message is unread at turn end (solo-leader — where `maybeWakeLeaderWhenAllIdle` can never fire);
- does **not** re-wake the leader when only `idle_notification`s are unread (guards the churn gate).

Both verified to fail when the source fix is reverted. Full suite green post-rebase (12512 passed). Adversarial review: CLEAN.
