### PR TITLE
feat(about): auto-check for updates on open and show status inline

### DIFF
--- a/src/renderer/components/settings/SettingsModal/contents/AboutModalContent.tsx
+++ b/src/renderer/components/settings/SettingsModal/contents/AboutModalContent.tsx
@@ -4,15 +4,42 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ChevronRight, Code } from 'lucide-react';
+import { CheckCircle2, ChevronRight, Code, Download, RefreshCw } from 'lucide-react';
 import { Divider, Typography, Button, Switch } from '@arco-design/web-react';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import classNames from 'classnames';
 import { useSettingsViewMode } from '../settingsViewContext';
 import { isElectronDesktop, openExternalUrl } from '@/renderer/utils/platform';
+import { runWaylandUpdaterExtensionCheck } from '@/renderer/pages/settings/utils/waylandUpdaterBridge';
 import packageJson from '../../../../../../package.json';
 import FeedbackReportModal from './FeedbackReportModal';
+
+/** Inline auto-check status shown on the About page (#731). */
+type AboutUpdateState = 'checking' | 'upToDate' | 'available' | 'error';
+
+/**
+ * The About tab remounts every time it's opened, and each check hits the
+ * unauthenticated GitHub REST API (60 req/hr/IP). Cache the last SUCCESSFUL
+ * result briefly so re-opening the tab serves the cached status instead of
+ * re-spending the rate limit; an explicit retry always forces a fresh check,
+ * and errors are never cached so a transient failure re-checks next time (#731).
+ */
+const ABOUT_CHECK_TTL_MS = 5 * 60_000;
+
+type AboutCheckCache = {
+  at: number;
+  includePrerelease: boolean;
+  state: Extract<AboutUpdateState, 'upToDate' | 'available'>;
+  latestVersion: string;
+};
+
+let aboutCheckCache: AboutCheckCache | null = null;
+
+/** Test-only: clear the module-level About update-check cache. */
+export function __resetAboutCheckCacheForTest(): void {
+  aboutCheckCache = null;
+}
 
 type LinkItem =
   | { title: string; url: string; icon: React.ReactNode; onClick?: never }
