### PR TITLE
feat/app gate smoke

### DIFF
--- a/tests/unit/webserver/detectNetworkContext.test.ts
+++ b/tests/unit/webserver/detectNetworkContext.test.ts
@@ -1,9 +1,25 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import os from 'os';
 import type { Request } from 'express';
 import {
   detectNetworkContext,
   __resetTailscaleIfaceCacheForTests,
 } from '@process/webserver/middleware/detectNetworkContext';
+
+/**
+ * `hasTailscaleInterface()` probes the REAL host via os.networkInterfaces(), so without this stub
+ * these assertions silently depend on whether the machine running the suite happens to have
+ * Tailscale up: a private-range peer resolves to 'tailscale' on a host with a `tailscale*` iface and
+ * to 'private_network' otherwise. That passed on CI (no Tailscale) and on macOS (Tailscale binds
+ * `utun*`, which doesn't match the `tailscale` prefix) while failing on any Linux host with
+ * Tailscale up. Stub the probe so the host can never decide the outcome.
+ */
+function stubIfaces(names: string[]): void {
+  vi.spyOn(os, 'networkInterfaces').mockReturnValue(
+    Object.fromEntries(names.map((n) => [n, []])) as ReturnType<typeof os.networkInterfaces>
+  );
+  __resetTailscaleIfaceCacheForTests(); // the probe is memoised — drop the cache so the stub is read
+}
 
 type ReqOpts = { hostname?: string; peer?: string; secure?: boolean };
 
