### PR TITLE
fix(models): keep embedding models out of chat/workflow picker (#740)

### DIFF
--- a/src/common/utils/modelCapabilities.ts
+++ b/src/common/utils/modelCapabilities.ts
@@ -20,6 +20,25 @@ import { isFluxModelId } from '@/common/config/flux';
 const FLUX_IMAGE_MODEL = /flux(?:[.-]?\d|-(?:dev|schnell|pro|kontext|realism|lora))/i;
 
 /**
+ * Embedding / retrieval model families. Many are NOT named with the literal
+ * `embed` (`bge-m3`, `gte-large`, `e5-mistral`, `voyage-3`, …), so the known
+ * families are matched by name. Exported so other classifiers (e.g. the
+ * models.dev catalog assembler) stay consistent with this one. See #740.
+ *
+ * Each family stem is anchored to a token boundary (start-of-id or a
+ * `/ . : _ -`/whitespace separator on both sides) so a short stem can't match
+ * inside an unrelated chat model id — e.g. `uae` must NOT trip on the vendored
+ * `kuae-*` ("KUAE Cloud Coding Plan") coding models, and `e5`/`bge`/`gte` can't
+ * match mid-word. `embed`/`embeddings` still catch `text-embedding-*`,
+ * `nomic-embed-*`, `gemini-embedding-*`, etc. via the same boundaries.
+ */
+export const EMBEDDING_MODEL =
+  /(?:^|[\s./:_-])(?:embeddings?|embed|bge|gte|e5|uae|voyage|jina-clip|retrieval|llm2vec)(?=$|[\s./:_-])/i;
+
+/** Reranker / retriever models (cross-encoders) - never chat models. */
+const RERANK_MODEL = /(?:rerank|re-rank|re-ranker|re-ranking|retrieval|retriever)/i;
+
+/**
  * Capability matching regex patterns
  */
 export const CAPABILITY_PATTERNS: Record<ModelType, RegExp> = {
@@ -32,10 +51,15 @@ export const CAPABILITY_PATTERNS: Record<ModelType, RegExp> = {
   ),
   web_search: /search|perplexity/i,
   reasoning: /o1-|reasoning|think/i,
-  embedding: /(?:^text-|embed|bge-|e5-|LLM2Vec|retrieval|uae-|gte-|jina-clip|jina-embeddings|voyage-)/i,
-  rerank: /(?:rerank|re-rank|re-ranker|re-ranking|retrieval|retriever)/i,
+  embedding: EMBEDDING_MODEL,
+  rerank: RERANK_MODEL,
+  // Must be a SUPERSET of embedding + rerank so a non-chat model (e.g.
+  // `bge-m3:latest`) is filtered OUT of the primary / workflow model picker
+  // instead of being offered for chat and failing with a provider 400
+  // ("does not support chat"). The bare `embed`/`rerank` literals alone missed
+  // family-named embeddings like bge-/gte-/e5-/voyage-, which is #740's bug.
   excludeFromPrimary: new RegExp(
-    `dall-e|${FLUX_IMAGE_MODEL.source}|stable-diffusion|midjourney|flash-image|image|embed|rerank`,
+    `dall-e|${FLUX_IMAGE_MODEL.source}|stable-diffusion|midjourney|flash-image|image|${EMBEDDING_MODEL.source}|${RERANK_MODEL.source}`,
     'i'
   ),
 };

--- a/tests/unit/common/modelCapabilities.embedding.test.ts
+++ b/tests/unit/common/modelCapabilities.embedding.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { hasSpecificModelCapability } from '@/common/utils/modelCapabilities';
+import type { IProvider } from '@/common/config/storage';
+
+// Regression for #740: embedding/retrieval models whose ids are NOT named with
+// the literal "embed" (bge-m3, gte-large, e5-mistral, voyage-3, …) were not
+// excluded from the primary/workflow model picker. They then got selected for a
+// chat turn and failed with a provider 400 ("<model> does not support chat"),
+// while the Workflow view still showed a green "Complete". The excludeFromPrimary
+// pattern must be a superset of the embedding + rerank families.
+const provider = { platform: 'ollama' } as unknown as IProvider;
+
+describe('hasSpecificModelCapability - embedding/retrieval exclusion (#740)', () => {
+  const embeddingIds = [
+    'bge-m3:latest', // the reported model
+    'bge-large-en-v1.5',
+    'gte-large',
+    'e5-mistral-7b-instruct',
+    'voyage-3',
+    'jina-embeddings-v3',
+    'nomic-embed-text', // already matched via "embed" - kept as a guard
+  ];
+
+  for (const id of embeddingIds) {
+    it(`${id} IS excluded from the primary picker`, () => {
+      expect(hasSpecificModelCapability(provider, id, 'excludeFromPrimary')).toBe(true);
+    });
+
+    it(`${id} is classified as an embedding model`, () => {
+      expect(hasSpecificModelCapability(provider, id, 'embedding')).toBe(true);
+    });
+  }
+
+  it('a reranker (cross-encoder) is excluded from the primary picker', () => {
+    expect(hasSpecificModelCapability(provider, 'bge-reranker-v2-m3', 'excludeFromPrimary')).toBe(true);
+  });
+
+  // Guard against over-exclusion: real chat models must NOT be filtered out.
+  // excludeFromPrimary returns `undefined` (no rule) for a normal chat model,
+  // which the picker treats as "not excluded" - so assert it is never `true`.
+  // The `kuae-*` + `text-davinci-*` ids specifically pin the token-boundary
+  // anchoring: a naive substring `uae`/`text-` would nuke the vendored "KUAE
+  // Cloud Coding Plan" chat models (repeat of #108) and legacy completion
+  // models. They must stay selectable AND not be misclassified as embeddings.
+  const chatIds = [
+    'gpt-4o',
+    'claude-3-5-sonnet',
+    'llama3.1:8b',
+    'qwen2.5-coder:7b',
+    'deepseek-chat',
+    'gemini-2.0-flash',
+    'mistral-large-latest',
+    'kuae-coder', // vendored "KUAE Cloud Coding Plan" - must NOT trip the `uae` stem
+    'kuae-cloud-coding',
+    'text-davinci-003', // legacy completion model - `^text-` must not blanket-exclude
+  ];
+
+  for (const id of chatIds) {
+    it(`${id} is NOT excluded from the primary picker`, () => {
+      expect(hasSpecificModelCapability(provider, id, 'excludeFromPrimary')).not.toBe(true);
+    });
+
+    it(`${id} is NOT misclassified as an embedding model`, () => {
+      expect(hasSpecificModelCapability(provider, id, 'embedding')).not.toBe(true);
+    });
+  }
+});

--- a/tests/unit/renderer/guidModelUtils.embedding.test.ts
+++ b/tests/unit/renderer/guidModelUtils.embedding.test.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getAvailableModels } from '@renderer/pages/guid/utils/modelUtils';
+import type { IProvider } from '@/common/config/storage';
+
+// End-to-end regression for #740: the primary model picker (getAvailableModels)
+// must drop embedding/retrieval models so they can never be selected for a chat
+// or workflow turn. Before the fix, `bge-m3:latest` passed the filter (its
+// excludeFromPrimary capability was `undefined`, not `true`) and was offered
+// alongside real chat models.
+describe('getAvailableModels - embedding models excluded (#740)', () => {
+  it('drops bge-m3 while keeping the chat model', () => {
+    const provider = {
+      id: 'ollama-740-a',
+      platform: 'ollama',
+      model: ['bge-m3:latest', 'llama3.1:8b'],
+    } as unknown as IProvider;
+
+    expect(getAvailableModels(provider)).toEqual(['llama3.1:8b']);
+  });
+
+  it('drops a range of family-named embedding models', () => {
+    const provider = {
+      id: 'ollama-740-b',
+      platform: 'ollama',
+      model: ['gte-large', 'e5-mistral-7b-instruct', 'voyage-3', 'qwen2.5-coder:7b'],
+    } as unknown as IProvider;
+
+    expect(getAvailableModels(provider)).toEqual(['qwen2.5-coder:7b']);
+  });
+});


### PR DESCRIPTION
Family-named embeddings (bge-m3, gte-large, e5-mistral, voyage-3, …) came back
capability=undefined from excludeFromPrimary (which only matched embed/rerank/
image), so getAvailableModels/useModelProviderList/teamModelUtils still offered
them in the primary/workflow picker. Selecting one for a workflow turn failed
with provider 400 ("does not support chat"). Make excludeFromPrimary a superset
of the embedding + rerank families via a shared EMBEDDING_MODEL regex, anchored
to token boundaries so a short stem can't match inside an unrelated chat id
(e.g. 'uae' must not trip the vendored kuae-* coding models — the #108 class).

Picker-gate side of #740; the catalog/detector classification is handled by
the complementary PR #742. Reproduce-first tests fail on pre-fix code.
