### PR TITLE
fix(acp): collapse adapter respawn-storm banners + name corrupt install

### DIFF
--- a/src/process/acp/compat/AcpAgentV2.ts
+++ b/src/process/acp/compat/AcpAgentV2.ts
@@ -127,6 +127,20 @@ export class AcpAgentV2 {
   // and cleared when a new start begins or the session reaches 'active'.
   private lastErrorMessage: string | null = null;
 
+  // Stable msg_id for the CURRENT error/crash episode. The renderer upserts
+  // stream messages by msg_id (Messages/hooks.ts), so a unique id per emission
+  // (the old `signal_${Date.now()}`) made every retry crash a NEW transcript row
+  // — a start-retry storm (maxStartRetries) flooded the chat with identical
+  // "process exited unexpectedly" banners (#676). Reusing one id across a burst
+  // collapses them into a single, upserted banner (mirrors the agent_status fix
+  // that uses `status_${conversationId}`). It is reset on forward progress (a new
+  // turn, the session reaching 'active', or a turn finishing) so a later,
+  // unrelated error still gets its own banner instead of overwriting an old one.
+  private errorBannerId: string | null = null;
+  // Monotonic episode counter so each new episode's id is unique even when two
+  // episodes open within the same millisecond (a Date.now() suffix could collide).
+  private errorEpisodeSeq = 0;
+
   // Promise bridges for async methods (Tasks 4-6)
   private startOp: PendingOp<void> | null = null;
   private modelOp: PendingOp<AcpModelInfo | null> | null = null;
@@ -348,6 +362,12 @@ export class AcpAgentV2 {
         this.lastStatus = status;
         this.persistStatus(status);
 
+        // Session made forward progress — end the current error/crash episode so a
+        // later, unrelated error surfaces as its own banner (#676).
+        if (status === 'active') {
+          this.errorBannerId = null;
+        }
+
         // Resolve startOp when reaching active/error
         if (status === 'active' && this.startOp) {
           this.lastErrorMessage = null;
@@ -491,6 +511,8 @@ export class AcpAgentV2 {
 
         switch (event.type) {
           case 'turn_finished':
+            // Forward progress — end the current error/crash episode (#676).
+            this.errorBannerId = null;
             this.onSignalEvent({
               type: 'finish',
               conversation_id: this.conversationId,
@@ -546,10 +568,15 @@ export class AcpAgentV2 {
               event.message.includes('PROCESS_CRASHED') ||
               event.message.includes('Process disconnected');
 
+            // Collapse a burst of error/crash banners (start-retry storm, #676)
+            // into ONE upserted transcript row by reusing a stable per-episode
+            // msg_id. The id is reset on forward progress (new turn / active /
+            // turn_finished), so an unrelated later error still gets its own row.
+            this.errorBannerId ??= `error_${this.conversationId}_${++this.errorEpisodeSeq}`;
             this.onSignalEvent({
               type: 'error',
               conversation_id: this.conversationId,
-              msg_id: `signal_${Date.now()}`,
+              msg_id: this.errorBannerId,
               data: event.message,
             });
 
@@ -710,6 +737,9 @@ export class AcpAgentV2 {
 
   async sendMessage(data: { content: string; files?: string[]; msg_id?: string }): Promise<AcpResult> {
     try {
+      // A new user turn starts a fresh error/crash episode (#676) so a failure
+      // here surfaces as its own banner rather than overwriting a prior one.
+      this.errorBannerId = null;
       // Auto-reconnect if session is in error/idle state (mirrors V1 behavior).
       // V1 checks isConnected/hasActiveSession before every prompt and calls start().
       if (this.lastStatus === 'error' || this.lastStatus === 'idle') {

--- a/src/process/acp/errors/setupFailure.ts
+++ b/src/process/acp/errors/setupFailure.ts
@@ -57,3 +57,35 @@ export function buildAcpSetupGuidance(backend: string, errorMsg: string): string
     `Install it, then send your message again:\n\n${installCmd}`
   );
 }
+
+// Corrupt/partial bunx adapter install (#676). A Node ACP adapter spawned via
+// bunx (e.g. @agentclientprotocol/claude-agent-acp) can be left half-installed —
+// a dependency's package.json / entry point missing — so module resolution fails
+// at startup with a cryptic "Cannot find module 'zod/v4'" the user can't act on.
+// The desktop already auto-clears the corrupt bunx cache and retries
+// (ProcessAcpClient.clearBunxCacheIfNeeded); this only rewrites the TERMINAL
+// message shown after retries are exhausted into actionable guidance. Distinct
+// from the missing-python-extra case above (a pip "No module named 'acp'"
+// signature), so that case is excluded to avoid a double-match.
+const ADAPTER_CORRUPTION_SIGNATURES = ['cannot find module', 'cannot find package', 'err_module_not_found'] as const;
+
+export function looksLikeAdapterCorruption(errorMsg: string): boolean {
+  if (looksLikeSetupFailure(errorMsg)) return false;
+  const haystack = errorMsg.toLowerCase();
+  const isModuleResolutionFailure = ADAPTER_CORRUPTION_SIGNATURES.some((s) => haystack.includes(s));
+  if (!isModuleResolutionFailure) return false;
+  // Anchor to an adapter-startup failure: the bunx working-dir path, or the
+  // "exited before initialize completed" prefix a startup crash carries. Keeps a
+  // mid-turn tool error that merely mentions a module name from matching.
+  return haystack.includes('bunx-') || haystack.includes('before initialize completed');
+}
+
+export function buildAcpAdapterCorruptionGuidance(backend: string, errorMsg: string): string | null {
+  if (!looksLikeAdapterCorruption(errorMsg)) return null;
+  const label = acpBackendLabel(backend);
+  return (
+    `${label}'s adapter files look corrupted — a dependency didn't finish installing, so it ` +
+    `couldn't start. Wayland cleared the bad install and will reinstall it on the next attempt. ` +
+    `If this keeps happening, fully quit and reopen Wayland to force a clean reinstall.`
+  );
+}

--- a/src/process/acp/session/AcpSession.ts
+++ b/src/process/acp/session/AcpSession.ts
@@ -7,7 +7,7 @@ import type {
 import * as path from 'node:path';
 import { resolveAcpSessionModeId } from '@/common/types/agentModes';
 import { AcpError } from '@process/acp/errors/AcpError';
-import { buildAcpSetupGuidance } from '@process/acp/errors/setupFailure';
+import { buildAcpAdapterCorruptionGuidance, buildAcpSetupGuidance } from '@process/acp/errors/setupFailure';
 import type { ClientFactory, DisconnectInfo } from '@process/acp/infra/IAcpClient';
 import { noopMetrics, type AcpMetrics } from '@process/acp/metrics/AcpMetrics';
 import { ConfigTracker } from '@process/acp/session/ConfigTracker';
@@ -435,10 +435,13 @@ export class AcpSession {
 
   enterError(message: string): void {
     // If the backend failed because it's installed but missing a runtime extra
-    // (e.g. Hermes without the ACP adapter), rewrite the raw stderr into
-    // actionable install guidance with the correct command. Otherwise pass the
-    // original message through unchanged.
-    const displayMessage = buildAcpSetupGuidance(this.agentConfig.agentBackend, message) ?? message;
+    // (e.g. Hermes without the ACP adapter), or because a bunx-spawned adapter
+    // install is corrupt (#676), rewrite the raw stderr into actionable guidance.
+    // Otherwise pass the original message through unchanged.
+    const displayMessage =
+      buildAcpSetupGuidance(this.agentConfig.agentBackend, message) ??
+      buildAcpAdapterCorruptionGuidance(this.agentConfig.agentBackend, message) ??
+      message;
     this.promptExecutor.clearPending();
     this.permissionResolver.rejectAll(new Error(displayMessage));
     this.promptExecutor.stopTimer();

--- a/tests/unit/process/acp/compat/AcpAgentV2.test.ts
+++ b/tests/unit/process/acp/compat/AcpAgentV2.test.ts
@@ -478,6 +478,101 @@ describe('AcpAgentV2 - Lifecycle Methods', () => {
       expect(mockSessionMethods.cancelPrompt).toHaveBeenCalledOnce();
     });
   });
+
+  // #676: a corrupt bunx adapter install made the session start crash; the start
+  // retry loop (maxStartRetries) respawned the adapter repeatedly, and because
+  // every error signal used a unique `signal_${Date.now()}` msg_id, the renderer
+  // (which upserts stream messages by msg_id) appended a NEW "process exited
+  // unexpectedly" banner per attempt — a storm. These lock in the collapse.
+  describe('error/crash banner collapse (#676)', () => {
+    const CRASH = 'process exited unexpectedly (code: 1, signal: none)';
+
+    /** Started agent whose signal sink is a spy we can inspect. */
+    async function startedAgentWithSignalSink(): Promise<{
+      agent: AcpAgentV2;
+      onSignalEvent: ReturnType<typeof vi.fn>;
+    }> {
+      const onSignalEvent = vi.fn();
+      const agent = createAgent({ onSignalEvent });
+      mockSessionMethods.start.mockImplementation(() => {
+        setTimeout(() => capturedCallbacks.onStatusChange('active'), 0);
+      });
+      await agent.start();
+      mockSessionMethods.start.mockReset();
+      onSignalEvent.mockClear(); // drop the start-up traffic; keep only what the test drives
+      return { agent, onSignalEvent };
+    }
+
+    const errorBannerIds = (spy: ReturnType<typeof vi.fn>): string[] =>
+      spy.mock.calls
+        .map((c) => c[0])
+        .filter((m) => m?.type === 'error')
+        .map((m) => m.msg_id as string);
+
+    it('collapses a burst of crash banners into a single upserted msg_id', async () => {
+      const { onSignalEvent } = await startedAgentWithSignalSink();
+
+      // Three consecutive crash signals — one per failed start retry.
+      capturedCallbacks.onSignal({ type: 'error', message: CRASH, recoverable: true });
+      capturedCallbacks.onSignal({ type: 'error', message: CRASH, recoverable: true });
+      capturedCallbacks.onSignal({ type: 'error', message: CRASH, recoverable: true });
+
+      const ids = errorBannerIds(onSignalEvent);
+      expect(ids).toHaveLength(3);
+      // The storm fix: all three reuse ONE id (renderer upserts → one banner).
+      expect(new Set(ids).size).toBe(1);
+      // And it must NOT be the old per-emission unique id.
+      expect(ids[0]).not.toMatch(/^signal_/);
+    });
+
+    it('lets the terminal error overwrite the collapsed crash banner (ends on one row)', async () => {
+      const { onSignalEvent } = await startedAgentWithSignalSink();
+
+      capturedCallbacks.onSignal({ type: 'error', message: CRASH, recoverable: true });
+      // Terminal failure after retries are exhausted (enterError path).
+      capturedCallbacks.onSignal({
+        type: 'error',
+        message: "Agent exited before initialize completed (code: 1)\nCannot find module 'zod/v4'",
+        recoverable: false,
+      });
+
+      const ids = errorBannerIds(onSignalEvent);
+      expect(ids).toHaveLength(2);
+      // Same id → the actionable terminal message replaces the crash banner.
+      expect(new Set(ids).size).toBe(1);
+    });
+
+    it('gives an UNRELATED later error its own banner after the session recovers', async () => {
+      const { onSignalEvent } = await startedAgentWithSignalSink();
+
+      capturedCallbacks.onSignal({ type: 'error', message: CRASH, recoverable: true });
+      const burstId = errorBannerIds(onSignalEvent)[0];
+
+      // Forward progress ends the episode.
+      capturedCallbacks.onStatusChange('active');
+      capturedCallbacks.onSignal({ type: 'error', message: 'Rate limited (429)', recoverable: true });
+
+      const ids = errorBannerIds(onSignalEvent);
+      const laterId = ids[ids.length - 1];
+      expect(laterId).not.toBe(burstId); // distinct row, not an overwrite of the old one
+    });
+
+    it('starts a fresh error episode on a new user turn', async () => {
+      const { agent, onSignalEvent } = await startedAgentWithSignalSink();
+
+      capturedCallbacks.onSignal({ type: 'error', message: CRASH, recoverable: true });
+      const firstTurnId = errorBannerIds(onSignalEvent)[0];
+
+      // A new user turn must not reuse the previous turn's error banner id.
+      capturedCallbacks.onStatusChange('active');
+      mockSessionMethods.sendMessage.mockResolvedValue(undefined);
+      await agent.sendMessage({ content: 'hi again' });
+      capturedCallbacks.onSignal({ type: 'error', message: CRASH, recoverable: true });
+
+      const ids = errorBannerIds(onSignalEvent);
+      expect(ids[ids.length - 1]).not.toBe(firstTurnId);
+    });
+  });
 });
 
 describe('AcpAgentV2 - Messaging + Permission Methods', () => {

--- a/tests/unit/process/acp/errors/setupFailure.test.ts
+++ b/tests/unit/process/acp/errors/setupFailure.test.ts
@@ -2,8 +2,10 @@
 
 import { describe, it, expect } from 'vitest';
 import {
+  buildAcpAdapterCorruptionGuidance,
   buildAcpSetupGuidance,
   getAcpSetupInstallCmd,
+  looksLikeAdapterCorruption,
   looksLikeSetupFailure,
 } from '@process/acp/errors/setupFailure';
 
@@ -47,5 +49,44 @@ describe('setupFailure', () => {
 
   it('returns no command when an unknown backend has no recoverable hint', () => {
     expect(getAcpSetupInstallCmd('someacpcli', 'acp dependencies not installed')).toBeUndefined();
+  });
+});
+
+// #676: a bunx-spawned Node ACP adapter left half-installed (missing package.json
+// / entry point) fails startup with a cryptic "Cannot find module 'zod/v4'".
+describe('adapter corruption (bunx half-install) guidance', () => {
+  const CORRUPT_MSG =
+    'Agent exited before initialize completed (code: 1)\n' +
+    "error: Cannot find module 'zod/v4' from " +
+    "'/var/folders/8h/T/bunx-501-@agentclientprotocol/claude-agent-acp@0.55.0/node_modules/@agentclientprotocol/sdk/dist/schema/zod.gen.js'";
+
+  it('detects a bunx module-resolution failure at adapter startup', () => {
+    expect(looksLikeAdapterCorruption(CORRUPT_MSG)).toBe(true);
+    // "before initialize completed" alone (no bunx path) also anchors it.
+    expect(
+      looksLikeAdapterCorruption('Agent exited before initialize completed (code: 1)\nCannot find package foo')
+    ).toBe(true);
+  });
+
+  it('does NOT match the python missing-extra case (owned by setup guidance)', () => {
+    // MISSING_DEPS_MSG contains "No module named 'acp'" — must route to setup, not corruption.
+    expect(looksLikeAdapterCorruption(MISSING_DEPS_MSG)).toBe(false);
+  });
+
+  it('does NOT match a mid-turn error that merely mentions a module', () => {
+    expect(looksLikeAdapterCorruption('Tool failed: cannot find module the user asked about')).toBe(false);
+    expect(looksLikeAdapterCorruption('HTTP 500 internal error')).toBe(false);
+  });
+
+  it('builds actionable, restart-oriented guidance instead of a raw stack', () => {
+    const g = buildAcpAdapterCorruptionGuidance('claude', CORRUPT_MSG);
+    expect(g).not.toBeNull();
+    expect(g).toContain('corrupted');
+    expect(g).toContain('reinstall');
+    expect(g).not.toContain('zod/v4'); // no raw module path leaks to the user
+  });
+
+  it('returns null guidance for a non-corruption error', () => {
+    expect(buildAcpAdapterCorruptionGuidance('claude', 'HTTP 401 unauthorized')).toBeNull();
   });
 });


### PR DESCRIPTION
On a corrupt bunx adapter install the session start-retry loop respawned the
adapter repeatedly; each crash emitted an error signal with a unique
signal_${Date.now()} msg_id, and the renderer upserts by msg_id, so every retry
appended a NEW 'process exited unexpectedly' banner — a storm (#676).

Reuse one stable per-episode msg_id across an error/crash burst so the banners
collapse into a single upserted row (mirrors the agent_status stable-id fix). The
episode id resets on forward progress (new turn / active / turn_finished) so an
unrelated later error still gets its own banner. Also rewrite the terminal
'Cannot find module zod/v4' start failure into actionable, restart-oriented
guidance instead of a raw Node stack.
