### PR TITLE
fix(context): size ACP context meter from the real model window (#733)

### DIFF
--- a/src/renderer/components/agent/ContextUsageIndicator.tsx
+++ b/src/renderer/components/agent/ContextUsageIndicator.tsx
@@ -28,24 +28,36 @@ const ContextUsageIndicator: React.FC<ContextUsageIndicatorProps> = ({
 }) => {
   const { t } = useTranslation();
 
-  const { percentage, displayTotal, displayLimit, isWarning, isDanger } = useMemo(() => {
+  const { percentage, rawPercentage, displayTotal, displayLimit, isWarning, isDanger } = useMemo(() => {
     if (!tokenUsage) {
       return {
         percentage: 0,
+        rawPercentage: 0,
         displayTotal: '0',
-        displayLimit: formatTokenCount(contextLimit, true),
+        displayLimit: formatTokenCount(contextLimit > 0 ? contextLimit : DEFAULT_CONTEXT_LIMIT, true),
         isWarning: false,
         isDanger: false,
       };
     }
 
-    const total = tokenUsage.totalTokens;
-    const pct = (total / contextLimit) * 100;
+    // Guard a non-finite/negative usage figure: `NaN` would sail through a bare
+    // `typeof === 'number'` check upstream and paint stroke-dashoffset="NaN".
+    const total = Number.isFinite(tokenUsage.totalTokens) ? Math.max(0, tokenUsage.totalTokens) : 0;
+    // Guard a non-positive limit: an agent that reports usage with no window
+    // would otherwise divide by zero here and drive the ring to Infinity/NaN.
+    const safeLimit = contextLimit > 0 ? contextLimit : DEFAULT_CONTEXT_LIMIT;
+    const pct = (total / safeLimit) * 100;
 
     return {
-      percentage: pct,
+      // The RING is clamped to [0,100]: a usage figure that exceeds the window
+      // (e.g. the "3M / 200K" in #733, where a cumulative counter is rendered
+      // against a per-turn window) drove strokeDashoffset negative and painted
+      // a corrupt arc. The TEXT below stays unclamped and honest - it still
+      // reports the real numbers and the real (>100%) percentage.
+      percentage: Math.min(100, Math.max(0, pct)),
+      rawPercentage: pct,
       displayTotal: formatTokenCount(total),
-      displayLimit: formatTokenCount(contextLimit, true),
+      displayLimit: formatTokenCount(safeLimit, true),
       isWarning: pct > 70,
       isDanger: pct > 90,
     };
@@ -77,7 +89,7 @@ const ContextUsageIndicator: React.FC<ContextUsageIndicatorProps> = ({
   const popoverContent = (
     <div className='p-8px min-w-160px'>
       <div className='text-14px font-medium text-t-primary'>
-        {percentage.toFixed(1)}% · {displayTotal} / {displayLimit}{' '}
+        {rawPercentage.toFixed(1)}% · {displayTotal} / {displayLimit}{' '}
         {t('conversation.contextUsage.contextUsed', 'context used')}
       </div>
     </div>

--- a/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -12,6 +12,7 @@ import ThoughtDisplay from '@/renderer/components/chat/ThoughtDisplay';
 import FileAttachButton from '@/renderer/components/media/FileAttachButton';
 import FilePreview from '@/renderer/components/media/FilePreview';
 import HorizontalFileList from '@/renderer/components/media/HorizontalFileList';
+import { useModelContextLimit } from '@/renderer/hooks/agent/useModelContextLimit';
 import { useAutoTitle } from '@/renderer/hooks/chat/useAutoTitle';
 import { getSendBoxDraftHook, type FileOrFolderItem } from '@/renderer/hooks/chat/useSendBoxDraft';
 import { createSetUploadFile, useSendBoxFiles } from '@/renderer/hooks/chat/useSendBoxFiles';
@@ -120,10 +121,18 @@ const AcpSendBox: React.FC<{
     resetState,
     tokenUsage,
     contextLimit,
+    currentModelId,
     hasThinkingMessage,
     routing,
     fluxTurnError,
   } = useAcpMessage(conversation_id);
+  // #733: when the ACP agent reports usage but NO context window (`size` 0/absent),
+  // the indicator used to fall back to the generic DEFAULT_CONTEXT_LIMIT (1M) for
+  // EVERY model - so the same Claude model could show a 200K max on one turn and
+  // 1M on another. Resolve the real window from the registry catalog (falling back
+  // to the static table) exactly like the Gemini/WCore send boxes already do.
+  // Agent-reported window still wins when present - it is the ground truth.
+  const getContextLimit = useModelContextLimit(backend);
   const { t } = useTranslation();
   const teamPermission = useTeamPermission();
   // In team mode, all agents show the permission mode selector (members don't propagate)
@@ -491,7 +500,7 @@ Please check your local CLI tool authentication status`,
           tokenUsage ? (
             <ContextUsageIndicator
               tokenUsage={tokenUsage}
-              contextLimit={contextLimit > 0 ? contextLimit : undefined}
+              contextLimit={contextLimit > 0 ? contextLimit : getContextLimit(currentModelId)}
               size={24}
             />
           ) : undefined

--- a/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
+++ b/src/renderer/pages/conversation/platforms/acp/useAcpMessage.ts
@@ -7,6 +7,7 @@
 import { ipcBridge } from '@/common';
 import { transformMessage } from '@/common/chat/chatLib';
 import type { IResponseMessage } from '@/common/adapter/ipcBridge';
+import type { AcpModelInfo } from '@/common/types/acpTypes';
 import type { TokenUsageData } from '@/common/config/storage';
 import { useAddOrUpdateMessage } from '@/renderer/pages/conversation/Messages/hooks';
 import { useTabResumeEffect } from '@/renderer/hooks/system/useTabResumeEffect';
@@ -26,6 +27,13 @@ type UseAcpMessageReturn = {
   resetState: () => void;
   tokenUsage: TokenUsageData | null;
   contextLimit: number;
+  /**
+   * Model the agent reports for this session (`acp_model_info`), or null before
+   * any arrives. The context-usage indicator sizes its denominator from this
+   * when `contextLimit` is 0 - i.e. the agent reported usage but no window -
+   * instead of falling back to the generic 1M default for every model (#733).
+   */
+  currentModelId: string | null;
   hasThinkingMessage: boolean;
   routing: 'flux' | 'native' | 'unknown';
   fluxTurnError: boolean;
@@ -46,6 +54,10 @@ export const useAcpMessage = (conversation_id: string): UseAcpMessageReturn => {
   const [aiProcessing, setAiProcessing] = useState(false); // New loading state for AI response
   const [tokenUsage, setTokenUsage] = useState<TokenUsageData | null>(null);
   const [contextLimit, setContextLimit] = useState<number>(0);
+  // The model the ACP agent reports it is running (`acp_model_info`). Only used
+  // to size the context-usage denominator when the agent does NOT report a
+  // window of its own - see the `currentModelId` note on the return value (#733).
+  const [currentModelId, setCurrentModelId] = useState<string | null>(null);
 
   // Use refs to sync state for immediate access in event handlers
   const runningRef = useRef(running);
@@ -247,9 +259,24 @@ export const useAcpMessage = (conversation_id: string): UseAcpMessageReturn => {
           }
           addOrUpdateMessage(transformedMessage);
           break;
-        case 'acp_model_info':
-          // Model info updates are handled by AcpModelSelector, no action needed here
+        case 'acp_model_info': {
+          // The SELECTOR owns rendering this event; we only mirror the current
+          // model id so the context-usage indicator can size its denominator
+          // from the real model window when the agent reports usage WITHOUT a
+          // window of its own (#733).
+          //
+          // The payload is an `AcpModelInfo` - the id lives on `currentModelId`
+          // (NOT `model`; that key only exists on the separate `codex_model_info`
+          // event). For the `claude` backend this is a SLOT id (`opus`/`sonnet`/
+          // `haiku`) rather than a catalog id; `getModelContextLimit` knows those
+          // slots, so the window still resolves.
+          const info = message.data as AcpModelInfo | undefined;
+          const reported = info?.currentModelId;
+          if (typeof reported === 'string' && reported.length > 0) {
+            setCurrentModelId(reported);
+          }
           break;
+        }
         case 'slash_commands_updated':
           // Slash commands became available (often during bootstrap when
           // agent_status events are suppressed). Update acpStatus so
@@ -321,7 +348,18 @@ export const useAcpMessage = (conversation_id: string): UseAcpMessageReturn => {
           break;
       }
     },
-    [conversation_id, addOrUpdateMessage, throttledSetThought, setThought, setRunning, setAiProcessing, setAcpStatus, setRouting, setFluxTurnError, t]
+    [
+      conversation_id,
+      addOrUpdateMessage,
+      throttledSetThought,
+      setThought,
+      setRunning,
+      setAiProcessing,
+      setAcpStatus,
+      setRouting,
+      setFluxTurnError,
+      t,
+    ]
   );
 
   useEffect(() => {
@@ -336,6 +374,7 @@ export const useAcpMessage = (conversation_id: string): UseAcpMessageReturn => {
     setAcpStatus(null);
     setTokenUsage(null);
     setContextLimit(0);
+    setCurrentModelId(null);
     hasContentInTurnRef.current = false;
     turnFinishedRef.current = false;
     hasThinkingMessageRef.current = false;
@@ -382,6 +421,23 @@ export const useAcpMessage = (conversation_id: string): UseAcpMessageReturn => {
         if (lastContextLimit && lastContextLimit > 0) {
           setContextLimit(lastContextLimit);
         }
+      }
+
+      // Seed the model the context meter sizes from (#733).
+      //
+      // The conversation row's `currentModelId` is the AUTHORITATIVE answer to
+      // "what model is this session running": it is what the manager persists
+      // (persistedModelId) and what becomes ANTHROPIC_MODEL at spawn. Deliberately
+      // NOT the `getModelInfo` IPC - with no task yet that falls back to
+      // getStaticModelInfo(), which reads the local Claude CLI config
+      // (~/.claude/settings.json / cc-switch) and knows nothing about THIS
+      // conversation's pick; it defaults to opus/sonnet and would confidently size
+      // the meter from a model the session isn't even running.
+      //
+      // Seed only - a later acp_model_info stream event still wins.
+      const persistedModelId = (res.extra as { currentModelId?: unknown } | undefined)?.currentModelId;
+      if (typeof persistedModelId === 'string' && persistedModelId.length > 0) {
+        setCurrentModelId((prev) => prev ?? persistedModelId);
       }
     });
 
@@ -437,6 +493,14 @@ export const useAcpMessage = (conversation_id: string): UseAcpMessageReturn => {
     resetState,
     tokenUsage,
     contextLimit,
+    /**
+     * Model the agent reports for this session, or null before any
+     * `acp_model_info` arrives. The context-usage indicator resolves its
+     * denominator from this when `contextLimit` is 0 (agent reported usage but
+     * no window), instead of silently falling back to the generic 1M default
+     * (#733).
+     */
+    currentModelId,
     hasThinkingMessage,
     routing,
     fluxTurnError,

--- a/src/renderer/utils/model/modelContextLimits.ts
+++ b/src/renderer/utils/model/modelContextLimits.ts
@@ -64,6 +64,31 @@ const MODEL_CONTEXT_LIMITS: Record<string, number> = {
   'claude-3-opus': 200_000,
   'claude-3-sonnet': 200_000,
   'claude-3-haiku': 200_000,
+
+  // Claude Code ACP "slot" aliases. The claude backend has no session/set_model
+  // and only honors the three ANTHROPIC_MODEL aliases, so it reports its current
+  // model as a bare SLOT (`opus`/`sonnet`/`haiku`) rather than a catalog id - see
+  // CLAUDE_SLOT_MODELS in src/process/agent/acp/utils.ts. Without these rows the
+  // context meter cannot size a window from what the agent actually reports and
+  // silently falls back to DEFAULT_CONTEXT_LIMIT (1M) for EVERY slot - so Haiku
+  // (really 200K) showed a 1M denominator. (#733)
+  //
+  // The fuzzy match is longest-key-wins, so these short keys never shadow a full
+  // catalog id (`claude-3-opus` still resolves via its own 13-char key, not `opus`).
+  //
+  // Only slots whose window we can state with CONFIDENCE are listed:
+  //   - `opus`: utils.ts verifies live that `--model opus` / `ANTHROPIC_MODEL=opus`
+  //     resolve to claude-opus-4-8 → 1M.
+  //   - `haiku`: version-independent - EVERY Haiku (4.5, 4.0, 3.5) is 200K, so the
+  //     window holds whichever one the alias picks.
+  // `sonnet` is deliberately OMITTED: its window depends on which Sonnet the alias
+  // resolves to (4.6 is 1M, but 4.5/4.0 are 200K) and that is NOT verified anywhere
+  // in-repo. Guessing 1M would show a 1M denominator for a 200K model - the exact
+  // over-sized-max half of this bug. Omitted, it falls through to
+  // DEFAULT_CONTEXT_LIMIT, i.e. today's behaviour - no better, but no new lie.
+  // Verify the alias against the claude CLI (as was done for opus) before adding it.
+  opus: 1_000_000, // → claude-opus-4-8 (verified)
+  haiku: 200_000, // → any claude-haiku-* (all 200K)
 };
 
 /**

--- a/tests/unit/modelContextLimits.test.ts
+++ b/tests/unit/modelContextLimits.test.ts
@@ -130,3 +130,46 @@ describe('resolveModelContextLimit (issue #733)', () => {
     expect(resolveModelContextLimit(catalog, '')).toBe(DEFAULT_CONTEXT_LIMIT);
   });
 });
+
+/**
+ * #733: the Claude Code ACP backend has no session/set_model, so it reports its
+ * current model as a bare SLOT alias (`opus`/`sonnet`/`haiku`, see
+ * CLAUDE_SLOT_MODELS) rather than a catalog id. Those slots previously matched
+ * nothing - not the registry catalog (real ids) and not the static table (the
+ * fuzzy match is `id.includes(key)`, and 'opus'.includes('claude-opus-4') is
+ * false) - so EVERY Claude slot silently fell back to DEFAULT_CONTEXT_LIMIT
+ * (1M). Haiku, a 200K model, showed a 1M denominator.
+ */
+describe('Claude ACP slot aliases resolve to a real window (#733)', () => {
+  it('resolves the opus slot to the 1M window (--model opus -> claude-opus-4-8)', () => {
+    expect(getModelContextLimit('opus')).toBe(1_000_000);
+  });
+
+  // `sonnet` is deliberately NOT in the table: which Sonnet the alias resolves to
+  // (4.6 = 1M vs 4.5/4.0 = 200K) is unverified, and guessing 1M would show an
+  // over-sized max for a 200K model. It must keep falling through to the default.
+  it('leaves the UNVERIFIED sonnet slot on the default rather than guessing', () => {
+    expect(getModelContextLimit('sonnet')).toBe(DEFAULT_CONTEXT_LIMIT);
+  });
+
+  // The slot rows duplicate a family row's literal; pin them so they cannot drift.
+  it('keeps the slot rows in lockstep with the model they alias', () => {
+    expect(getModelContextLimit('opus')).toBe(getModelContextLimit('claude-opus-4-8'));
+    expect(getModelContextLimit('haiku')).toBe(getModelContextLimit('claude-haiku-4-5'));
+  });
+
+  it('resolves the haiku slot to 200K - NOT the 1M default', () => {
+    expect(getModelContextLimit('haiku')).toBe(200_000);
+    expect(getModelContextLimit('haiku')).not.toBe(DEFAULT_CONTEXT_LIMIT);
+  });
+
+  // The slot keys are short; longest-match must still let a full catalog id win
+  // so they can never shadow a real model's window.
+  it('does not let the short slot keys shadow full catalog ids', () => {
+    expect(getModelContextLimit('claude-3-opus')).toBe(200_000);
+    expect(getModelContextLimit('claude-opus-4-5')).toBe(200_000);
+    expect(getModelContextLimit('claude-3-5-sonnet')).toBe(200_000);
+    expect(getModelContextLimit('claude-haiku-4-5')).toBe(200_000);
+    expect(getModelContextLimit('claude-opus-4-8')).toBe(1_000_000);
+  });
+});

--- a/tests/unit/renderer/contextUsageIndicator.dom.test.tsx
+++ b/tests/unit/renderer/contextUsageIndicator.dom.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import ContextUsageIndicator from '@/renderer/components/agent/ContextUsageIndicator';
+import { DEFAULT_CONTEXT_LIMIT } from '@/renderer/utils/model/modelContextLimits';
+
+/**
+ * Regression for #733 (the context-usage indicator half).
+ *
+ * The reporter's screenshots showed nonsense denominators - "3M / 200K" for
+ * Haiku and "1.2M / 1M" - i.e. a `used` figure that EXCEEDS the window. The
+ * ring's stroke-dashoffset is `circumference - (pct/100)*circumference`, so a
+ * pct > 100 drove the offset NEGATIVE and painted a corrupt arc; a
+ * `contextLimit` of 0 divided by zero and produced Infinity/NaN.
+ *
+ * The ring is now clamped to [0,100] while the popover TEXT stays unclamped and
+ * honest (it still reports the real, >100% figure so the overflow is visible
+ * rather than hidden).
+ */
+
+/** The progress ring is the 2nd <circle> (the 1st is the background track). */
+function progressDashoffset(container: HTMLElement): number {
+  const circles = container.querySelectorAll('circle');
+  const ring = circles[1];
+  return Number(ring.getAttribute('stroke-dashoffset'));
+}
+
+function circumferenceFor(container: HTMLElement): number {
+  const circles = container.querySelectorAll('circle');
+  return Number(circles[1].getAttribute('stroke-dasharray'));
+}
+
+describe('ContextUsageIndicator - over-limit + zero-limit guards (#733)', () => {
+  it('clamps the ring at 100% when usage EXCEEDS the window (the "3M / 200K" case)', () => {
+    const { container } = render(
+      <ContextUsageIndicator tokenUsage={{ totalTokens: 3_000_000 }} contextLimit={200_000} />
+    );
+
+    // pct would be 1500%. Pre-fix the offset went negative (corrupt arc);
+    // clamped it must land exactly on "full ring" = 0, and never below.
+    const offset = progressDashoffset(container);
+    expect(offset).toBe(0);
+    expect(offset).toBeGreaterThanOrEqual(0);
+  });
+
+  // NOTE: the popover TEXT (which deliberately reports the real, UNCLAMPED
+  // percentage - the clamp is cosmetic, applied to the ring only) is not
+  // asserted here on purpose: Arco's Popover mounts its content into a portal
+  // on hover, and a hover+portal assertion is precisely the load-flaky
+  // renderer-dom pattern that has been failing shard runs. The ring assertions
+  // below are deterministic and cover the actual regression.
+
+  it('does not divide by zero when the agent reports usage with NO window', () => {
+    const { container } = render(<ContextUsageIndicator tokenUsage={{ totalTokens: 50_000 }} contextLimit={0} />);
+
+    const offset = progressDashoffset(container);
+    expect(Number.isFinite(offset)).toBe(true);
+    expect(Number.isNaN(offset)).toBe(false);
+
+    // Falls back to the documented default window rather than Infinity%.
+    const circumference = circumferenceFor(container);
+    const expectedPct = (50_000 / DEFAULT_CONTEXT_LIMIT) * 100;
+    expect(offset).toBeCloseTo(circumference - (expectedPct / 100) * circumference, 5);
+  });
+
+  it('renders a normal under-limit ring unchanged (no clamp side effects)', () => {
+    const { container } = render(<ContextUsageIndicator tokenUsage={{ totalTokens: 50_000 }} contextLimit={200_000} />);
+
+    const circumference = circumferenceFor(container);
+    const offset = progressDashoffset(container);
+    // 25% used -> offset is 75% of the circumference.
+    expect(offset).toBeCloseTo(circumference * 0.75, 5);
+  });
+});

--- a/tests/unit/renderer/useAcpMessage.dom.test.tsx
+++ b/tests/unit/renderer/useAcpMessage.dom.test.tsx
@@ -1,6 +1,8 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AcpModelInfo } from '@/common/types/acpTypes';
 import { useAcpMessage } from '@/renderer/pages/conversation/platforms/acp/useAcpMessage';
+import { DEFAULT_CONTEXT_LIMIT, getModelContextLimit } from '@/renderer/utils/model/modelContextLimits';
 
 const mockAddOrUpdateMessage = vi.fn();
 const mockConversationGetInvoke = vi.fn();
@@ -112,5 +114,237 @@ describe('useAcpMessage - conversation hydration', () => {
 
     await waitFor(() => expect(result.current.aiProcessing).toBe(false));
     expect(result.current.hasThinkingMessage).toBe(false);
+  });
+});
+
+/**
+ * Regression for #733: the ACP context-usage denominator.
+ *
+ * `AcpSendBox` sized the indicator from the agent-reported window only, and fell
+ * back to the generic 1M DEFAULT_CONTEXT_LIMIT for EVERY model when the agent
+ * reported usage without a window - so the same Claude model could show a 200K
+ * max on one turn and 1M on another (the reporter's "intermittent" flip).
+ *
+ * The hook now mirrors the model the agent reports (`acp_model_info`) so the
+ * send box can resolve the REAL window for that model instead of guessing 1M.
+ * Pre-fix the hook exposed no `currentModelId` at all and these fail.
+ *
+ * These payloads are the REAL `AcpModelInfo` shape the producers emit
+ * (`toAcpModelInfo` / `buildClaudeSlotModelInfo`): the id lives on
+ * `currentModelId`. It is NOT `{ model }` - that key belongs to the separate
+ * `codex_model_info` event, and asserting it here would be a vacuous guard that
+ * passes while the production path stays dead.
+ */
+function acpModelInfo(currentModelId: string | null): AcpModelInfo {
+  return {
+    currentModelId,
+    currentModelLabel: currentModelId,
+    availableModels: [],
+    canSwitch: true,
+    source: 'models',
+  };
+}
+
+describe('useAcpMessage - acp_model_info mirrors the current model (#733)', () => {
+  /** Grab the stream handler the hook registers so tests can emit events. */
+  function captureStreamHandler(): () => (message: unknown) => void {
+    let handler: ((message: unknown) => void) | undefined;
+    mockResponseStreamOn.mockImplementation((...args: unknown[]) => {
+      handler = args[0] as (message: unknown) => void;
+      return () => {};
+    });
+    return () => {
+      if (!handler) throw new Error('responseStream.on handler was never registered');
+      return handler;
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConversationGetInvoke.mockResolvedValue({ status: 'idle', type: 'acp' });
+  });
+
+  it('captures the model id from an acp_model_info event', async () => {
+    const getHandler = captureStreamHandler();
+    const { result } = renderHook(() => useAcpMessage('conv-model-1'));
+
+    await waitFor(() => expect(result.current.hasHydratedRunningState).toBe(true));
+    expect(result.current.currentModelId).toBeNull();
+
+    act(() => {
+      getHandler()({
+        conversation_id: 'conv-model-1',
+        type: 'acp_model_info',
+        data: acpModelInfo('claude-opus-4-5'),
+      });
+    });
+
+    await waitFor(() => expect(result.current.currentModelId).toBe('claude-opus-4-5'));
+  });
+
+  it('captures a Claude SLOT id (what the claude backend actually reports)', async () => {
+    const getHandler = captureStreamHandler();
+    const { result } = renderHook(() => useAcpMessage('conv-slot'));
+
+    await waitFor(() => expect(result.current.hasHydratedRunningState).toBe(true));
+
+    // buildClaudeSlotModelInfo reports a bare slot, not a catalog id.
+    act(() => {
+      getHandler()({
+        conversation_id: 'conv-slot',
+        type: 'acp_model_info',
+        data: acpModelInfo('haiku'),
+      });
+    });
+
+    await waitFor(() => expect(result.current.currentModelId).toBe('haiku'));
+  });
+
+  it('ignores an acp_model_info for a DIFFERENT conversation', async () => {
+    const getHandler = captureStreamHandler();
+    const { result } = renderHook(() => useAcpMessage('conv-model-2'));
+
+    await waitFor(() => expect(result.current.hasHydratedRunningState).toBe(true));
+
+    act(() => {
+      getHandler()({
+        conversation_id: 'someone-elses-conversation',
+        type: 'acp_model_info',
+        data: acpModelInfo('claude-haiku-4-5'),
+      });
+    });
+
+    expect(result.current.currentModelId).toBeNull();
+  });
+
+  it('ignores a malformed acp_model_info payload (no model)', async () => {
+    const getHandler = captureStreamHandler();
+    const { result } = renderHook(() => useAcpMessage('conv-model-3'));
+
+    await waitFor(() => expect(result.current.hasHydratedRunningState).toBe(true));
+
+    act(() => {
+      getHandler()({ conversation_id: 'conv-model-3', type: 'acp_model_info', data: {} });
+      getHandler()({ conversation_id: 'conv-model-3', type: 'acp_model_info', data: acpModelInfo(null) });
+      getHandler()({ conversation_id: 'conv-model-3', type: 'acp_model_info', data: acpModelInfo('') });
+    });
+
+    expect(result.current.currentModelId).toBeNull();
+  });
+
+  it('clears the model id when the conversation changes', async () => {
+    const getHandler = captureStreamHandler();
+    const { result, rerender } = renderHook(({ id }: { id: string }) => useAcpMessage(id), {
+      initialProps: { id: 'conv-model-a' },
+    });
+
+    await waitFor(() => expect(result.current.hasHydratedRunningState).toBe(true));
+
+    act(() => {
+      getHandler()({
+        conversation_id: 'conv-model-a',
+        type: 'acp_model_info',
+        data: acpModelInfo('claude-opus-4-5'),
+      });
+    });
+    await waitFor(() => expect(result.current.currentModelId).toBe('claude-opus-4-5'));
+
+    // A stale model id would size the NEXT conversation's indicator wrongly.
+    rerender({ id: 'conv-model-b' });
+
+    await waitFor(() => expect(result.current.currentModelId).toBeNull());
+  });
+});
+
+/**
+ * #733 — the seeding path that makes the fix REACHABLE on the default Claude path.
+ *
+ * The `acp_model_info` STREAM only carries ConfigTracker.currentModelId, and Claude
+ * Code's ACP wrapper advertises no model list, so NO model ever reaches the stream
+ * for the `claude` backend. The meter must therefore seed from the conversation row,
+ * whose `extra.currentModelId` is the AUTHORITATIVE running model (it is what the
+ * manager persists and what becomes ANTHROPIC_MODEL at spawn).
+ *
+ * NOT the `getModelInfo` IPC: with no task yet that falls back to getStaticModelInfo(),
+ * which reads the LOCAL Claude CLI config (~/.claude/settings.json / cc-switch),
+ * knows nothing about this conversation's pick, and defaults to opus/sonnet — it
+ * would confidently size the meter from a model the session isn't running.
+ */
+describe('useAcpMessage - seeds the model from the conversation row (#733)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConversationGetInvoke.mockResolvedValue({ status: 'idle', type: 'acp' });
+  });
+
+  it('seeds the persisted model so a Haiku session sizes to 200K, not the 1M default', async () => {
+    mockConversationGetInvoke.mockResolvedValue({
+      status: 'idle',
+      type: 'acp',
+      extra: { currentModelId: 'claude-haiku-4-5' },
+    });
+
+    const { result } = renderHook(() => useAcpMessage('conv-seed-1'));
+
+    await waitFor(() => expect(result.current.currentModelId).toBe('claude-haiku-4-5'));
+    // The denominator the send box then resolves - the actual #733 symptom.
+    expect(getModelContextLimit(result.current.currentModelId)).toBe(200_000);
+    expect(getModelContextLimit(result.current.currentModelId)).not.toBe(DEFAULT_CONTEXT_LIMIT);
+  });
+
+  it('seeds an Opus session to the 1M window', async () => {
+    mockConversationGetInvoke.mockResolvedValue({
+      status: 'idle',
+      type: 'acp',
+      extra: { currentModelId: 'claude-opus-4-8' },
+    });
+
+    const { result } = renderHook(() => useAcpMessage('conv-seed-2'));
+
+    await waitFor(() => expect(result.current.currentModelId).toBe('claude-opus-4-8'));
+    expect(getModelContextLimit(result.current.currentModelId)).toBe(1_000_000);
+  });
+
+  it('does not clobber a model id that already arrived on the stream', async () => {
+    let resolveGet!: (value: unknown) => void;
+    mockConversationGetInvoke.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveGet = resolve;
+        })
+    );
+    let handler: ((message: unknown) => void) | undefined;
+    mockResponseStreamOn.mockImplementation((...args: unknown[]) => {
+      handler = args[0] as (message: unknown) => void;
+      return () => {};
+    });
+
+    const { result } = renderHook(() => useAcpMessage('conv-seed-3'));
+
+    await waitFor(() => expect(handler).toBeDefined());
+    act(() => {
+      handler!({
+        conversation_id: 'conv-seed-3',
+        type: 'acp_model_info',
+        data: acpModelInfo('claude-opus-4-8'),
+      });
+    });
+    await waitFor(() => expect(result.current.currentModelId).toBe('claude-opus-4-8'));
+
+    // A late, staler row must NOT overwrite the live stream value.
+    act(() => {
+      resolveGet({ status: 'idle', type: 'acp', extra: { currentModelId: 'claude-haiku-4-5' } });
+    });
+
+    await waitFor(() => expect(result.current.hasHydratedRunningState).toBe(true));
+    expect(result.current.currentModelId).toBe('claude-opus-4-8');
+  });
+
+  it('leaves the model null when the row has no persisted model', async () => {
+    mockConversationGetInvoke.mockResolvedValue({ status: 'idle', type: 'acp', extra: {} });
+
+    const { result } = renderHook(() => useAcpMessage('conv-seed-4'));
+
+    await waitFor(() => expect(result.current.hasHydratedRunningState).toBe(true));
+    expect(result.current.currentModelId).toBeNull();
   });
 });


### PR DESCRIPTION
The context-usage indicator reported an inconsistent maximum for the same
model - 200K on one turn, 1M on another, plus nonsense ratios like 3M/200K.

The ACP path (where Claude Opus/Haiku run) never sized the meter from the
model at all:

1. AcpSendBox sized it ONLY from the agent-reported window, falling back to
   the generic 1M DEFAULT_CONTEXT_LIMIT for EVERY model when the agent
   reported usage without one. PR #776 gave the Gemini/WCore send boxes
   registry-backed resolution but never wired it into the ACP box. It now
   resolves the real window (registry -> static table -> default); an
   agent-reported window still wins, byte-identical to before.

2. The send box had no model to resolve against. useAcpMessage now seeds the
   model from the conversation row's currentModelId - the authoritative answer
   to what the session is running (it is what the manager persists and what
   becomes ANTHROPIC_MODEL at spawn). It is deliberately NOT read from the
   getModelInfo IPC: with no task yet that falls back to getStaticModelInfo(),
   which reads the local Claude CLI config (~/.claude/settings.json /
   cc-switch), knows nothing about this conversation's pick, and defaults to
   opus/sonnet - it would confidently size the meter from a model the session
   is not running. A later acp_model_info stream event still wins, and the
   model is cleared on conversation change so a stale id cannot size the next
   meter.

3. Claude also reports a bare SLOT (opus/haiku) rather than a catalog id, and
   slots matched nothing - not the registry (real ids) nor the static table
   (the fuzzy match is id.includes(key), and 'opus'.includes('claude-opus-4')
   is false). Add rows for the slots whose window is certain: opus (verified:
   --model opus resolves to claude-opus-4-8 = 1M) and haiku
   (version-independent, every Haiku is 200K). sonnet is deliberately omitted -
   which Sonnet the alias resolves to is unverified (4.6 is 1M but 4.5/4.0 are
   200K) and guessing 1M would show an over-sized max for a 200K model.
   Longest-key-wins keeps full catalog ids winning over the short keys.

Also clamp the indicator ring to [0,100] and guard non-finite/zero inputs:
usage above the window drove stroke-dashoffset negative and painted a corrupt
arc (the reporter's 3M/200K). The popover text stays unclamped and honest.

Desktop half of cluster C3. Reproduce-first tests fail on pre-fix code.
