### PR TITLE
fix(updater): match app theme in the updater extension + add feedback

### DIFF
--- a/resources/bundled-extensions/wayland-updater/settings/updater.html
+++ b/resources/bundled-extensions/wayland-updater/settings/updater.html
@@ -15,6 +15,25 @@
           BlinkMacSystemFont,
           'Segoe UI',
           sans-serif;
+        /* Default to Wayland's dark palette so this panel never flashes white
+           before the host declares the app theme. Wayland's own UI is always
+           dark unless the user chose light; the host forwards the resolved
+           theme via aion:init / aion:theme and light is applied only when it
+           explicitly sets data-theme="light" (#730). */
+        --bg: #111318;
+        --panel: #171a21;
+        --panel-soft: #20242d;
+        --text: #f5f7fb;
+        --muted: #9aa3b2;
+        --border: #2d3340;
+        --primary: #60a5fa;
+        --primary-strong: #3b82f6;
+        --success: #16a34a;
+        --warning: #d97706;
+        --danger: #dc2626;
+      }
+
+      :root[data-theme='light'] {
         --bg: #f7f8fa;
         --panel: #ffffff;
         --panel-soft: #f2f3f5;
@@ -23,22 +42,6 @@
         --border: #e5e7eb;
         --primary: #2563eb;
         --primary-strong: #1d4ed8;
-        --success: #16a34a;
-        --warning: #d97706;
-        --danger: #dc2626;
-      }
-
-      @media (prefers-color-scheme: dark) {
-        :root {
-          --bg: #111318;
-          --panel: #171a21;
-          --panel-soft: #20242d;
-          --text: #f5f7fb;
-          --muted: #9aa3b2;
-          --border: #2d3340;
-          --primary: #60a5fa;
-          --primary-strong: #3b82f6;
-        }
       }
 
       * {
@@ -166,9 +169,41 @@
         background: var(--primary-strong);
       }
 
+      button:disabled {
+        opacity: 0.6;
+        cursor: default;
+      }
+
       button.secondary {
         background: var(--panel-soft);
         color: var(--text);
+      }
+
+      .check-wrap {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .spinner {
+        width: 14px;
+        height: 14px;
+        border: 2px solid var(--border);
+        border-top-color: var(--primary);
+        border-radius: 50%;
+        animation: updater-spin 0.7s linear infinite;
+      }
+
+      @keyframes updater-spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      .last-checked {
+        margin-top: 6px;
+        color: var(--muted);
+        font-size: 12px;
       }
 
       label {
@@ -204,13 +239,17 @@
             <h1>Updater</h1>
             <div class="subtitle">Wayland and Wayland Core update status from the extension host.</div>
           </div>
-          <button id="check">Check now</button>
+          <div class="check-wrap">
+            <span class="spinner" id="spinner" hidden></span>
+            <button id="check">Check now</button>
+          </div>
         </header>
         <div class="body">
           <div class="card row">
             <div>
               <div class="title">Release channel</div>
               <div class="meta" id="summary">Ready to check for updates.</div>
+              <div class="last-checked" id="lastChecked" hidden></div>
             </div>
             <label><input id="prerelease" type="checkbox" /> Include prereleases</label>
           </div>
@@ -269,8 +308,20 @@
           });
         }
 
