### PR TITLE
fix(787): consume engine per-turn turn_id on the ACP signal finish

### DIFF
--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -1590,15 +1590,21 @@ export interface IResponseMessage {
   conversation_id: string;
   hidden?: boolean;
   /**
-   * #787: monotonic per-conversation turn id of the turn that PRODUCED this
-   * terminal (`finish`/`error`) event, stamped at emission by AcpAgentManager.
-   * TeammateManager keys its finalize-dedup on `${conversation_id}#${turnId}`
-   * so a late duplicate of a prior turn's finish (arriving after the agent was
-   * re-woken) can't collapse the re-wake's fresh dedup window. Absent for
-   * non-ACP / signal-channel finishes, which fall back to conversation-only
-   * keying (unchanged behaviour).
+   * #787: per-conversation turn id of the turn that PRODUCED this terminal
+   * (`finish`/`error`) event. TeammateManager keys its finalize-dedup on
+   * `${conversation_id}#${turnId}` so a late duplicate of a prior turn's finish
+   * (arriving after the agent was re-woken) can't collapse the re-wake's fresh
+   * dedup window. Two producers:
+   *  - the real ACP signal finish carries the engine's per-turn `turn_id` (a
+   *    string uuid = the turn's `msg_id`, stamped by wayland-core on the
+   *    `Done`/`Error` terminal frames, wired through here from AcpConnection);
+   *  - the desktop-synthesized fallback finishes carry the local sequential
+   *    `beginTrackedTurn()` id (a number).
+   * Both are stable-per-turn and distinct-across-turns, which is all the dedup
+   * key needs (it stringifies either). Absent for non-ACP finishes, which fall
+   * back to conversation-only keying (unchanged behaviour).
    */
-  turnId?: number;
+  turnId?: string | number;
 }
 
 export interface IConversationTurnCompletedEvent {

--- a/src/process/agent/acp/AcpConnection.ts
+++ b/src/process/agent/acp/AcpConnection.ts
@@ -129,7 +129,7 @@ export class AcpConnection {
   public onPermissionRequest: (data: AcpPermissionRequest) => Promise<{
     optionId: string;
   }> = () => Promise.resolve({ optionId: 'allow' }); // Returns a resolved Promise for interface consistency
-  public onEndTurn: () => void = () => {}; // Handler for end_turn messages
+  public onEndTurn: (turnId?: string) => void = () => {}; // Handler for end_turn messages
   public onPromptUsage: (usage: AcpPromptResponseUsage) => void = () => {}; // Handler for PromptResponse.usage (per-turn token data)
   public onFileOperation: (operation: { method: string; path: string; content?: string; sessionId: string }) => void =
     () => {};
@@ -628,7 +628,11 @@ export class AcpConnection {
           if (message.result && typeof message.result === 'object') {
             const promptResult = message.result as Record<string, unknown>;
             if (promptResult.stopReason === 'end_turn') {
-              this.onEndTurn();
+              // #787: wayland-core stamps a per-turn `turn_id` (uuid) on the ACP
+              // terminal frame. `promptResult` is an untyped record so the field
+              // survives deserialization; forward it so the finish carries turn
+              // identity for TeammateManager's per-turn dedup.
+              this.onEndTurn(typeof promptResult.turn_id === 'string' ? promptResult.turn_id : undefined);
             }
             // Extract PromptResponse.usage (per-turn token data from codex-acp / PR #167)
             if (promptResult.usage && typeof promptResult.usage === 'object') {

--- a/src/process/agent/acp/index.ts
+++ b/src/process/agent/acp/index.ts
@@ -215,8 +215,8 @@ export class AcpAgent {
     this.connection.onPermissionRequest = (data: AcpPermissionRequest) => {
       return this.handlePermissionRequest(data);
     };
-    this.connection.onEndTurn = () => {
-      this.handleEndTurn();
+    this.connection.onEndTurn = (turnId) => {
+      this.handleEndTurn(turnId);
     };
     this.connection.onPromptUsage = (usage: AcpPromptResponseUsage) => {
       this.handlePromptUsage(usage);
@@ -1259,7 +1259,7 @@ export class AcpAgent {
     });
   }
 
-  private handleEndTurn(): void {
+  private handleEndTurn(turnId?: string): void {
     if (this.turnHasThought && !this.turnHasContent) {
       console.warn(
         `[ACP-STREAM] End turn with thought but no content (conversation=${this.id}, backend=${this.extra.backend})`
@@ -1273,6 +1273,10 @@ export class AcpAgent {
         conversation_id: this.id,
         msg_id: uuid(),
         data: null,
+        // #787: carry the engine's per-turn turn_id so TeammateManager dedups
+        // this real signal finish by (conversation, turn) and a late duplicate
+        // after a re-wake can't fire a second idle_notification.
+        ...(turnId !== undefined ? { turnId } : {}),
       });
     }
   }

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -424,11 +424,12 @@ ${collectedResponses.join('\n')}`;
     const finishMessage: IResponseMessage = {
       ...(message as IResponseMessage),
       conversation_id: this.conversation_id,
-      // #787: stamp the producing turn so TeammateManager can key its dedup by
-      // (conversation, turn). Only set from callers that hold an explicit,
-      // race-free turnId (the synthesized-finish fallbacks); the signal-channel
-      // finish has no reliable turn provenance desktop-side (that requires
-      // wayland-core to stamp the terminal event) and is left conversation-keyed.
+      // #787: carry the producing turn so TeammateManager keys its dedup by
+      // (conversation, turn). The real signal finish already carries the
+      // engine's per-turn `turn_id` on `message` (spread above, wired from
+      // AcpConnection via handleEndTurn — this now covers the signal path that
+      // core PR #219 unblocked); the synthesized-finish fallbacks have no id on
+      // `message` and pass it explicitly via `options.turnId`.
       ...(options.turnId !== undefined ? { turnId: options.turnId } : {}),
     };
     ipcBridge.acpConversation.responseStream.emit(finishMessage);

--- a/src/process/team/TeammateManager.ts
+++ b/src/process/team/TeammateManager.ts
@@ -787,7 +787,7 @@ export class TeammateManager extends EventEmitter {
    * All agent coordination (send_message, task_create, etc.) is handled via MCP tool calls
    * in TeamMcpServer - this method only needs to manage lifecycle.
    */
-  private async finalizeTurn(conversationId: string, turnId?: number): Promise<void> {
+  private async finalizeTurn(conversationId: string, turnId?: string | number): Promise<void> {
     // #787: dedup per (conversation, turn). A late duplicate of a prior turn's
     // finish that arrives AFTER the agent was re-woken must still be suppressed,
     // yet the re-wake's own fresh turn must be free to finalize. Keying by

--- a/tests/unit/acpAgentManagerCronGuard.test.ts
+++ b/tests/unit/acpAgentManagerCronGuard.test.ts
@@ -161,6 +161,34 @@ describe('AcpAgentManager.sendMessage - real class cronBusyGuard cleanup', () =>
     expect(manager.status).toBe('finished');
   });
 
+  // #787: the REAL signal-channel finish carries the engine's per-turn turn_id
+  // on the message itself (wired from AcpConnection). handleFinishSignal must
+  // stamp it onto the team-bus finish (via `options.turnId ?? message.turnId`)
+  // so the signal path is deduped by turn — this is the path core PR #219
+  // unblocked. A mutation dropping the `?? message.turnId` fallback fails here.
+  it('#787: forwards a signal-channel finish turnId (from the wire) to the team bus', async () => {
+    const emitSpy = vi.spyOn(teamEventBus, 'emit');
+    try {
+      const { manager } = makeManager('conv-sig-787');
+      await (
+        manager as unknown as {
+          handleSignalEvent: (v: unknown, backend: string) => Promise<void>;
+        }
+      ).handleSignalEvent(
+        { type: 'finish', conversation_id: 'conv-sig-787', msg_id: 'm-sig', data: null, turnId: 'wire-uuid-1' },
+        'claude'
+      );
+
+      const finishEmit = emitSpy.mock.calls.find(
+        ([evt, msg]) => evt === 'responseStream' && (msg as { type?: string }).type === 'finish'
+      );
+      expect(finishEmit).toBeDefined();
+      expect((finishEmit![1] as { turnId?: string }).turnId).toBe('wire-uuid-1');
+    } finally {
+      emitSpy.mockRestore();
+    }
+  });
+
   // #787: the synthesized finish must carry the PRODUCING turn's id so
   // TeammateManager can key its dedup by (conversation, turn). Without the
   // turnId stamp the finish reaches the team bus conversation-keyed and a late

--- a/tests/unit/acpConnectionTurnId.test.ts
+++ b/tests/unit/acpConnectionTurnId.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * #787: AcpConnection must forward wayland-core's per-turn `turn_id` (stamped on
+ * the ACP terminal frame, wcore PR #219) from the end_turn prompt result to
+ * `onEndTurn`, so the finish signal carries turn identity for TeammateManager's
+ * per-turn finalize dedup. Older engines omit the field → forward `undefined`
+ * (the finish then falls back to conversation-only keying, unchanged behaviour).
+ */
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+vi.mock('child_process', () => ({
+  execFile: vi.fn(),
+  spawn: vi.fn(),
+}));
+vi.mock('@process/utils/mainLogger', () => ({
+  mainLog: vi.fn(),
+  mainWarn: vi.fn(),
+}));
+vi.mock('@process/utils/shellEnv', () => ({
+  getNpxCacheDir: vi.fn(() => '/tmp/npx'),
+  getWindowsShellExecutionOptions: vi.fn(() => ({})),
+  resolveNpxPath: vi.fn(() => 'npx'),
+}));
+vi.mock('@process/agent/acp/acpConnectors', () => ({
+  ACP_PERF_LOG: false,
+  spawnGenericBackend: vi.fn(),
+  connectClaude: vi.fn(),
+  connectCodebuddy: vi.fn(),
+  connectCodex: vi.fn(),
+  prepareCleanEnv: vi.fn(async () => ({})),
+}));
+
+import { AcpConnection } from '../../src/process/agent/acp/AcpConnection';
+
+type Internal = {
+  pendingRequests: Map<number, { resolve: (v: unknown) => void; reject: (e: unknown) => void }>;
+  handleMessage: (m: unknown) => void;
+};
+
+/** Drive a JSON-RPC prompt RESULT through the connection's message handler. */
+function deliverPromptResult(conn: AcpConnection, result: Record<string, unknown>): void {
+  const internal = conn as unknown as Internal;
+  internal.pendingRequests.set(1, { resolve: () => {}, reject: () => {} });
+  internal.handleMessage({ id: 1, result });
+}
+
+describe('AcpConnection #787 turn_id forwarding', () => {
+  let conn: AcpConnection;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    conn = new AcpConnection();
+  });
+
+  it('forwards the per-turn turn_id from an end_turn result to onEndTurn', () => {
+    const onEndTurn = vi.fn();
+    conn.onEndTurn = onEndTurn;
+
+    deliverPromptResult(conn, { stopReason: 'end_turn', turn_id: 'turn-uuid-1' });
+
+    expect(onEndTurn).toHaveBeenCalledTimes(1);
+    expect(onEndTurn).toHaveBeenCalledWith('turn-uuid-1');
+  });
+
+  it('forwards undefined when an older engine omits turn_id', () => {
+    const onEndTurn = vi.fn();
+    conn.onEndTurn = onEndTurn;
+
+    deliverPromptResult(conn, { stopReason: 'end_turn' });
+
+    expect(onEndTurn).toHaveBeenCalledTimes(1);
+    expect(onEndTurn).toHaveBeenCalledWith(undefined);
+  });
+
+  it('ignores a non-string turn_id (defensive) → undefined', () => {
+    const onEndTurn = vi.fn();
+    conn.onEndTurn = onEndTurn;
+
+    deliverPromptResult(conn, { stopReason: 'end_turn', turn_id: 12345 });
+
+    expect(onEndTurn).toHaveBeenCalledWith(undefined);
+  });
+});


### PR DESCRIPTION
## #787 — consume the engine per-turn `turn_id` on the ACP signal finish

Completes the desktop half now that **wayland-core PR #219** stamps a per-turn `turn_id` (the turn's `msg_id` uuid) on the ACP `Done`/`Error` terminal frames. Before this, only the desktop-**synthesized fallback** finishes carried a turnId; the **real signal-channel finish** was conversation-keyed and still exposed to the #787 re-wake dedup collapse.

### Wiring (6 hops)
`AcpConnection.handleMessage` forwards `promptResult.turn_id` → `onEndTurn(turnId)` → `handleEndTurn` stamps it on the `onSignalEvent` finish → the existing `finishMessage` spread carries it to `TeammateManager.finalizeTurn`, which now dedups the real signal finish by `${conversation_id}#${turnId}`. `IResponseMessage.turnId` widens to `string | number` (engine uuid vs local sequential id — both stringify identically in the key).

### Verification
- Reproduce-first + **mutation-tested**: `turn_id` extraction (AcpConnection) and signal-path stamping both fail under mutation.
- Independent adversarial review: **no blocking findings** (verified end-to-end chain, no string/number key collision, mutual-exclusion of signal-vs-fallback per turn, no non-team/non-ACP regression).

### ⚠️ Scope + one item to confirm before closing #787
- **Scope**: covers the `end_turn` (Done) path — the primary #787 case. The desktop error-recovery finishes (qwen/timeout UI-unstick emits) stay conversation-keyed; they're **one-shot per prompt** (no re-send straggler), so they don't reopen #787 on the error path — narrow pre-existing residual, no regression.
- **Integration assumption (confirm before closing #787)**: the chain reads `turn_id` off the same PromptResponse **result** that carries `stopReason: 'end_turn'`. If core PR #219 instead emits `turn_id` on a separate `session/update` notification, this silently no-ops (unchanged behaviour, **not** a break). @core — please confirm the field location; needs a live team-turn re-wake check to close #787.

Keep #787 OPEN on merge.
