### PR TITLE
ci: label the superseded-run red so it stops reading as a test failure

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -191,6 +191,25 @@ jobs:
   # failed, so a single failing unit test anywhere blocks the merge. GitHub's
   # `needs.<job>.result` for a matrix job is success only when every cell
   # succeeded.
+  #
+  # The `always()` guard is LOAD-BEARING — do NOT "fix" it to `!cancelled()`.
+  # It is tempting, because on a run cancelled by the concurrency group above
+  # `needs.unit-tests.result` is "cancelled", which trips the != "success" check
+  # and stamps a red required check from a dead run (three of them, so it reads as
+  # "unit tests failing on all three platforms" when nothing is broken at all).
+  # But `!cancelled()` would SKIP these jobs on a cancelled run, and GitHub counts
+  # a skipped required check as a PASS. Since the live run publishes no
+  # "Unit Tests (<os>)" check until all 12 shards finish (~10-20 min), the PR would
+  # go CLEAN — and auto-merge would fire — while the real tests were still running.
+  # That trades a cosmetic false-red for a fail-open merge gate. Never do it.
+  #
+  # So the red stays (it is fail-closed and correct), and the step below instead
+  # makes the superseded case unmistakable in the log + job summary. The stale red
+  # is transient: the newest run stamps these same check names and supersedes it.
+  #
+  # KNOWN LIMITATION (follow-up): each aggregator gates on the WHOLE 12-cell matrix,
+  # so one macOS-only shard failure also reds out "Unit Tests (ubuntu-latest)" and
+  # "Unit Tests (windows-2022)". Per-OS gating needs the matrix restructured.
   unit-tests-ubuntu:
     name: Unit Tests (ubuntu-latest)
     if: always() && (github.event_name == 'workflow_dispatch' || (github.event.action != 'closed' && github.event.pull_request.draft == false))
@@ -201,11 +220,30 @@ jobs:
         env:
           SHARDS_RESULT: ${{ needs.unit-tests.result }}
         run: |
-          if [ "$SHARDS_RESULT" != "success" ]; then
-            echo "One or more unit-test shards did not pass (result: $SHARDS_RESULT)."
+          if [ "$SHARDS_RESULT" = "success" ]; then
+            echo "All unit-test shards passed."
+            exit 0
+          fi
+
+          if [ "$SHARDS_RESULT" = "cancelled" ]; then
+            echo "::warning::SUPERSEDED RUN - NOT A REAL TEST FAILURE. The shards were cancelled because a newer run replaced this one for the same PR. The newest run is authoritative."
+            {
+              echo "### Superseded run - NOT a real test failure"
+              echo ""
+              echo 'The unit-test shards were `cancelled`: a newer run replaced this one for the'
+              echo 'same PR (the `pr-checks-<pr>` concurrency group is `cancel-in-progress`).'
+              echo ""
+              echo 'This job still fails **on purpose** - a required check must never report green'
+              echo 'when the tests it gates did not actually run. The red is correct but STALE: the'
+              echo 'newest run stamps its own verdict on these same check names and supersedes it.'
+              echo ""
+              echo '**Do not go bug-hunting.** Open the newest `PR Checks` run for this commit.'
+            } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
-          echo "All unit-test shards passed."
+
+          echo "One or more unit-test shards did not pass (result: $SHARDS_RESULT)."
+          exit 1
 
   unit-tests-macos:
     name: Unit Tests (macos-14)
@@ -217,11 +255,30 @@ jobs:
         env:
           SHARDS_RESULT: ${{ needs.unit-tests.result }}
         run: |
-          if [ "$SHARDS_RESULT" != "success" ]; then
-            echo "One or more unit-test shards did not pass (result: $SHARDS_RESULT)."
+          if [ "$SHARDS_RESULT" = "success" ]; then
+            echo "All unit-test shards passed."
+            exit 0
+          fi
+
+          if [ "$SHARDS_RESULT" = "cancelled" ]; then
+            echo "::warning::SUPERSEDED RUN - NOT A REAL TEST FAILURE. The shards were cancelled because a newer run replaced this one for the same PR. The newest run is authoritative."
+            {
+              echo "### Superseded run - NOT a real test failure"
+              echo ""
+              echo 'The unit-test shards were `cancelled`: a newer run replaced this one for the'
+              echo 'same PR (the `pr-checks-<pr>` concurrency group is `cancel-in-progress`).'
+              echo ""
+              echo 'This job still fails **on purpose** - a required check must never report green'
+              echo 'when the tests it gates did not actually run. The red is correct but STALE: the'
+              echo 'newest run stamps its own verdict on these same check names and supersedes it.'
+              echo ""
+              echo '**Do not go bug-hunting.** Open the newest `PR Checks` run for this commit.'
+            } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
-          echo "All unit-test shards passed."
+
+          echo "One or more unit-test shards did not pass (result: $SHARDS_RESULT)."
+          exit 1
 
   unit-tests-windows:
     name: Unit Tests (windows-2022)