+        function applyTheme(theme) {
+          if (theme === 'light' || theme === 'dark') {
+            document.documentElement.setAttribute('data-theme', theme);
+          }
+        }
+
         window.addEventListener('message', function (event) {
           var data = event.data || {};
+          // The host forwards Wayland's resolved app theme so this panel matches
+          // the app instead of the OS color-scheme (#730).
+          if (data.type === 'aion:init' || data.type === 'aion:theme') {
+            applyTheme(data.theme);
+            return;
+          }
           if (data.type !== 'wayland-updater:response' || !data.reqId) return;
           var resolve = pending.get(data.reqId);
           if (!resolve) return;
@@ -337,11 +388,30 @@
           resize();
         }
 
-        $('check').addEventListener('click', function () {
+        function setChecking(on) {
+          $('check').disabled = on;
+          $('spinner').hidden = !on;
+        }
+
+        function stampLastChecked() {
+          var el = $('lastChecked');
+          el.hidden = false;
+          el.textContent = 'Last checked: ' + new Date().toLocaleString();
+        }
+
+        function runCheck() {
+          setChecking(true);
           $('summary').textContent = 'Checking...';
           setBadge('waylandBadge', 'Checking', '');
-          request('check', { includePrerelease: $('prerelease').checked }).then(renderCheck);
-        });
+          return request('check', { includePrerelease: $('prerelease').checked }).then(function (result) {
+            setChecking(false);
+            stampLastChecked();
+            renderCheck(result);
+          });
+        }
+
+        $('check').addEventListener('click', runCheck);
+        $('prerelease').addEventListener('change', runCheck);
 
         $('openModal').addEventListener('click', function () {
           request('openModal', {});
@@ -349,7 +419,10 @@
 
         window.addEventListener('load', function () {
           resize();
-          request('check', { includePrerelease: $('prerelease').checked }).then(renderCheck);
+          // Ask the host to (re)send init incl. the resolved app theme, in case
+          // its automatic post raced ahead of this listener being registered (#730).
+          parent.postMessage({ type: 'aion:get-locale' }, '*');
+          runCheck();
         });
       })();
     </script>

--- a/src/renderer/components/settings/SettingsModal/contents/ExtensionSettingsTabContent.tsx
+++ b/src/renderer/components/settings/SettingsModal/contents/ExtensionSettingsTabContent.tsx
@@ -13,6 +13,15 @@ import { runWaylandUpdaterExtensionCheck } from '@/renderer/pages/settings/utils
 
 const isExternalSettingsUrl = (url?: string): boolean => /^https?:\/\//i.test(url || '');
 
+/**
+ * Wayland's resolved app theme ('light' | 'dark'), as set by useTheme on the
+ * host document. Sandboxed extension iframes can't read the parent DOM, so we
+ * forward this to them; without it a local extension page falls back to the OS
+ * `prefers-color-scheme` and renders light inside always-dark Wayland (#730).
+ */
+const getResolvedAppTheme = (): 'light' | 'dark' =>
+  document.documentElement.getAttribute('data-theme') === 'light' ? 'light' : 'dark';
+
 interface ExtensionSettingsTabContentProps {
   /** wayland-asset:// local page URL or external https:// URL */
   entryUrl: string;
@@ -59,6 +68,7 @@ const ExtensionSettingsTabContent: React.FC<ExtensionSettingsTabContentProps> = 
           locale: i18n.language,
           extensionName,
           translations,
+          theme: getResolvedAppTheme(),
         },
         '*'
       );
@@ -66,6 +76,21 @@ const ExtensionSettingsTabContent: React.FC<ExtensionSettingsTabContentProps> = 
       console.error('[ExtensionSettingsTabContent] Failed to post locale init:', err);
     }
   }, [extensionName, i18n.language, isExternalTab]);
