### PR TITLE
feat(security): warn once when an undeclared proxy fronts the app

### DIFF
--- a/src/process/webserver/middleware/networkTrust.ts
+++ b/src/process/webserver/middleware/networkTrust.ts
@@ -89,9 +89,15 @@ function isLoopback(ip: string): boolean {
  * password reset has a direct IPC path (webui-direct-reset-password) that bypasses this
  * classifier entirely.
  */
-function trustedProxyDeclared(): boolean {
+export function trustedProxyDeclared(): boolean {
   const raw = process.env.WAYLAND_TRUSTED_PROXY?.trim().toLowerCase();
   return raw === '1' || raw === 'true' || raw === 'yes';
+}
+
+/** Public helper: whether a raw peer address is loopback (after normalization). (#830) */
+export function isLoopbackAddress(rawIp: string | undefined | null): boolean {
+  if (!rawIp) return false;
+  return isLoopback(normalizeIp(rawIp));
 }
 
 /**
@@ -285,6 +291,12 @@ function parseCidr(token: string): Cidr | null {
  * Operator CIDR allowlist from `WAYLAND_OPERATOR_CIDRS` (comma-separated IPv4
  * CIDRs). Default empty: loopback + Tailscale are always operator regardless of
  * this var. Re-parsed only when the env value changes (so tests can flip it).
+ *
+ * FOOTGUN (#830): do NOT list loopback (`127.0.0.0/8`, or a superset like `0.0.0.0/0`)
+ * here when `WAYLAND_TRUSTED_PROXY` is set - it re-grants loopback => operator via
+ * `matchesOperatorCidr` and reopens the same-host-proxy hole #808 closed. If you are
+ * behind a proxy, prove operator by the tailnet path or a NON-loopback forwarded
+ * identity, never by allowlisting the loopback the proxy itself connects from.
  */
 function getOperatorCidrs(): Cidr[] {
   const raw = process.env.WAYLAND_OPERATOR_CIDRS ?? '';

--- a/src/process/webserver/setup.ts
+++ b/src/process/webserver/setup.ts
@@ -11,7 +11,11 @@ import cookieParser from 'cookie-parser';
 import csrf from 'tiny-csrf';
 import crypto from 'crypto';
 import { AuthMiddleware } from '@process/webserver/auth/middleware/AuthMiddleware';
-import { classifyClientTrust } from '@process/webserver/middleware/networkTrust';
+import {
+  classifyClientTrust,
+  isLoopbackAddress,
+  trustedProxyDeclared,
+} from '@process/webserver/middleware/networkTrust';
 import { errorHandler } from './middleware/errorHandler';
 import { attachCsrfToken } from './middleware/security';
 
@@ -215,7 +219,37 @@ export function deriveTrustedProxyOrigin(req: Request): string | null {
 
   const proto = singleForwardedValue(req.headers['x-forwarded-proto'])?.toLowerCase();
   const scheme = proto === 'http' || proto === 'https' ? proto : req.protocol || 'https';
-  return normalizeOrigin(`${scheme}://${host}`);
+  const origin = normalizeOrigin(`${scheme}://${host}`);
+
+  if (origin) warnUndeclaredProxyOnce(req.socket?.remoteAddress, origin);
+  return origin;
+}
+
+/**
+ * #830 - a same-host reverse proxy forwards public traffic as a loopback peer. When it
+ * does AND the operator has NOT declared `WAYLAND_TRUSTED_PROXY`, loopback still
+ * auto-grants `operator` (the #808 exposure), and this very function has just believed
+ * an attacker-influencable `X-Forwarded-Host`. That is the strongest available signal a
+ * fronting proxy exists, so warn ONCE per process (guarded so it can't spam the log).
+ * A tailnet/CIDR operator peer deriving an origin is a genuine trusted proxy, not this
+ * hole, so the warning is scoped to a LOOPBACK peer only.
+ */
+let warnedUndeclaredProxy = false;
+function warnUndeclaredProxyOnce(peer: string | undefined, origin: string): void {
+  if (warnedUndeclaredProxy) return;
+  if (trustedProxyDeclared()) return; // operator declared the proxy - loopback already demoted
+  if (!isLoopbackAddress(peer)) return; // genuine tailnet/CIDR proxy, not the loopback hole
+  warnedUndeclaredProxy = true;
+  console.warn(
+    `[security] Trusted X-Forwarded-Host "${origin}" from a loopback peer, but ` +
+      'WAYLAND_TRUSTED_PROXY is not set. If a same-host reverse proxy fronts this app, set ' +
+      'WAYLAND_TRUSTED_PROXY=1 so forwarded requests are not treated as local operator (#808).'
+  );
+}
+
+/** Test seam: reset the once-per-process proxy-exposure warning. */
+export function _resetProxyExposureWarningForTests(): void {
+  warnedUndeclaredProxy = false;
 }
 
 /**

--- a/tests/unit/webserver/proxyExposureWarning.test.ts
+++ b/tests/unit/webserver/proxyExposureWarning.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * #830 - when a same-host reverse proxy forwards public traffic (loopback peer +
+ * X-Forwarded-Host) and the operator has NOT declared WAYLAND_TRUSTED_PROXY, loopback
+ * still auto-grants operator (the #808 exposure) and deriveTrustedProxyOrigin believes
+ * the forwarded host. Warn ONCE. When the proxy IS declared (loopback demoted) or the
+ * operator peer is a genuine tailnet/CIDR proxy, do not warn.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Request } from 'express';
+import { deriveTrustedProxyOrigin, _resetProxyExposureWarningForTests } from '@process/webserver/setup';
+
+const priorTrusted = process.env.WAYLAND_TRUSTED_PROXY;
+const priorCidrs = process.env.WAYLAND_OPERATOR_CIDRS;
+
+function makeReq(remoteAddress: string): Request {
+  return {
+    protocol: 'https',
+    socket: { remoteAddress, localAddress: remoteAddress },
+    headers: { 'x-forwarded-host': 'box.example.com', 'x-forwarded-proto': 'https' },
+  } as unknown as Request;
+}
+
+beforeEach(() => {
+  _resetProxyExposureWarningForTests();
+  delete process.env.WAYLAND_TRUSTED_PROXY;
+  delete process.env.WAYLAND_OPERATOR_CIDRS;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (priorTrusted === undefined) delete process.env.WAYLAND_TRUSTED_PROXY;
+  else process.env.WAYLAND_TRUSTED_PROXY = priorTrusted;
+  if (priorCidrs === undefined) delete process.env.WAYLAND_OPERATOR_CIDRS;
+  else process.env.WAYLAND_OPERATOR_CIDRS = priorCidrs;
+});
+
+describe('#830 undeclared-proxy exposure warning', () => {
+  it('warns ONCE when a loopback peer forwards a host and WAYLAND_TRUSTED_PROXY is unset', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const origin = deriveTrustedProxyOrigin(makeReq('127.0.0.1'));
+    expect(origin).toBe('https://box.example.com'); // still derived (behavior unchanged)
+
+    const hits = warn.mock.calls.filter((c) => String(c[0]).includes('WAYLAND_TRUSTED_PROXY'));
+    expect(hits).toHaveLength(1);
+
+    // Second forwarded request must NOT warn again (once per process).
+    deriveTrustedProxyOrigin(makeReq('127.0.0.1'));
+    const hits2 = warn.mock.calls.filter((c) => String(c[0]).includes('WAYLAND_TRUSTED_PROXY'));
+    expect(hits2).toHaveLength(1);
+  });
+
+  it('does NOT warn when WAYLAND_TRUSTED_PROXY is declared (loopback already demoted)', () => {
+    process.env.WAYLAND_TRUSTED_PROXY = '1';
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // With the proxy declared, loopback is no longer operator, so no origin is derived.
+    expect(deriveTrustedProxyOrigin(makeReq('127.0.0.1'))).toBeNull();
+    expect(warn.mock.calls.some((c) => String(c[0]).includes('WAYLAND_TRUSTED_PROXY'))).toBe(false);
+  });
+
+  it('does NOT warn when the proxy IS declared but loopback was re-allowlisted (footgun path)', () => {
+    // The CIDR-loopback footgun (#830): WAYLAND_OPERATOR_CIDRS re-grants loopback => operator,
+    // so a loopback peer reaches the warn site even with the proxy declared. The warning
+    // ("set WAYLAND_TRUSTED_PROXY") would be wrong here - it is already set - so suppress it.
+    process.env.WAYLAND_TRUSTED_PROXY = '1';
+    process.env.WAYLAND_OPERATOR_CIDRS = '127.0.0.0/8';
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(deriveTrustedProxyOrigin(makeReq('127.0.0.1'))).toBe('https://box.example.com');
+    expect(warn.mock.calls.some((c) => String(c[0]).includes('WAYLAND_TRUSTED_PROXY'))).toBe(false);
+  });
+
+  it('does NOT warn for a genuine allowlisted (non-loopback) operator proxy', () => {
+    process.env.WAYLAND_OPERATOR_CIDRS = '203.0.113.0/24';
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const origin = deriveTrustedProxyOrigin(makeReq('203.0.113.7'));
+    expect(origin).toBe('https://box.example.com'); // trusted proxy, origin derived
+    expect(warn.mock.calls.some((c) => String(c[0]).includes('WAYLAND_TRUSTED_PROXY'))).toBe(false);
+  });
+});


### PR DESCRIPTION
Follow-up to #808. When a same-host reverse proxy forwards public traffic it
arrives as a loopback peer; with WAYLAND_TRUSTED_PROXY unset, loopback still
auto-grants operator and deriveTrustedProxyOrigin believes the forwarded
X-Forwarded-Host - the #808 exposure. That derivation is the strongest signal
a fronting proxy exists, so warn once per process, scoped to a loopback peer
(a tailnet/CIDR operator proxy is genuine, not this hole) and suppressed when
the proxy is already declared. Origin derivation is unchanged.

Also document the CIDR-loopback footgun: allowlisting loopback in
WAYLAND_OPERATOR_CIDRS re-opens #808 even with the proxy declared.

Closes #830
