### PR TITLE
fix(ijfw): correct the manual install command shown in settings

### DIFF
--- a/src/renderer/pages/settings/IjfwSettingsPanel.tsx
+++ b/src/renderer/pages/settings/IjfwSettingsPanel.tsx
@@ -130,14 +130,15 @@ const IjfwSettingsPanel: React.FC = () => {
         <div className='flex flex-col gap-6px'>
           <Typography.Text type='secondary' className='text-12px'>
             {t('memory.settings.manual_install_hint', {
-              defaultValue: 'To install manually: run `npx -y @ijfw/install@latest` in a terminal',
+              defaultValue:
+                'To install manually: run `npx -y --package @ijfw/install@latest ijfw-install --yes` in a terminal',
             })}
           </Typography.Text>
           <code
             data-testid='ijfw-settings-manual-install-code'
             className='inline-block self-start px-8px py-4px rd-6px bg-fill-2 text-12px text-t-primary font-mono'
           >
-            npx -y @ijfw/install@latest
+            npx -y --package @ijfw/install@latest ijfw-install --yes
           </code>
         </div>
 

--- a/src/renderer/services/i18n/locales/de-DE/memory.json
+++ b/src/renderer/services/i18n/locales/de-DE/memory.json
@@ -98,7 +98,7 @@
     "panel_title": "IJFW Memory (Ferrox Labs)",
     "skip_label": "Automatische IJFW-Einrichtung überspringen",
     "skip_description": "Wenn aktiviert, installiert oder aktualisiert Wayland IJFW nicht. Du kannst es später manuell über die Gedächtnis-Seite installieren.",
-    "manual_install_hint": "Manuelle Installation: Führe `npx -y @ijfw/install@latest` in einem Terminal aus",
+    "manual_install_hint": "Manuelle Installation: Führe `npx -y --package @ijfw/install@latest ijfw-install --yes` in einem Terminal aus",
     "about_title": "IJFW Memory",
     "about_body": "Eine Open-Source-Engine für dauerhaftes Gedächtnis von Ferrox Labs.",
     "setup_status_title": "Einrichtungsstatus",

--- a/src/renderer/services/i18n/locales/en-US/memory.json
+++ b/src/renderer/services/i18n/locales/en-US/memory.json
@@ -99,7 +99,7 @@
     "panel_title": "IJFW Memory (Ferrox Labs)",
     "skip_label": "Skip IJFW automatic setup",
     "skip_description": "When enabled, Wayland will not install or upgrade IJFW. You can install manually later via the Memory page.",
-    "manual_install_hint": "To install manually: run `npx -y @ijfw/install@latest` in a terminal",
+    "manual_install_hint": "To install manually: run `npx -y --package @ijfw/install@latest ijfw-install --yes` in a terminal",
     "about_title": "IJFW Memory",
     "about_body": "An open-source persistent memory engine by Ferrox Labs.",
     "setup_status_title": "Setup status",

--- a/src/renderer/services/i18n/locales/es-ES/memory.json
+++ b/src/renderer/services/i18n/locales/es-ES/memory.json
@@ -98,7 +98,7 @@
     "panel_title": "IJFW Memory (Ferrox Labs)",
     "skip_label": "Omitir la configuración automática de IJFW",
     "skip_description": "Cuando está activado, Wayland no instalará ni actualizará IJFW. Puedes instalarlo manualmente más tarde desde la página de Memoria.",
-    "manual_install_hint": "Para instalar manualmente: ejecuta `npx -y @ijfw/install@latest` en un terminal",
+    "manual_install_hint": "Para instalar manualmente: ejecuta `npx -y --package @ijfw/install@latest ijfw-install --yes` en un terminal",
     "about_title": "IJFW Memory",
     "about_body": "Un motor de memoria persistente de código abierto de Ferrox Labs.",
     "setup_status_title": "Estado de configuración",

--- a/src/renderer/services/i18n/locales/fr-FR/memory.json
+++ b/src/renderer/services/i18n/locales/fr-FR/memory.json
@@ -98,7 +98,7 @@
     "panel_title": "IJFW Memory (Ferrox Labs)",
     "skip_label": "Ignorer la configuration automatique d'IJFW",
     "skip_description": "Lorsque cette option est activée, Wayland n'installera ni ne mettra à jour IJFW. Vous pourrez l'installer manuellement plus tard depuis la page Mémoire.",
-    "manual_install_hint": "Pour installer manuellement : exécutez `npx -y @ijfw/install@latest` dans un terminal",
+    "manual_install_hint": "Pour installer manuellement : exécutez `npx -y --package @ijfw/install@latest ijfw-install --yes` dans un terminal",
     "about_title": "IJFW Memory",
     "about_body": "Un moteur de mémoire persistante open source de Ferrox Labs.",
     "setup_status_title": "État de la configuration",

--- a/src/renderer/services/i18n/locales/ja-JP/memory.json
+++ b/src/renderer/services/i18n/locales/ja-JP/memory.json
@@ -98,7 +98,7 @@
     "panel_title": "IJFW Memory（Ferrox Labs）",
     "skip_label": "IJFW の自動セットアップをスキップ",
     "skip_description": "有効にすると、Wayland は IJFW をインストールまたはアップグレードしません。後でメモリページから手動でインストールできます。",
-    "manual_install_hint": "手動でインストールするには、ターミナルで `npx -y @ijfw/install@latest` を実行してください",
+    "manual_install_hint": "手動でインストールするには、ターミナルで `npx -y --package @ijfw/install@latest ijfw-install --yes` を実行してください",
     "about_title": "IJFW Memory",
     "about_body": "Ferrox Labs によるオープンソースの永続メモリエンジンです。",
     "setup_status_title": "セットアップ状況",

--- a/src/renderer/services/i18n/locales/ko-KR/memory.json
+++ b/src/renderer/services/i18n/locales/ko-KR/memory.json
@@ -98,7 +98,7 @@
     "panel_title": "IJFW Memory (Ferrox Labs)",
     "skip_label": "IJFW 자동 설정 건너뛰기",
     "skip_description": "활성화하면 Wayland가 IJFW를 설치하거나 업그레이드하지 않습니다. 나중에 메모리 페이지를 통해 수동으로 설치할 수 있습니다.",
-    "manual_install_hint": "수동으로 설치하려면 터미널에서 `npx -y @ijfw/install@latest`를 실행하세요",
+    "manual_install_hint": "수동으로 설치하려면 터미널에서 `npx -y --package @ijfw/install@latest ijfw-install --yes`를 실행하세요",
     "about_title": "IJFW Memory",
     "about_body": "Ferrox Labs가 개발한 오픈소스 영구 메모리 엔진입니다.",
     "setup_status_title": "설정 상태",

--- a/src/renderer/services/i18n/locales/pt-BR/memory.json
+++ b/src/renderer/services/i18n/locales/pt-BR/memory.json
@@ -98,7 +98,7 @@
     "panel_title": "IJFW Memory (Ferrox Labs)",
     "skip_label": "Pular a configuração automática do IJFW",
     "skip_description": "Quando ativado, o Wayland não vai instalar nem atualizar o IJFW. Você pode instalar manualmente depois pela página Memória.",
-    "manual_install_hint": "Para instalar manualmente: execute `npx -y @ijfw/install@latest` em um terminal",
+    "manual_install_hint": "Para instalar manualmente: execute `npx -y --package @ijfw/install@latest ijfw-install --yes` em um terminal",
     "about_title": "IJFW Memory",
     "about_body": "Um mecanismo de memória persistente open-source da Ferrox Labs.",
     "setup_status_title": "Status da configuração",

--- a/src/renderer/services/i18n/locales/ru-RU/memory.json
+++ b/src/renderer/services/i18n/locales/ru-RU/memory.json
@@ -98,7 +98,7 @@
     "panel_title": "IJFW Memory (Ferrox Labs)",
     "skip_label": "Пропустить автоматическую настройку IJFW",
     "skip_description": "Когда включено, Wayland не будет устанавливать или обновлять IJFW. Вы сможете установить его вручную позже через страницу Памяти.",
-    "manual_install_hint": "Для ручной установки выполните в терминале: `npx -y @ijfw/install@latest`",
+    "manual_install_hint": "Для ручной установки выполните в терминале: `npx -y --package @ijfw/install@latest ijfw-install --yes`",
     "about_title": "IJFW Memory",
     "about_body": "Открытый движок постоянной памяти от Ferrox Labs.",
     "setup_status_title": "Состояние настройки",

--- a/src/renderer/services/i18n/locales/tr-TR/memory.json
+++ b/src/renderer/services/i18n/locales/tr-TR/memory.json
@@ -98,7 +98,7 @@
     "panel_title": "IJFW Memory (Ferrox Labs)",
     "skip_label": "IJFW otomatik kurulumu atla",
     "skip_description": "Etkin olduğunda Wayland, IJFW'yi yüklemez veya yükseltmez. Daha sonra Bellek sayfası üzerinden elle yükleyebilirsiniz.",
-    "manual_install_hint": "Elle yüklemek için bir terminalde `npx -y @ijfw/install@latest` komutunu çalıştırın",
+    "manual_install_hint": "Elle yüklemek için bir terminalde `npx -y --package @ijfw/install@latest ijfw-install --yes` komutunu çalıştırın",
     "about_title": "IJFW Memory",
     "about_body": "Ferrox Labs tarafından geliştirilen açık kaynaklı kalıcı bellek motoru.",
     "setup_status_title": "Kurulum durumu",

--- a/src/renderer/services/i18n/locales/uk-UA/memory.json
+++ b/src/renderer/services/i18n/locales/uk-UA/memory.json
@@ -98,7 +98,7 @@
     "panel_title": "IJFW Memory (Ferrox Labs)",
     "skip_label": "Пропустити автоматичне налаштування IJFW",
     "skip_description": "Коли увімкнено, Wayland не встановлюватиме і не оновлюватиме IJFW. Ви зможете встановити вручну пізніше через сторінку Пам'яті.",
-    "manual_install_hint": "Для встановлення вручну виконайте в терміналі: `npx -y @ijfw/install@latest`",
+    "manual_install_hint": "Для встановлення вручну виконайте в терміналі: `npx -y --package @ijfw/install@latest ijfw-install --yes`",
     "about_title": "IJFW Memory",
     "about_body": "Відкритий рушій постійної пам'яті від Ferrox Labs.",
     "setup_status_title": "Стан налаштування",

--- a/src/renderer/services/i18n/locales/zh-CN/memory.json
+++ b/src/renderer/services/i18n/locales/zh-CN/memory.json
@@ -98,7 +98,7 @@
     "panel_title": "IJFW Memory（Ferrox Labs）",
     "skip_label": "跳过 IJFW 自动设置",
     "skip_description": "启用后，Wayland 将不会安装或升级 IJFW。你之后可以通过记忆页面手动安装。",
-    "manual_install_hint": "手动安装：在终端中运行 `npx -y @ijfw/install@latest`",
+    "manual_install_hint": "手动安装：在终端中运行 `npx -y --package @ijfw/install@latest ijfw-install --yes`",
     "about_title": "IJFW Memory",
     "about_body": "由 Ferrox Labs 出品的开源持久化记忆引擎。",
     "setup_status_title": "设置状态",

--- a/src/renderer/services/i18n/locales/zh-TW/memory.json
+++ b/src/renderer/services/i18n/locales/zh-TW/memory.json
@@ -98,7 +98,7 @@
     "panel_title": "IJFW Memory（Ferrox Labs）",
     "skip_label": "略過 IJFW 自動設定",
     "skip_description": "啟用後，Wayland 將不會安裝或升級 IJFW。你之後可以透過記憶頁面手動安裝。",
-    "manual_install_hint": "手動安裝：在終端機中執行 `npx -y @ijfw/install@latest`",
+    "manual_install_hint": "手動安裝：在終端機中執行 `npx -y --package @ijfw/install@latest ijfw-install --yes`",
     "about_title": "IJFW Memory",
     "about_body": "由 Ferrox Labs 出品的開源持久化記憶引擎。",
     "setup_status_title": "設定狀態",

--- a/tests/unit/renderer/pages/settings/IjfwSettingsPanel.dom.test.tsx
+++ b/tests/unit/renderer/pages/settings/IjfwSettingsPanel.dom.test.tsx
@@ -125,7 +125,14 @@ describe('IjfwSettingsPanel', () => {
       )
     ).toBeTruthy();
     expect(screen.getByTestId('ijfw-settings-skip-switch')).toBeTruthy();
-    expect(screen.getByTestId('ijfw-settings-manual-install-code')).toBeTruthy();
+    // #572: the manual-install command must name the bin via --package. A bare
+    // `npx @ijfw/install` fails with "could not determine executable to run"
+    // because the package's bins (ijfw/ijfw-install/ijfw-uninstall) don't match
+    // the package name — see ijfwSystemService spawn args.
+    const codeEl = screen.getByTestId('ijfw-settings-manual-install-code');
+    expect(codeEl.textContent).toContain('--package @ijfw/install');
+    expect(codeEl.textContent).toContain('ijfw-install --yes');
+    expect(codeEl.textContent).not.toBe('npx -y @ijfw/install@latest');
   });
 
   it('reads initial switch state from getStatus (opt_out → ON)', async () => {


### PR DESCRIPTION
The IJFW settings panel and the memory manual-install hint told users to run
`npx -y @ijfw/install@latest`, which fails with "could not determine
executable to run": the package exposes bins named ijfw / ijfw-install /
ijfw-uninstall, none of which matches the unscoped package name, so npx can't
pick one. The correct invocation — the same one the app itself spawns — names
the bin explicitly:

  npx -y --package @ijfw/install@latest ijfw-install --yes

Fixed the copyable code block, its fallback hint, and the manual_install_hint
string across all locales, and strengthened the panel test to assert the
command names the bin (so it can't silently drift back).

Closes #572