+
+  // Keep a local extension iframe's theme in sync when the user switches the
+  // app theme while its settings tab is open (#730). useTheme flips data-theme
+  // on the host <html>; forward the resolved value so the iframe restyles live.
+  useEffect(() => {
+    if (isExternalTab) return;
+    const root = document.documentElement;
+    const observer = new MutationObserver(() => {
+      const frameWindow = iframeRef.current?.contentWindow;
+      if (!frameWindow) return;
+      frameWindow.postMessage({ type: 'aion:theme', theme: getResolvedAppTheme() }, '*');
+    });
+    observer.observe(root, { attributes: true, attributeFilter: ['data-theme'] });
+    return () => observer.disconnect();
+  }, [isExternalTab]);
 
   // postMessage bridge for local iframe tabs (wayland-asset://)
   useEffect(() => {

--- a/tests/unit/renderer/settings/ExtensionSettingsTabContent.dom.test.tsx
+++ b/tests/unit/renderer/settings/ExtensionSettingsTabContent.dom.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/// <reference types="@testing-library/jest-dom/vitest" />
+
+/**
+ * #730 — a local extension settings iframe (sandboxed, no same-origin) can't
+ * read the host's theme, so the host must forward Wayland's resolved app theme.
+ * These tests pin that: the initial `aion:init` carries the resolved theme, and
+ * a live app-theme switch reposts it via `aion:theme` (so the panel stops
+ * rendering light inside always-dark Wayland).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+
+vi.mock('@/common/adapter/ipcBridge', () => ({
+  extensions: {
+    getExtI18nForLocale: { invoke: vi.fn().mockResolvedValue({}) },
+    getAgentActivitySnapshot: { invoke: vi.fn().mockResolvedValue({}) },
+  },
+}));
+
+vi.mock('@/renderer/components/media/WebviewHost', () => ({ default: () => null }));
+
+vi.mock('@/renderer/utils/platform', () => ({
+  resolveExtensionAssetUrl: (url: string) => url,
+}));
+
+vi.mock('@/renderer/pages/settings/utils/waylandUpdaterBridge', () => ({
+  runWaylandUpdaterExtensionCheck: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k, i18n: { language: 'en-US' } }),
+}));
+
+import ExtensionSettingsTabContent from '@/renderer/components/settings/SettingsModal/contents/ExtensionSettingsTabContent';
+
+const LOCAL_URL = 'wayland-asset://wayland-updater/settings/updater.html';
+
+function renderTab() {
+  const utils = render(<ExtensionSettingsTabContent entryUrl={LOCAL_URL} tabId='t1' extensionName='wayland-updater' />);
+  const iframe = utils.container.querySelector('iframe') as HTMLIFrameElement;
+  const post = vi.spyOn(iframe.contentWindow as Window, 'postMessage').mockImplementation(() => {});
+  return { ...utils, iframe, post };
+}
+
+beforeEach(() => {
+  document.documentElement.setAttribute('data-theme', 'dark');
+});
+
+afterEach(() => {
+  cleanup();
+  document.documentElement.removeAttribute('data-theme');
+});
+
+describe('ExtensionSettingsTabContent theme forwarding (#730)', () => {
+  it('includes the resolved app theme in the aion:init payload', async () => {
+    const { iframe, post } = renderTab();
+    // onLoad clears the loading flag, which triggers the locale/theme init post.
+    fireEvent.load(iframe);
+
+    await waitFor(() => {
+      const init = post.mock.calls.find((c) => (c[0] as { type?: string })?.type === 'aion:init')?.[0] as
+        | { theme?: string }
+        | undefined;
+      expect(init?.theme).toBe('dark');
+    });
+  });
+
+  it('reposts the theme via aion:theme when the app theme changes', async () => {
+    const { post } = renderTab();
+
+    document.documentElement.setAttribute('data-theme', 'light');
+
+    await waitFor(() => {
+      const themeMsg = post.mock.calls.find((c) => (c[0] as { type?: string })?.type === 'aion:theme')?.[0] as
+        | { theme?: string }
+        | undefined;
+      expect(themeMsg?.theme).toBe('light');
+    });
+  });
+});


### PR DESCRIPTION
The bundled updater settings extension renders in a sandboxed iframe that
couldn't see the app theme, so it defaulted to a light palette and only went
dark via the OS prefers-color-scheme. On a light-mode OS it showed a bright
white panel inside Wayland's always-dark UI — the "embedded web page" feel
reported in #730 — and it lacked a loading indicator and a last-checked time.

- The extension host now forwards Wayland's resolved data-theme into the
  iframe via the existing aion:init message, and reposts it (aion:theme) when
  the user switches theme while the tab is open.
- The updater page now defaults to the dark palette and applies light only on
  an explicit data-theme="light", so it matches the app instead of the OS.
- "Check now" shows a spinner and disables the button while checking, stamps a
  "Last checked" time, and re-checks when the prerelease toggle changes.

Closes #730