@@ -24,18 +51,73 @@ const AboutModalContent: React.FC = () => {
   const isPageMode = viewMode === 'page';
   const isElectron = isElectronDesktop();
 
-  const [includePrerelease, setIncludePrerelease] = useState(false);
+  // Read the persisted prerelease preference synchronously so the first
+  // auto-check (below) runs with the correct channel and doesn't double-fire.
+  const [includePrerelease, setIncludePrerelease] = useState<boolean>(
+    () => localStorage.getItem('update.includePrerelease') === 'true'
+  );
   const [showFeedbackModal, setShowFeedbackModal] = useState(false);
 
-  useEffect(() => {
-    const saved = localStorage.getItem('update.includePrerelease');
-    setIncludePrerelease(saved === 'true');
-  }, []);
+  // #731: auto-check for updates when the About page opens and surface the
+  // status inline, so users see "up to date" / "update available" without
+  // having to press a button first.
+  const [updateState, setUpdateState] = useState<AboutUpdateState>('checking');
+  const [latestVersion, setLatestVersion] = useState('');
+  // Bumping this re-runs the check effect (manual retry) without duplicating
+  // the check logic. The effect's cancelled-guard keeps a superseded in-flight
+  // check from clobbering a newer result.
+  const [checkNonce, setCheckNonce] = useState(0);
 
   const handlePrereleaseChange = (val: boolean) => {
     setIncludePrerelease(val);
     localStorage.setItem('update.includePrerelease', String(val));
   };
+
+  useEffect(() => {
+    if (!isElectron) return;
+
+    // Serve a recent cached result on remount to avoid re-hitting the rate
+    // limit. checkNonce > 0 means an explicit retry, which always re-checks.
+    if (
+      checkNonce === 0 &&
+      aboutCheckCache &&
+      aboutCheckCache.includePrerelease === includePrerelease &&
+      Date.now() - aboutCheckCache.at < ABOUT_CHECK_TTL_MS
+    ) {
+      setLatestVersion(aboutCheckCache.latestVersion);
+      setUpdateState(aboutCheckCache.state);
+      return;
+    }
+
+    let cancelled = false;
+    setUpdateState('checking');
+    void (async () => {
+      try {
+        const result = await runWaylandUpdaterExtensionCheck(includePrerelease, '[AboutModalContent]');
+        if (cancelled) return;
+        if (!result.ok) {
+          setUpdateState('error');
+          return;
+        }
+        const data = result.manual?.data;
+        // Wayland-app update only — an IJFW-only update (data.ijfw) must not flip
+        // this to "available" (mirrors UpdateModal's waylandUpdateAvailable logic).
+        const waylandUpdateAvailable = Boolean(data?.updateAvailable || result.autoUpdateAvailable);
+        const nextState: AboutCheckCache['state'] = waylandUpdateAvailable ? 'available' : 'upToDate';
+        const nextVersion = waylandUpdateAvailable ? data?.latest?.version || result.autoVersion || '' : '';
+        setLatestVersion(nextVersion);
+        setUpdateState(nextState);
+        // Only successful checks are cached; errors fall through so the next
+        // open re-checks rather than pinning a stale failure.
+        aboutCheckCache = { at: Date.now(), includePrerelease, state: nextState, latestVersion: nextVersion };
+      } catch {
+        if (!cancelled) setUpdateState('error');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isElectron, includePrerelease, checkNonce]);
 
   const openLink = async (url: string) => {
     try {
@@ -117,12 +199,55 @@ const AboutModalContent: React.FC = () => {
               </div>
             </div>
 
-            {/* Check Update Section */}
+            {/* Check Update Section (#731: auto-checks on open, shows status inline) */}
             {isElectron && (
               <div className='flex flex-col items-center gap-12px w-full max-w-300px bg-fill-2 p-16px rounded-lg'>
-                <Button type='primary' long onClick={checkUpdate}>
-                  {t('settings.checkForUpdates')}
-                </Button>
+                {updateState === 'checking' && (
+                  <div className='flex items-center gap-8px text-13px text-t-secondary'>
+                    <RefreshCw size={14} className='animate-spin' />
+                    <span>{t('update.checking')}</span>
+                  </div>
+                )}
+
+                {updateState === 'upToDate' && (
+                  <>
+                    <div className='flex items-center gap-8px text-13px text-t-primary font-500'>
+                      <CheckCircle2 size={16} color='rgb(var(--success-6))' />
+                      <span>{t('update.upToDateTitle')}</span>
+                    </div>
+                    <Button type='secondary' long onClick={() => setCheckNonce((n) => n + 1)}>
+                      {t('settings.checkForUpdates')}
+                    </Button>
+                  </>
+                )}
+
+                {updateState === 'available' && (
+                  <>
+                    <Typography.Text className='text-13px text-t-primary text-center font-500'>
+                      {t('update.pill.tooltip', { version: latestVersion || '' })}
+                    </Typography.Text>
+                    <Button type='primary' long icon={<Download size={14} />} onClick={checkUpdate}>
+                      {t('update.availableTitle')}
+                    </Button>
+                  </>
+                )}
+
+                {updateState === 'error' && (
+                  <>
+                    <Typography.Text className='text-12px text-t-tertiary text-center'>
+                      {t('update.checkFailed')}
+                    </Typography.Text>
+                    <Button
+                      type='primary'
+                      long
+                      icon={<RefreshCw size={14} />}
+                      onClick={() => setCheckNonce((n) => n + 1)}
+                    >
+                      {t('settings.checkForUpdates')}
+                    </Button>
+                  </>
+                )}
+
                 <div className='flex items-center justify-between w-full'>
                   <Typography.Text className='text-12px text-t-secondary'>
                     {t('settings.includePrereleaseUpdates')}

--- a/tests/unit/renderer/settings/AboutModalContent.dom.test.tsx
+++ b/tests/unit/renderer/settings/AboutModalContent.dom.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/// <reference types="@testing-library/jest-dom/vitest" />
+
+/**
+ * #731 — the About page auto-checks for updates on open and surfaces the result
+ * inline (checking → up-to-date / available / error), without the user pressing
+ * a button first. These tests pin: auto-check-on-mount, the Wayland-vs-IJFW
+ * distinction (an IJFW-only update must NOT read as an app update), the
+ * electron-updater-only version fallback, manual retry, failure surfacing, and
+ * the short-TTL cache that avoids re-hitting the rate limit on every reopen.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+const runCheckMock = vi.fn();
+
+vi.mock('@/renderer/pages/settings/utils/waylandUpdaterBridge', () => ({
+  runWaylandUpdaterExtensionCheck: (...args: unknown[]) => runCheckMock(...args),
+}));
+
+vi.mock('@/renderer/utils/platform', () => ({
+  isElectronDesktop: () => true,
+  openExternalUrl: vi.fn(),
+}));
+
+vi.mock('@/renderer/components/settings/SettingsModal/settingsViewContext', () => ({
+  useSettingsViewMode: () => 'modal' as const,
+}));
+
+// FeedbackReportModal drags in a heavy import chain irrelevant to this surface.
+vi.mock('@/renderer/components/settings/SettingsModal/contents/FeedbackReportModal', () => ({
+  default: () => null,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts && opts.version !== undefined ? `${key} ${String(opts.version)}` : key,
+    i18n: { language: 'en-US' },
+  }),
+}));
+
+import AboutModalContent, {
+  __resetAboutCheckCacheForTest,
+} from '@/renderer/components/settings/SettingsModal/contents/AboutModalContent';
+
+const upToDate = {
+  ok: true,
+  autoUpdateAvailable: false,
+  autoVersion: '',
+  manual: { success: true, data: { currentVersion: '1.0.0', updateAvailable: false } },
+};
+
+const manualAvailable = {
+  ok: true,
+  autoUpdateAvailable: false,
+  autoVersion: '',
+  manual: {
+    success: true,
+    data: { currentVersion: '1.0.0', updateAvailable: true, latest: { version: '9.9.9' } },
+  },
+};
+
+beforeEach(() => {
+  runCheckMock.mockReset();
+  localStorage.clear();
+  __resetAboutCheckCacheForTest();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('AboutModalContent update auto-check (#731)', () => {
+  it('runs an update check on mount and shows "up to date"', async () => {
+    runCheckMock.mockResolvedValue(upToDate);
+    render(<AboutModalContent />);
+
+    // Fires without any user interaction.
+    await waitFor(() => expect(runCheckMock).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText('update.upToDateTitle')).toBeInTheDocument();
+  });
+
+  it('passes the persisted prerelease preference into the check', async () => {
+    localStorage.setItem('update.includePrerelease', 'true');
+    runCheckMock.mockResolvedValue(upToDate);
+    render(<AboutModalContent />);
+
+    await waitFor(() => expect(runCheckMock).toHaveBeenCalledTimes(1));
+    expect(runCheckMock.mock.calls[0][0]).toBe(true);
+  });
+
+  it('shows the available version when a Wayland app update exists', async () => {
+    runCheckMock.mockResolvedValue(manualAvailable);
+    render(<AboutModalContent />);
+
+    expect(await screen.findByText('update.availableTitle')).toBeInTheDocument();
+    expect(screen.getByText(/9\.9\.9/)).toBeInTheDocument();
+  });
+
+  it('falls back to the electron-updater version when only auto-update is available', async () => {
+    runCheckMock.mockResolvedValue({
+      ok: true,
+      autoUpdateAvailable: true,
+      autoVersion: '2.0.0',
+      manual: { success: true, data: { currentVersion: '1.0.0', updateAvailable: false } },
+    });
+    render(<AboutModalContent />);
+
+    expect(await screen.findByText('update.availableTitle')).toBeInTheDocument();
+    expect(screen.getByText(/2\.0\.0/)).toBeInTheDocument();
+  });
+
+  it('treats an IJFW-only update as up to date (not an app update)', async () => {
+    runCheckMock.mockResolvedValue({
+      ok: true,
+      autoUpdateAvailable: false,
+      autoVersion: '',
+      manual: {
+        success: true,
+        data: {
+          currentVersion: '1.0.0',
+          updateAvailable: false,
+          ijfw: { installed: true, updateAvailable: true },
+        },
+      },
+    });
+    render(<AboutModalContent />);
+
+    expect(await screen.findByText('update.upToDateTitle')).toBeInTheDocument();
+    expect(screen.queryByText('update.availableTitle')).not.toBeInTheDocument();
+  });
+
+  it('surfaces a failed check (ok: false)', async () => {
+    runCheckMock.mockResolvedValue({ ok: false, error: 'boom' });
+    render(<AboutModalContent />);
+
+    expect(await screen.findByText('update.checkFailed')).toBeInTheDocument();
+  });
+
+  it('surfaces a rejected check (thrown error)', async () => {
+    runCheckMock.mockRejectedValue(new Error('network down'));
+    render(<AboutModalContent />);
+
+    expect(await screen.findByText('update.checkFailed')).toBeInTheDocument();
+  });
+
+  it('re-checks when the user clicks retry, and reflects the new result', async () => {
+    runCheckMock.mockResolvedValueOnce(upToDate).mockResolvedValueOnce(manualAvailable);
+    render(<AboutModalContent />);
+
+    await screen.findByText('update.upToDateTitle');
+    expect(runCheckMock).toHaveBeenCalledTimes(1);
+
+    // The up-to-date state exposes a manual re-check button.
+    fireEvent.click(screen.getByText('settings.checkForUpdates'));
+
+    expect(await screen.findByText('update.availableTitle')).toBeInTheDocument();
+    expect(runCheckMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('serves the cached result on remount without re-hitting the network', async () => {
+    runCheckMock.mockResolvedValue(upToDate);
+    const first = render(<AboutModalContent />);
+    await screen.findByText('update.upToDateTitle');
+    expect(runCheckMock).toHaveBeenCalledTimes(1);
+    first.unmount();
+
+    // Reopening the About tab within the TTL must not spend another API call.
+    render(<AboutModalContent />);
+    expect(await screen.findByText('update.upToDateTitle')).toBeInTheDocument();
+    expect(runCheckMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not cache failures (a later reopen re-checks)', async () => {
+    runCheckMock.mockResolvedValueOnce({ ok: false, error: 'boom' }).mockResolvedValueOnce(upToDate);
+    const first = render(<AboutModalContent />);
+    await screen.findByText('update.checkFailed');
+    first.unmount();
+
+    render(<AboutModalContent />);
+    expect(await screen.findByText('update.upToDateTitle')).toBeInTheDocument();
+    expect(runCheckMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
The About page showed the app version and a "Check for updates" button that
only opened the updater modal — users had to click before learning whether
they were current. Now it auto-runs a background update check on open and
renders the result inline: checking (spinner), "You're up to date", or
"Update available: vX" with an action button, plus an error+retry state.

- Reuses the shared runWaylandUpdaterExtensionCheck helper (same check the
  updater modal and updater extension use), so results stay consistent.
- Wayland-app updates only — an IJFW-only update does not read as an app
  update (mirrors UpdateModal's waylandUpdateAvailable gating).
- Caches the last successful result for a short TTL so re-opening the tab
  doesn't re-spend the unauthenticated GitHub API rate limit; explicit retry
  always forces a fresh check and failures are never cached.
- The full updater modal stays reachable (available-state CTA, titlebar pill,
  System settings tab).

Closes #731
