### PR TITLE
fix(context): resize the meter on model switch, size the sonnet slot

### DIFF
--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -2300,6 +2300,49 @@ ${collectedResponses.join('\n')}`;
     } catch (error) {
       mainWarn('[AcpAgentManager]', 'Failed to save model ID', error);
     }
+
+    // The DB row is the AUTHORITATIVE model id and the renderer seeds the context
+    // meter from it on load (#733) - but only on load. A mid-chat switch wrote the
+    // row and told nobody, so the meter kept sizing itself from the PREVIOUS model:
+    // switching opus (1M) -> haiku (200K) left a 1M denominator on a 200K window,
+    // i.e. the meter reported ~5x the headroom that actually existed and the user
+    // hit the ceiling with no warning. Push the new id to the live renderer. (#801)
+    this.emitModelInfoUpdate(modelId);
+  }
+
+  /**
+   * Tell the renderer the active model changed, so anything sized from the model's
+   * context window (the ACP context meter) re-sizes immediately instead of at the
+   * next conversation load.
+   *
+   * MERGES onto the agent's current info rather than emitting a fresh payload: an
+   * `acp_model_info` whose `availableModels` is EMPTY reverts the in-chat picker to
+   * "Select Model" (#184 - AcpAgentV2.onModelUpdate guards the same hazard for the
+   * bridge's own empty snapshots). Spreading `info` means this emit can only ever
+   * change `currentModelId`/`currentModelLabel`; it can never shrink the model list.
+   */
+  private emitModelInfoUpdate(modelId: string): void {
+    const info = this.getModelInfo();
+    // Nothing authoritative to merge onto -> stay silent. An EMPTY availableModels
+    // is not merely useless, it is destructive: the renderer's selector adopts an
+    // incoming acp_model_info unconditionally, so an empty list reverts the in-chat
+    // picker to "Select Model" (#184). Two reachable states produce a non-null but
+    // EMPTY info - the no-agent/persisted-id branch of getModelInfo(), and a
+    // non-claude bridge whose first snapshot (or 10s timeout fallback) was empty -
+    // so guarding on `!info` alone is not enough. The renderer still seeds the
+    // model id from the conversation row on its next load (#733).
+    if (!info || info.availableModels.length === 0) return;
+
+    ipcBridge.acpConversation.responseStream.emit({
+      type: 'acp_model_info',
+      conversation_id: this.conversation_id,
+      msg_id: uuid(),
+      data: {
+        ...info,
+        currentModelId: modelId,
+        currentModelLabel: info.availableModels.find((m) => m.id === modelId)?.label ?? modelId,
+      },
+    });
   }
 
   /**

--- a/src/renderer/utils/model/modelContextLimits.ts
+++ b/src/renderer/utils/model/modelContextLimits.ts
@@ -53,6 +53,7 @@ const MODEL_CONTEXT_LIMITS: Record<string, number> = {
   'claude-opus-4-5': 200_000,
   'claude-opus-4-1': 200_000,
   'claude-opus-4': 200_000,
+  'claude-sonnet-5': 1_000_000,
   'claude-sonnet-4-6': 1_000_000,
   'claude-sonnet-4-5': 200_000,
   'claude-sonnet-4': 200_000,
@@ -69,26 +70,32 @@ const MODEL_CONTEXT_LIMITS: Record<string, number> = {
   // and only honors the three ANTHROPIC_MODEL aliases, so it reports its current
   // model as a bare SLOT (`opus`/`sonnet`/`haiku`) rather than a catalog id - see
   // CLAUDE_SLOT_MODELS in src/process/agent/acp/utils.ts. Without these rows the
-  // context meter cannot size a window from what the agent actually reports and
-  // silently falls back to DEFAULT_CONTEXT_LIMIT (1M) for EVERY slot - so Haiku
-  // (really 200K) showed a 1M denominator. (#733)
+  // meter cannot size a window from what the agent actually reports and falls back
+  // to DEFAULT_CONTEXT_LIMIT for EVERY slot - so Haiku (really 200K) showed a ~1M
+  // denominator. (#733)
   //
-  // The fuzzy match is longest-key-wins, so these short keys never shadow a full
-  // catalog id (`claude-3-opus` still resolves via its own 13-char key, not `opus`).
+  // Each alias is resolved LIVE against the claude CLI (`ANTHROPIC_MODEL=<slot>`,
+  // verified 2026-07-11):
+  //   opus   -> claude-opus-4-8            -> 1M
+  //   sonnet -> claude-sonnet-5            -> 1M   (#802)
+  //   haiku  -> claude-haiku-4-5-20251001  -> 200K
   //
-  // Only slots whose window we can state with CONFIDENCE are listed:
-  //   - `opus`: utils.ts verifies live that `--model opus` / `ANTHROPIC_MODEL=opus`
-  //     resolve to claude-opus-4-8 → 1M.
-  //   - `haiku`: version-independent - EVERY Haiku (4.5, 4.0, 3.5) is 200K, so the
-  //     window holds whichever one the alias picks.
-  // `sonnet` is deliberately OMITTED: its window depends on which Sonnet the alias
-  // resolves to (4.6 is 1M, but 4.5/4.0 are 200K) and that is NOT verified anywhere
-  // in-repo. Guessing 1M would show a 1M denominator for a 200K model - the exact
-  // over-sized-max half of this bug. Omitted, it falls through to
-  // DEFAULT_CONTEXT_LIMIT, i.e. today's behaviour - no better, but no new lie.
-  // Verify the alias against the claude CLI (as was done for opus) before adding it.
-  opus: 1_000_000, // → claude-opus-4-8 (verified)
-  haiku: 200_000, // → any claude-haiku-* (all 200K)
+  // These short keys stay in the FUZZY table ON PURPOSE. Real catalog ids like
+  // `claude-4.5-haiku`, `anthropic/claude-haiku-latest` and `duo-chat-haiku-4-5`
+  // match NONE of the `claude-haiku-*` keys above and reach 200K only through the
+  // bare `haiku` key. Moving the slots to an exact-match-only table sounds safer
+  // but is strictly worse: those ids then fall through to DEFAULT_CONTEXT_LIMIT
+  // (1,048,576) - a 5.2x over-size on a 200K window. Every Haiku ever shipped is
+  // 200K, so the bare key cannot over-size anything.
+  //
+  // The bare keys do NOT rescue ids like `opus-4-5`/`sonnet-4` (really 200K, still
+  // sized ~1M) - but removing them does not either, because DEFAULT_CONTEXT_LIMIT
+  // is itself LARGER than 1M. That over-sizing belongs to the optimistic default,
+  // not to these keys. Tracked separately (#807) - a too-large default is the
+  // unsafe direction: it promises headroom that isn't there.
+  opus: 1_000_000,
+  sonnet: 1_000_000,
+  haiku: 200_000,
 };
 
 /**

--- a/tests/unit/acpAgentManagerModelInfoEmit.test.ts
+++ b/tests/unit/acpAgentManagerModelInfoEmit.test.ts
@@ -1,0 +1,233 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * AcpAgentManager model-switch -> renderer notification (#801)
+ *
+ * `saveModelId` writes the AUTHORITATIVE model id to the conversation row, and the
+ * renderer seeds the context meter from that row (#733) - but only on LOAD. A
+ * mid-chat switch therefore wrote the row and told nobody: the meter kept sizing
+ * itself from the PREVIOUS model, so switching opus (1M) -> haiku (200K) left a 1M
+ * denominator over a 200K window and the user hit the ceiling with no warning.
+ *
+ * `saveModelId` now pushes an `acp_model_info` to the live renderer.
+ *
+ * The dangerous way to do that is to emit a FRESH payload: an `acp_model_info`
+ * whose `availableModels` is empty reverts the in-chat picker to "Select Model"
+ * (#184). So the emit MERGES onto the agent's current info and can only ever change
+ * currentModelId/currentModelLabel - never shrink the model list. That is the
+ * property these tests pin.
+ *
+ * Mock setup mirrors acpAgentManagerDbErrorLogging.test.ts.
+ */
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+const { mockEmit, mockUpdateConversation, mockGetConversation } = vi.hoisted(() => ({
+  mockEmit: vi.fn(),
+  mockUpdateConversation: vi.fn(),
+  mockGetConversation: vi.fn(() => ({ success: true, data: { type: 'acp', extra: {} } })),
+}));
+
+vi.mock('@process/services/cron/CronBusyGuard', () => ({
+  cronBusyGuard: { setProcessing: vi.fn(), isProcessing: vi.fn(() => false) },
+}));
+vi.mock('@process/utils/mainLogger', () => ({ mainLog: vi.fn(), mainWarn: vi.fn(), mainError: vi.fn() }));
+vi.mock('@process/utils/initStorage', () => ({
+  ProcessConfig: { getConfig: vi.fn(() => ({})), get: vi.fn() },
+}));
+vi.mock('@/common', () => ({
+  ipcBridge: { acpConversation: { responseStream: { emit: mockEmit } } },
+}));
+vi.mock('@process/services/database', () => ({
+  getDatabase: vi.fn(() =>
+    Promise.resolve({ updateConversation: mockUpdateConversation, getConversation: mockGetConversation })
+  ),
+}));
+vi.mock('@process/utils/message', () => ({
+  addMessage: vi.fn(),
+  addOrUpdateMessage: vi.fn(),
+  nextTickToLocalFinish: vi.fn((cb: () => void) => cb()),
+}));
+vi.mock('@process/channels/agent/ChannelEventBus', () => ({
+  channelEventBus: { emit: vi.fn(), on: vi.fn(), off: vi.fn(), emitAgentMessage: vi.fn() },
+}));
+vi.mock('@process/utils/previewUtils', () => ({ handlePreviewOpenEvent: vi.fn() }));
+vi.mock('@process/extensions', () => ({
+  ExtensionRegistry: {
+    getInstance: vi.fn(() => ({ getAll: vi.fn(() => []), getAcpAdapters: vi.fn(() => []) })),
+  },
+}));
+vi.mock('@process/agent/acp', () => ({
+  AcpAgent: class {
+    sendMessage = vi.fn().mockResolvedValue({ success: true });
+    stop = vi.fn();
+    kill = vi.fn();
+    cancelPrompt = vi.fn();
+  },
+}));
+vi.mock('@process/task/BaseAgentManager', () => ({
+  default: class {
+    conversation_id = '';
+    status: string | undefined;
+    workspace = '';
+    bootstrapping = false;
+    yoloMode = false;
+    constructor(_type: string, data: Record<string, unknown>, _emitter: unknown) {
+      if (data?.conversation_id) this.conversation_id = data.conversation_id as string;
+      if (data?.workspace) this.workspace = data.workspace as string;
+    }
+    isYoloMode() {
+      return false;
+    }
+    addConfirmation() {}
+    getConfirmations() {
+      return [];
+    }
+  },
+}));
+vi.mock('@process/task/ConversationTurnCompletionService', () => ({
+  ConversationTurnCompletionService: {
+    getInstance: () => ({ notifyPotentialCompletion: vi.fn(() => Promise.resolve()) }),
+  },
+}));
+vi.mock('@process/task/IpcAgentEventEmitter', () => ({ IpcAgentEventEmitter: vi.fn() }));
+vi.mock('@process/task/CronCommandDetector', () => ({ hasCronCommands: vi.fn(() => false) }));
+vi.mock('@process/task/MessageMiddleware', () => ({
+  extractTextFromMessage: vi.fn(() => ''),
+  processCronInMessage: vi.fn((x: unknown) => x),
+}));
+vi.mock('@process/task/ThinkTagDetector', () => ({ stripThinkTags: vi.fn((x: unknown) => x) }));
+vi.mock('@process/utils/initAgent', () => ({ hasNativeSkillSupport: vi.fn(() => false) }));
+vi.mock('@process/task/agentUtils', () => ({
+  prepareFirstMessageWithSkillsIndex: vi.fn((x: string) => Promise.resolve({ content: x, loadedSkills: [] })),
+}));
+vi.mock('@/common/utils', () => ({ parseError: vi.fn((e: unknown) => e), uuid: vi.fn(() => 'test-uuid') }));
+vi.mock('@/common/chat/chatLib', () => ({ transformMessage: vi.fn(), uuid: vi.fn(() => 'uuid') }));
+
+import AcpAgentManager from '../../src/process/task/AcpAgentManager';
+import type { AcpBackend, AcpModelInfo } from '../../src/common/types/acpTypes';
+
+const SLOTS = [
+  { id: 'opus', label: 'Opus' },
+  { id: 'sonnet', label: 'Sonnet' },
+  { id: 'haiku', label: 'Haiku' },
+];
+
+function makeManager(modelInfo: AcpModelInfo | null) {
+  const manager = new AcpAgentManager({
+    conversation_id: 'conv-801',
+    backend: 'claude' as AcpBackend,
+    workspace: '/tmp/workspace',
+  });
+  (manager as unknown as { agent: unknown }).agent = {
+    sendMessage: vi.fn().mockResolvedValue({ success: true }),
+    getModelInfo: vi.fn(() => modelInfo),
+  };
+  return manager;
+}
+
+/** Invoke the private choke point every switch path funnels through. */
+async function saveModelId(manager: AcpAgentManager, modelId: string) {
+  await (manager as unknown as { saveModelId: (id: string) => Promise<void> }).saveModelId(modelId);
+}
+
+function emittedModelInfo(): Array<{ type: string; data: AcpModelInfo }> {
+  return mockEmit.mock.calls.map((c) => c[0]).filter((m) => m?.type === 'acp_model_info');
+}
+
+describe('AcpAgentManager notifies the renderer when the model changes (#801)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetConversation.mockReturnValue({ success: true, data: { type: 'acp', extra: {} } });
+  });
+
+  const current: AcpModelInfo = {
+    currentModelId: 'opus',
+    currentModelLabel: 'Opus',
+    availableModels: SLOTS,
+  } as AcpModelInfo;
+
+  it('pushes the NEW model id to the live renderer, not just the DB row', async () => {
+    const manager = makeManager(current);
+
+    await saveModelId(manager, 'haiku');
+
+    const infos = emittedModelInfo();
+    expect(infos).toHaveLength(1);
+    // The renderer sizes the context meter off THIS field (#733). Before #801 the
+    // switch was DB-only, so it kept reporting the previous model's window.
+    expect(infos[0].data.currentModelId).toBe('haiku');
+    expect(infos[0].data.currentModelLabel).toBe('Haiku');
+    expect(infos[0].conversation_id).toBe('conv-801');
+  });
+
+  it('MERGES onto the cached info - an emit can never wipe the model picker (#184)', async () => {
+    const manager = makeManager(current);
+
+    await saveModelId(manager, 'sonnet');
+
+    const infos = emittedModelInfo();
+    expect(infos).toHaveLength(1);
+    // The #184 hazard: an acp_model_info with an empty availableModels reverts the
+    // in-chat picker to "Select Model". This emit must carry the list through intact.
+    expect(infos[0].data.availableModels).toEqual(SLOTS);
+    expect(infos[0].data.availableModels.length).toBeGreaterThan(0);
+  });
+
+  it('still emits for a model the agent does not list, without inventing a list', async () => {
+    const manager = makeManager(current);
+
+    // A Flux routing alias is not in availableModels; the label falls back to the id.
+    await saveModelId(manager, 'flux-auto');
+
+    const infos = emittedModelInfo();
+    expect(infos[0].data.currentModelId).toBe('flux-auto');
+    expect(infos[0].data.currentModelLabel).toBe('flux-auto');
+    expect(infos[0].data.availableModels).toEqual(SLOTS);
+  });
+
+  it('emits nothing when there is no model info to merge onto', async () => {
+    const manager = makeManager(null);
+
+    await saveModelId(manager, 'haiku');
+
+    // Nothing authoritative to merge onto -> stay silent rather than push a payload
+    // with an empty model list. The renderer still seeds from the conversation row
+    // on its next load (#733).
+    expect(emittedModelInfo()).toHaveLength(0);
+  });
+
+  // The load-bearing guard. `!info` alone is NOT enough: getModelInfo() has two
+  // reachable states that return a non-null info with an EMPTY availableModels -
+  // the no-agent/persisted-id branch, and a non-claude bridge whose first snapshot
+  // (or 10s timeout fallback) was empty. The renderer's selector adopts an incoming
+  // acp_model_info unconditionally, so emitting either one reverts the in-chat
+  // picker to "Select Model" (#184) - trading a stale meter for a broken picker.
+  it('stays silent rather than emit an EMPTY model list and wipe the picker (#184)', async () => {
+    const manager = makeManager({
+      currentModelId: 'gpt-5',
+      currentModelLabel: 'GPT-5',
+      availableModels: [],
+    } as unknown as AcpModelInfo);
+
+    await saveModelId(manager, 'gpt-5.1');
+
+    expect(emittedModelInfo()).toHaveLength(0);
+  });
+
+  it('still notifies the renderer even if the DB write fails', async () => {
+    const manager = makeManager(current);
+    mockGetConversation.mockImplementation(() => {
+      throw new Error('disk full');
+    });
+
+    await saveModelId(manager, 'haiku');
+
+    // The in-memory agent HAS switched; a persist failure must not also leave the
+    // meter silently sized to the old model for the rest of the session.
+    expect(emittedModelInfo()[0]?.data.currentModelId).toBe('haiku');
+  });
+});

--- a/tests/unit/modelContextLimits.test.ts
+++ b/tests/unit/modelContextLimits.test.ts
@@ -145,17 +145,50 @@ describe('Claude ACP slot aliases resolve to a real window (#733)', () => {
     expect(getModelContextLimit('opus')).toBe(1_000_000);
   });
 
-  // `sonnet` is deliberately NOT in the table: which Sonnet the alias resolves to
-  // (4.6 = 1M vs 4.5/4.0 = 200K) is unverified, and guessing 1M would show an
-  // over-sized max for a 200K model. It must keep falling through to the default.
-  it('leaves the UNVERIFIED sonnet slot on the default rather than guessing', () => {
-    expect(getModelContextLimit('sonnet')).toBe(DEFAULT_CONTEXT_LIMIT);
+  // #733 left `sonnet` on the default because which Sonnet the alias resolved to was
+  // UNVERIFIED (4.6 = 1M vs 4.5/4.0 = 200K) and guessing 1M would have shown an
+  // over-sized max for a 200K model. It is now verified live (#802): the alias
+  // resolves to claude-sonnet-5, which models.dev puts at 1M. No longer a guess.
+  it('resolves the sonnet slot to 1M (ANTHROPIC_MODEL=sonnet -> claude-sonnet-5)', () => {
+    expect(getModelContextLimit('sonnet')).toBe(1_000_000);
+    expect(getModelContextLimit('sonnet')).not.toBe(DEFAULT_CONTEXT_LIMIT);
+  });
+
+  it('knows the Claude 5 family the static table used to miss entirely', () => {
+    expect(getModelContextLimit('claude-sonnet-5')).toBe(1_000_000);
+    // A dated/variant id must fuzzy-match the family row, not the default.
+    expect(getModelContextLimit('claude-sonnet-5-20260101')).toBe(1_000_000);
   });
 
   // The slot rows duplicate a family row's literal; pin them so they cannot drift.
   it('keeps the slot rows in lockstep with the model they alias', () => {
     expect(getModelContextLimit('opus')).toBe(getModelContextLimit('claude-opus-4-8'));
+    expect(getModelContextLimit('sonnet')).toBe(getModelContextLimit('claude-sonnet-5'));
     expect(getModelContextLimit('haiku')).toBe(getModelContextLimit('claude-haiku-4-5'));
+  });
+
+  // REGRESSION GUARD. The bare `haiku` key looks like a fuzzy-matching hazard and
+  // is tempting to "harden" into an exact-match-only table. Doing that silently
+  // over-sizes every real Haiku id that matches none of the `claude-haiku-*` keys:
+  // they fall through to DEFAULT_CONTEXT_LIMIT (1,048,576) on a 200K window - a
+  // 5.2x over-size, i.e. the meter promises 5x the headroom that exists. All of
+  // these ids are real and present in resources/modelsdev-snapshot.json.
+  //
+  // Note the assertion is `toBe(200_000)`, NOT `not.toBe(1_000_000)`: DEFAULT is
+  // 1,048,576, so a "not 1M" assertion PASSES on the over-sized default and would
+  // certify this very regression as a fix.
+  it('sizes every real Haiku catalog id at 200K, not the ~1M default', () => {
+    for (const id of [
+      'claude-4.5-haiku',
+      'anthropic/claude-3.5-haiku',
+      'anthropic/claude-haiku-latest',
+      'duo-chat-haiku-4-5',
+      'claude-haiku-4-5',
+      'haiku',
+    ]) {
+      expect(getModelContextLimit(id)).toBe(200_000);
+      expect(getModelContextLimit(id)).not.toBe(DEFAULT_CONTEXT_LIMIT);
+    }
   });
 
   it('resolves the haiku slot to 200K - NOT the 1M default', () => {


### PR DESCRIPTION
The renderer seeds the context meter from the conversation row's model id, but
only on load. A mid-chat switch wrote the row and told nobody, so the meter kept
sizing itself from the PREVIOUS model: opus (1M) -> haiku (200K) left a ~1M
denominator over a 200K window, reporting ~5x the headroom that existed and no
warning before the ceiling. Push an acp_model_info to the live renderer from
saveModelId, the choke point every switch path funnels through.

The emit merges onto the agent's cached info and stays SILENT when that info has
no models: the renderer's selector adopts an incoming acp_model_info
unconditionally, so shipping an empty availableModels would revert the in-chat
picker to Select Model (#184) -- trading a stale meter for a broken picker.

Size the sonnet slot: it was left on the default by #733 because the alias target
was unverified. It resolves live to claude-sonnet-5 (1M), so the slot and the
Claude 5 family now have rows. sonnet previously fell through to
DEFAULT_CONTEXT_LIMIT (1,048,576), so this makes the denominator smaller, never
larger.

Fixes #801, #802