@@ -233,11 +290,30 @@ jobs:
         env:
           SHARDS_RESULT: ${{ needs.unit-tests.result }}
         run: |
-          if [ "$SHARDS_RESULT" != "success" ]; then
-            echo "One or more unit-test shards did not pass (result: $SHARDS_RESULT)."
+          if [ "$SHARDS_RESULT" = "success" ]; then
+            echo "All unit-test shards passed."
+            exit 0
+          fi
+
+          if [ "$SHARDS_RESULT" = "cancelled" ]; then
+            echo "::warning::SUPERSEDED RUN - NOT A REAL TEST FAILURE. The shards were cancelled because a newer run replaced this one for the same PR. The newest run is authoritative."
+            {
+              echo "### Superseded run - NOT a real test failure"
+              echo ""
+              echo 'The unit-test shards were `cancelled`: a newer run replaced this one for the'
+              echo 'same PR (the `pr-checks-<pr>` concurrency group is `cancel-in-progress`).'
+              echo ""
+              echo 'This job still fails **on purpose** - a required check must never report green'
+              echo 'when the tests it gates did not actually run. The red is correct but STALE: the'
+              echo 'newest run stamps its own verdict on these same check names and supersedes it.'
+              echo ""
+              echo '**Do not go bug-hunting.** Open the newest `PR Checks` run for this commit.'
+            } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
-          echo "All unit-test shards passed."
+
+          echo "One or more unit-test shards did not pass (result: $SHARDS_RESULT)."
+          exit 1
 
   # Job 3: Coverage test (Linux only) + Codecov upload
   coverage-tests:


### PR DESCRIPTION
## The bug

The `Unit Tests (<os>)` checks are **not test jobs** — they're name-preserving aggregators (`pr-checks.yml`) whose only step asserts `needs.unit-tests.result == "success"`.

When a run is cancelled by the `pr-checks-<pr>` concurrency group (a push, an auto-merge re-arm, an `update-branch`), that result is `"cancelled"` — which is `!= "success"` — so the aggregator **exits 1 and stamps three red required checks on the commit from the dead run.**

They look exactly like a real cross-platform break. **#803, #800 and #779 were each triaged as "unit tests failing on all three platforms"** while their live runs were green and the red jobs had died in ~3 seconds with `SHARDS_RESULT: cancelled`. Real time was spent hunting a bug that did not exist.

## Why the obvious fix is a fail-open — do not do it

The tempting one-liner is `always()` → `!cancelled()`. **It must never ship**, and this PR adds a comment saying so:

- `!cancelled()` **skips** the aggregators on a cancelled run, and **GitHub counts a skipped required check as a pass**.
- The live run publishes **no** `Unit Tests (<os>)` check until all 12 shards finish (~10–20 min; the windows shards alone are 8–9 min).
- So in that window the only checks bearing the required names are the dead run's three *skipped → green*, and `Code Quality` (~2 min) is already green. **All four required checks satisfied → the PR flips to CLEAN → armed auto-merge fires → it merges with its unit tests never evaluated.** On a manual cancel with no successor run, that skipped-green sticks to the SHA permanently.
- `pr-ship` / `pr-verify` wouldn't catch it either: they only count `FAILURE`/`CANCELLED` as failed, so `SKIPPED` sails through.

The current red is **fail-closed and self-healing** — the newest run stamps the same check names and supersedes it. It's triage noise, not a merge blocker. Trading recoverable noise for an unrecoverable fail-open is a bad deal.

## What this PR does instead

Keeps the gate exactly as fail-closed as it was, and fixes the thing that actually caused harm — the *misreading*:

- On `cancelled`, emit a `::warning::` and a job-summary banner: **"Superseded run — NOT a real test failure … do not go bug-hunting, open the newest `PR Checks` run."**
- A genuine shard failure still exits 1 and still blocks the merge.
- Adds a load-bearing comment on `always()` so the next person doesn't "fix" it into the fail-open above.

Verified by executing the step script directly against every result value:

| `needs.unit-tests.result` | exit | effect |
|---|---|---|
| `success` | 0 | check green |
| `failure` | 1 | **merge blocked** (unchanged) |
| `cancelled` | 1 | merge blocked, now clearly labelled as superseded |
| `skipped` | 1 | merge blocked |

## Also documented (follow-up, not fixed here)

Each aggregator `needs:` the **whole 12-cell matrix**, so a single macOS-only shard failure also reds out `Unit Tests (ubuntu-latest)` *and* `(windows-2022)`. That is a second reason a one-shard failure reads as "failing on all three platforms". Per-OS gating requires restructuring the matrix — flagged in-file.

CI-only change; no product code touched. Full suite green at the land gate: 12558 passed.