### PR TITLE
fix(extensions): gate cleartext-http entryUrl in native hooks (#824)

### DIFF
--- a/src/process/extensions/resolvers/NativeHookResolver.ts
+++ b/src/process/extensions/resolvers/NativeHookResolver.ts
@@ -17,6 +17,7 @@ import type {
 import { toAssetUrl } from '../protocol/assetProtocol';
 import { isPathWithinDirectory } from '../sandbox/pathSafety';
 import { resolveRuntimeEntryPath } from './utils/entryPointResolver';
+import { resolveExternalEntryUrl } from './utils/externalEntryUrlResolver';
 
 export type ResolvedExtensionAcronym = {
   id: string;
@@ -86,17 +87,9 @@ function resolveIcon(ext: LoadedExtension, icon: string | undefined, label: stri
 function resolveEntryUrl(ext: LoadedExtension, entryPoint: string, label: string): string | undefined {
   const isExternalEntry = /^https?:\/\//i.test(entryPoint);
   if (isExternalEntry) {
-    try {
-      const external = new URL(entryPoint);
-      if (external.protocol !== 'http:' && external.protocol !== 'https:') {
-        console.warn(`[Extensions] Unsupported ${label} external protocol: ${entryPoint} (${ext.manifest.name})`);
-        return undefined;
-      }
-      return external.toString();
-    } catch {
-      console.warn(`[Extensions] Invalid ${label} external URL: ${entryPoint} (${ext.manifest.name})`);
-      return undefined;
-    }
+    // #824: gate cleartext http (loopback-only) through the shared resolver so this
+    // surface can't reintroduce the MITM shape once it's wired into a webview.
+    return resolveExternalEntryUrl(entryPoint, label, ext.manifest.name);
   }
 
   const absEntry = resolveRuntimeEntryPath(ext.directory, entryPoint);

--- a/src/process/extensions/resolvers/SettingsTabResolver.ts
+++ b/src/process/extensions/resolvers/SettingsTabResolver.ts
@@ -11,6 +11,7 @@ import { BUILTIN_SETTINGS_TAB_IDS } from '../types';
 import { isPathWithinDirectory } from '../sandbox/pathSafety';
 import { toAssetUrl } from '../protocol/assetProtocol';
 import { resolveRuntimeEntryPath } from './utils/entryPointResolver';
+import { resolveExternalEntryUrl } from './utils/externalEntryUrlResolver';
 
 /**
  * Resolved settings tab contribution - ready to be consumed by the renderer.
@@ -31,12 +32,6 @@ export type ResolvedSettingsTab = {
   /** Source extension name */
   _extensionName: string;
 };
-
-/** Loopback is not MITM-able, so cleartext there is safe (and is how a hosted tab is developed). */
-function isLoopbackHost(hostname: string): boolean {
-  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
-  return host === 'localhost' || host === '127.0.0.1' || host === '::1';
-}
 
 /**
  * Resolve `contributes.settingsTabs` from all enabled extensions.
@@ -75,25 +70,9 @@ export function resolveSettingsTabs(extensions: LoadedExtension[]): ResolvedSett
       let entryUrl: string;
 
       if (isExternalEntry) {
-        try {
-          const external = new URL(tab.entryPoint);
-          if (external.protocol !== 'http:' && external.protocol !== 'https:') {
-            console.warn(
-              `[Extensions] Unsupported settings tab external protocol: ${tab.entryPoint} (extension: ${extName})`
-            );
-            continue;
-          }
-          if (external.protocol === 'http:' && !isLoopbackHost(external.hostname)) {
-            console.warn(
-              `[Extensions] Refusing cleartext http settings tab (use https): ${tab.entryPoint} (extension: ${extName})`
-            );
-            continue;
-          }
-          entryUrl = external.toString();
-        } catch {
-          console.warn(`[Extensions] Invalid settings tab external URL: ${tab.entryPoint} (extension: ${extName})`);
-          continue;
-        }
+        const resolved = resolveExternalEntryUrl(tab.entryPoint, 'settings tab', extName);
+        if (!resolved) continue;
+        entryUrl = resolved;
       } else {
         const absEntry = resolveRuntimeEntryPath(extDir, tab.entryPoint);
         if (!absEntry) {

--- a/src/process/extensions/resolvers/utils/externalEntryUrlResolver.ts
+++ b/src/process/extensions/resolvers/utils/externalEntryUrlResolver.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Shared gate for an extension contribution's EXTERNAL (`http(s)://`) entry URL.
+ *
+ * Multiple resolvers (settings tabs, workspace panels, file-preview actions)
+ * accept an external `entryPoint` and feed the result into a webview/iframe. Each
+ * used to re-derive the same validation, and the cleartext-http guard was added to
+ * only one of them (#818 / PR #823) — leaving the identical hole open on the others
+ * (#824). Hoisting the rule here means one gate protects every surface, so wiring a
+ * new external entry URL into a webview cannot silently reintroduce the MITM shape.
+ *
+ * The rule: `https` is always allowed; `http` is allowed ONLY on loopback
+ * (localhost / 127.0.0.1 / ::1), which is not MITM-able and is how a hosted panel is
+ * developed. Any other protocol, or cleartext http to a non-loopback host, or an
+ * unparseable URL, is refused (returns `undefined` + a warning) so it never renders.
+ */
+
+/** Loopback is not MITM-able, so cleartext there is safe (and is how a hosted surface is developed). */
+export function isLoopbackHost(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  return host === 'localhost' || host === '127.0.0.1' || host === '::1';
+}
+
+/**
+ * Validate an external `http(s)://` entry point. Returns the normalized URL string,
+ * or `undefined` (with a warning) if the protocol is unsupported, the URL is
+ * malformed, or it is cleartext http to a non-loopback host.
+ *
+ * @param entryPoint The raw external URL from the extension manifest.
+ * @param label      Human label for the contribution surface (used in warnings).
+ * @param extName    Source extension name (used in warnings).
+ */
+export function resolveExternalEntryUrl(entryPoint: string, label: string, extName: string): string | undefined {
+  try {
+    const external = new URL(entryPoint);
+    if (external.protocol !== 'http:' && external.protocol !== 'https:') {
+      console.warn(`[Extensions] Unsupported ${label} external protocol: ${entryPoint} (extension: ${extName})`);
+      return undefined;
+    }
+    if (external.protocol === 'http:' && !isLoopbackHost(external.hostname)) {
+      console.warn(`[Extensions] Refusing cleartext http ${label} (use https): ${entryPoint} (extension: ${extName})`);
+      return undefined;
+    }
+    return external.toString();
+  } catch {
+    console.warn(`[Extensions] Invalid ${label} external URL: ${entryPoint} (extension: ${extName})`);
+    return undefined;
+  }
+}

--- a/tests/unit/extensions/nativeHookRemoteEntry.test.ts
+++ b/tests/unit/extensions/nativeHookRemoteEntry.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * #824 - the sibling of #818/#823. A workspace-panel / file-preview-action external
+ * `entryPoint` resolves through `NativeHookResolver.resolveEntryUrl` into
+ * `entryUrl`, a document surface destined for a webview/iframe. That resolver
+ * accepted any `http(s)://` verbatim with NO loopback guard - the same cleartext
+ * MITM shape #823 closed for settings tabs, left open here. The guard now lives in
+ * the SHARED `resolveExternalEntryUrl`, so both surfaces reject cleartext http to a
+ * non-loopback host while keeping https and loopback-http (local dev).
+ */
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  resolveWorkspacePanels,
+  resolveFilePreviewActions,
+} from '../../../src/process/extensions/resolvers/NativeHookResolver';
+import type { LoadedExtension } from '../../../src/process/extensions/types';
+
+const tempDirs: string[] = [];
+
+async function makeExtension(entryPoint: string): Promise<LoadedExtension> {
+  const directory = await mkdtemp(path.join(os.tmpdir(), 'wayland-native-hook-remote-'));
+  tempDirs.push(directory);
+  await writeFile(path.join(directory, 'panel.html'), '<h1>Panel</h1>');
+
+  return {
+    directory,
+    source: 'local',
+    manifest: {
+      name: 'remote-hook-extension',
+      version: '1.0.0',
+      displayName: 'remote hook extension',
+      contributes: {
+        workspacePanels: [{ id: 'panel', name: 'Panel', entryPoint, order: 100 }],
+        filePreviewActions: [{ id: 'preview', name: 'Preview', entryPoint, order: 100 }],
+      },
+    },
+  } as LoadedExtension;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('NativeHookResolver - remote entryPoint transport (#824)', () => {
+  it('REJECTS a cleartext http:// workspace panel (was accepted before the shared gate)', async () => {
+    const panels = resolveWorkspacePanels([await makeExtension('http://evil.example.com/panel.html')]);
+    expect(panels).toHaveLength(0);
+  });
+
+  it('REJECTS a cleartext http:// file preview action', async () => {
+    const actions = resolveFilePreviewActions([await makeExtension('http://evil.example.com/panel.html')]);
+    expect(actions).toHaveLength(0);
+  });
+
+  it('rejects cleartext http:// even when the host looks trustworthy', async () => {
+    const ext = await makeExtension('http://ferroxlabs.com/panel.html');
+    expect(resolveWorkspacePanels([ext])).toHaveLength(0);
+    expect(resolveFilePreviewActions([ext])).toHaveLength(0);
+  });
+
+  it('KEEPS https:// hosted panels/actions (documented capability)', async () => {
+    const ext = await makeExtension('https://ferroxlabs.com/panel.html');
+    const panels = resolveWorkspacePanels([ext]);
+    const actions = resolveFilePreviewActions([ext]);
+    expect(panels).toHaveLength(1);
+    expect(panels[0].entryUrl).toBe('https://ferroxlabs.com/panel.html');
+    expect(actions).toHaveLength(1);
+    expect(actions[0].entryUrl).toBe('https://ferroxlabs.com/panel.html');
+  });
+
+  it('exempts loopback http (not MITM-able; local dev of a hosted panel)', async () => {
+    for (const entry of ['http://localhost:5173/panel.html', 'http://127.0.0.1:5173/panel.html']) {
+      const ext = await makeExtension(entry);
+      const panels = resolveWorkspacePanels([ext]);
+      expect(panels).toHaveLength(1);
+      expect(panels[0].entryUrl).toBe(entry);
+    }
+  });
+
+  it('still resolves a local (wayland-asset://) workspace panel', async () => {
+    const panels = resolveWorkspacePanels([await makeExtension('panel.html')]);
+    expect(panels).toHaveLength(1);
+    expect(panels[0].entryUrl).toMatch(/^wayland-asset:\/\//);
+  });
+
+  it('a file preview action with NO entryPoint still resolves (entryPoint is optional)', async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), 'wayland-native-hook-noentry-'));
+    tempDirs.push(directory);
+    const ext = {
+      directory,
+      source: 'local',
+      manifest: {
+        name: 'no-entry-extension',
+        version: '1.0.0',
+        displayName: 'no entry',
+        contributes: {
+          filePreviewActions: [{ id: 'promptonly', name: 'Prompt Only', promptTemplate: 'summarize', order: 100 }],
+        },
+      },
+    } as LoadedExtension;
+    expect(resolveFilePreviewActions([ext])).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## The hole (#824)

`NativeHookResolver.resolveEntryUrl` accepted any `http(s)://` external `entryPoint` **verbatim, with no loopback guard** — the same cleartext-MITM shape #823 closed for `SettingsTabResolver`, left open on **workspace panels** and **file-preview actions**. Their `entryUrl` is a document surface destined for a webview/iframe. It dead-ends today (no IPC provider / renderer consumer), but the moment one is wired into a `WebviewHost`/iframe, cleartext `http` rides in unguarded and reintroduces #818 on a new surface.

## The fix

Hoist the loopback-only cleartext rule into a **shared** `resolveExternalEntryUrl` (`resolvers/utils/externalEntryUrlResolver.ts`) so both resolvers share one gate instead of each re-deriving it:

- **`https` always allowed**; **`http` only on loopback** (`localhost` / `127.0.0.1` / `::1`, which is not MITM-able and is how a hosted panel is developed locally).
- Unsupported protocol, cleartext-http to a non-loopback host, or an unparseable URL → refused (`undefined` + warning), so it never renders.
- `SettingsTabResolver` now delegates to the shared gate (its inline `isLoopbackHost` + try/catch removed) — **byte-equivalent**; its #818 tests still pass.
- `NativeHookResolver` gains the guard it was missing on both its surfaces.

## Tests

- New `tests/unit/extensions/nativeHookRemoteEntry.test.ts` — workspace panels + file-preview actions REJECT cleartext http (incl. trustworthy-looking hosts), KEEP https, exempt loopback http, still resolve local `wayland-asset://`, and preserve the optional-`entryPoint` action.
- Existing `settingsTabRemoteEntry.test.ts` (#818) preserved as the refactor's regression guard.
- Mutation-pinned: neutering the shared cleartext guard turns the reject tests red across **both** surfaces.

Independent adversarial review found no bypass — every loopback-spoof candidate (`localhost.evil.com`, `127.0.0.1.evil.com`, `localhost@evil.com` userinfo, `0.0.0.0`, decimal/octal/hex IP encodings, trailing-dot, IPv6 brackets) resolves to the correct reject/allow, and `isLoopbackHost` has no false-positive (only the exact loopback strings match). No third unguarded content sink (icon URLs are `<img src>`, not webview content — out of scope).

Closes #824.