@@ -28,7 +44,7 @@ describe('detectNetworkContext', () => {
     delete process.env.SERVER_BASE_URL;
     delete process.env.HTTPS;
     process.env.NODE_ENV = 'test';
-    __resetTailscaleIfaceCacheForTests();
+    stubIfaces(['lo', 'eth0']); // default: a host WITHOUT Tailscale, whatever the real machine is
   });
 
   afterEach(() => {
@@ -36,6 +52,8 @@ describe('detectNetworkContext', () => {
       if (v === undefined) delete process.env[k];
       else process.env[k] = v;
     }
+    vi.restoreAllMocks();
+    __resetTailscaleIfaceCacheForTests();
   });
 
   it('isHttps reflects WAYLAND_HTTPS env', () => {
@@ -86,9 +104,18 @@ describe('detectNetworkContext', () => {
     );
   });
 
-  it('reachedVia=private_network for a bare RFC1918 peer', () => {
+  it('reachedVia=private_network for a bare RFC1918 peer on a host without Tailscale', () => {
     expect(detectNetworkContext(makeReq({ hostname: 'box.example.com', peer: '192.168.1.10' })).reachedVia).toBe(
       'private_network'
+    );
+  });
+
+  // The other half of the same branch, previously unasserted (and the reason the test above was
+  // host-dependent): the SAME private peer reads as 'tailscale' when the host has a Tailscale iface.
+  it('reachedVia=tailscale for an RFC1918 peer when the host HAS a Tailscale interface', () => {
+    stubIfaces(['lo', 'eth0', 'tailscale0']);
+    expect(detectNetworkContext(makeReq({ hostname: 'box.example.com', peer: '192.168.1.10' })).reachedVia).toBe(
+      'tailscale'
     );
   });
 

--- a/tests/unit/webserver/detectNetworkContext.test.ts
+++ b/tests/unit/webserver/detectNetworkContext.test.ts
@@ -15,8 +15,11 @@ import {
  * Tailscale up. Stub the probe so the host can never decide the outcome.
  */
 function stubIfaces(names: string[]): void {
+  // The explicit tuple return type is load-bearing: without it `noImplicitAny` infers
+  // `[string, any[]]`, Object.fromEntries falls to its `any`-returning overload, and the cast below
+  // would assert nothing at all.
   vi.spyOn(os, 'networkInterfaces').mockReturnValue(
-    Object.fromEntries(names.map((n) => [n, []])) as ReturnType<typeof os.networkInterfaces>
+    Object.fromEntries(names.map((n): [string, os.NetworkInterfaceInfo[]] => [n, []]))
   );
   __resetTailscaleIfaceCacheForTests(); // the probe is memoised — drop the cache so the stub is read
 }
@@ -79,7 +82,9 @@ describe('detectNetworkContext', () => {
   });
 
   it('hostnameIsStable is false for an IPv4 literal, localhost, and missing host', () => {
-    expect(detectNetworkContext(makeReq({ hostname: '192.168.1.5', peer: '192.168.1.5' })).hostnameIsStable).toBe(false);
+    expect(detectNetworkContext(makeReq({ hostname: '192.168.1.5', peer: '192.168.1.5' })).hostnameIsStable).toBe(
+      false
+    );
     expect(detectNetworkContext(makeReq({ hostname: 'localhost', peer: '127.0.0.1' })).hostnameIsStable).toBe(false);
     expect(detectNetworkContext(makeReq({ hostname: '127.0.0.1', peer: '127.0.0.1' })).hostnameIsStable).toBe(false);
     expect(detectNetworkContext(makeReq({ hostname: undefined, peer: '203.0.113.5' })).hostnameIsStable).toBe(false);
@@ -87,7 +92,9 @@ describe('detectNetworkContext', () => {
 
   it('hostnameIsStable is false for an IPv6 literal host', () => {
     expect(detectNetworkContext(makeReq({ hostname: '::1', peer: '::1' })).hostnameIsStable).toBe(false);
-    expect(detectNetworkContext(makeReq({ hostname: '2001:db8::1', peer: '2001:db8::1' })).hostnameIsStable).toBe(false);
+    expect(detectNetworkContext(makeReq({ hostname: '2001:db8::1', peer: '2001:db8::1' })).hostnameIsStable).toBe(
+      false
+    );
   });
 
   it('reachedVia=loopback for a loopback peer', () => {
@@ -119,6 +126,28 @@ describe('detectNetworkContext', () => {
     );
   });
 
+  // A Tailscale iface being up must NOT relabel a PUBLIC peer. This is a security floor, not a nicety:
+  // requireSecureConfigWrite() only refuses when reachedVia === 'public_internet' && !isHttps, so a
+  // classifier that called every public peer 'tailscale' on a Tailscale-running host would silently
+  // open the plain-HTTP secret-write path. Without this assertion, dropping the `isPrivateNetworkIp(ip)`
+  // guard from the impl leaves the whole suite green.
+  it('a public peer stays public_internet even when the host HAS a Tailscale interface', () => {
+    stubIfaces(['lo', 'eth0', 'tailscale0']);
+    expect(detectNetworkContext(makeReq({ hostname: 'box.example.com', peer: '203.0.113.5' })).reachedVia).toBe(
+      'public_internet'
+    );
+  });
+
+  // Pins the claim the hermetic stub rests on: macOS Tailscale binds `utun*`, which does NOT match the
+  // `tailscale` prefix the detector looks for. If someone "improves" the detector to match utun*/wg*,
+  // classification (and the config-write floor above) shifts under every macOS dev — loudly, here.
+  it('a utun* interface (macOS Tailscale) does not count as a Tailscale interface', () => {
+    stubIfaces(['lo0', 'utun0', 'utun1', 'en0']);
+    expect(detectNetworkContext(makeReq({ hostname: 'box.example.com', peer: '192.168.1.10' })).reachedVia).toBe(
+      'private_network'
+    );
+  });
+
   it('reachedVia=public_internet for a public peer', () => {
     expect(detectNetworkContext(makeReq({ hostname: 'box.example.com', peer: '203.0.113.5' })).reachedVia).toBe(
       'public_internet'
@@ -128,15 +157,15 @@ describe('detectNetworkContext', () => {
   it('passkeyEligible = isHttps && hostnameIsStable (vendor-neutral)', () => {
     process.env.WAYLAND_HTTPS = 'true';
     // HTTPS + stable hostname, public peer -> still eligible (NOT gated on Tailscale).
-    expect(detectNetworkContext(makeReq({ hostname: 'wayland.example.com', peer: '203.0.113.5' })).passkeyEligible).toBe(
-      true
-    );
+    expect(
+      detectNetworkContext(makeReq({ hostname: 'wayland.example.com', peer: '203.0.113.5' })).passkeyEligible
+    ).toBe(true);
   });
 
   it('passkeyEligible is false without HTTPS even on a stable hostname', () => {
-    expect(detectNetworkContext(makeReq({ hostname: 'wayland.example.com', peer: '203.0.113.5' })).passkeyEligible).toBe(
-      false
-    );
+    expect(
+      detectNetworkContext(makeReq({ hostname: 'wayland.example.com', peer: '203.0.113.5' })).passkeyEligible
+    ).toBe(false);
   });
 
   it('passkeyEligible is false on HTTPS with an IP-literal host', () => {


### PR DESCRIPTION
- **test(webserver): make detectNetworkContext hermetic, not host-dependent**
- **test(webserver): cover the Tailscale public-peer floor and utun case**
