### PR TITLE
fix(win): remove wayland: protocol + Run-key residue on uninstall (#490)

### DIFF
--- a/resources/windows-installer-arm64.nsh
+++ b/resources/windows-installer-arm64.nsh
@@ -35,3 +35,17 @@ FunctionEnd
   nsExec::Exec `powershell -NoProfile -ExecutionPolicy Bypass -Command "$$d = '$INSTDIR'; $$self = $9; Get-Process -ErrorAction SilentlyContinue | Where-Object { $$_.Id -ne $$self -and $$_.Path -and $$_.Path.ToLower().StartsWith($$d.ToLower()) } | Stop-Process -Force -ErrorAction SilentlyContinue"`
   Sleep 1500
 !macroend
+
+; #490: the generated uninstaller removes only electron-builder's own
+; install/uninstall registry keys. Two HKCU entries Wayland writes at RUNTIME are
+; left behind, dangling at a now-deleted executable:
+;   - the `wayland:` protocol handler (app.setAsDefaultProtocolClient, src/index.ts)
+;   - the start-on-boot Run entry (app.setLoginItemSettings, applicationBridge.ts)
+; Remove both per-user keys on uninstall. DeleteReg* on an absent key is a no-op,
+; so this is safe whether or not start-on-boot was ever enabled. Both are HKCU to
+; match exactly what Electron wrote (never widen to HKLM).
+; (Keep in sync with windows-installer-x64.nsh.)
+!macro customUnInstall
+  DeleteRegKey HKCU "Software\Classes\wayland"
+  DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Run" "${PRODUCT_NAME}"
+!macroend

--- a/resources/windows-installer-x64.nsh
+++ b/resources/windows-installer-x64.nsh
@@ -45,3 +45,17 @@ FunctionEnd
   nsExec::Exec `powershell -NoProfile -ExecutionPolicy Bypass -Command "$$d = '$INSTDIR'; $$self = $9; Get-Process -ErrorAction SilentlyContinue | Where-Object { $$_.Id -ne $$self -and $$_.Path -and $$_.Path.ToLower().StartsWith($$d.ToLower()) } | Stop-Process -Force -ErrorAction SilentlyContinue"`
   Sleep 1500
 !macroend
+
+; #490: the generated uninstaller removes only electron-builder's own
+; install/uninstall registry keys. Two HKCU entries Wayland writes at RUNTIME are
+; left behind, dangling at a now-deleted executable:
+;   - the `wayland:` protocol handler (app.setAsDefaultProtocolClient, src/index.ts)
+;   - the start-on-boot Run entry (app.setLoginItemSettings, applicationBridge.ts)
+; Remove both per-user keys on uninstall. DeleteReg* on an absent key is a no-op,
+; so this is safe whether or not start-on-boot was ever enabled. Both are HKCU to
+; match exactly what Electron wrote (never widen to HKLM).
+; (Keep in sync with windows-installer-arm64.nsh.)
+!macro customUnInstall
+  DeleteRegKey HKCU "Software\Classes\wayland"
+  DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Run" "${PRODUCT_NAME}"
+!macroend


### PR DESCRIPTION
Closes #490.

## Problem
The generated NSIS uninstaller removes only electron-builder's own install/uninstall registry keys. Two HKCU entries Wayland writes at **runtime** are left dangling at a now-deleted executable after uninstall:

- the `wayland:` protocol handler — `app.setAsDefaultProtocolClient` (`src/index.ts`)
- the start-on-boot Run entry — `app.setLoginItemSettings` (`applicationBridge.ts`)

## Fix
Add a `customUnInstall` macro (a real electron-builder hook — `app-builder-lib/templates/nsis/uninstaller.nsh`) to both `resources/windows-installer-x64.nsh` and `windows-installer-arm64.nsh`, deleting both per-user keys:

```
DeleteRegKey   HKCU "Software\Classes\wayland"
DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Run" "${PRODUCT_NAME}"
```

`DeleteReg*` on an absent key is a no-op, so this is safe whether or not start-on-boot was ever enabled. Both are HKCU to match exactly what Electron wrote (never widened to HKLM). Kept in sync across both arch files.

## On the "broke my other Electron apps" claim
Investigated and **could not reproduce / found no mechanism** — Wayland only ever writes its own per-app HKCU keys, never anything shared across Electron apps. Recording as **unreproducible**; this PR fixes the concrete registry-residue half.

## Verification
NSIS is declarative and only exercised when electron-builder packages the Windows installer — there is no unit surface. Real verification is the **packaged-Windows installer/uninstall smoke on SEANDESKTOP** (install → confirm both HKCU keys present → uninstall → confirm both keys gone). Holding land for that packaged verify per the Windows-leg discipline; no macOS/Linux impact.