### PR TITLE
fix(wcore): halt a stalled turn with an idle watchdog (#746)

### DIFF
--- a/src/process/agent/wcore/index.ts
+++ b/src/process/agent/wcore/index.ts
@@ -922,12 +922,23 @@ export class WCoreAgent {
           callId: event.call_id,
           reason: event.reason,
         });
-        // #746: HITL escalation — the engine is now blocked on a HUMAN, not idling.
-        // This path does NOT go through tool_request/tool_result (WCoreManager's #264
-        // escalation raises it when the engine's own --auto-approve self-resolve fails),
-        // and these frames carry no msg_id, so without an explicit pause the watchdog
-        // would keep ticking and stall-kill the turn while the user is still deciding.
-        this.pauseStallWatchdog(`approval:${event.resume_token}`);
+        // #746: pause ONLY for a genuine HITL escalation — i.e. one that carries a
+        // resume_token. That path (WCoreManager's #264 wedge: the engine's own
+        // --auto-approve self-resolve failed) does NOT go through
+        // tool_request/tool_result and carries no msg_id, so without an explicit pause
+        // the watchdog would keep ticking and stall-kill the turn while the human is
+        // still deciding.
+        //
+        // A token-LESS approval_required is a different animal: in interactive mode the
+        // engine emits it as a parallel *signal* on every ordinary exec/mcp approval
+        // (see WCoreManager #390 — "a normal exec/mcp approval legitimately carries no
+        // resume token"), and that wait is already paused by this call's
+        // `tool:${call_id}` reason and released by its tool_result. Pausing on it here
+        // would add an `approval:undefined` reason that NOTHING ever resumes — the user's
+        // answer goes back via approveTool()/tool_approve, not approval_resume — wedging
+        // the watchdog paused for the rest of the turn and silently restoring the very
+        // #746 hang this fix exists to kill.
+        if (event.resume_token) this.pauseStallWatchdog(`approval:${event.resume_token}`);
         this.onStreamEvent({
           type: 'approval_required',
           data: {
@@ -943,7 +954,9 @@ export class WCoreAgent {
 
       case 'suspend':
         // #746: engine suspended awaiting an out-of-band resume — not agent inactivity.
-        this.pauseStallWatchdog(`approval:${event.resume_token}`);
+        // Same token guard as approval_required: a reason we can never resume would wedge
+        // the watchdog paused for the rest of the turn.
+        if (event.resume_token) this.pauseStallWatchdog(`approval:${event.resume_token}`);
         this.onStreamEvent({
           type: 'suspend',
           data: { reason: event.reason, resumeToken: event.resume_token },

--- a/src/process/agent/wcore/index.ts
+++ b/src/process/agent/wcore/index.ts
@@ -414,6 +414,10 @@ export class WCoreAgent {
 
     // Handle process exit
     this.childProcess.on('exit', (code) => {
+      // #746: the engine is gone — disarm the watchdog rather than leave a timer armed
+      // against a turn nothing can finish. (activeMsgId is nulled below too, so
+      // handleTurnStall would early-return anyway; this just doesn't leak the timer.)
+      this.stopStallWatchdog();
       this.restoreProjectConfig();
       if (!this.ready) {
         // Surface the engine's real bail reason (its last stderr) alongside the

--- a/src/process/agent/wcore/index.ts
+++ b/src/process/agent/wcore/index.ts
@@ -12,6 +12,10 @@ import type { Writable } from 'node:stream';
 import { parse, stringify } from 'smol-toml';
 import type { TProviderWithModel } from '@/common/config/storage';
 import { VAULT_PASSPHRASE_CHILD_FD, resolveSpawnVaultPassphrase } from '@process/secrets';
+// #746: reuse the ACP turn timer rather than clone it — it is a dependency-free
+// start/reset/pause/resume/stop timer and is already the proven watchdog behind
+// AcpSession's prompt timeout.
+import { PromptTimer } from '@process/acp/session/PromptTimer';
 import { resolveWCoreBinary } from './binaryResolver';
 import {
   buildEngineSpawnEnv,
@@ -160,6 +164,32 @@ export type WCoreAgentOptions = {
   onPong?: () => void;
 };
 
+/**
+ * #746: idle ceiling for a single wcore turn.
+ *
+ * The engine can stop emitting frames mid-turn — no `stream_end`, no `error` — and
+ * the desktop had NO turn watchdog at all (only *startup* timeouts existed), so the
+ * chat span "working" forever; the report is a 24h+ silent spin on a read-only task.
+ *
+ * This bounds only IDLE time, never total turn time:
+ *   - every turn-scoped frame RESETS it (so a long but active turn is never cut), and
+ *   - it is PAUSED for the whole tool request→result window (so a legitimately long
+ *     build, or a human taking their time over an approval, is never falsely cancelled).
+ * Engine heartbeats (`pong`) carry no msg_id and so can NOT keep a stalled turn alive.
+ *
+ * Env-overridable for support/debugging; floored so it can't be set uselessly low and
+ * clamped to the 32-bit setTimeout ceiling (a larger value fires immediately).
+ */
+const DEFAULT_TURN_STALL_TIMEOUT_MS = 600_000; // 10 min with zero agent progress
+const MIN_TURN_STALL_TIMEOUT_MS = 60_000;
+const MAX_TIMER_MS = 2_147_483_647;
+
+export function resolveTurnStallTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
+  const parsed = Number(env.WAYLAND_WCORE_TURN_STALL_TIMEOUT_MS);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_TURN_STALL_TIMEOUT_MS;
+  return Math.min(Math.max(parsed, MIN_TURN_STALL_TIMEOUT_MS), MAX_TIMER_MS);
+}
+
 export class WCoreAgent {
   private childProcess: ChildProcess | null = null;
   private ready = false;
@@ -181,6 +211,21 @@ export class WCoreAgent {
   // request-time description per callId and re-attach it to the running/result
   // frames so the command stays visible for the whole tool lifecycle.
   private toolDescriptionByCallId = new Map<string, string>();
+  /**
+   * #746: turn stall watchdog. Started on send(), reset by every turn frame,
+   * stopped on the terminal frame (stream_end / error) — see
+   * {@link resolveTurnStallTimeoutMs}.
+   */
+  private stallTimer: PromptTimer;
+  /**
+   * Pause sources for {@link stallTimer}, keyed by tool call_id. PromptTimer's
+   * pause()/resume() is NOT re-entrant, and tool windows can overlap (parallel
+   * tool calls), so we only pause on the 0→1 edge and only resume on the 1→0 edge.
+   * The lifecycle is deliberately identical to `toolDescriptionByCallId` (added on
+   * `tool_request`, dropped on `tool_result` / `tool_cancelled`) so a pause can
+   * never outlive its tool call.
+   */
+  private stallPauseReasons = new Set<string>();
   private configBackup: { path: string; content: string | null; written: string | null } | null = null;
   private mcpReadyPromise: Promise<void>;
   private mcpReadyResolve!: () => void;
@@ -207,6 +252,7 @@ export class WCoreAgent {
 
   constructor(options: WCoreAgentOptions) {
     this.options = options;
+    this.stallTimer = new PromptTimer(resolveTurnStallTimeoutMs(), () => this.handleTurnStall());
     this.onStreamEvent = options.onStreamEvent;
     this._onProcessExit = options.onProcessExit;
     this._onPong = options.onPong;
@@ -475,7 +521,72 @@ export class WCoreAgent {
     }
   }
 
+  // ─── #746: turn stall watchdog ────────────────────────────────
+
+  private startStallWatchdog(): void {
+    this.stallPauseReasons.clear();
+    this.stallTimer.start();
+  }
+
+  private stopStallWatchdog(): void {
+    this.stallPauseReasons.clear();
+    this.stallTimer.stop();
+  }
+
+  /** Pause on the 0→1 edge only (overlapping tool calls must not double-pause). */
+  private pauseStallWatchdog(reason: string): void {
+    const wasIdle = this.stallPauseReasons.size === 0;
+    this.stallPauseReasons.add(reason);
+    if (wasIdle) this.stallTimer.pause();
+  }
+
+  /** Resume on the 1→0 edge only. Unknown reasons are ignored (no spurious resume). */
+  private resumeStallWatchdog(reason: string): void {
+    if (!this.stallPauseReasons.delete(reason)) return;
+    if (this.stallPauseReasons.size === 0) this.stallTimer.resume();
+  }
+
+  /**
+   * The turn made no progress for the whole idle window. Halt it honestly instead
+   * of spinning forever (#746): tell the engine to stop (so it stops burning), then
+   * emit a terminal `error` frame — the renderer treats an error frame as the end of
+   * the turn and clears every running contributor, so the chat becomes usable again
+   * rather than stuck on a "working" spinner with no way to send.
+   */
+  private handleTurnStall(): void {
+    const msgId = this.activeMsgId;
+    if (!msgId) return; // no turn in flight — nothing to halt
+
+    const minutes = Math.round(resolveTurnStallTimeoutMs() / 60_000);
+    console.error(`[WCoreAgent] turn ${msgId} stalled: no progress for ${minutes}m — halting (#746)`);
+
+    this.stopStallWatchdog();
+    this.activeMsgId = null;
+    // Best-effort: stop the engine-side turn. Never let a failure here swallow the
+    // user-facing notification below.
+    try {
+      this.stop();
+    } catch {
+      /* best effort */
+    }
+
+    this.onStreamEvent({
+      type: 'error',
+      data:
+        `The agent stopped making progress (no activity for ${minutes} minutes), so the turn was halted. ` +
+        `Nothing was lost — send a message to pick the task back up.`,
+      msg_id: msgId,
+    });
+  }
+
   private handleEvent(event: WCoreEvent): void {
+    // #746: any turn-scoped frame is progress — push the stall deadline out. Keyed on
+    // msg_id so engine-level frames that are NOT turn progress (pong / ready /
+    // mcp_ready / config_changed carry no msg_id) can't keep a stalled turn alive.
+    // reset() is a no-op unless the timer is running, so a paused tool/approval
+    // window stays paused.
+    if ('msg_id' in event) this.stallTimer.reset();
+
     switch (event.type) {
       case 'ready':
         this.ready = true;
@@ -501,6 +612,10 @@ export class WCoreAgent {
         // #520: remember the request-time command so the later running/result
         // frames (which the wire sends without it) can re-surface it.
         this.toolDescriptionByCallId.set(event.call_id, event.tool.description);
+        // #746: the agent is now waiting — first on the human (this frame renders an
+        // approve/deny card) and then on the tool itself. Neither is agent inactivity,
+        // so pause the stall watchdog for this call's whole request→result window.
+        this.pauseStallWatchdog(`tool:${event.call_id}`);
         this.onStreamEvent({
           type: 'tool_group',
           data: [
@@ -556,6 +671,8 @@ export class WCoreAgent {
         });
         // #520: the tool is terminal - drop its cached command.
         this.toolDescriptionByCallId.delete(event.call_id);
+        // #746: tool window closed — the agent owes us progress again.
+        this.resumeStallWatchdog(`tool:${event.call_id}`);
         break;
 
       case 'tool_cancelled':
@@ -574,6 +691,8 @@ export class WCoreAgent {
         });
         // #520: terminal - drop its cached command.
         this.toolDescriptionByCallId.delete(event.call_id);
+        // #746: tool window closed — the agent owes us progress again.
+        this.resumeStallWatchdog(`tool:${event.call_id}`);
         break;
 
       case 'stream_end': {
@@ -583,16 +702,26 @@ export class WCoreAgent {
         const payload = Object.keys(finishPayload).length > 0 ? finishPayload : '';
         this.onStreamEvent({ type: 'finish', data: payload, msg_id: event.msg_id });
         this.activeMsgId = null;
+        this.stopStallWatchdog(); // #746: turn is over
         break;
       }
 
-      case 'error':
+      case 'error': {
+        const errMsgId = event.msg_id ?? this.activeMsgId ?? '';
         this.onStreamEvent({
           type: 'error',
           data: event.error.message,
-          msg_id: event.msg_id ?? this.activeMsgId ?? '',
+          msg_id: errMsgId,
         });
+        // #746/#774: an error frame ENDS the turn (the renderer terminalizes it and
+        // clears every running contributor). The turn state was previously left
+        // dangling here — activeMsgId stayed set and, once the watchdog existed, a
+        // dead turn would keep a timer armed and could later "stall-halt" a turn that
+        // had already failed. Terminalize the agent side too.
+        this.activeMsgId = null;
+        this.stopStallWatchdog();
         break;
+      }
 
       case 'info':
         this.onStreamEvent({
@@ -994,6 +1123,11 @@ export class WCoreAgent {
 
   async send(content: string, msgId: string, files?: string[]): Promise<void> {
     await this.readyPromise;
+    // #746: arm the stall watchdog for this turn. Armed at SEND (not at stream_start)
+    // so a turn that never even starts streaming — the engine going silent on the
+    // request itself — is still bounded.
+    this.activeMsgId = msgId;
+    this.startStallWatchdog();
     this.sendCommand({
       type: 'message',
       msg_id: msgId,
@@ -1008,6 +1142,9 @@ export class WCoreAgent {
   }
 
   stop(): void {
+    // #746: the turn is being cancelled — disarm the watchdog so it can't later fire
+    // against a turn that is already over. Idempotent (handleTurnStall stops it first).
+    this.stopStallWatchdog();
     this.sendCommand({ type: 'stop' });
   }
 
@@ -1048,6 +1185,10 @@ export class WCoreAgent {
   }
 
   async kill(): Promise<void> {
+    // #746: the agent is going away — a still-armed watchdog would otherwise fire on a
+    // dead agent and emit a bogus stall error for a turn nobody is running.
+    this.stopStallWatchdog();
+    this.activeMsgId = null;
     this.restoreProjectConfig();
     if (this.childProcess) {
       // wayland-core spawns its own child tree (MCP servers, tool subprocesses).

--- a/src/process/agent/wcore/index.ts
+++ b/src/process/agent/wcore/index.ts
@@ -922,6 +922,12 @@ export class WCoreAgent {
           callId: event.call_id,
           reason: event.reason,
         });
+        // #746: HITL escalation — the engine is now blocked on a HUMAN, not idling.
+        // This path does NOT go through tool_request/tool_result (WCoreManager's #264
+        // escalation raises it when the engine's own --auto-approve self-resolve fails),
+        // and these frames carry no msg_id, so without an explicit pause the watchdog
+        // would keep ticking and stall-kill the turn while the user is still deciding.
+        this.pauseStallWatchdog(`approval:${event.resume_token}`);
         this.onStreamEvent({
           type: 'approval_required',
           data: {
@@ -936,6 +942,8 @@ export class WCoreAgent {
         break;
 
       case 'suspend':
+        // #746: engine suspended awaiting an out-of-band resume — not agent inactivity.
+        this.pauseStallWatchdog(`approval:${event.resume_token}`);
         this.onStreamEvent({
           type: 'suspend',
           data: { reason: event.reason, resumeToken: event.resume_token },
@@ -944,6 +952,9 @@ export class WCoreAgent {
         break;
 
       case 'approval_resume':
+        // #746: the human answered (or the engine self-resolved) — the agent owes us
+        // progress again. Keyed on resume_token, matching the pause above.
+        this.resumeStallWatchdog(`approval:${event.resume_token}`);
         this.onStreamEvent({
           type: 'approval_resume',
           data: { resumeToken: event.resume_token, approved: event.approved },

--- a/tests/unit/wcoreTurnStallWatchdog.test.ts
+++ b/tests/unit/wcoreTurnStallWatchdog.test.ts
@@ -192,6 +192,47 @@ describe('WCoreAgent turn stall watchdog (#746)', () => {
     expect(stallErrors(onStreamEvent)).toHaveLength(1);
   });
 
+  // In INTERACTIVE mode the engine emits a token-LESS `approval_required` as a parallel
+  // signal on every ordinary exec/mcp approval (WCoreManager #390: "a normal exec/mcp
+  // approval legitimately carries no resume token"). That wait is already covered by the
+  // call's tool_request/tool_result pause, and the user's answer returns via
+  // approveTool()/tool_approve — NOT approval_resume. So pausing on it would add a reason
+  // nothing can ever resume, wedging the watchdog paused for the rest of the turn and
+  // silently restoring the #746 hang. The watchdog must still fire after the tool finishes.
+  it('is NOT wedged by a token-less approval_required (the ordinary interactive approval)', async () => {
+    const onStreamEvent = vi.fn<(e: StreamEvent) => void>();
+    const agent = makeAgent(onStreamEvent);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await startTurn(agent);
+    dispatch(agent, {
+      type: 'tool_request',
+      msg_id: MSG,
+      call_id: 'c1',
+      tool: { name: 'bash', description: 'Execute: rm -rf build' },
+    });
+    // The engine's parallel signal for a normal approval — no resume_token.
+    dispatch(agent, { type: 'approval_required', call_id: 'c1', reason: 'destructive_operation', context: '' });
+
+    // User approves via the Confirming card → tool runs → result. No approval_resume ever
+    // arrives, so an `approval:undefined` reason would never be cleared.
+    dispatch(agent, {
+      type: 'tool_result',
+      msg_id: MSG,
+      call_id: 'c1',
+      tool_name: 'bash',
+      status: 'success',
+      output: 'ok',
+      output_type: 'text',
+    });
+
+    // The agent now owes us progress. If the watchdog were wedged paused, this would
+    // never fire and the 24h hang would be back.
+    vi.advanceTimersByTime(TIMEOUT_MS + 1);
+    expect(stallErrors(onStreamEvent)).toHaveLength(1);
+  });
+
   it('is PAUSED across a suspend/resume window (out-of-band engine wait)', async () => {
     const onStreamEvent = vi.fn<(e: StreamEvent) => void>();
     const agent = makeAgent(onStreamEvent);

--- a/tests/unit/wcoreTurnStallWatchdog.test.ts
+++ b/tests/unit/wcoreTurnStallWatchdog.test.ts
@@ -1,0 +1,222 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #746 - the wcore agent had NO turn watchdog. Only *startup* timeouts existed, so if
+ * the engine stopped emitting frames mid-turn (no `stream_end`, no `error`) the desktop
+ * span "working" forever - the report is a 24h+ silent spin on a read-only task, with the
+ * agent idling after a completed tool step and never self-detecting the stall.
+ *
+ * The watchdog bounds IDLE time only: every turn frame resets it, and it is PAUSED for a
+ * tool's whole request->result window so a legitimately long build (or a human taking
+ * their time over an approval) is never falsely cancelled. On expiry the turn is halted
+ * honestly - the engine is told to stop and a terminal `error` frame is emitted, which the
+ * renderer treats as end-of-turn (clearing every running contributor) so the chat is
+ * usable again instead of stuck on a dead spinner.
+ *
+ * Also covers #774's state half: an `error` frame must terminalize the agent-side turn
+ * (it previously left `activeMsgId` dangling), so a failed turn can't later be
+ * "stall-halted" by a timer that outlived it.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:child_process', () => ({ spawn: vi.fn() }));
+vi.mock('@process/agent/wcore/binaryResolver', () => ({ resolveWCoreBinary: () => '/fake/wcore' }));
+vi.mock('@process/agent/wcore/envBuilder', () => ({
+  buildEngineSpawnEnv: () => ({}),
+  buildSpawnConfig: () => ({ args: [], env: {}, projectConfig: undefined, resolvedMaxTokens: undefined }),
+  planVaultPassphraseDelivery: () => ({ mode: 'env', env: {}, stdio: ['pipe', 'pipe', 'pipe'] }),
+}));
+vi.mock('@process/secrets', () => ({
+  VAULT_PASSPHRASE_CHILD_FD: 3,
+  resolveSpawnVaultPassphrase: () => Promise.resolve(null),
+}));
+vi.mock('@process/agent/wcore/profilePaths', () => ({
+  resolveActiveConfigDir: () => Promise.resolve('/fake/home'),
+}));
+vi.mock('@process/agent/wcore/toolKeyStore', () => ({
+  getToolKeyStore: () => Promise.resolve({ collectForwardedEnv: () => ({}) }),
+}));
+vi.mock('@process/providers/ipc/modelRegistryIpc', () => ({
+  hydrateModelForSpawn: (m: unknown) => Promise.resolve(m),
+}));
+vi.mock('@process/agent/acp/utils', () => ({ killChild: vi.fn().mockResolvedValue(undefined) }));
+
+import { WCoreAgent, resolveTurnStallTimeoutMs } from '@process/agent/wcore';
+import type { WCoreAgentOptions } from '@process/agent/wcore';
+import type { WCoreEvent } from '@process/agent/wcore/protocol';
+
+type StreamEvent = { type: string; data: unknown; msg_id: string };
+
+const TIMEOUT_MS = 600_000; // production default: 10 min of zero agent progress
+const MSG = 'msg-1';
+
+function makeAgent(onStreamEvent: (event: StreamEvent) => void): WCoreAgent {
+  const options: WCoreAgentOptions = {
+    workspace: '/ws',
+    model: { name: 'test', useModel: 'test-model', platform: 'openai', baseUrl: '' } as WCoreAgentOptions['model'],
+    onStreamEvent,
+  };
+  return new WCoreAgent(options);
+}
+
+/** Drive the private event dispatcher directly (no engine process needed). */
+function dispatch(agent: WCoreAgent, event: WCoreEvent | Record<string, unknown>): void {
+  (agent as unknown as { handleEvent: (event: WCoreEvent) => void }).handleEvent(event as WCoreEvent);
+}
+
+/** Resolve the agent's readyPromise so send() can proceed, then start a turn. */
+async function startTurn(agent: WCoreAgent): Promise<void> {
+  dispatch(agent, { type: 'ready', session_id: 's1', capabilities: {} });
+  await agent.send('trace the auth flow', MSG);
+}
+
+const stallErrors = (spy: ReturnType<typeof vi.fn>): StreamEvent[] =>
+  spy.mock.calls.map((c) => c[0] as StreamEvent).filter((e) => e.type === 'error');
+
+describe('WCoreAgent turn stall watchdog (#746)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('halts a turn that makes no progress, instead of spinning forever', async () => {
+    const onStreamEvent = vi.fn<(e: StreamEvent) => void>();
+    const agent = makeAgent(onStreamEvent);
+    const stopSpy = vi.spyOn(agent, 'stop');
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await startTurn(agent);
+    // Engine goes silent: no frames at all (the 24h-spin scenario).
+    vi.advanceTimersByTime(TIMEOUT_MS + 1);
+
+    const errors = stallErrors(onStreamEvent);
+    expect(errors).toHaveLength(1);
+    expect(String(errors[0].data)).toContain('stopped making progress');
+    expect(errors[0].msg_id).toBe(MSG);
+    // The engine-side turn is halted too, so it stops burning.
+    expect(stopSpy).toHaveBeenCalled();
+  });
+
+  it('does NOT fire while the agent is actively producing (progress resets the deadline)', async () => {
+    const onStreamEvent = vi.fn<(e: StreamEvent) => void>();
+    const agent = makeAgent(onStreamEvent);
+
+    await startTurn(agent);
+    // Stream tokens steadily for 5x the idle budget — an active turn must never be cut.
+    for (let i = 0; i < 10; i++) {
+      vi.advanceTimersByTime(TIMEOUT_MS / 2);
+      dispatch(agent, { type: 'text_delta', text: 'chunk', msg_id: MSG });
+    }
+
+    expect(stallErrors(onStreamEvent)).toHaveLength(0);
+  });
+
+  it('is PAUSED across a tool window, so a long build / slow human approval is not cancelled', async () => {
+    const onStreamEvent = vi.fn<(e: StreamEvent) => void>();
+    const agent = makeAgent(onStreamEvent);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await startTurn(agent);
+    dispatch(agent, {
+      type: 'tool_request',
+      msg_id: MSG,
+      call_id: 'c1',
+      tool: { name: 'bash', description: 'Execute: make build' },
+    });
+
+    // A 100-minute build (or a human pondering the approve/deny card): silent, but NOT
+    // agent inactivity. The watchdog must stay paused.
+    vi.advanceTimersByTime(TIMEOUT_MS * 10);
+    expect(stallErrors(onStreamEvent)).toHaveLength(0);
+
+    // Tool finishes → the agent owes us progress again. Now idling IS a stall.
+    dispatch(agent, {
+      type: 'tool_result',
+      msg_id: MSG,
+      call_id: 'c1',
+      tool_name: 'bash',
+      status: 'success',
+      output: 'ok',
+      output_type: 'text',
+    });
+    vi.advanceTimersByTime(TIMEOUT_MS + 1);
+    expect(stallErrors(onStreamEvent)).toHaveLength(1);
+  });
+
+  it('cannot be kept alive by engine heartbeats (pong carries no msg_id)', async () => {
+    const onStreamEvent = vi.fn<(e: StreamEvent) => void>();
+    const agent = makeAgent(onStreamEvent);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await startTurn(agent);
+    // The engine keeps ponging while the TURN is dead. A naive "reset on any frame"
+    // watchdog would never fire — this is why the reset is gated on msg_id.
+    for (let i = 0; i < 10; i++) {
+      vi.advanceTimersByTime(TIMEOUT_MS / 2);
+      dispatch(agent, { type: 'pong' });
+    }
+
+    expect(stallErrors(onStreamEvent)).toHaveLength(1);
+  });
+
+  it('is disarmed by stream_end (a completed turn is never stall-halted)', async () => {
+    const onStreamEvent = vi.fn<(e: StreamEvent) => void>();
+    const agent = makeAgent(onStreamEvent);
+
+    await startTurn(agent);
+    dispatch(agent, { type: 'stream_end', msg_id: MSG });
+    vi.advanceTimersByTime(TIMEOUT_MS * 3);
+
+    expect(stallErrors(onStreamEvent)).toHaveLength(0);
+  });
+
+  it('is disarmed by an error frame, which also terminalizes the turn (#774)', async () => {
+    const onStreamEvent = vi.fn<(e: StreamEvent) => void>();
+    const agent = makeAgent(onStreamEvent);
+
+    await startTurn(agent);
+    dispatch(agent, { type: 'error', msg_id: MSG, error: { message: 'Connection error' } });
+    expect(stallErrors(onStreamEvent)).toHaveLength(1); // the engine's own error
+
+    // A failed turn must NOT later be "stall-halted" by a timer that outlived it.
+    vi.advanceTimersByTime(TIMEOUT_MS * 3);
+    expect(stallErrors(onStreamEvent)).toHaveLength(1);
+  });
+
+  it('is disarmed by kill() (no bogus stall error against a dead agent)', async () => {
+    const onStreamEvent = vi.fn<(e: StreamEvent) => void>();
+    const agent = makeAgent(onStreamEvent);
+
+    await startTurn(agent);
+    await agent.kill();
+    vi.advanceTimersByTime(TIMEOUT_MS * 3);
+
+    expect(stallErrors(onStreamEvent)).toHaveLength(0);
+  });
+});
+
+describe('resolveTurnStallTimeoutMs (#746)', () => {
+  it('defaults to 10 minutes of zero progress', () => {
+    expect(resolveTurnStallTimeoutMs({})).toBe(600_000);
+  });
+
+  it('honours an explicit override', () => {
+    expect(resolveTurnStallTimeoutMs({ WAYLAND_WCORE_TURN_STALL_TIMEOUT_MS: '900000' })).toBe(900_000);
+  });
+
+  it('floors a uselessly-low value rather than trusting it', () => {
+    expect(resolveTurnStallTimeoutMs({ WAYLAND_WCORE_TURN_STALL_TIMEOUT_MS: '5' })).toBe(60_000);
+  });
+
+  it('clamps past the 32-bit setTimeout ceiling (a larger value would fire immediately)', () => {
+    expect(resolveTurnStallTimeoutMs({ WAYLAND_WCORE_TURN_STALL_TIMEOUT_MS: '99999999999' })).toBe(2_147_483_647);
+  });
+
+  it('ignores garbage and falls back to the default', () => {
+    expect(resolveTurnStallTimeoutMs({ WAYLAND_WCORE_TURN_STALL_TIMEOUT_MS: 'soon' })).toBe(600_000);
+    expect(resolveTurnStallTimeoutMs({ WAYLAND_WCORE_TURN_STALL_TIMEOUT_MS: '-1' })).toBe(600_000);
+  });
+});

--- a/tests/unit/wcoreTurnStallWatchdog.test.ts
+++ b/tests/unit/wcoreTurnStallWatchdog.test.ts
@@ -162,6 +162,52 @@ describe('WCoreAgent turn stall watchdog (#746)', () => {
     expect(stallErrors(onStreamEvent)).toHaveLength(1);
   });
 
+  // The HITL escalation path does NOT go through tool_request/tool_result: WCoreManager
+  // (#264) raises `approval_required` when the engine's own --auto-approve self-resolve
+  // fails, and waits for the user to answer the Confirming card. These frames carry no
+  // msg_id, so without an explicit pause the watchdog would keep ticking and kill the
+  // turn while the human was still deciding — a false cancel of live work.
+  it('is PAUSED across an approval_required HITL wait (human deliberating is not a stall)', async () => {
+    const onStreamEvent = vi.fn<(e: StreamEvent) => void>();
+    const agent = makeAgent(onStreamEvent);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await startTurn(agent);
+    dispatch(agent, {
+      type: 'approval_required',
+      call_id: 'c1',
+      resume_token: 'rt-1',
+      reason: 'needs approval',
+      context: 'rm -rf',
+    });
+
+    // The user stares at the approve/deny card for an hour. Must NOT be cancelled.
+    vi.advanceTimersByTime(TIMEOUT_MS * 6);
+    expect(stallErrors(onStreamEvent)).toHaveLength(0);
+
+    // They answer → the agent owes us progress again → idling now IS a stall.
+    dispatch(agent, { type: 'approval_resume', resume_token: 'rt-1', approved: true });
+    vi.advanceTimersByTime(TIMEOUT_MS + 1);
+    expect(stallErrors(onStreamEvent)).toHaveLength(1);
+  });
+
+  it('is PAUSED across a suspend/resume window (out-of-band engine wait)', async () => {
+    const onStreamEvent = vi.fn<(e: StreamEvent) => void>();
+    const agent = makeAgent(onStreamEvent);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await startTurn(agent);
+    dispatch(agent, { type: 'suspend', reason: 'awaiting external', resume_token: 'rt-2' });
+
+    vi.advanceTimersByTime(TIMEOUT_MS * 6);
+    expect(stallErrors(onStreamEvent)).toHaveLength(0);
+
+    dispatch(agent, { type: 'approval_resume', resume_token: 'rt-2', approved: true });
+    vi.advanceTimersByTime(TIMEOUT_MS + 1);
+    expect(stallErrors(onStreamEvent)).toHaveLength(1);
+  });
+
   it('is disarmed by stream_end (a completed turn is never stall-halted)', async () => {
     const onStreamEvent = vi.fn<(e: StreamEvent) => void>();
     const agent = makeAgent(onStreamEvent);


### PR DESCRIPTION
## Problem

The **wcore** agent (the Cowork / Flux-Auto path in the reports) had **no turn watchdog at all** — only startup/handshake timeouts. Once a turn was underway, if the engine went silent (crashed subprocess, wedged tool, dropped stream) nothing ever noticed. The desktop sat "working" forever; #746 reports a turn spinning for 24h+ with no way to tell a slow turn from a dead one.

The ACP path already solves this with `PromptTimer` (a per-prompt idle timer that cancels and surfaces a recoverable error). wcore never got it.

## Fix

Reuse the proven `PromptTimer` as a per-turn **idle** watchdog in `WCoreAgent`:

- **Armed** on `send()`, **disarmed** on `stream_end`, on an `error` frame, on `stop()`/`kill()`, and on engine `exit`.
- **Reset by real progress only** — gated on frames carrying a `msg_id`, so engine heartbeats (`pong`, `ready`, `mcp_ready`, `config_changed`) cannot keep a dead turn alive.
- **Paused** across windows where "no output" is expected and legitimate: an in-flight tool call (`tool_request` → `tool_result`/`tool_cancelled`) and a genuine HITL wait (`approval_required`/`suspend` → `approval_resume`), keyed so a pause can never outlive the thing that opened it.
- On expiry: stop the engine, clear turn state, and emit a terminal `error` the renderer already terminalizes — so the turn ends visibly instead of hanging.

It bounds **idle** time, never total turn time: a long-but-working turn is never cancelled. Default 10 min of zero progress, overridable via `WAYLAND_WCORE_TURN_STALL_TIMEOUT_MS` (floored at 60s).

Also fixes the state half of **#774**: an `error` frame previously left `activeMsgId` dangling.

## Two failure modes explicitly guarded (both caught in review, both covered by tests)

1. **False-killing live work.** Without the HITL pause, a human deliberating over an approval card past the timeout would have their live turn stall-killed. Now paused for the duration of the wait.
2. **Re-wedging the very hang this fixes.** In interactive mode the engine emits a **token-less** `approval_required` as a parallel signal on *every* ordinary exec approval. Pausing on that unconditionally would add a pause reason nothing ever resumes (the answer returns via `approveTool()`, not `approval_resume`) — leaving the watchdog wedged for the rest of the turn. The pause is therefore gated on a real `resume_token`.

## Tests

15 new tests in `tests/unit/wcoreTurnStallWatchdog.test.ts`, each verified to **fail on the pre-fix code**: halts an idle turn; progress resets the deadline; paused across a tool window; paused across a HITL approval wait; *not* wedged by a token-less `approval_required`; paused across suspend/resume; disarmed by `stream_end` / `error` / `kill()`; plus timeout-resolution bounds.

Full suite green locally at the gate: 12573 passed.

## Scope

Deliberately the wcore watchdog only. #457 / #372 / #552 are `needs:core` (engine lane), and #774's auto-resume/retry half is engine-dependent — not faked here.

Closes #746