### PR TITLE
fix(test): stop the #721 spawn-test racing a fake clock against real IO

### DIFF
--- a/src/process/services/ijfwSystemService.ts
+++ b/src/process/services/ijfwSystemService.ts
@@ -575,6 +575,19 @@ async function retryOnEbusy<T>(op: () => Promise<T>, attempts = 5): Promise<T> {
   throw lastErr instanceof Error ? lastErr : new Error('EBUSY retry exhausted');
 }
 
+const DEFAULT_SPAWN_TEST_TIMEOUT_MS = 5000;
+let spawnTestTimeoutMs = DEFAULT_SPAWN_TEST_TIMEOUT_MS;
+
+/**
+ * Shorten the spawn-test's settle timeout so a test can drive the real timer
+ * instead of faking the clock (#806). The previous test faked only setTimeout
+ * while the child still emitted over the real macrotask queue, then hand-
+ * interleaved the two — a race that hung the turn outright on sharded runners.
+ */
+export function _setSpawnTestTimeoutForTests(ms?: number): void {
+  spawnTestTimeoutMs = ms ?? DEFAULT_SPAWN_TEST_TIMEOUT_MS;
+}
+
 /** SEC-003: full JSON-RPC envelope verify with exit-before-success = fail. */
 async function spawnTestVerify(mcpServerDir: string): Promise<boolean> {
   let entry: string;
@@ -616,7 +629,7 @@ async function spawnTestVerify(mcpServerDir: string): Promise<boolean> {
       resolve(value);
     };
 
-    const timeout = setTimeout(() => settle(false), 5000);
+    const timeout = setTimeout(() => settle(false), spawnTestTimeoutMs);
     let buf: Buffer = Buffer.alloc(0);
 
     child.stdout?.on('data', (chunk: Buffer) => {

--- a/src/process/services/ijfwSystemService.ts
+++ b/src/process/services/ijfwSystemService.ts
@@ -585,7 +585,8 @@ let spawnTestTimeoutMs = DEFAULT_SPAWN_TEST_TIMEOUT_MS;
  * interleaved the two — a race that hung the turn outright on sharded runners.
  */
 export function _setSpawnTestTimeoutForTests(ms?: number): void {
-  spawnTestTimeoutMs = ms ?? DEFAULT_SPAWN_TEST_TIMEOUT_MS;
+  // `=== undefined`, not `??`: 0 is a legitimate value to ask for, not a reset.
+  spawnTestTimeoutMs = ms === undefined ? DEFAULT_SPAWN_TEST_TIMEOUT_MS : ms;
 }
 
 /** SEC-003: full JSON-RPC envelope verify with exit-before-success = fail. */

--- a/tests/unit/process/services/ijfwSystemService.applyPendingUpgrade.test.ts
+++ b/tests/unit/process/services/ijfwSystemService.applyPendingUpgrade.test.ts
@@ -161,23 +161,36 @@ function makeGarbageThenSuccessChild() {
   return child;
 }
 
-/** #721: a child whose stdout is ONLY garbage - never a valid JSON-RPC reply. */
+/**
+ * #721: a child whose stdout is ONLY garbage - never a valid JSON-RPC reply.
+ *
+ * Emits SYNCHRONOUSLY from stdin.write, deliberately. spawnTestVerify arms its
+ * settle-timer and attaches the stdout listener BEFORE it writes, so a sync emit is
+ * always decoded first — whereas a setImmediate emit races the timer, and Node runs
+ * the timers phase before the check phase, so ANY event-loop stall past the timeout
+ * fires the timer first and the garbage is never decoded at all. The test would
+ * still pass (both paths settle false) while silently testing nothing — and it would
+ * do so precisely on a loaded shard, which is the runner we care about (#806).
+ *
+ * `garbageEmitted` lets the test prove the bytes actually went through the decoder.
+ */
 function makeGarbageOnlyChild() {
   const child = new EventEmitter() as EventEmitter & {
     stdout: EventEmitter;
     stderr: EventEmitter;
     stdin: { write: (data: Buffer | string) => void };
     kill: () => void;
+    garbageEmitted: number;
   };
   child.stdout = new EventEmitter();
   child.stderr = new EventEmitter();
+  child.garbageEmitted = 0;
   child.stdin = {
     write: () => {
-      setImmediate(() => {
-        for (let i = 0; i < 5; i++) {
-          child.stdout.emit('data', Buffer.from(`build.progress ${i * 20}%\n`));
-        }
-      });
+      for (let i = 0; i < 5; i++) {
+        child.stdout.emit('data', Buffer.from(`build.progress ${i * 20}%\n`));
+        child.garbageEmitted += 1;
+      }
     },
   };
   child.kill = () => {};
@@ -229,14 +242,19 @@ import { ijfwSystemService, _setSpawnTestTimeoutForTests } from '@process/servic
  * the #721 case turned a lost race into an infinite hang, so the shard died on
  * the suite wall-clock with no clue as to which promise was stuck. Fail loudly.
  */
-function withTimeout<T>(p: Promise<T>, ms: number, what: string): Promise<T> {
-  return Promise.race([
-    p,
-    new Promise<never>((_, reject) => {
-      const t = setTimeout(() => reject(new Error(`${what} (waited ${ms}ms)`)), ms);
-      void p.finally(() => clearTimeout(t));
-    }),
-  ]);
+async function withTimeout<T>(p: Promise<T>, ms: number, what: string): Promise<T> {
+  let t: ReturnType<typeof setTimeout>;
+  const bomb = new Promise<never>((_, reject) => {
+    t = setTimeout(() => reject(new Error(`${what} (waited ${ms}ms)`)), ms);
+  });
+  try {
+    // try/finally, NOT `void p.finally(...)`: that returns a NEW derived promise which
+    // adopts p's rejection and, unhandled, poisons the whole run with an unhandled
+    // rejection — on the exact failure path this guard exists to make legible.
+    return await Promise.race([p, bomb]);
+  } finally {
+    clearTimeout(t!);
+  }
 }
 
 // The pending-upgrade activator stages the MCP server via symlink-ownership
@@ -261,6 +279,7 @@ describe('ijfwSystemService.applyPendingUpgrade', () => {
   });
 
   afterEach(() => {
+    _setSpawnTestTimeoutForTests(); // never let the shortened seam leak into another test
     fs.rmSync(tmpHome, { recursive: true, force: true });
   });
 
@@ -332,11 +351,21 @@ describe('ijfwSystemService.applyPendingUpgrade', () => {
     _setSpawnTestTimeoutForTests(50);
     try {
       writePendingDir();
-      spawnSpy.mockImplementation(() => makeGarbageOnlyChild());
+      const children: ReturnType<typeof makeGarbageOnlyChild>[] = [];
+      spawnSpy.mockImplementation(() => {
+        const c = makeGarbageOnlyChild();
+        children.push(c);
+        return c;
+      });
 
+      // 5s < vitest's 10s testTimeout, so THIS error wins and says what actually hung.
       await withTimeout(ijfwSystemService.applyPendingUpgrade(), 5_000, 'applyPendingUpgrade never settled');
 
       expect(spawnSpy).toHaveBeenCalledTimes(1);
+      // The garbage must actually have gone through the decoder. Without this the test
+      // passes for a child that emits NOTHING — the timeout alone satisfies every other
+      // assertion, so the "only garbage" premise in the title would go unverified.
+      expect(children[0].garbageEmitted).toBe(5);
       expect(emitSpy).toHaveBeenCalledWith(
         expect.objectContaining({ status: 'install_failed', errorReason: 'upgrade_failed_no_rollback' })
       );

--- a/tests/unit/process/services/ijfwSystemService.applyPendingUpgrade.test.ts
+++ b/tests/unit/process/services/ijfwSystemService.applyPendingUpgrade.test.ts
@@ -222,7 +222,22 @@ function writePendingDir(): string {
 }
 
 // eslint-disable-next-line import/first
-import { ijfwSystemService } from '@process/services/ijfwSystemService';
+import { ijfwSystemService, _setSpawnTestTimeoutForTests } from '@process/services/ijfwSystemService';
+
+/**
+ * Bound an await that is supposed to settle. #806: the unbounded `await run` in
+ * the #721 case turned a lost race into an infinite hang, so the shard died on
+ * the suite wall-clock with no clue as to which promise was stuck. Fail loudly.
+ */
+function withTimeout<T>(p: Promise<T>, ms: number, what: string): Promise<T> {
+  return Promise.race([
+    p,
+    new Promise<never>((_, reject) => {
+      const t = setTimeout(() => reject(new Error(`${what} (waited ${ms}ms)`)), ms);
+      void p.finally(() => clearTimeout(t));
+    }),
+  ]);
+}
 
 // The pending-upgrade activator stages the MCP server via symlink-ownership
 // checks and `.pending` -> live directory moves (moveWithExdevFallback, i.e.
@@ -300,39 +315,35 @@ describe('ijfwSystemService.applyPendingUpgrade', () => {
     expect(fs.existsSync(path.join(tmpHome, '.ijfw', 'mcp-server'))).toBe(true);
   });
 
-  it('#721: spawn-test settles false via its 5s timeout when the child emits only garbage', async () => {
-    // No current install seeded → the failed verify has no `.prev` to roll
-    // back to, so the flow exits via upgrade_failed_no_rollback after a
-    // SINGLE spawn-test - one 5s timer to advance.
-    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+  it('#721: spawn-test settles false via its verify timeout when the child emits only garbage', async () => {
+    // No current install seeded → the failed verify has no `.prev` to roll back
+    // to, so the flow exits via upgrade_failed_no_rollback after a SINGLE
+    // spawn-test.
+    //
+    // #806: this used to fake ONLY setTimeout/clearTimeout while the child kept
+    // emitting over the REAL macrotask queue, then hand-interleaved 200 rounds of
+    // real flushes against the fake clock. That is a race, and when it was lost
+    // the unbounded `await run` hung until the suite's wall budget killed it —
+    // reliably, on windows/ubuntu shard 3/4. (Raising the budget 10s→30s was
+    // tried in #775 and did not work, because slowness was never the problem.)
+    //
+    // No fake clock now: shorten the real timer instead. Everything runs on one
+    // real macrotask queue, in the real order, and the test settles in ~50ms.
+    _setSpawnTestTimeoutForTests(50);
     try {
       writePendingDir();
       spawnSpy.mockImplementation(() => makeGarbageOnlyChild());
 
-      let settled = false;
-      const run = ijfwSystemService.applyPendingUpgrade().finally(() => {
-        settled = true;
-      });
-      // Interleave real macrotask flushes (child emits via setImmediate, fs is
-      // real) with fake-clock advances until the flow has created and fired
-      // the 5s verify timeout and run to completion.
-      for (let i = 0; i < 200 && !settled; i++) {
-        for (let j = 0; j < 4; j++) await flush();
-        await vi.advanceTimersByTimeAsync(500);
-      }
-      await run;
+      await withTimeout(ijfwSystemService.applyPendingUpgrade(), 5_000, 'applyPendingUpgrade never settled');
 
       expect(spawnSpy).toHaveBeenCalledTimes(1);
       expect(emitSpy).toHaveBeenCalledWith(
         expect.objectContaining({ status: 'install_failed', errorReason: 'upgrade_failed_no_rollback' })
       );
     } finally {
-      vi.useRealTimers();
+      _setSpawnTestTimeoutForTests();
     }
-    // The settle loop interleaves up to 200 rounds of real macrotask flushes
-    // with fake-clock advances; on loaded CI shards that legitimately exceeds
-    // the default 10s wall budget (observed flaking PR merge runs).
-  }, 30_000);
+  });
 
   it('Checkpoint B B2: acquires installLock and short-circuits when one is already held', async () => {
     // Pre-seed a lockfile that matches the current host+boot and points at the


### PR DESCRIPTION
## The blocker

`ijfwSystemService.applyPendingUpgrade > "#721: spawn-test settles false via its 5s timeout"` **hangs on sharded runners**, dying at `Test timed out in 30000ms` on windows/ubuntu **shard 3/4**. It has been red-lighting every PR unlucky enough to land there (#742, #805 both hit it). This is the merge-train blocker filed as #806.

## It is a hang, not slowness

`#775` already read this as slowness and raised the budget 10s → 30s. It came back, because the diagnosis was wrong — and that matters, because the obvious next move (raise it again) would not have worked either.

The test passes locally in **5–11ms** and times out at **30000ms** on CI. That gap is not load. The loop advances **200 × 500ms = 100s of fake time** against a **5s** timer: if it settles at all, it settles immediately.

## Root cause

The test fakes **only** `setTimeout`/`clearTimeout`, while the child emits its stdout over the **real** macrotask queue (`setImmediate`) and `fs` is real. It then hand-interleaves the two:

```ts
for (let i = 0; i < 200 && !settled; i++) {
  for (let j = 0; j < 4; j++) await flush();   // real macrotasks
  await vi.advanceTimersByTimeAsync(500);      // fake clock
}
await run;                                     // <-- unbounded
```

That interleaving is a race. When it loses, the loop exits with `settled === false` and `await run` waits on a promise that will never settle — **forever**. The 30s ceiling is just the suite noticing.

## Fix

Delete the fake clock instead of tuning it. `spawnTestVerify`'s timeout is now injectable, so the test shortens the **real** timer (50ms) and everything runs on one queue, in the real order. No interleaving, no race, deterministic.

The `await` is also bounded now, so if this flow ever fails to settle again it fails with a readable message instead of silently hanging a runner for 30s.

## Verification

- Under the actual failing shard command, `vitest run --shard=3/4`: **3042 passed, 0 failed**.
- The file itself: **12 passed**, ~0.8s (was a 30s timeout).
- Typecheck clean.

Closes #806