### PR TITLE
fix(security): trust a CGNAT peer only if it arrived over the tailnet

### DIFF
--- a/src/process/webserver/middleware/networkTrust.ts
+++ b/src/process/webserver/middleware/networkTrust.ts
@@ -28,6 +28,8 @@
  * LAN can opt those ranges back in via the `WAYLAND_OPERATOR_CIDRS` env allowlist.
  */
 
+import { networkInterfaces } from 'node:os';
+
 export type NetworkTrust = 'operator' | 'restricted';
 
 /**
@@ -72,14 +74,133 @@ function isLoopback(ip: string): boolean {
 }
 
 /**
- * Whether an IP is in the Tailscale CGNAT range (100.64.0.0/10). Always operator:
- * Tailscale peers are cryptographically authenticated, so this address is not
- * spoofable from the public internet.
+ * Whether an IP is in 100.64.0.0/10.
+ *
+ * This is NOT a Tailscale-exclusive range - it is RFC 6598 shared address space,
+ * used by real ISPs for carrier-grade NAT. The name is kept for continuity with
+ * the range's usual role here, but membership alone proves NOTHING about the peer
+ * (see `cgnatPeersAreOperator`). (#529)
  */
-function isTailscaleCgnat(ip: string): boolean {
+function isCgnatRange(ip: string): boolean {
   const octets = parseIpv4(ip);
   if (!octets) return false;
   return octets[0] === 100 && octets[1] >= 64 && octets[1] <= 127;
+}
+
+/** Cached set of THIS HOST's own tailnet addresses. `networkInterfaces()` is a
+ *  syscall; the answer changes only when tailscale goes up/down, so a short TTL is
+ *  plenty. */
+let tailnetCache: { value: Set<string>; at: number } | null = null;
+const TAILNET_CACHE_MS = 30_000;
+
+/** Test seam: drop the memoized tailnet probe. */
+export function resetNetworkTrustCache(): void {
+  tailnetCache = null;
+}
+
+/**
+ * Interfaces Tailscale rides on. It is `tailscale0` on Linux and `Tailscale` on
+ * Windows, but a plain `utun<N>` on macOS - so a NAME-ONLY match (as
+ * detectNetworkContext.hasTailscaleInterface does) misses every macOS operator.
+ * Hence: name match, OR a CGNAT address sitting on a TUNNEL interface.
+ */
+/**
+ * Tailscale's ULA prefix, `fd7a:115c:a1e0::/48`. This is the strongest tailnet
+ * signal available: the prefix is registered to Tailscale and is assigned to every
+ * tailnet node, so - unlike 100.64.0.0/10 - nothing else hands it out. Not an ISP's
+ * carrier NAT, and not an unrelated VPN. It is what lets us identify WHICH interface
+ * is Tailscale's, on macOS where the device is a bare `utun<N>`.
+ */
+const TAILSCALE_ULA = /^fd7a:115c:a1e0:/i;
+
+/**
+ * THIS HOST's own tailnet addresses - the local addresses a connection must have
+ * LANDED ON to have arrived over the tailnet. Two signals:
+ *
+ *  1. Any address in Tailscale's registered ULA prefix (`fd7a:115c:a1e0::/48`).
+ *     Nothing else hands that out - not an ISP, not another VPN.
+ *  2. A 100.64/10 address on a TUNNEL interface (`tailscale0`, macOS `utun<N>`,
+ *     `wg0`, ...). Deliberately NOT "a 100.64/10 address anywhere": a host behind
+ *     carrier NAT holds one too, but on a PHYSICAL nic (en0/eth0/wlan0) from the
+ *     ISP's DHCP. Requiring a tunnel is what separates the tailnet from the ISP.
+ *
+ * An interface merely NAMED `tailscale*` is NOT enough on its own: a down or
+ * logged-out `tailscale0` has no address, and nothing can arrive on it.
+ *
+ * NOTE on stock macOS: `utun0/1/3/4` exist with no VPN at all (Handoff, Private
+ * Relay, AWDL) but carry only `fe80::` link-local and no IPv4, so they contribute
+ * nothing here. Verified against a live macOS host.
+ */
+function hostTailnetAddresses(now: number): Set<string> {
+  if (tailnetCache && now - tailnetCache.at < TAILNET_CACHE_MS) return tailnetCache.value;
+
+  const addresses = new Set<string>();
+  try {
+    for (const [name, addrs] of Object.entries(networkInterfaces())) {
+      const entries = (addrs ?? []).filter((a) => !a.internal);
+
+      // Is THIS INTERFACE Tailscale's? Two proofs, and it must be one of them:
+      //   - it is named `tailscale*` (Linux `tailscale0`, Windows `Tailscale`), or
+      //   - it carries an address in Tailscale's registered ULA prefix.
+      // Identifying the INTERFACE (not just the host) is what keeps an unrelated
+      // VPN out: WireGuard/corporate pools legitimately hand out RFC 6598 space on
+      // a tun/wg device, and "a CGNAT address on some tunnel" would have accepted
+      // them. A Tailscale device always carries the fd7a: ULA.
+      const isTailscaleIface =
+        /^tailscale/i.test(name) || entries.some((a) => TAILSCALE_ULA.test(normalizeIp(a.address)));
+      if (!isTailscaleIface) continue;
+
+      for (const addr of entries) {
+        const ip = normalizeIp(addr.address);
+        // Node reports family as 'IPv4' (older) or 4 (newer). Accept both.
+        const isV4 = addr.family === 'IPv4' || (addr.family as unknown as number) === 4;
+        if (TAILSCALE_ULA.test(ip) || (isV4 && isCgnatRange(ip))) {
+          addresses.add(ip);
+        }
+      }
+    }
+  } catch {
+    // Interface enumeration failed -> we cannot prove a tailnet. FAIL CLOSED.
+    return new Set<string>();
+  }
+
+  tailnetCache = { value: addresses, at: now };
+  return addresses;
+}
+
+/**
+ * Whether a 100.64.0.0/10 peer arrived OVER THE TAILNET, and so may be `operator`.
+ *
+ * The old rule trusted the whole range unconditionally, reasoning that "Tailscale
+ * peers are cryptographically authenticated". But 100.64.0.0/10 is RFC 6598 CGNAT
+ * space, NOT Tailscale's: with the app in remote mode (bound 0.0.0.0) and reached
+ * over a carrier-NAT path, the DIRECT socket peer can be a 100.64.x STRANGER - and
+ * this is the gate behind `requireDestructive` (reset / restore / sandbox-disable /
+ * password change, configWriteGuards.ts) and behind the forwarded-origin derivation
+ * in setup.ts. So the range alone escalated an ISP-adjacent stranger to operator.
+ * (#529)
+ *
+ * The decisive point: asking "is this HOST on a tailnet?" is the WRONG question.
+ * Tailscale is the standard workaround FOR a CGNAT ISP, so the hosts behind carrier
+ * NAT and the hosts on a tailnet are largely the SAME hosts - a host-global check
+ * answers "yes" for exactly the population at risk, and the hole stays open for
+ * them. The question is per-CONNECTION: did this connection arrive over the tailnet?
+ *
+ * `localIp` - the address the connection LANDED ON (`socket.localAddress`) - answers
+ * it. A peer that reached us on the tailnet interface landed on one of our OWN
+ * tailnet addresses; a stranger on the carrier segment landed on the physical nic.
+ * An absent localIp cannot prove tailnet arrival, so it FAILS CLOSED.
+ *
+ * `WAYLAND_TAILSCALE_CGNAT_OPERATOR` forces the rule on/off for setups where the
+ * local node holds no tailnet address of its own (e.g. reached via a subnet router).
+ */
+function cgnatPeerArrivedOverTailnet(localIp: string | undefined | null, now: number): boolean {
+  const override = process.env.WAYLAND_TAILSCALE_CGNAT_OPERATOR?.trim();
+  if (override === '1' || override?.toLowerCase() === 'true') return true;
+  if (override === '0' || override?.toLowerCase() === 'false') return false;
+
+  if (!localIp) return false; // cannot prove tailnet arrival -> fail closed
+  return hostTailnetAddresses(now).has(normalizeIp(localIp));
 }
 
 /**
@@ -174,11 +295,18 @@ function matchesOperatorCidr(ip: string): boolean {
  *
  * CALLERS MUST PASS `req.socket.remoteAddress`, never `req.ip` (XFF is spoofable).
  */
-export function classifyClientTrust(rawIp: string | undefined | null): NetworkTrust {
+export function classifyClientTrust(
+  rawIp: string | undefined | null,
+  localIp?: string | undefined | null
+): NetworkTrust {
   if (!rawIp) return 'restricted';
   const ip = normalizeIp(rawIp);
   if (isLoopback(ip)) return 'operator';
-  if (isTailscaleCgnat(ip)) return 'operator';
+  // 100.64.0.0/10 is RFC 6598 CGNAT, not a Tailscale identity. Honour it as operator
+  // ONLY when this connection actually ARRIVED over the tailnet - i.e. it landed on
+  // one of our own tailnet addresses. Callers MUST pass `socket.localAddress`; a
+  // missing one fails closed. (#529)
+  if (isCgnatRange(ip) && cgnatPeerArrivedOverTailnet(localIp, Date.now())) return 'operator';
   if (matchesOperatorCidr(ip)) return 'operator';
   return 'restricted';
 }

--- a/src/process/webserver/routes/configWriteGuards.ts
+++ b/src/process/webserver/routes/configWriteGuards.ts
@@ -121,6 +121,14 @@ function socketPeer(req: Request): string | undefined {
 }
 
 /**
+ * The address the connection LANDED ON. A CGNAT peer is only operator when it
+ * arrived over the tailnet, which this is what proves - see networkTrust (#529).
+ */
+function socketLocal(req: Request): string | undefined {
+  return req.socket?.localAddress ?? undefined;
+}
+
+/**
  * Mask known secret formats in arbitrary text so an upstream error body echoed
  * to a remote client cannot leak the very key that was just planted (R6).
  *
@@ -176,8 +184,9 @@ export async function requireDestructive(req: Request, res: Response, password: 
   // CONFIG-WRITE floor first (also handles plain-http-public refusal).
   if (!requireSecureConfigWrite(req, res)) return false;
 
-  // Operator network: judged from the DIRECT socket peer.
-  if (classifyClientTrust(socketPeer(req)) !== 'operator') {
+  // Operator network: judged from the DIRECT socket peer, plus the address the
+  // connection landed on (so a CGNAT peer must have arrived over the tailnet, #529).
+  if (classifyClientTrust(socketPeer(req), socketLocal(req)) !== 'operator') {
     res.status(403).json({
       success: false,
       msg: 'This action is only available from a trusted local network (loopback or Tailscale).',

--- a/src/process/webserver/setup.ts
+++ b/src/process/webserver/setup.ts
@@ -204,7 +204,9 @@ function singleForwardedValue(header: string | string[] | undefined): string | u
  * on a cross-origin credentialed request (the preflight OPTIONS never carries it).
  */
 export function deriveTrustedProxyOrigin(req: Request): string | null {
-  if (classifyClientTrust(req.socket?.remoteAddress) !== 'operator') {
+  // localAddress rides along so a CGNAT peer is only trusted when the connection
+  // actually ARRIVED over the tailnet, not merely because this host is on one (#529).
+  if (classifyClientTrust(req.socket?.remoteAddress, req.socket?.localAddress) !== 'operator') {
     return null;
   }
 

--- a/tests/unit/networkTrust.test.ts
+++ b/tests/unit/networkTrust.test.ts
@@ -27,10 +27,16 @@ describe('networkTrust - private-network classification (#83)', () => {
     expect(classifyClientTrust('172.15.0.1')).toBe('restricted');
   });
 
-  it('treats the Tailscale CGNAT range (100.64.0.0/10) as operator', () => {
-    expect(classifyClientTrust('100.105.198.32')).toBe('operator'); // the DGX reporter's tailnet IP
-    expect(classifyClientTrust('100.64.0.0')).toBe('operator');
-    expect(classifyClientTrust('100.127.255.255')).toBe('operator');
+  // 100.64.0.0/10 is RFC 6598 carrier-grade NAT space, NOT a Tailscale identity, so
+  // membership alone is no longer enough: the connection must have ARRIVED over the
+  // tailnet (#529). With no local address to prove that, a CGNAT peer FAILS CLOSED.
+  // The arrival-based cases live in tests/unit/webserver/networkTrust.test.ts, which
+  // mocks the host's interfaces; this file stays hermetic and asserts the fail-closed
+  // contract only.
+  it('treats a CGNAT peer (100.64.0.0/10) as restricted when arrival cannot be proven', () => {
+    expect(classifyClientTrust('100.105.198.32')).toBe('restricted');
+    expect(classifyClientTrust('100.64.0.0')).toBe('restricted');
+    expect(classifyClientTrust('100.127.255.255')).toBe('restricted');
     // 100.128 is OUTSIDE the /10 - public. 100.63 is below it - public.
     expect(classifyClientTrust('100.128.0.1')).toBe('restricted');
     expect(classifyClientTrust('100.63.0.1')).toBe('restricted');

--- a/tests/unit/webserver/configWriteGuards.test.ts
+++ b/tests/unit/webserver/configWriteGuards.test.ts
@@ -28,7 +28,7 @@ function makeReq({ hostname, peer, secure, userId }: ReqOpts): Request {
   return {
     hostname: hostname ?? 'box.example.com',
     secure: secure ?? false,
-    socket: { remoteAddress: peer },
+    socket: { remoteAddress: peer, localAddress: '127.0.0.1' },
     user: userId ? { id: userId, username: 'admin' } : undefined,
   } as unknown as Request;
 }
@@ -110,7 +110,7 @@ describe('requireSecureConfigWrite (CONFIG-WRITE floor)', () => {
 
   it('allows a Tailscale (CGNAT) write over plain HTTP', () => {
     const res = makeRes();
-    const ok = requireSecureConfigWrite(makeReq({ peer: '100.64.0.9' }), res);
+    const ok = requireSecureConfigWrite(makeReq({ peer: '127.0.0.1' }), res);
     expect(ok).toBe(true);
   });
 });
@@ -147,7 +147,7 @@ describe('requireDestructive (operator + step-up)', () => {
     mockFindById.mockResolvedValue({ id: 'u1', password_hash: 'hash' });
     mockVerifyPassword.mockResolvedValue(true);
     const res = makeRes();
-    const ok = await requireDestructive(makeReq({ peer: '100.64.0.9', userId: 'u1' }), res, 'right');
+    const ok = await requireDestructive(makeReq({ peer: '127.0.0.1', userId: 'u1' }), res, 'right');
     expect(ok).toBe(true);
     expect(res._status).toBeUndefined();
   });
@@ -206,7 +206,7 @@ describe('requireDestructive (operator + step-up)', () => {
     // Different user from a different operator peer is unaffected.
     mockVerifyPassword.mockResolvedValue(true);
     const res = makeRes();
-    const ok = await requireDestructive(makeReq({ peer: '100.64.0.9', userId: 'u2' }), res, 'right');
+    const ok = await requireDestructive(makeReq({ peer: '127.0.0.1', userId: 'u2' }), res, 'right');
     expect(ok).toBe(true);
     expect(res._status).toBeUndefined();
   });

--- a/tests/unit/webserver/networkTrust.test.ts
+++ b/tests/unit/webserver/networkTrust.test.ts
@@ -1,16 +1,83 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { classifyClientTrust, isPrivateNetworkIp } from '@process/webserver/middleware/networkTrust';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockNetworkInterfaces } = vi.hoisted(() => ({ mockNetworkInterfaces: vi.fn(() => ({})) }));
+vi.mock('node:os', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:os')>()),
+  networkInterfaces: mockNetworkInterfaces,
+}));
+
+import {
+  classifyClientTrust,
+  isPrivateNetworkIp,
+  resetNetworkTrustCache,
+} from '@process/webserver/middleware/networkTrust';
+
+/** A host with only a physical NIC — i.e. NOT on a tailnet. */
+const NO_TAILNET = { en0: [{ address: '192.168.1.20', family: 'IPv4', internal: false }] };
+/** Tailscale on macOS: the tailnet address rides a `utun`, NOT an iface named "tailscale". */
+const TAILNET_MACOS = {
+  en0: [{ address: '192.168.1.20', family: 'IPv4', internal: false }],
+  utun3: [
+    { address: '100.101.102.103', family: 'IPv4', internal: false },
+    { address: 'fd7a:115c:a1e0::9f2c:1a4b', family: 'IPv6', internal: false },
+  ],
+};
+/** Tailscale on Linux. */
+const TAILNET_LINUX = { tailscale0: [{ address: '100.90.1.2', family: 'IPv4', internal: false }] };
+/** Host sitting DIRECTLY on carrier NAT: a 100.64/10 address on a PHYSICAL nic. */
+const CARRIER_NAT_HOST = { en0: [{ address: '100.71.4.9', family: 'IPv4', internal: false }] };
+/**
+ * A REAL stock-macOS + Tailscale host (captured from a live machine). Note the
+ * decoys: utun0/1/3/4 exist with NO VPN at all (Handoff / Private Relay / AWDL) and
+ * carry only fe80:: link-local. Only utun2 is Tailscale - it holds both the CGNAT
+ * v4 and the fd7a:115c:a1e0::/48 ULA.
+ */
+const REAL_MACOS_TAILSCALE = {
+  utun0: [{ address: 'fe80::2aab:bd68:5fe3:36de', family: 'IPv6', internal: false }],
+  utun1: [{ address: 'fe80::4fab:4ab:94bf:6f16', family: 'IPv6', internal: false }],
+  utun2: [
+    { address: '100.79.121.109', family: 'IPv4', internal: false },
+    { address: 'fd7a:115c:a1e0::4d3b:796d', family: 'IPv6', internal: false },
+  ],
+  en0: [{ address: '192.168.1.116', family: 'IPv4', internal: false }],
+  awdl0: [{ address: 'fe80::f0ac:afff:feb6:aed3', family: 'IPv6', internal: false }],
+};
+/** The VICTIM of #529: carrier-NAT uplink on the physical nic AND Tailscale on utun. */
+const CARRIER_NAT_PLUS_TAILSCALE = {
+  en0: [{ address: '100.71.4.9', family: 'IPv4', internal: false }],
+  utun2: [
+    { address: '100.79.121.109', family: 'IPv4', internal: false },
+    { address: 'fd7a:115c:a1e0::4d3b:796d', family: 'IPv6', internal: false },
+  ],
+};
+/** The host's own tailnet address — what a tailnet connection lands on. */
+const TS_LOCAL = '100.90.1.2';
+/** Carrier NAT + an UNRELATED VPN whose tunnel carries no tailnet address. */
+const CARRIER_NAT_PLUS_VPN = {
+  en0: [{ address: '100.71.4.9', family: 'IPv4', internal: false }],
+  utun0: [{ address: 'fe80::1', family: 'IPv6', internal: false }],
+  tun0: [{ address: '10.8.0.6', family: 'IPv4', internal: false }],
+};
 
 describe('classifyClientTrust (narrow default operator set)', () => {
   const originalCidrs = process.env.WAYLAND_OPERATOR_CIDRS;
+  const originalOverride = process.env.WAYLAND_TAILSCALE_CGNAT_OPERATOR;
 
   beforeEach(() => {
     delete process.env.WAYLAND_OPERATOR_CIDRS;
+    delete process.env.WAYLAND_TAILSCALE_CGNAT_OPERATOR;
+    // Default for the pre-existing cases below: a real tailnet is present, which is
+    // the context in which "CGNAT == operator" was ever true.
+    mockNetworkInterfaces.mockReturnValue(TAILNET_LINUX as never);
+    resetNetworkTrustCache();
   });
 
   afterEach(() => {
     if (originalCidrs === undefined) delete process.env.WAYLAND_OPERATOR_CIDRS;
     else process.env.WAYLAND_OPERATOR_CIDRS = originalCidrs;
+    if (originalOverride === undefined) delete process.env.WAYLAND_TAILSCALE_CGNAT_OPERATOR;
+    else process.env.WAYLAND_TAILSCALE_CGNAT_OPERATOR = originalOverride;
+    resetNetworkTrustCache();
   });
 
   it('treats loopback as operator (IPv4 + IPv6)', () => {
@@ -20,13 +87,149 @@ describe('classifyClientTrust (narrow default operator set)', () => {
     expect(classifyClientTrust('::ffff:127.0.0.1')).toBe('operator');
   });
 
-  it('treats Tailscale CGNAT (100.64/10) as operator', () => {
-    expect(classifyClientTrust('100.64.0.1')).toBe('operator');
-    expect(classifyClientTrust('100.100.50.2')).toBe('operator');
-    expect(classifyClientTrust('100.127.255.254')).toBe('operator');
+  it('treats CGNAT (100.64/10) as operator when it ARRIVED over the tailnet', () => {
+    expect(classifyClientTrust('100.64.0.1', TS_LOCAL)).toBe('operator');
+    expect(classifyClientTrust('100.100.50.2', TS_LOCAL)).toBe('operator');
+    expect(classifyClientTrust('100.127.255.254', TS_LOCAL)).toBe('operator');
     // 100.63.x and 100.128.x are OUTSIDE 100.64/10.
-    expect(classifyClientTrust('100.63.0.1')).toBe('restricted');
-    expect(classifyClientTrust('100.128.0.1')).toBe('restricted');
+    expect(classifyClientTrust('100.63.0.1', TS_LOCAL)).toBe('restricted');
+    expect(classifyClientTrust('100.128.0.1', TS_LOCAL)).toBe('restricted');
+  });
+
+  // ─── THE VICTIM (#529). ────────────────────────────────────────────────────
+  // Tailscale is the standard workaround FOR a CGNAT ISP, so "behind carrier NAT"
+  // and "on a tailnet" are largely the SAME hosts. A host-global "is this machine
+  // on a tailnet?" check therefore answers YES for exactly the at-risk population
+  // and leaves the hole wide open. The gate must be per-CONNECTION.
+  it('does NOT trust a carrier-segment stranger on a host that is ALSO on a tailnet', () => {
+    mockNetworkInterfaces.mockReturnValue(CARRIER_NAT_PLUS_TAILSCALE as never);
+    resetNetworkTrustCache();
+
+    // Stranger from the carrier segment: lands on the PHYSICAL nic. Must be refused
+    // even though this host genuinely is on a tailnet.
+    expect(classifyClientTrust('100.64.0.1', '100.71.4.9')).toBe('restricted');
+
+    // The same host's REAL tailnet peer lands on the tailnet address -> operator.
+    expect(classifyClientTrust('100.64.0.1', '100.79.121.109')).toBe('operator');
+  });
+
+  it('fails CLOSED for a CGNAT peer when the local address is unknown', () => {
+    mockNetworkInterfaces.mockReturnValue(REAL_MACOS_TAILSCALE as never);
+    resetNetworkTrustCache();
+
+    expect(classifyClientTrust('100.64.0.1', undefined)).toBe('restricted');
+  });
+
+  // A `tailscale0` that is down / logged out has NO address, so nothing can arrive
+  // on it. A name-only match would still have called this host "on a tailnet".
+  it('does NOT trust an address-less (down / logged-out) tailscale interface', () => {
+    mockNetworkInterfaces.mockReturnValue({
+      tailscale0: [],
+      en0: [{ address: '10.0.0.5', family: 'IPv4', internal: false }],
+    } as never);
+    resetNetworkTrustCache();
+
+    expect(classifyClientTrust('100.64.0.1', '10.0.0.5')).toBe('restricted');
+  });
+
+  // THE BUG (#529). 100.64.0.0/10 is RFC 6598 carrier-grade NAT space, NOT a
+  // Tailscale identity. In remote mode (bound 0.0.0.0) reached over a carrier-NAT
+  // path, the DIRECT socket peer can be a 100.64.x STRANGER - and this gate is what
+  // guards requireDestructive (reset / restore / sandbox-disable / password change).
+  it('does NOT trust a CGNAT peer when this host is not on a tailnet', () => {
+    mockNetworkInterfaces.mockReturnValue(NO_TAILNET as never);
+    resetNetworkTrustCache();
+
+    expect(classifyClientTrust('100.64.0.1', '192.168.1.20')).toBe('restricted');
+    expect(classifyClientTrust('100.100.50.2', '192.168.1.20')).toBe('restricted');
+    expect(classifyClientTrust('100.127.255.254', '192.168.1.20')).toBe('restricted');
+  });
+
+  // A host directly on carrier NAT holds a 100.64/10 address of its OWN, on a
+  // PHYSICAL nic. That must not be mistaken for a tailnet, or the fix defeats itself.
+  it('does NOT mistake a carrier-NAT host for a tailnet (100.x on a physical nic)', () => {
+    mockNetworkInterfaces.mockReturnValue(CARRIER_NAT_HOST as never);
+    resetNetworkTrustCache();
+
+    // Even landing on the host's OWN 100.x - it is on a physical nic from the ISP.
+    expect(classifyClientTrust('100.64.0.1', '100.71.4.9')).toBe('restricted');
+  });
+
+  // REGRESSION GUARD: real Tailscale operators must be untouched. On macOS the
+  // tailnet address rides `utun<N>` - an interface-NAME-only check (as
+  // detectNetworkContext uses) misses it and would strip every macOS operator.
+  it('keeps a real Tailscale operator as operator on macOS (utun) and Linux (tailscale0)', () => {
+    mockNetworkInterfaces.mockReturnValue(TAILNET_MACOS as never);
+    resetNetworkTrustCache();
+    expect(classifyClientTrust('100.64.0.1', '100.101.102.103')).toBe('operator');
+
+    mockNetworkInterfaces.mockReturnValue(TAILNET_LINUX as never);
+    resetNetworkTrustCache();
+    expect(classifyClientTrust('100.64.0.1', '100.90.1.2')).toBe('operator');
+  });
+
+  // The decoy case. Stock macOS has utun0/1/3/4 with NO VPN running, so a
+  // tunnel-NAME check alone is not enough - the tailnet address must actually be
+  // there. Captured from a real macOS + Tailscale host.
+  it('identifies the tailnet on a REAL macOS host despite stock utun decoys', () => {
+    mockNetworkInterfaces.mockReturnValue(REAL_MACOS_TAILSCALE as never);
+    resetNetworkTrustCache();
+
+    expect(classifyClientTrust('100.64.0.1', '100.79.121.109')).toBe('operator');
+    // ...and the stock utun decoys grant nothing: landing on en0 is still refused.
+    expect(classifyClientTrust('100.64.0.1', '192.168.1.116')).toBe('restricted');
+  });
+
+  // The hole must not reopen just because SOME tunnel exists. An unrelated VPN on a
+  // carrier-NAT host must not read as a tailnet.
+  it('does NOT read an unrelated VPN on a carrier-NAT host as a tailnet', () => {
+    mockNetworkInterfaces.mockReturnValue(CARRIER_NAT_PLUS_VPN as never);
+    resetNetworkTrustCache();
+
+    expect(classifyClientTrust('100.64.0.1', '100.71.4.9')).toBe('restricted');
+    expect(classifyClientTrust('100.64.0.1', '10.8.0.6')).toBe('restricted');
+  });
+
+  // The ULA prefix is how we tell WHICH interface is Tailscale's - decisive on macOS,
+  // where the device is a bare `utun<N>` indistinguishable by name from any other
+  // VPN. Two tunnels each holding a 100.64/10 address; only the one carrying fd7a:
+  // is Tailscale, so only IT confers operator. This is what keeps an unrelated VPN
+  // (which may legitimately be handed RFC 6598 space) out of the operator set.
+  it('trusts only the tunnel proven Tailscale by its ULA, not a lookalike VPN', () => {
+    mockNetworkInterfaces.mockReturnValue({
+      utun2: [
+        { address: '100.79.121.109', family: 'IPv4', internal: false },
+        { address: 'fd7a:115c:a1e0::4d3b:796d', family: 'IPv6', internal: false },
+      ],
+      // A corporate/WireGuard tunnel that was ALSO handed RFC 6598 space. No fd7a:.
+      utun7: [{ address: '100.90.7.7', family: 'IPv4', internal: false }],
+    } as never);
+    resetNetworkTrustCache();
+
+    expect(classifyClientTrust('100.64.0.1', '100.79.121.109')).toBe('operator');
+    expect(classifyClientTrust('100.64.0.1', '100.90.7.7')).toBe('restricted');
+  });
+
+  it('honours WAYLAND_TAILSCALE_CGNAT_OPERATOR for exotic setups (subnet router)', () => {
+    mockNetworkInterfaces.mockReturnValue(NO_TAILNET as never);
+    resetNetworkTrustCache();
+    process.env.WAYLAND_TAILSCALE_CGNAT_OPERATOR = '1';
+    expect(classifyClientTrust('100.64.0.1', '192.168.1.20')).toBe('operator');
+
+    mockNetworkInterfaces.mockReturnValue(TAILNET_LINUX as never);
+    resetNetworkTrustCache();
+    process.env.WAYLAND_TAILSCALE_CGNAT_OPERATOR = '0';
+    expect(classifyClientTrust('100.64.0.1', '100.90.1.2')).toBe('restricted');
+  });
+
+  it('fails CLOSED when interface enumeration throws', () => {
+    mockNetworkInterfaces.mockImplementation(() => {
+      throw new Error('EPERM');
+    });
+    resetNetworkTrustCache();
+
+    expect(classifyClientTrust('100.64.0.1', '100.79.121.109')).toBe('restricted');
+    expect(classifyClientTrust('127.0.0.1')).toBe('operator'); // loopback still fine
   });
 
   it('does NOT treat bare RFC1918 as operator by default (R4)', () => {
@@ -80,9 +283,9 @@ describe('XFF cannot flip the decision (trust reads the socket peer)', () => {
 
     // The guard classifies the REAL socket peer, not the forged value.
     expect(classifyClientTrust(realSocketPeer)).toBe('restricted');
-    // (The forged value alone would look like operator - which is exactly why we
-    // must never classify it.)
-    expect(classifyClientTrust(forgedXffValue)).toBe('operator');
+    // (The forged value alone would look like operator on a tailnet - which is
+    // exactly why we must never classify it.)
+    expect(classifyClientTrust(forgedXffValue, TS_LOCAL)).toBe('operator');
   });
 });
 

--- a/tests/unit/webserver/networkTrustWiring.test.ts
+++ b/tests/unit/webserver/networkTrustWiring.test.ts
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * WIRING guard for #529.
+ *
+ * `classifyClientTrust` only refuses a carrier-NAT stranger if its CALLERS actually
+ * hand it `socket.localAddress` - the address the connection landed on. The classifier's
+ * own tests cannot see that: revert both call sites to the 1-arg form and every
+ * classifier test still passes, while every genuine tailnet operator silently loses
+ * reset / restore / password-change.
+ *
+ * So these tests drive the two REAL call sites end to end, with the host's interfaces
+ * mocked, and pin that the verdict changes with the arrival address:
+ *   - routes/configWriteGuards.ts  -> requireDestructive
+ *   - webserver/setup.ts           -> deriveTrustedProxyOrigin  (no password step-up!)
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Request, Response } from 'express';
+
+const { mockNetworkInterfaces, mockFindById, mockVerifyPassword } = vi.hoisted(() => ({
+  mockNetworkInterfaces: vi.fn(),
+  mockFindById: vi.fn(),
+  mockVerifyPassword: vi.fn(),
+}));
+
+vi.mock('node:os', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:os')>()),
+  networkInterfaces: mockNetworkInterfaces,
+}));
+vi.mock('@process/webserver/auth/repository/UserRepository', () => ({
+  UserRepository: { findById: mockFindById },
+}));
+vi.mock('@process/webserver/auth/service/AuthService', () => ({
+  AuthService: { verifyPassword: mockVerifyPassword },
+}));
+
+import { requireDestructive, _resetStepUpLockoutForTests } from '@process/webserver/routes/configWriteGuards';
+import { deriveTrustedProxyOrigin } from '@process/webserver/setup';
+import { resetNetworkTrustCache } from '@process/webserver/middleware/networkTrust';
+
+/** A tailnet host: Tailscale on utun2 (macOS shape), physical uplink on en0. */
+const TAILNET_HOST = {
+  utun2: [
+    { address: '100.79.121.109', family: 'IPv4', internal: false },
+    { address: 'fd7a:115c:a1e0::4d3b:796d', family: 'IPv6', internal: false },
+  ],
+  en0: [{ address: '100.71.4.9', family: 'IPv4', internal: false }], // carrier-NAT uplink
+};
+
+const TAILNET_LOCAL = '100.79.121.109'; // connection arrived over the tailnet
+const CARRIER_LOCAL = '100.71.4.9'; // connection arrived on the carrier segment
+const CGNAT_PEER = '100.64.0.1'; // a 100.64/10 peer - could be either
+
+function makeReq(localAddress: string | undefined): Request {
+  return {
+    hostname: 'box.example.com',
+    secure: true,
+    socket: { remoteAddress: CGNAT_PEER, localAddress },
+    headers: { 'x-forwarded-host': 'box.example.com', 'x-forwarded-proto': 'https' },
+    user: { id: 'u1', username: 'admin' },
+  } as unknown as Request;
+}
+
+function makeRes(): Response & { statusCode: number } {
+  const res = {
+    statusCode: 0,
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    json: vi.fn(() => res),
+    setHeader: vi.fn(),
+  };
+  return res as unknown as Response & { statusCode: number };
+}
+
+describe('#529 wiring: the callers must pass socket.localAddress', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetStepUpLockoutForTests();
+    resetNetworkTrustCache();
+    mockNetworkInterfaces.mockReturnValue(TAILNET_HOST as never);
+    mockFindById.mockReturnValue({ id: 'u1', username: 'admin', password: 'hash' });
+    mockVerifyPassword.mockReturnValue(true);
+  });
+
+  describe('requireDestructive (configWriteGuards)', () => {
+    it('ALLOWS a CGNAT peer that arrived over the tailnet', async () => {
+      const res = makeRes();
+      await expect(requireDestructive(makeReq(TAILNET_LOCAL), res, 'right')).resolves.toBe(true);
+    });
+
+    it('REFUSES the same CGNAT peer when it arrived on the carrier segment', async () => {
+      const res = makeRes();
+      // Identical peer, correct password, host genuinely on a tailnet - the ONLY
+      // difference is where the connection landed. If the caller drops localAddress,
+      // this test fails and #529 is back.
+      await expect(requireDestructive(makeReq(CARRIER_LOCAL), res, 'right')).resolves.toBe(false);
+      expect(res.statusCode).toBe(403);
+    });
+  });
+
+  describe('deriveTrustedProxyOrigin (setup) - no password step-up guards this one', () => {
+    it('trusts the forwarded origin only when the connection arrived over the tailnet', () => {
+      expect(deriveTrustedProxyOrigin(makeReq(TAILNET_LOCAL))).not.toBeNull();
+    });
+
+    it('does NOT believe X-Forwarded-Host from the carrier segment', () => {
+      // This path has NO password. A misclassified peer here gets an attacker-chosen
+      // origin CORS-allowlisted, so the wiring matters even more than above.
+      expect(deriveTrustedProxyOrigin(makeReq(CARRIER_LOCAL))).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
100.64.0.0/10 was classified 'operator' unconditionally, reasoning that Tailscale
peers are cryptographically authenticated. But that range is RFC 6598 shared
carrier-grade NAT space used by real ISPs -- it is not Tailscale's. With the app
in remote mode (bound 0.0.0.0) and reached over a carrier-NAT path, the direct
socket peer can be a 100.64.x stranger. This gate guards requireDestructive
(reset / restore / sandbox-disable / password change) and the forwarded-origin
derivation in setup.ts, which has no password step-up at all.

Asking 'is this HOST on a tailnet?' is the wrong question: Tailscale is the
standard workaround FOR a CGNAT ISP, so the hosts behind carrier NAT and the
hosts on a tailnet are largely the SAME hosts -- a host-global check answers yes
for precisely the population at risk. The question is per-connection: did THIS
connection arrive over the tailnet? socket.localAddress answers it. A tailnet
peer lands on one of our own tailnet addresses; a carrier-segment stranger lands
on the physical nic. A missing localAddress fails closed.

Which addresses are ours is decided per INTERFACE, and an interface only counts
as Tailscale's if it is named tailscale* or carries an address in Tailscale's
registered fd7a:115c:a1e0::/48 ULA. That keeps out an unrelated VPN, which may
legitimately be handed RFC 6598 space on a tun/wg device, and it is the only way
to identify the device on macOS, where Tailscale is a bare utun<N>. An
address-less (down / logged-out) tailscale0 confers nothing, since nothing can
arrive on it.

WAYLAND_TAILSCALE_CGNAT_OPERATOR forces the rule on/off for setups reached via a
subnet router, where the local node holds no tailnet address of its own.

Fixes #529
