### PR TITLE
test(787): assert synthesized finish stamps producing turnId

### DIFF
--- a/tests/unit/acpAgentManagerCronGuard.test.ts
+++ b/tests/unit/acpAgentManagerCronGuard.test.ts
@@ -108,6 +108,7 @@ vi.mock('@/common/chat/chatLib', () => ({ transformMessage: vi.fn(), uuid: vi.fn
 
 // ── Import real AcpAgentManager after all mocks are set up ───────────────────
 import AcpAgentManager from '../../src/process/task/AcpAgentManager';
+import { teamEventBus } from '../../src/process/team/teamEventBus';
 import type { AcpBackend } from '../../src/common/types/acpTypes';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -158,6 +159,29 @@ describe('AcpAgentManager.sendMessage - real class cronBusyGuard cleanup', () =>
     await manager.sendMessage({ content: 'hello', msg_id: 'msg-1' });
 
     expect(manager.status).toBe('finished');
+  });
+
+  // #787: the synthesized finish must carry the PRODUCING turn's id so
+  // TeammateManager can key its dedup by (conversation, turn). Without the
+  // turnId stamp the finish reaches the team bus conversation-keyed and a late
+  // duplicate after a re-wake double-notifies the leader.
+  it('#787: stamps the producing turnId on the synthesized finish sent to the team bus', async () => {
+    const emitSpy = vi.spyOn(teamEventBus, 'emit');
+    try {
+      const { manager, mockAgent } = makeManager('conv-787');
+      mockAgent.sendMessage.mockResolvedValue({ success: false });
+
+      // First turn on a fresh manager → beginTrackedTurn() assigns turnId 1.
+      await manager.sendMessage({ content: 'hello', msg_id: 'msg-1' });
+
+      const finishEmit = emitSpy.mock.calls.find(
+        ([evt, msg]) => evt === 'responseStream' && (msg as { type?: string }).type === 'finish'
+      );
+      expect(finishEmit).toBeDefined();
+      expect((finishEmit![1] as { turnId?: number }).turnId).toBe(1);
+    } finally {
+      emitSpy.mockRestore();
+    }
   });
 
   it('synthesizes finish and clears cronBusyGuard when first-path returns {success:true} without runtime activity', async () => {


### PR DESCRIPTION
Re-lands the AcpAgentManager emission coverage dropped by the #815 merge
race. Covers the stamping side of the #787 dedup fix (2f4932b5c); the
TeammateManager tests drive teamEventBus directly and don't exercise it.
Mutation-verified: dropping turnId from the fallback callers or the
finishMessage stamp both fail this test.
