### PR TITLE
fix(webui): deny remote peers writing webui.desktop.* config (#819)

### DIFF
--- a/src/common/adapter/bridgeAllowlist.ts
+++ b/src/common/adapter/bridgeAllowlist.ts
@@ -422,6 +422,55 @@ export function isAllowedForRemote(name: string): boolean {
 }
 
 /**
+ * Wire key for the shared `agent.config` config store's setter. `ConfigStorage`
+ * and `ProcessConfig` are the same store (initStorage.ts), so a value written
+ * here is what `restoreDesktopWebUIFromPreferences` reads on the next launch.
+ */
+const CONFIG_STORAGE_SET_KEY = 'agent.config.storage.set';
+
+/**
+ * Config keys a REMOTE (paired-device WebSocket) caller must never WRITE, even
+ * though the generic `agent.config.storage.set` wire key stays allowed for the
+ * config reads/writes the paired WebUI legitimately needs.
+ *
+ * #819: `webui.start`/`webui.stop` are correctly remote-denied, but arming LAN
+ * exposure does not require them - it only needs the PREFERENCE. A paired peer
+ * writing `webui.desktop.allowRemote=true` (+ `enabled=true`) makes the app bind
+ * `0.0.0.0` itself on the next launch, no dialog, no `webui.start`. The pref IS
+ * the consent record, so the denylist has to guard the DECLARATIVE door too, not
+ * just the imperative one. `restoreDesktopWebUIFromPreferences` reads only the
+ * `webui.desktop.*` keys (enabled / allowRemote / port), so the prefix covers the
+ * whole re-arm surface.
+ */
+const REMOTE_DENIED_CONFIG_KEY_PREFIXES: readonly string[] = ['webui.desktop.'];
+
+/**
+ * True iff `(name, data)` is a remote config write to a protected key.
+ *
+ * Applied AFTER {@link isAllowedForRemote} on the WS dispatch path. The setter's
+ * wire key (`agent.config.storage.set`) is intentionally NOT in the remote
+ * denylist - denying it wholesale would break every legitimate remote config
+ * write - so the gate has to be VALUE-level: inspect the target key carried in
+ * the invocation payload and reject only the protected prefixes. The per-call
+ * remote signal a `buildProvider` handler lacks exists here at the wire, which is
+ * exactly why this belongs in the adapter and not in the storage provider.
+ *
+ * @param name Full inbound wire name (`subscribe-agent.config.storage.set`).
+ * @param data Invocation payload as received: `{ id, data: { key, data } }`.
+ */
+export function isRemoteDeniedConfigWrite(name: string, data: unknown): boolean {
+  if (typeof name !== 'string' || name !== `subscribe-${CONFIG_STORAGE_SET_KEY}`) return false;
+
+  const targetKey = (data as { data?: { key?: unknown } } | null | undefined)?.data?.key;
+  if (typeof targetKey !== 'string') return false;
+
+  for (const prefix of REMOTE_DENIED_CONFIG_KEY_PREFIXES) {
+    if (targetKey.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+/**
  * Emitter/broadcast (main -> client) names that must NOT be forwarded to a
  * remote WebSocket peer. Inbound denial (isAllowedForRemote) stops a peer
  * INVOKING a provider; this stops a peer passively RECEIVING an emitter stream.

--- a/src/process/webserver/adapter.ts
+++ b/src/process/webserver/adapter.ts
@@ -6,7 +6,12 @@
 
 import type { WebSocket, WebSocketServer } from 'ws';
 import { registerWebSocketBroadcaster, getBridgeEmitter } from '@/common/adapter/registry';
-import { isAllowedInboundName, isAllowedForRemote, isAllowedOutboundToRemote } from '@/common/adapter/bridgeAllowlist';
+import {
+  isAllowedInboundName,
+  isAllowedForRemote,
+  isAllowedOutboundToRemote,
+  isRemoteDeniedConfigWrite,
+} from '@/common/adapter/bridgeAllowlist';
 import { WebSocketManager } from './websocket/WebSocketManager';
 
 /**
@@ -76,6 +81,15 @@ export function initWebAdapter(wss: WebSocketServer): void {
     // fs.*/shell.*/skill-mutation/mcp-mutation/hub/app write/exec providers.
     if (!isAllowedForRemote(name)) {
       console.error('[adapter] Rejected remote-forbidden WebSocket bridge event:', name);
+      settleRejectedInvoke(ws, name, data, 'remote-forbidden');
+      return;
+    }
+    // #819: the config setter wire key stays allowed (the paired WebUI writes
+    // legitimate config), so gate the DANGEROUS VALUES here - a remote peer must
+    // not write `webui.desktop.*` and arm LAN exposure without ever hitting
+    // `webui.start`. The pref is the consent record; deny forging it.
+    if (isRemoteDeniedConfigWrite(name, data)) {
+      console.error('[adapter] Rejected remote config write to a protected key:', name);
       settleRejectedInvoke(ws, name, data, 'remote-forbidden');
       return;
     }

--- a/tests/unit/bridgeAllowlistWebuiConfig.redteam.test.ts
+++ b/tests/unit/bridgeAllowlistWebuiConfig.redteam.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isAllowedForRemote, isRemoteDeniedConfigWrite } from '@/common/adapter/bridgeAllowlist';
+
+/**
+ * #819 (the security gate): a paired-device WebSocket peer must never be able to
+ * arm WebUI LAN exposure by writing the PREFERENCE. `webui.start`/`webui.stop`
+ * are remote-denied, but arming exposure does not need them — it only needs
+ * `webui.desktop.allowRemote=true` (+ `enabled=true`) in the shared `agent.config`
+ * store, which `restoreDesktopWebUIFromPreferences` reads to bind `0.0.0.0` on the
+ * next launch. That write rides the generic `agent.config.storage.set` wire key,
+ * which stays ALLOWED for the config the paired WebUI legitimately writes — so the
+ * gate is value-level, on the target key carried in the invocation payload.
+ *
+ * Wire payload shape (verified against @office-ai/platform's buildStorage.set):
+ *   storage.set(key, value) → invoke({ key, data: value })
+ *   → wire `{ name: 'subscribe-agent.config.storage.set', data: { id, data: { key, data } } }`
+ */
+describe('isRemoteDeniedConfigWrite — webui.desktop.* writes denied to remote callers (#819)', () => {
+  const set = (key: string, value: unknown) => ({
+    id: `${key}deadbeef`,
+    data: { key, data: value },
+  });
+  const NAME = 'subscribe-agent.config.storage.set';
+
+  // The re-arm surface: every key restoreDesktopWebUIFromPreferences reads.
+  const deniedKeys: ReadonlyArray<string> = [
+    'webui.desktop.allowRemote', // the LAN-exposure switch — the critical one
+    'webui.desktop.enabled', // the other half of a from-cold auto-bind
+    'webui.desktop.port',
+    'webui.desktop.anythingElse', // a hypothetical future webui.desktop.* key
+  ];
+
+  it.each(deniedKeys)('denies a remote write to %s', (key) => {
+    expect(isRemoteDeniedConfigWrite(NAME, set(key, true))).toBe(true);
+  });
+
+  it('does not over-deny: a legitimate config write the paired WebUI needs stays allowed', () => {
+    expect(isRemoteDeniedConfigWrite(NAME, set('theme', 'dark'))).toBe(false);
+    expect(isRemoteDeniedConfigWrite(NAME, set('webui.someOtherKey', true))).toBe(false);
+  });
+
+  it('only gates the agent.config setter, not reads or other wire keys', () => {
+    expect(isRemoteDeniedConfigWrite('subscribe-agent.config.storage.get', 'webui.desktop.allowRemote')).toBe(false);
+    expect(isRemoteDeniedConfigWrite('subscribe-cron.list-jobs', set('webui.desktop.allowRemote', true))).toBe(false);
+  });
+
+  it('is robust to malformed / missing payloads (defaults to not-denied, dispatch is unaffected)', () => {
+    expect(isRemoteDeniedConfigWrite(NAME, undefined)).toBe(false);
+    expect(isRemoteDeniedConfigWrite(NAME, null)).toBe(false);
+    expect(isRemoteDeniedConfigWrite(NAME, {})).toBe(false);
+    expect(isRemoteDeniedConfigWrite(NAME, { data: {} })).toBe(false);
+    expect(isRemoteDeniedConfigWrite(NAME, { data: { key: 42 } })).toBe(false);
+  });
+
+  /**
+   * The reason this gate has to exist: the setter wire key is NOT in the remote
+   * denylist (it can't be — the paired WebUI writes legitimate config through it),
+   * so isAllowedForRemote lets `agent.config.storage.set` through. Without the
+   * value-gate the malicious write would be dispatched. This pins that the wire
+   * key stays allowed AND that the value-gate is the thing that denies the write.
+   */
+  it('documents the two-layer design: setter stays wire-allowed, value-gate does the denial', () => {
+    expect(isAllowedForRemote(NAME)).toBe(true);
+    expect(isRemoteDeniedConfigWrite(NAME, set('webui.desktop.allowRemote', true))).toBe(true);
+  });
+});

--- a/tests/unit/webserver/adapterRejectionSettles.test.ts
+++ b/tests/unit/webserver/adapterRejectionSettles.test.ts
@@ -59,6 +59,9 @@ import { initWebAdapter } from '@process/webserver/adapter';
 // denylist (the #684 trigger); `conversation.get-list-684-test` is not.
 buildProvider('project.generate-knowledge-draft');
 buildProvider('conversation.get-list-684-test');
+// #819: the shared config setter — wire-allowed (the paired WebUI writes config),
+// value-gated so a remote peer cannot write `webui.desktop.*` and arm LAN exposure.
+buildProvider('agent.config.storage.set');
 
 function makeWs(): { send: ReturnType<typeof vi.fn> } {
   return { send: vi.fn() };
@@ -131,6 +134,50 @@ describe('webserver adapter - rejected bridge invocations settle the caller (#68
     capturedHandler.fn!('subscribe-conversation.get-list-684-test', message, ws);
 
     expect(registryMocks.emitter.emit).toHaveBeenCalledWith('subscribe-conversation.get-list-684-test', message);
+    expect(ws.send).not.toHaveBeenCalled();
+  });
+});
+
+describe('webserver adapter - remote peer cannot arm LAN exposure via a config write (#819)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedHandler.fn = null;
+    initWebAdapter({} as never);
+    expect(capturedHandler.fn).toBeTypeOf('function');
+  });
+
+  const NAME = 'subscribe-agent.config.storage.set';
+
+  it('blocks a remote webui.desktop.allowRemote write and settles the caller', () => {
+    const ws = makeWs();
+    const id = 'agent.config.storage.setdeadbeef';
+    capturedHandler.fn!(NAME, { id, data: { key: 'webui.desktop.allowRemote', data: true } }, ws);
+
+    // The write never reaches the store — no auto-bind on the next launch.
+    expect(registryMocks.emitter.emit).not.toHaveBeenCalled();
+    // The caller's invoke() settles instead of hanging (#684 contract).
+    expect(ws.send).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(ws.send.mock.calls[0][0] as string);
+    expect(payload.name).toBe(`subscribe.callback-agent.config.storage.set${id}`);
+    expect(payload.data).toEqual({ error: 'failed', detail: 'remote-forbidden' });
+  });
+
+  it('also blocks the enabled half of a from-cold auto-bind', () => {
+    const ws = makeWs();
+    capturedHandler.fn!(
+      NAME,
+      { id: 'agent.config.storage.setcafebabe', data: { key: 'webui.desktop.enabled', data: true } },
+      ws
+    );
+    expect(registryMocks.emitter.emit).not.toHaveBeenCalled();
+  });
+
+  it('still dispatches a legitimate config write the paired WebUI needs', () => {
+    const ws = makeWs();
+    const message = { id: 'agent.config.storage.setfeedface', data: { key: 'theme', data: 'dark' } };
+    capturedHandler.fn!(NAME, message, ws);
+
+    expect(registryMocks.emitter.emit).toHaveBeenCalledWith(NAME, message);
     expect(ws.send).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## The hole (#819)

`webui.start` / `webui.stop` are correctly remote-denied — but arming WebUI LAN exposure never needs them. It only needs the **preference**. A paired-device WebSocket peer writes `webui.desktop.allowRemote=true` (+ `enabled=true`) through the generic, **un-denied** `agent.config.storage.set` wire key, and on the next launch `restoreDesktopWebUIFromPreferences()` reads exactly those keys and binds `0.0.0.0` itself — no dialog, no `webui.start`. The denylist guarded the *imperative* door and left the *declarative* one open, and the pref **is** the consent record.

## The fix

A wire-level **value-gate**, `isRemoteDeniedConfigWrite(name, data)`, added to `bridgeAllowlist.ts` (the single source of truth) and enforced in the WS adapter right after `isAllowedForRemote`:

- The setter key `agent.config.storage.set` stays **wire-allowed** — the paired WebUI writes legitimate config through it.
- The gate inspects the **target key** carried in the invocation payload (`data.data.key`, the verified `buildStorage.set` shape) and rejects only `webui.desktop.*`, the exact prefix `restoreDesktopWebUIFromPreferences` consumes.
- Enforced in `src/process/webserver/adapter.ts`, where the per-call remote signal a `buildProvider` handler lacks actually exists — the same reason `terminal.*` is denied at the wire. The local Electron renderer uses the in-process IPC adapter and is unaffected.
- Rejected invocations settle the caller (`remote-forbidden`) per the #684 contract, so no remote hang.

## Tests

- `tests/unit/bridgeAllowlistWebuiConfig.redteam.test.ts` — pure-function denials (allowRemote/enabled/port + future `webui.desktop.*`), no over-denial, malformed-payload safety, and the two-layer design (setter stays wire-allowed, value-gate denies).
- New describe in `tests/unit/webserver/adapterRejectionSettles.test.ts` — end-to-end through the real `initWebAdapter` dispatch: the malicious write never reaches the emitter and settles the caller; a legit `theme` write still dispatches.
- Mutation-pinned: neutering the gate turns the denials red.

Independent adversarial review found no bypass (verified against the platform `buildStorage` source and the `agent.config`→`ProcessConfig` store binding: single consumed store, single writer key, no array/batch variant, no casing dodge that reaches a consumed key).

Closes #819.
