### PR TITLE
fix(787): key team finalize dedup by turn to survive re-wake

### DIFF
--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -1589,6 +1589,16 @@ export interface IResponseMessage {
   msg_id: string;
   conversation_id: string;
   hidden?: boolean;
+  /**
+   * #787: monotonic per-conversation turn id of the turn that PRODUCED this
+   * terminal (`finish`/`error`) event, stamped at emission by AcpAgentManager.
+   * TeammateManager keys its finalize-dedup on `${conversation_id}#${turnId}`
+   * so a late duplicate of a prior turn's finish (arriving after the agent was
+   * re-woken) can't collapse the re-wake's fresh dedup window. Absent for
+   * non-ACP / signal-channel finishes, which fall back to conversation-only
+   * keying (unchanged behaviour).
+   */
+  turnId?: number;
 }
 
 export interface IConversationTurnCompletedEvent {

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -359,14 +359,14 @@ class AcpAgentManager extends BaseAgentManager<AcpAgentManagerData, AcpPermissio
         data: null,
       },
       this.options.backend,
-      { trackActiveTurn: false }
+      { trackActiveTurn: false, turnId }
     );
   }
 
   private async handleFinishSignal(
     message: IResponseMessage,
     backend: AcpBackend,
-    options: { trackActiveTurn?: boolean } = {}
+    options: { trackActiveTurn?: boolean; turnId?: number } = {}
   ): Promise<void> {
     if (options.trackActiveTurn !== false) {
       this.markActiveTurnFinished();
@@ -424,6 +424,12 @@ ${collectedResponses.join('\n')}`;
     const finishMessage: IResponseMessage = {
       ...(message as IResponseMessage),
       conversation_id: this.conversation_id,
+      // #787: stamp the producing turn so TeammateManager can key its dedup by
+      // (conversation, turn). Only set from callers that hold an explicit,
+      // race-free turnId (the synthesized-finish fallbacks); the signal-channel
+      // finish has no reliable turn provenance desktop-side (that requires
+      // wayland-core to stamp the terminal event) and is left conversation-keyed.
+      ...(options.turnId !== undefined ? { turnId: options.turnId } : {}),
     };
     ipcBridge.acpConversation.responseStream.emit(finishMessage);
     teamEventBus.emit('responseStream', finishMessage);
@@ -487,7 +493,7 @@ ${collectedResponses.join('\n')}`;
               data: null,
             },
             this.options.backend,
-            { trackActiveTurn: false }
+            { trackActiveTurn: false, turnId }
           );
         }
         return result;
@@ -518,7 +524,7 @@ ${collectedResponses.join('\n')}`;
           data: null,
         },
         this.options.backend,
-        { trackActiveTurn: false }
+        { trackActiveTurn: false, turnId }
       );
       return result;
     } catch (error) {

--- a/src/process/team/TeammateManager.ts
+++ b/src/process/team/TeammateManager.ts
@@ -684,7 +684,7 @@ export class TeammateManager extends EventEmitter {
 
     // Detect terminal stream messages and trigger turn completion.
     if (msg.type === 'finish' || msg.type === 'error') {
-      void this.finalizeTurn(msg.conversation_id);
+      void this.finalizeTurn(msg.conversation_id, msg.turnId);
       return;
     }
 
@@ -787,12 +787,24 @@ export class TeammateManager extends EventEmitter {
    * All agent coordination (send_message, task_create, etc.) is handled via MCP tool calls
    * in TeamMcpServer - this method only needs to manage lifecycle.
    */
-  private async finalizeTurn(conversationId: string): Promise<void> {
+  private async finalizeTurn(conversationId: string, turnId?: number): Promise<void> {
+    // #787: dedup per (conversation, turn). A late duplicate of a prior turn's
+    // finish that arrives AFTER the agent was re-woken must still be suppressed,
+    // yet the re-wake's own fresh turn must be free to finalize. Keying by
+    // conversation alone can't distinguish them: `wake()` clears the entry so
+    // the new turn isn't wrongly deduped, which simultaneously un-dedups the old
+    // turn's straggler → a duplicate idle_notification. A per-turn key fixes
+    // both: the straggler (turnId=A) stays deduped while the re-wake (turnId=B)
+    // uses a distinct key. Non-ACP / signal-channel finishes carry no turnId and
+    // fall back to conversation-only keying (unchanged behaviour) — and note
+    // `wake()`'s bare-`conversationId` delete only removes that fallback key, so
+    // it never disturbs a live `${conv}#${turnId}` entry.
+    const dedupKey = turnId === undefined ? conversationId : `${conversationId}#${turnId}`;
     // Dedup: skip if this turn was already finalized
