### PR TITLE
fix(acp): stop false "no YOLO mode" warning for claude backend

### DIFF
--- a/src/process/acp/session/SessionLifecycle.ts
+++ b/src/process/acp/session/SessionLifecycle.ts
@@ -1,4 +1,4 @@
-import { getFullAutoMode, resolveAcpSessionModeId } from '@/common/types/agentModes';
+import { getFullAutoMode, isAutoGuardedMode, resolveAcpSessionModeId } from '@/common/types/agentModes';
 import { isFluxModelId } from '@/common/config/flux';
 import { parseInitializeResult } from '@/common/types/acpTypes';
 import type { AuthMethod, LoadSessionResponse, McpServer, NewSessionResponse } from '@agentclientprotocol/sdk';
@@ -279,11 +279,20 @@ export class SessionLifecycle {
    * and fires an immediate setMode call to the agent.
    */
   private applyYoloMode(): void {
+    const backend = this.host.agentConfig.agentBackend;
     const availableModes = this.host.configTracker.modeSnapshot().availableModes;
-    const yoloModeId = resolveYoloModeId(this.host.agentConfig.agentBackend, availableModes);
+    const yoloModeId = resolveYoloModeId(backend, availableModes);
     if (!yoloModeId) {
+      // A backend whose full-auto IS the Wayland-internal 'autoGuarded' mode (claude)
+      // has nothing to set on the agent: guarded-auto is enforced entirely client-side
+      // by the AcpAgentManager guardrail (auto-approve every escalated tool except a
+      // destructive one), and the bridge never advertises the internal mode. That is
+      // expected, not a missing capability - warning here reads as "claude has no
+      // full-auto", which is false and drove a bug report (#749). Full blind auto is
+      // still available via Autopilot ('bypassPermissions'), a separate advertised mode.
+      if (isAutoGuardedMode(getFullAutoMode(backend))) return;
       console.warn(
-        `[SessionLifecycle] No YOLO mode found for backend ${this.host.agentConfig.agentBackend}, ` +
+        `[SessionLifecycle] No YOLO mode found for backend ${backend}, ` +
           'falling back to client-side auto-approve only'
       );
       return;

--- a/tests/unit/claudeYoloModeWarning.test.ts
+++ b/tests/unit/claudeYoloModeWarning.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * #749 - "No YOLO mode found for backend claude" logged every session, which reads as
+ * "claude has no full-auto mode" and drove a false bug report. It is cosmetic: claude's
+ * full-auto is the Wayland-internal `autoGuarded` mode, which the bridge never advertises
+ * because guarded-auto is enforced client-side by the AcpAgentManager guardrail
+ * (auto-approve every escalated tool except a destructive one). Full blind auto is
+ * separately available via Autopilot (`bypassPermissions`).
+ *
+ * The load-bearing predicate SessionLifecycle now uses to suppress the false warning is
+ * `isAutoGuardedMode(getFullAutoMode(backend))`. Pin it: TRUE for claude (suppress),
+ * FALSE for backends whose full-auto is a real advertised agent mode (a genuinely-absent
+ * mode there SHOULD still warn).
+ */
+import { describe, expect, it } from 'vitest';
+import { getFullAutoMode, isAutoGuardedMode } from '@/common/types/agentModes';
+
+describe('#749 claude full-auto is the internal guarded mode (warning is cosmetic)', () => {
+  it("claude's full-auto is the internal autoGuarded mode -> warning suppressed", () => {
+    expect(getFullAutoMode('claude')).toBe('autoGuarded');
+    expect(isAutoGuardedMode(getFullAutoMode('claude'))).toBe(true);
+  });
+
+  it('backends with a real advertised full-auto mode still warn on a genuine miss', () => {
+    for (const backend of ['gemini', 'qwen', 'wcore']) {
+      expect(isAutoGuardedMode(getFullAutoMode(backend))).toBe(false);
+    }
+  });
+
+  it('an unknown backend is not guarded-auto (falls back to yolo, still warns)', () => {
+    expect(getFullAutoMode('totally-unknown')).toBe('yolo');
+    expect(isAutoGuardedMode(getFullAutoMode('totally-unknown'))).toBe(false);
+  });
+});


### PR DESCRIPTION
claude's full-auto is the Wayland-internal `autoGuarded` mode, which the ACP
bridge never advertises because guarded-auto is enforced client-side by the
AcpAgentManager guardrail (auto-approve every escalated tool except a
destructive one). So resolveYoloModeId returns null and SessionLifecycle logged
"No YOLO mode found for backend claude" every session - which reads as "claude
has no full-auto" and drove a bug report (#749). It is cosmetic: Autopilot
(bypassPermissions) auto-approves everything incl. Bash, and Accept Edits is
edits-only by design.

Suppress the warning when the backend's full-auto is the internal autoGuarded
mode (nothing to set on the agent); keep it for backends whose full-auto is a
real advertised mode that genuinely went missing. No change to auto-approval.

Closes #749
