### PR TITLE
fix(context): size unknown models conservatively, not 1M (#807)

### DIFF
--- a/src/renderer/utils/model/modelContextLimits.ts
+++ b/src/renderer/utils/model/modelContextLimits.ts
@@ -84,24 +84,31 @@ const MODEL_CONTEXT_LIMITS: Record<string, number> = {
   // `claude-4.5-haiku`, `anthropic/claude-haiku-latest` and `duo-chat-haiku-4-5`
   // match NONE of the `claude-haiku-*` keys above and reach 200K only through the
   // bare `haiku` key. Moving the slots to an exact-match-only table sounds safer
-  // but is strictly worse: those ids then fall through to DEFAULT_CONTEXT_LIMIT
-  // (1,048,576) - a 5.2x over-size on a 200K window. Every Haiku ever shipped is
-  // 200K, so the bare key cannot over-size anything.
+  // but is strictly worse: those ids then fall through to DEFAULT_CONTEXT_LIMIT.
+  // For `opus`/`sonnet` (really 1M) that would UNDER-size the window to the
+  // conservative default; the bare keys give the slot its true 1M. (`haiku` lands
+  // on 200K either way now, but stays explicit for the same reason.)
   //
-  // The bare keys do NOT rescue ids like `opus-4-5`/`sonnet-4` (really 200K, still
-  // sized ~1M) - but removing them does not either, because DEFAULT_CONTEXT_LIMIT
-  // is itself LARGER than 1M. That over-sizing belongs to the optimistic default,
-  // not to these keys. Tracked separately (#807) - a too-large default is the
-  // unsafe direction: it promises headroom that isn't there.
+  // The bare keys do NOT rescue ids like `opus-4-5`/`sonnet-4` (really 200K) - but
+  // they no longer NEED to: the default is now conservative (#807 fixed), so an
+  // unmatched id is sized at the safe 200K floor rather than an optimistic 1M+.
   opus: 1_000_000,
   sonnet: 1_000_000,
   haiku: 200_000,
 };
 
 /**
- * Default context limit (used when the model cannot be determined)
+ * Default context limit for a model we cannot identify at all — absent from the
+ * live catalog (resolveModelContextLimit) AND unmatched in the table above.
+ *
+ * Conservative ON PURPOSE (#807). An optimistic default is the UNSAFE direction:
+ * sizing an unknown model at ~1M when it is really 200K reports ~19% usage at the
+ * exact moment the user is at 100%, so they hit "out of headroom" with no warning
+ * at all. 200K is the overwhelmingly common floor, so an unknown model now nags
+ * early (safe) instead of never (unsafe). A genuinely-1M unknown is sized
+ * conservatively only until it appears in the catalog or the table.
  */
-export const DEFAULT_CONTEXT_LIMIT = 1_048_576;
+export const DEFAULT_CONTEXT_LIMIT = 200_000;
 
 /**
  * Get context limit by model name

--- a/tests/unit/modelContextLimits.test.ts
+++ b/tests/unit/modelContextLimits.test.ts
@@ -86,6 +86,16 @@ describe('getModelContextLimit', () => {
       expect(getModelContextLimit(undefined)).toBe(DEFAULT_CONTEXT_LIMIT);
       expect(getModelContextLimit(null)).toBe(DEFAULT_CONTEXT_LIMIT);
     });
+
+    // #807: the default is conservative, not optimistic. An unknown model must be
+    // sized at the safe 200K floor, NOT the old 1,048,576 that over-promised
+    // headroom (~19% shown at 100% real usage → no warning before running out).
+    // Pin the literal value: a "not 1M" assertion would pass on the old 1,048,576.
+    it('sizes an unknown model conservatively at 200K, never the optimistic 1M+ (#807)', () => {
+      expect(DEFAULT_CONTEXT_LIMIT).toBe(200_000);
+      expect(getModelContextLimit('router-alias-nobody-knows')).toBe(200_000);
+      expect(getModelContextLimit('some-finetune:v3')).toBe(200_000);
+    });
   });
 });
 
@@ -168,16 +178,17 @@ describe('Claude ACP slot aliases resolve to a real window (#733)', () => {
   });
 
   // REGRESSION GUARD. The bare `haiku` key looks like a fuzzy-matching hazard and
-  // is tempting to "harden" into an exact-match-only table. Doing that silently
-  // over-sizes every real Haiku id that matches none of the `claude-haiku-*` keys:
-  // they fall through to DEFAULT_CONTEXT_LIMIT (1,048,576) on a 200K window - a
-  // 5.2x over-size, i.e. the meter promises 5x the headroom that exists. All of
-  // these ids are real and present in resources/modelsdev-snapshot.json.
+  // is tempting to "harden" into an exact-match-only table. These ids are all real
+  // (present in resources/modelsdev-snapshot.json) and must every one size to 200K.
   //
-  // Note the assertion is `toBe(200_000)`, NOT `not.toBe(1_000_000)`: DEFAULT is
-  // 1,048,576, so a "not 1M" assertion PASSES on the over-sized default and would
-  // certify this very regression as a fix.
-  it('sizes every real Haiku catalog id at 200K, not the ~1M default', () => {
+  // Since #807 the default is itself a conservative 200K, so a Haiku id that fell
+  // through to the default would COINCIDENTALLY read 200K - value comparison can no
+  // longer distinguish "resolved via the bare key" from "fell to the default" here
+  // (that is why the old `not.toBe(DEFAULT)` companion is gone). The `toBe(200_000)`
+  // below still pins the required window; the structural guarantee that the bare
+  // slot keys RESOLVE rather than defaulting is enforced by the opus/sonnet slots
+  // above, whose real 1M window differs from the 200K default.
+  it('sizes every real Haiku catalog id at 200K (#733)', () => {
     for (const id of [
       'claude-4.5-haiku',
       'anthropic/claude-3.5-haiku',
@@ -187,13 +198,11 @@ describe('Claude ACP slot aliases resolve to a real window (#733)', () => {
       'haiku',
     ]) {
       expect(getModelContextLimit(id)).toBe(200_000);
-      expect(getModelContextLimit(id)).not.toBe(DEFAULT_CONTEXT_LIMIT);
     }
   });
 
-  it('resolves the haiku slot to 200K - NOT the 1M default', () => {
+  it('resolves the haiku slot to 200K (#733)', () => {
     expect(getModelContextLimit('haiku')).toBe(200_000);
-    expect(getModelContextLimit('haiku')).not.toBe(DEFAULT_CONTEXT_LIMIT);
   });
 
   // The slot keys are short; longest-match must still let a full catalog id win

--- a/tests/unit/renderer/useAcpMessage.dom.test.tsx
+++ b/tests/unit/renderer/useAcpMessage.dom.test.tsx
@@ -2,7 +2,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AcpModelInfo } from '@/common/types/acpTypes';
 import { useAcpMessage } from '@/renderer/pages/conversation/platforms/acp/useAcpMessage';
-import { DEFAULT_CONTEXT_LIMIT, getModelContextLimit } from '@/renderer/utils/model/modelContextLimits';
+import { getModelContextLimit } from '@/renderer/utils/model/modelContextLimits';
 
 const mockAddOrUpdateMessage = vi.fn();
 const mockConversationGetInvoke = vi.fn();
@@ -276,7 +276,7 @@ describe('useAcpMessage - seeds the model from the conversation row (#733)', () 
     mockConversationGetInvoke.mockResolvedValue({ status: 'idle', type: 'acp' });
   });
 
-  it('seeds the persisted model so a Haiku session sizes to 200K, not the 1M default', async () => {
+  it('seeds the persisted model so a Haiku session sizes to 200K (#733)', async () => {
     mockConversationGetInvoke.mockResolvedValue({
       status: 'idle',
       type: 'acp',
@@ -288,7 +288,6 @@ describe('useAcpMessage - seeds the model from the conversation row (#733)', () 
     await waitFor(() => expect(result.current.currentModelId).toBe('claude-haiku-4-5'));
     // The denominator the send box then resolves - the actual #733 symptom.
     expect(getModelContextLimit(result.current.currentModelId)).toBe(200_000);
-    expect(getModelContextLimit(result.current.currentModelId)).not.toBe(DEFAULT_CONTEXT_LIMIT);
   });
 
   it('seeds an Opus session to the 1M window', async () => {


### PR DESCRIPTION
## The bug (#807)

`DEFAULT_CONTEXT_LIMIT` was `1_048_576` — **larger than any real model we know about** (genuine 1M models are `1_000_000`). It's the denominator the context meter uses for a model absent from the live catalog AND unmatched in the static table. Optimistic is the unsafe direction: if that unknown model is really 200K, the meter shows ~19% usage at the exact moment the user is at **100%** — so they hit "out of headroom" with **no warning at all** (the complaint behind #480/#174/#508).

## The fix

Drop the default to `200_000` — the overwhelmingly common floor. An unknown model now nags **early (safe)** instead of **never (unsafe)**. A genuinely-1M unknown is sized conservatively only until it appears in the catalog or the table.

- **Every KNOWN model is unchanged**: the live catalog (`resolveModelContextLimit`, #733) and the static `MODEL_CONTEXT_LIMITS` table (exact + fuzzy) size all real models exactly as before. Only the genuine-unknown fallback changes.
- Single source: `DEFAULT_CONTEXT_LIMIT` is the only context default (consumed by `ContextUsageIndicator` + the send boxes via `resolveModelContextLimit`), so all surfaces stay consistent.

## Tests

- New pinning test asserts the **literal** `200_000` for the default and for unknown ids — never a `not.toBe(1M)` assertion (which would pass on the old over-sized default and certify the bug as fixed).
- Mutation-pinned: reverting the default to 1M turns the pin red.
- Updated the #733 haiku guards: with a conservative 200K default, a haiku id that fell to the default now coincidentally reads 200K, so value comparison can't distinguish key-resolved from defaulted — the `toBe(200_000)` pins stay; the removed `not.toBe(DEFAULT)` companions are structurally covered by the opus/sonnet 1M slots.

Independent adversarial review found no correctness defects: no known model relied on the 1M default; no parallel default disagrees; the proportional meter math and 70/90% thresholds are unaffected.

Closes #807.
