### PR TITLE
fix(806): stop CI merge-train hang from spawn-verify settle test

### DIFF
--- a/src/process/services/ijfwSystemService.ts
+++ b/src/process/services/ijfwSystemService.ts
@@ -575,6 +575,16 @@ async function retryOnEbusy<T>(op: () => Promise<T>, attempts = 5): Promise<T> {
   throw lastErr instanceof Error ? lastErr : new Error('EBUSY retry exhausted');
 }
 
+/**
+ * Verify-probe timeout. Defaults to 5s in prod; overridable via env (same
+ * pattern as IJFW_AUTO_INSTALL) so tests can drive the timeout path in real
+ * time instead of interleaving real fs macrotasks with a fake clock.
+ */
+function resolveVerifyTimeoutMs(): number {
+  const raw = Number(process.env.IJFW_SPAWN_VERIFY_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 5000;
+}
+
 /** SEC-003: full JSON-RPC envelope verify with exit-before-success = fail. */
 async function spawnTestVerify(mcpServerDir: string): Promise<boolean> {
   let entry: string;
@@ -616,7 +626,7 @@ async function spawnTestVerify(mcpServerDir: string): Promise<boolean> {
       resolve(value);
     };
 
-    const timeout = setTimeout(() => settle(false), 5000);
+    const timeout = setTimeout(() => settle(false), resolveVerifyTimeoutMs());
     let buf: Buffer = Buffer.alloc(0);
 
     child.stdout?.on('data', (chunk: Buffer) => {

--- a/tests/unit/process/services/ijfwSystemService.applyPendingUpgrade.test.ts
+++ b/tests/unit/process/services/ijfwSystemService.applyPendingUpgrade.test.ts
@@ -303,36 +303,33 @@ describe('ijfwSystemService.applyPendingUpgrade', () => {
   it('#721: spawn-test settles false via its 5s timeout when the child emits only garbage', async () => {
     // No current install seeded → the failed verify has no `.prev` to roll
     // back to, so the flow exits via upgrade_failed_no_rollback after a
-    // SINGLE spawn-test - one 5s timer to advance.
-    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    // SINGLE spawn-test.
+    //
+    // #806: the previous version faked the clock and hand-interleaved REAL fs
+    // macrotasks with fake-clock advances across 200 rounds — settlement then
+    // depended on how many real event-loop turns the OS granted per round,
+    // which starves under parallel CI shard load and hangs (false red on the
+    // merge train). Instead we shrink the verify timeout to a small REAL value
+    // and run with real timers: the garbage child never produces a valid reply
+    // and never exits, so the real timeout is the only settle path and the flow
+    // completes deterministically in real time — no fake/real interleaving.
+    const prevTimeout = process.env.IJFW_SPAWN_VERIFY_TIMEOUT_MS;
+    process.env.IJFW_SPAWN_VERIFY_TIMEOUT_MS = '30';
     try {
       writePendingDir();
       spawnSpy.mockImplementation(() => makeGarbageOnlyChild());
 
-      let settled = false;
-      const run = ijfwSystemService.applyPendingUpgrade().finally(() => {
-        settled = true;
-      });
-      // Interleave real macrotask flushes (child emits via setImmediate, fs is
-      // real) with fake-clock advances until the flow has created and fired
-      // the 5s verify timeout and run to completion.
-      for (let i = 0; i < 200 && !settled; i++) {
-        for (let j = 0; j < 4; j++) await flush();
-        await vi.advanceTimersByTimeAsync(500);
-      }
-      await run;
+      await ijfwSystemService.applyPendingUpgrade();
 
       expect(spawnSpy).toHaveBeenCalledTimes(1);
       expect(emitSpy).toHaveBeenCalledWith(
         expect.objectContaining({ status: 'install_failed', errorReason: 'upgrade_failed_no_rollback' })
       );
     } finally {
-      vi.useRealTimers();
+      if (prevTimeout === undefined) delete process.env.IJFW_SPAWN_VERIFY_TIMEOUT_MS;
+      else process.env.IJFW_SPAWN_VERIFY_TIMEOUT_MS = prevTimeout;
     }
-    // The settle loop interleaves up to 200 rounds of real macrotask flushes
-    // with fake-clock advances; on loaded CI shards that legitimately exceeds
-    // the default 10s wall budget (observed flaking PR merge runs).
-  }, 30_000);
+  });
 
   it('Checkpoint B B2: acquires installLock and short-circuits when one is already held', async () => {
     // Pre-seed a lockfile that matches the current host+boot and points at the


### PR DESCRIPTION
The #721 spawn-verify settle test faked the clock and interleaved real fs
macrotasks with fake-clock advances over 200 rounds; settlement depended on
how many real event-loop turns the OS granted per round, which starves under
parallel CI shard load and hangs (>30s false-red blocking the merge train).
Raising the wall budget twice did not help — it is a race, not slowness.

Add an IJFW_SPAWN_VERIFY_TIMEOUT_MS env seam (default 5000, mirroring the
existing IJFW_AUTO_INSTALL tunable) and rewrite the test to run with real
timers at a 30ms timeout. The garbage-only child never yields a valid reply
or exit, so the real timeout is the sole settle path and the flow resolves
deterministically in real time — no fake/real interleaving.