-    if (this.finalizedTurns.has(conversationId)) return;
-    this.finalizedTurns.add(conversationId);
+    if (this.finalizedTurns.has(dedupKey)) return;
+    this.finalizedTurns.add(dedupKey);
     // Clean up the dedup entry after a short delay so future turns can be processed
-    setTimeout(() => this.finalizedTurns.delete(conversationId), 5000);
+    setTimeout(() => this.finalizedTurns.delete(dedupKey), 5000);
 
     const agent = this.agents.find((a) => a.conversationId === conversationId);
     if (!agent) return;

--- a/tests/unit/team-TeammateManager.test.ts
+++ b/tests/unit/team-TeammateManager.test.ts
@@ -30,6 +30,12 @@ vi.mock('@process/agent/acp/AcpDetector', () => ({
 vi.mock('@process/utils/initStorage', () => ({
   ProcessConfig: { get: vi.fn(async () => null) },
 }));
+// #787: finalizeTurn reads the last assistant excerpt from the DB for the leader
+// notification; keep it hermetic (no real SQLite) — an empty result yields the
+// bare "Turn completed" notification, which is all the dedup tests care about.
+vi.mock('@process/services/database', () => ({
+  getDatabase: vi.fn(async () => ({ getConversationMessages: () => ({ data: [] }) })),
+}));
 
 import { TeammateManager, computeUsageDelta } from '@process/team/TeammateManager';
 import { teamEventBus } from '@process/team/teamEventBus';
@@ -925,6 +931,92 @@ describe('TeammateManager', () => {
 
       // No IPC calls should have been made for unowned conversation
       expect(mockIpcBridge.team.agentStatusChanged.emit).not.toHaveBeenCalled();
+      mgr.dispose();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // #787: finalize dedup keyed by (conversation, turn) survives re-wake
+  // -------------------------------------------------------------------------
+
+  describe('#787 finalize dedup survives re-wake', () => {
+    const idleWrites = (mailbox: Mailbox): number =>
+      (mailbox.write as ReturnType<typeof vi.fn>).mock.calls.filter(
+        ([m]) => (m as { type?: string }).type === 'idle_notification'
+      ).length;
+
+    // finalizeTurn runs fire-and-forget off the sync stream handler and awaits a
+    // DB read + mailbox write; drain those real macrotasks before asserting.
+    const drain = async (): Promise<void> => {
+      for (let i = 0; i < 6; i++) await new Promise((r) => setTimeout(r, 0));
+    };
+
+    function makeLeaderAndMember() {
+      const leadAgent = makeAgent({
+        slotId: 'slot-lead',
+        conversationId: 'conv-lead',
+        role: 'leader',
+        status: 'idle',
+      });
+      const teammate = makeAgent({
+        slotId: 'slot-member',
+        conversationId: 'conv-member',
+        role: 'teammate',
+        status: 'idle',
+        agentName: 'Codex',
+      });
+      const harness = makeTeammateManager([leadAgent, teammate]);
+      const mockSendMessage = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(harness.workerTaskManager.getOrBuildTask).mockResolvedValue({
+        sendMessage: mockSendMessage,
+      } as never);
+      return harness;
+    }
+
+    const finish = (conversationId: string, msgId: string, turnId?: number) =>
+      teamEventBus.emit('responseStream', {
+        type: 'finish',
+        conversation_id: conversationId,
+        msg_id: msgId,
+        data: null,
+        ...(turnId === undefined ? {} : { turnId }),
+      });
+
+    it('suppresses a late duplicate of the SAME turn arriving after a re-wake', async () => {
+      const { mgr, mailbox } = makeLeaderAndMember();
+
+      await mgr.wake('slot-member');
+      finish('conv-member', 'm1', 1); // turn 1 finishes -> one leader notification
+      await drain();
+      expect(idleWrites(mailbox)).toBe(1);
+
+      // Agent re-woken: wake() clears the conversation-level fallback key. A
+      // straggler duplicate of turn 1 then arrives. Pre-#787 (conversation-only
+      // keying) this slipped past the just-cleared dedup and fired a SECOND
+      // notification; per-turn keying keeps turn 1 deduped across the re-wake.
+      await mgr.wake('slot-member');
+      finish('conv-member', 'm1-dup', 1);
+      await drain();
+      expect(idleWrites(mailbox)).toBe(1);
+
+      mgr.dispose();
+    });
+
+    it('still finalizes a genuinely new turn after a re-wake (no over-dedup)', async () => {
+      const { mgr, mailbox } = makeLeaderAndMember();
+
+      await mgr.wake('slot-member');
+      finish('conv-member', 'm1', 1);
+      await drain();
+      expect(idleWrites(mailbox)).toBe(1);
+
+      // A real second turn (distinct turnId) MUST notify — the fix must not
+      // collapse legitimately separate turns.
+      await mgr.wake('slot-member');
+      finish('conv-member', 'm2', 2);
+      await drain();
+      expect(idleWrites(mailbox)).toBe(2);
+
       mgr.dispose();
     });
   });


### PR DESCRIPTION
## #787 — team finalize dedup collapses on re-wake (desktop half)

`TeammateManager.finalizeTurn` deduped finish/error finalization by `conversation_id` alone (5s TTL). `wake()` clears that entry so a re-woken agent's fresh turn isn't wrongly deduped — but the same clear un-dedups a **late duplicate of the prior turn's finish**, firing a second `idle_notification` to the leader.

### Fix
- `IResponseMessage.turnId?: number` — the producing turn's id, stamped at emission.
- `finalizeTurn` keys dedup on `${conversation_id}#${turnId}` when present, else bare `conversation_id`. `wake()`'s bare-conversation delete never disturbs a live per-turn entry, so a straggler (turn A) stays deduped while the re-wake (turn B) uses a distinct key.
- `AcpAgentManager` stamps the explicit, **race-free** `turnId` onto the 3 synthesized-finish fallbacks (the "no finish signal arrived" paths, guarded by `consumeTrackedTurnFinished` so they're mutually exclusive with a real finish per turn). Non-ACP finishes keep conversation-only keying → **no regression**.

### Reproduce-first
A late duplicate after re-wake fired **2** notifications pre-fix (proven by reverting only the key line), **1** post-fix; a genuinely new turn still notifies (no over-dedup). Full suite 12,627 green; adversarial review returned no blocking findings.

### ⚠️ Scope — desktop half; NOT a full #787 close
The **signal-channel real finish** (`handleSignalEvent → handleFinishSignal`) carries no desktop-side turn provenance, so it stays conversation-keyed. Fully closing #787 needs **wayland-core to stamp a stable per-turn id on ACP terminal `finish`/`error` events**; this PR is the desktop keying + infrastructure that core plugs into.

Adversarial-review NIT (acknowledged, closed by the core piece): a missing-finish synth followed by a real finish arriving >15s later can double-notify in a narrow window — the same class, much rarer, and resolved once the real signal finish also carries a turnId.

**Auto-merge intentionally NOT armed** — routing to Overwatch for the arm-alone vs. hold-and-pair-with-the-core-half decision. Do NOT close #787 on merge.
