### PR TITLE
fix(acp): persist allow-always approvals across restart (#672)

### DIFF
--- a/src/common/config/storage.ts
+++ b/src/common/config/storage.ts
@@ -147,6 +147,13 @@ export interface IConfigStorageRefer {
   'assistant.presetAgentTypeOverrides'?: Record<string, string>;
   // Cached initialize results per ACP backend (persisted across sessions)
   'acp.cachedInitializeResult'?: Record<string, import('@/common/types/acpTypes').AcpInitializeResult>;
+  /**
+   * #672: durable, per-workspace "allow always" ACP approval decisions. Keyed by
+   * workspace cwd → serialized approval key → optionId. The live PermissionResolver
+   * cache is otherwise in-memory/session-scoped, so an "allow always" was lost on
+   * restart and re-prompted. Rehydrated on session start; main-process only.
+   */
+  'acp.workspaceApprovals'?: Record<string, Record<string, string>>;
   // Cached model lists per ACP backend for Guid page pre-selection
   'acp.cachedModels'?: Record<string, import('@/common/types/acpTypes').AcpModelInfo>;
   // Cached config options per ACP backend for Guid page pre-selection

--- a/src/process/acp/session/AcpSession.ts
+++ b/src/process/acp/session/AcpSession.ts
@@ -14,6 +14,7 @@ import { ConfigTracker } from '@process/acp/session/ConfigTracker';
 import { InputPreprocessor } from '@process/acp/session/InputPreprocessor';
 import { MessageTranslator } from '@process/acp/session/MessageTranslator';
 import { PermissionResolver } from '@process/acp/session/PermissionResolver';
+import { loadWorkspaceApprovals, saveWorkspaceApproval } from '@process/acp/session/ApprovalPersistence';
 import { PromptExecutor } from '@process/acp/session/PromptExecutor';
 import { SessionLifecycle } from '@process/acp/session/SessionLifecycle';
 import type {
@@ -108,6 +109,13 @@ export class AcpSession {
     this.permissionResolver = new PermissionResolver({
       autoApproveAll: agentConfig.yoloMode ?? false,
       cacheMaxSize: options?.approvalCacheMaxSize,
+      // #672: persist "allow always" grants per workspace (cwd) so they survive
+      // an app restart instead of re-prompting. hydrate loads them lazily on the
+      // first permission check; persist write-throughs new grants.
+      hydrate: () => loadWorkspaceApprovals(agentConfig.cwd),
+      persist: (cacheKey, optionId) => {
+        void saveWorkspaceApproval(agentConfig.cwd, cacheKey, optionId);
+      },
     });
 
     this.lifecycle = new SessionLifecycle(

--- a/src/process/acp/session/ApprovalPersistence.ts
+++ b/src/process/acp/session/ApprovalPersistence.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * ApprovalPersistence - durable, per-workspace backing store for the ACP
+ * PermissionResolver "allow always" cache (#672, part of the #656 audit).
+ *
+ * The live approval cache (PermissionResolver.ApprovalCache) is in-memory and
+ * session-scoped, so a user who chose "allow always" for a command/path was
+ * re-prompted after an app restart. This store persists those decisions to
+ * ProcessConfig, keyed by workspace (the session cwd), and rehydrates them on
+ * session start. It only ever holds explicit "allow always" grants — deny
+ * decisions and one-time allows are never persisted.
+ *
+ * Main-process only (ProcessConfig is a main-process JSON config file).
+ */
+
+import { ProcessConfig } from '@process/utils/initStorage';
+import { mainLog, mainError } from '@process/utils/mainLogger';
+
+const CONFIG_KEY = 'acp.workspaceApprovals' as const;
+
+/** In-memory-typed view of the persisted structure: workspace → (approvalKey → optionId). */
+type WorkspaceApprovals = Record<string, Record<string, string>>;
+
+async function readAll(): Promise<WorkspaceApprovals> {
+  const stored = await ProcessConfig.get(CONFIG_KEY).catch((): undefined => undefined);
+  return stored && typeof stored === 'object' ? stored : {};
+}
+
+/**
+ * Load the persisted "allow always" entries for a workspace as [approvalKey,
+ * optionId] pairs, ready to seed a PermissionResolver cache. Returns an empty
+ * list on any read error (persistence must never block a session from starting).
+ */
+export async function loadWorkspaceApprovals(workspace: string | undefined): Promise<Array<[string, string]>> {
+  if (!workspace) return [];
+  try {
+    const all = await readAll();
+    const forWorkspace = all[workspace];
+    return forWorkspace ? Object.entries(forWorkspace) : [];
+  } catch (err) {
+    mainError(
+      '[ApprovalPersistence]',
+      'loadWorkspaceApprovals failed',
+      err instanceof Error ? err.message : String(err)
+    );
+    return [];
+  }
+}
+
+/**
+ * Durably record an "allow always" decision for a workspace. A no-op when the
+ * workspace is unknown. Failures are logged, never thrown: losing a persist
+ * write only means the user is re-prompted next session (the pre-#672 behavior),
+ * which must never break the in-memory fast path or the turn.
+ */
+export async function saveWorkspaceApproval(
+  workspace: string | undefined,
+  approvalKey: string,
+  optionId: string
+): Promise<void> {
+  if (!workspace) return;
+  try {
+    const all = await readAll();
+    const forWorkspace = { ...(all[workspace] ?? {}) };
+    if (forWorkspace[approvalKey] === optionId) return; // already persisted - avoid a redundant write
+    forWorkspace[approvalKey] = optionId;
+    await ProcessConfig.set(CONFIG_KEY, { ...all, [workspace]: forWorkspace });
+  } catch (err) {
+    mainError(
+      '[ApprovalPersistence]',
+      'saveWorkspaceApproval failed',
+      err instanceof Error ? err.message : String(err)
+    );
+  }
+}
+
+/**
+ * Clear all persisted approvals for a workspace (the "can be cleared" path).
+ * Exposed for a future revoke affordance; not wired to any auto-clear so the
+ * whole point of persistence isn't defeated by a session reset.
+ */
+export async function clearWorkspaceApprovals(workspace: string | undefined): Promise<void> {
+  if (!workspace) return;
+  try {
+    const all = await readAll();
+    if (!(workspace in all)) return;
+    const next = { ...all };
+    delete next[workspace];
+    await ProcessConfig.set(CONFIG_KEY, next);
+    mainLog('[ApprovalPersistence]', `cleared persisted approvals for workspace`);
+  } catch (err) {
+    mainError(
+      '[ApprovalPersistence]',
+      'clearWorkspaceApprovals failed',
+      err instanceof Error ? err.message : String(err)
+    );
+  }
+}

--- a/src/process/acp/session/ApprovalPersistence.ts
+++ b/src/process/acp/session/ApprovalPersistence.ts
@@ -66,7 +66,7 @@ export async function saveWorkspaceApproval(
   if (!workspace) return;
   try {
     const all = await readAll();
-    const forWorkspace = { ...(all[workspace] ?? {}) };
+    const forWorkspace = { ...all[workspace] };
     if (forWorkspace[approvalKey] === optionId) return; // already persisted - avoid a redundant write
     forWorkspace[approvalKey] = optionId;
     await ProcessConfig.set(CONFIG_KEY, { ...all, [workspace]: forWorkspace });

--- a/src/process/acp/session/PermissionResolver.ts
+++ b/src/process/acp/session/PermissionResolver.ts
@@ -127,6 +127,10 @@ export class PermissionResolver {
       this.hydration = this.hydrateFn()
         .then((entries) => {
           for (const [key, optionId] of entries) {
+            // Defense-in-depth: only honor persisted "allow always" grants (the
+            // only shape we ever write). A tampered on-disk store therefore
+            // can't inject some other decision to auto-select from the cache.
+            if (!(optionId.startsWith('allow_') && optionId.includes('always'))) continue;
             // Do not clobber a decision the user made this session (already in
             // cache) with a stale persisted one; only fill gaps.
             if (this.cache.get(key) === undefined) this.cache.set(key, optionId);

--- a/src/process/acp/session/PermissionResolver.ts
+++ b/src/process/acp/session/PermissionResolver.ts
@@ -80,6 +80,16 @@ type PendingPermission = {
 type PermissionResolverConfig = {
   autoApproveAll: boolean;
   cacheMaxSize?: number;
+  /**
+   * #672: durable, workspace-scoped persistence for "allow always" decisions.
+   * `hydrate` loads previously-persisted [cacheKey, optionId] entries ONCE
+   * (lazily, before the first cache lookup) so an "allow always" survives an
+   * app restart. `persist` write-throughs a newly-cached always decision. Both
+   * are optional — without them the resolver is the original in-memory-only
+   * session cache.
+   */
+  hydrate?: () => Promise<Iterable<[string, string]>>;
+  persist?: (cacheKey: string, optionId: string) => void;
 };
 
 type PendingPermissionWithContext = PendingPermission & {
@@ -90,28 +100,64 @@ export class PermissionResolver {
   private readonly yoloMode: boolean;
   private readonly cache: ApprovalCache;
   private readonly pending = new Map<string, PendingPermissionWithContext>();
+  private readonly hydrateFn?: () => Promise<Iterable<[string, string]>>;
+  private readonly persistFn?: (cacheKey: string, optionId: string) => void;
+  /** Memoized one-shot rehydration of persisted approvals (#672). */
+  private hydration?: Promise<void>;
 
   constructor(config: PermissionResolverConfig) {
     this.yoloMode = config.autoApproveAll;
     this.cache = new ApprovalCache(config.cacheMaxSize ?? 500);
+    this.hydrateFn = config.hydrate;
+    this.persistFn = config.persist;
   }
 
   get hasPending(): boolean {
     return this.pending.size > 0;
   }
 
+  /**
+   * Seed persisted "allow always" entries into the cache exactly once (#672).
+   * Idempotent + lazy: runs on the first cache lookup, never re-runs, and a
+   * failed load resolves (empty) so it can never block a permission decision.
+   */
+  private ensureHydrated(): Promise<void> {
+    if (!this.hydrateFn) return Promise.resolve();
+    if (!this.hydration) {
+      this.hydration = this.hydrateFn()
+        .then((entries) => {
+          for (const [key, optionId] of entries) {
+            // Do not clobber a decision the user made this session (already in
+            // cache) with a stale persisted one; only fill gaps.
+            if (this.cache.get(key) === undefined) this.cache.set(key, optionId);
+          }
+        })
+        .catch(() => {
+          /* load failure = behave as if nothing persisted; never block a turn */
+        });
+    }
+    return this.hydration;
+  }
+
   async evaluate(
     request: RequestPermissionRequest,
     uiCallback: (data: PermissionUIData) => void
   ): Promise<RequestPermissionResponse> {
-    // Level 1: YOLO mode - auto-approve everything (client-side fallback)
+    // Level 1: YOLO mode - auto-approve everything (client-side fallback).
+    // Short-circuits before the cache, so no need to hydrate persisted approvals.
     if (this.yoloMode) {
       const allowOption = request.options.find((o) => o.kind.startsWith('allow_'));
       const optionId = allowOption?.optionId ?? request.options[0].optionId;
       return { outcome: { outcome: 'selected', optionId } };
     }
 
-    // Level 2: Cache hit (session-level "always allow" memory)
+    // #672: ensure persisted "allow always" decisions are loaded before the
+    // first cache lookup, so an approval from a prior session is honored. Guard
+    // the await so a resolver WITHOUT persistence keeps the original synchronous
+    // UI-delegation timing (a bare `await` would defer the uiCallback a tick).
+    if (this.hydrateFn) await this.ensureHydrated();
+
+    // Level 2: Cache hit (persisted + session "always allow" memory)
     const cacheKey = buildCacheKey(request);
     const cached = this.cache.get(cacheKey);
     if (cached) {
@@ -150,6 +196,10 @@ export class PermissionResolver {
     // Cache "allow always" decisions for future auto-approval (never cache deny)
     if (optionId.startsWith('allow_') && optionId.includes('always')) {
       this.cache.set(entry.cacheKey, optionId);
+      // #672: write-through to durable per-workspace persistence so the grant
+      // survives an app restart. Fire-and-forget: a failed persist only costs a
+      // re-prompt next session and must not affect this decision.
+      this.persistFn?.(entry.cacheKey, optionId);
     }
 
     entry.resolve({ outcome: { outcome: 'selected', optionId } });

--- a/tests/unit/process/acp/session/ApprovalPersistence.test.ts
+++ b/tests/unit/process/acp/session/ApprovalPersistence.test.ts
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * #672: durable, per-workspace persistence for ACP "allow always" approvals.
+ * These tests drive the store against an in-memory ProcessConfig stand-in and
+ * prove a grant survives a "restart" (a fresh read), is workspace-scoped, and
+ * fails soft.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// In-memory ProcessConfig stand-in (a real restart = the same JSON file re-read).
+const store = new Map<string, unknown>();
+vi.mock('@process/utils/initStorage', () => ({
+  ProcessConfig: {
+    get: vi.fn(async (key: string) => store.get(key)),
+    set: vi.fn(async (key: string, value: unknown) => {
+      store.set(key, value);
+      return value;
+    }),
+  },
+}));
+vi.mock('@process/utils/mainLogger', () => ({
+  mainLog: vi.fn(),
+  mainError: vi.fn(),
+}));
+
+import {
+  loadWorkspaceApprovals,
+  saveWorkspaceApproval,
+  clearWorkspaceApprovals,
+} from '@process/acp/session/ApprovalPersistence';
+
+const WS_A = '/home/user/project-a';
+const WS_B = '/home/user/project-b';
+const KEY = JSON.stringify({ kind: 'execute', title: 'bash', rawInput: { command: 'ls' } });
+
+beforeEach(() => store.clear());
+afterEach(() => vi.clearAllMocks());
+
+describe('ApprovalPersistence (#672)', () => {
+  it('a saved grant is returned on a fresh load (survives restart)', async () => {
+    await saveWorkspaceApproval(WS_A, KEY, 'allow_always');
+    // Fresh read = the store the next app launch would rehydrate from.
+    expect(await loadWorkspaceApprovals(WS_A)).toEqual([[KEY, 'allow_always']]);
+  });
+
+  it('is workspace-scoped: a grant in A is not visible in B', async () => {
+    await saveWorkspaceApproval(WS_A, KEY, 'allow_always');
+    expect(await loadWorkspaceApprovals(WS_B)).toEqual([]);
+  });
+
+  it('accumulates multiple grants in one workspace without dropping earlier ones', async () => {
+    const KEY2 = JSON.stringify({ kind: 'execute', title: 'bash', rawInput: { command: 'git status' } });
+    await saveWorkspaceApproval(WS_A, KEY, 'allow_always');
+    await saveWorkspaceApproval(WS_A, KEY2, 'allow_always');
+    const loaded = await loadWorkspaceApprovals(WS_A);
+    expect(loaded).toHaveLength(2);
+    expect(Object.fromEntries(loaded)).toEqual({ [KEY]: 'allow_always', [KEY2]: 'allow_always' });
+  });
+
+  it('clearWorkspaceApprovals removes a workspace and leaves others intact', async () => {
+    await saveWorkspaceApproval(WS_A, KEY, 'allow_always');
+    await saveWorkspaceApproval(WS_B, KEY, 'allow_always');
+    await clearWorkspaceApprovals(WS_A);
+    expect(await loadWorkspaceApprovals(WS_A)).toEqual([]);
+    expect(await loadWorkspaceApprovals(WS_B)).toEqual([[KEY, 'allow_always']]);
+  });
+
+  it('an undefined workspace is a no-op for save and returns empty for load', async () => {
+    await saveWorkspaceApproval(undefined, KEY, 'allow_always');
+    expect(store.size).toBe(0);
+    expect(await loadWorkspaceApprovals(undefined)).toEqual([]);
+  });
+
+  it('a redundant save of the same value does not rewrite config', async () => {
+    const { ProcessConfig } = await import('@process/utils/initStorage');
+    await saveWorkspaceApproval(WS_A, KEY, 'allow_always');
+    const writesAfterFirst = vi.mocked(ProcessConfig.set).mock.calls.length;
+    await saveWorkspaceApproval(WS_A, KEY, 'allow_always'); // identical - should skip
+    expect(vi.mocked(ProcessConfig.set).mock.calls.length).toBe(writesAfterFirst);
+  });
+});

--- a/tests/unit/process/acp/session/PermissionResolver.test.ts
+++ b/tests/unit/process/acp/session/PermissionResolver.test.ts
@@ -142,4 +142,94 @@ describe('PermissionResolver', () => {
     await expect(p2).rejects.toThrow('disconnect');
     expect(resolver.hasPending).toBe(false);
   });
+
+  // #672: "allow always" must survive an app restart via durable persistence,
+  // instead of the in-memory-only session cache re-prompting every restart.
+  describe('durable persistence (#672)', () => {
+    it('write-throughs an allow_always grant to persist()', async () => {
+      const persisted = new Map<string, string>();
+      const resolver = new PermissionResolver({ autoApproveAll: false, persist: (k, v) => persisted.set(k, v) });
+      const p = resolver.evaluate(makeRequest('bash', 'c1', { kind: 'execute', rawInput: { command: 'ls' } }), vi.fn());
+      resolver.resolve('c1', 'allow_always');
+      await p;
+      expect(persisted.size).toBe(1);
+      expect([...persisted.values()]).toEqual(['allow_always']);
+    });
+
+    it('does NOT persist a one-time allow or a deny', async () => {
+      const persisted = new Map<string, string>();
+      const resolver = new PermissionResolver({ autoApproveAll: false, persist: (k, v) => persisted.set(k, v) });
+      const p1 = resolver.evaluate(
+        makeRequest('bash', 'c1', { kind: 'execute', rawInput: { command: 'ls' } }),
+        vi.fn()
+      );
+      resolver.resolve('c1', 'allow'); // one-time
+      await p1;
+      const p2 = resolver.evaluate(
+        makeRequest('bash', 'c2', { kind: 'execute', rawInput: { command: 'rm' } }),
+        vi.fn()
+      );
+      resolver.resolve('c2', 'reject_once'); // deny
+      await p2;
+      expect(persisted.size).toBe(0);
+    });
+
+    it('rehydrates a persisted grant so a NEW resolver (restart) auto-approves without UI', async () => {
+      // Session 1: user grants "allow always"; capture what gets persisted.
+      const persisted = new Map<string, string>();
+      const r1 = new PermissionResolver({ autoApproveAll: false, persist: (k, v) => persisted.set(k, v) });
+      const p = r1.evaluate(makeRequest('bash', 'c1', { kind: 'execute', rawInput: { command: 'ls' } }), vi.fn());
+      r1.resolve('c1', 'allow_always');
+      await p;
+      expect(persisted.size).toBe(1);
+
+      // Session 2 (simulated app restart): fresh resolver hydrated from persistence.
+      const uiCallback = vi.fn();
+      const r2 = new PermissionResolver({ autoApproveAll: false, hydrate: async () => [...persisted.entries()] });
+      const result = await r2.evaluate(
+        makeRequest('bash', 'c2', { kind: 'execute', rawInput: { command: 'ls' } }),
+        uiCallback
+      );
+      expect(uiCallback).not.toHaveBeenCalled();
+      expect(result.outcome).toEqual({ outcome: 'selected', optionId: 'allow_always' });
+    });
+
+    it('hydrate runs at most once across many evaluations (memoized)', async () => {
+      let hydrateCalls = 0;
+      const resolver = new PermissionResolver({
+        autoApproveAll: false,
+        hydrate: async () => {
+          hydrateCalls++;
+          return [];
+        },
+      });
+      // With persistence, evaluate registers the pending entry only AFTER the
+      // hydration await, so wait for it before resolving (in production, resolve
+      // is user-driven long after the UI callback, so this race never occurs).
+      const p1 = resolver.evaluate(makeRequest('a', 'c1'), vi.fn());
+      await vi.waitFor(() => expect(resolver.hasPending).toBe(true));
+      resolver.resolve('c1', 'allow');
+      await p1;
+      const p2 = resolver.evaluate(makeRequest('b', 'c2'), vi.fn());
+      await vi.waitFor(() => expect(resolver.hasPending).toBe(true));
+      resolver.resolve('c2', 'allow');
+      await p2;
+      expect(hydrateCalls).toBe(1);
+    });
+
+    it('a failed hydrate does not block permission evaluation', async () => {
+      const uiCallback = vi.fn();
+      const resolver = new PermissionResolver({
+        autoApproveAll: false,
+        hydrate: async () => {
+          throw new Error('config read failed');
+        },
+      });
+      const p = resolver.evaluate(makeRequest('write_file', 'c1'), uiCallback);
+      await vi.waitFor(() => expect(uiCallback).toHaveBeenCalledOnce());
+      resolver.resolve('c1', 'allow');
+      const result = await p;
+      expect(result.outcome).toEqual({ outcome: 'selected', optionId: 'allow' });
+    });
+  });
 });

--- a/tests/unit/process/acp/session/PermissionResolver.test.ts
+++ b/tests/unit/process/acp/session/PermissionResolver.test.ts
@@ -217,6 +217,27 @@ describe('PermissionResolver', () => {
       expect(hydrateCalls).toBe(1);
     });
 
+    it('ignores a persisted entry whose optionId is not an allow_always grant (tamper defense)', async () => {
+      // A tampered store maps a command key to a non-always decision. Hydration
+      // must drop it, so the request still delegates to the UI (no silent action).
+      const key = JSON.stringify({ kind: 'execute', title: 'bash', rawInput: { command: 'ls' } });
+      const uiCallback = vi.fn();
+      const resolver = new PermissionResolver({
+        autoApproveAll: false,
+        hydrate: async () => [
+          [key, 'reject_once'], // not an allow_always - must be ignored
+          [key, 'allow'], // one-time allow - must be ignored
+        ],
+      });
+      const p = resolver.evaluate(
+        makeRequest('bash', 'c1', { kind: 'execute', rawInput: { command: 'ls' } }),
+        uiCallback
+      );
+      await vi.waitFor(() => expect(uiCallback).toHaveBeenCalledOnce());
+      resolver.resolve('c1', 'allow');
+      await p;
+    });
+
     it('a failed hydrate does not block permission evaluation', async () => {
       const uiCallback = vi.fn();
       const resolver = new PermissionResolver({


### PR DESCRIPTION
## What & why

Part of the #656 capability-honesty / WorkspaceTrust audit — the **#672** slice.

The live ACP permission cache (`ApprovalCache` inside `src/process/acp/session/PermissionResolver.ts`) was in-memory and session-scoped, so a user who chose **"allow always"** for a command/path was **re-prompted after every app restart**. (The issue's anchors pointed at `src/process/agent/acp/ApprovalStore.ts`, which is on the **dead** legacy `AcpAgent` path — not instantiated in production. The real live path is `AcpAgentManager → AcpAgentV2 → AcpSession`, so the fix targets `PermissionResolver` there.)

## Fix

- New `ApprovalPersistence` (ProcessConfig-backed, keyed by workspace = session `cwd`): `load` / `save` / `clear`. New typed config key `acp.workspaceApprovals`.
- `PermissionResolver` gains optional `hydrate` (lazy, once, before the first cache lookup) + `persist` (write-through on `allow_always` in `resolve()`). `AcpSession` wires them to `agentConfig.cwd`.
- **Only `allow_always` is persisted** — deny and one-time allow never are. On hydrate, entries are additionally filtered to `allow_always`-shaped optionIds (defense-in-depth against a tampered on-disk store injecting other decision shapes).
- Fails soft: a load/persist failure only costs a re-prompt next session, never a blocked turn. Resolvers without persistence keep the exact original synchronous timing (the `if (this.hydrateFn)` guard).

## Honest residual notes (from adversarial review — all low-severity, non-blocking)

- **Trust model:** persisting auto-approval of sensitive ops across restarts widens the blast radius of a config-file write, but crosses **no new trust boundary** — anyone who can write the config can already set `yoloMode` / rewrite MCP commands / steal keys. The hydrate allow_always filter narrows commodity tampering.
- **Concurrency:** `saveWorkspaceApproval` is read-modify-write on the `acp.workspaceApprovals` key; two sessions granting concurrently could drop one grant (last-write-wins) — worst case one re-prompt, never config corruption (other keys untouched).
- **Teardown window:** with persistence wired, `evaluate()` defers pending-registration by the hydration microtask; a `rejectAll()` in that window wouldn't reject that one in-flight evaluate — benign (the session is being torn down anyway).

## Tests (reproduce-first)

`PermissionResolver.test.ts` (write-through; no-persist on deny/one-time; **rehydrate → fresh resolver auto-approves without UI**; memoized-once; tamper-filter; fail-soft) + `ApprovalPersistence.test.ts` (round-trip survives restart; workspace-scoped; accumulate; clear; undefined no-op; redundant-save skip). Verified to fail on revert. Full suite green (12570). Adversarial review: NON-BLOCKING.
