### PR TITLE
fix(mcp): resolve npx to bundled Bun on chat session injection

### DIFF
--- a/src/process/acp/session/McpConfig.ts
+++ b/src/process/acp/session/McpConfig.ts
@@ -2,6 +2,7 @@
 import type { IMcpServer } from '@/common/config/storage';
 import type { AcpMcpCapabilities } from '@/common/types/acpTypes';
 import type { McpServer } from '@agentclientprotocol/sdk';
+import { resolveStdioMcpCommand } from '@process/utils/mcpStdioResolve';
 
 type MergeParams = {
   userServers?: McpServer[];
@@ -63,14 +64,18 @@ export class McpConfig {
       )
       .map((server): McpServer | null => {
         switch (server.transport.type) {
-          case 'stdio':
+          case 'stdio': {
             if (!caps.stdio) return null;
+            // Resolve `npx` to bundled Bun so the server actually spawns at
+            // session start on machines with no system npx (#827, Windows).
+            const stdio = resolveStdioMcpCommand(server.transport.command, server.transport.args || []);
             return {
               name: server.name,
-              command: server.transport.command,
-              args: server.transport.args || [],
+              command: stdio.command,
+              args: stdio.args,
               env: toNameValueArray(server.transport.env),
             };
+          }
           case 'http':
           case 'streamable_http':
             if (!caps.http) return null;

--- a/src/process/agent/acp/mcpSessionConfig.ts
+++ b/src/process/agent/acp/mcpSessionConfig.ts
@@ -8,6 +8,7 @@ import type { IMcpServer } from '@/common/config/storage';
 import type { AcpMcpCapabilities } from '@/common/types/acpTypes';
 import { BUILTIN_CONCIERGE_DIAG_ID } from '@process/resources/builtinMcp/constants';
 import { sanitizeMcpServerName } from '@process/services/mcpServices/validateMcpServer';
+import { resolveStdioMcpCommand } from '@process/utils/mcpStdioResolve';
 
 export interface AcpSessionMcpNameValue {
   name: string;
@@ -107,15 +108,19 @@ export function buildAcpSessionMcpServers(
       .filter((server) => server.id !== BUILTIN_CONCIERGE_DIAG_ID || allowConciergeDiag)
       .map((server): AcpSessionMcpServer | null => {
         switch (server.transport.type) {
-          case 'stdio':
+          case 'stdio': {
             if (!capabilities.stdio) return null;
+            // Resolve `npx` to bundled Bun so tools actually load at session
+            // start where no system npx exists (#827, Windows).
+            const stdio = resolveStdioMcpCommand(server.transport.command, server.transport.args || []);
             return {
               type: 'stdio',
               name: server.name,
-              command: server.transport.command,
-              args: server.transport.args || [],
+              command: stdio.command,
+              args: stdio.args,
               env: toNameValueEntries(server.transport.env) ?? [],
             };
+          }
           case 'http':
           case 'streamable_http':
             if (!capabilities.http) return null;
@@ -183,11 +188,14 @@ export function buildWCoreUserStdioMcpServers(
     .filter((server) => server.transport.type === 'stdio')
     .map((server): AcpSessionMcpServerStdio => {
       const transport = server.transport as Extract<IMcpServer['transport'], { type: 'stdio' }>;
+      // Resolve `npx` to bundled Bun so the wcore engine spawns a runtime that
+      // exists on machines with no system npx (#827, Windows).
+      const stdio = resolveStdioMcpCommand(transport.command, transport.args || []);
       return {
         type: 'stdio',
         name: sanitizeMcpServerName(server.name),
-        command: transport.command,
-        args: transport.args || [],
+        command: stdio.command,
+        args: stdio.args,
         env: toNameValueEntries(transport.env) ?? [],
       };
     })

--- a/src/process/utils/mcpStdioResolve.ts
+++ b/src/process/utils/mcpStdioResolve.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { normalizeNpxArgsForBundledBun, resolveNpxPath } from './shellEnv';
+
+/**
+ * Resolve a stdio MCP server's launch command/args so a bare `npx` invocation
+ * runs through Wayland's bundled Bun runtime instead of a system-installed npx.
+ *
+ * End-user machines - especially Windows, which bundles no system Node - often
+ * have no `npx` on PATH, so a raw `{ command: 'npx' }` handed to a spawner dies
+ * at launch. The Settings "Test Connection" probe already rewrites npx to bundled
+ * Bun (`McpProtocol.testStdioConnection`), but the live chat-session injection
+ * path did NOT - so a server could show green in Settings yet expose zero tools
+ * in a chat (#827, Windows). Every session-injection path routes stdio commands
+ * through this single rewrite so it can never diverge from the probe again.
+ * Non-npx commands pass through unchanged.
+ *
+ * Lives in its own module (not shellEnv) so the many unit tests that `vi.mock`
+ * shellEnv do not lose this export and turn calls into `undefined`.
+ */
+export function resolveStdioMcpCommand(command: string, args: string[]): { command: string; args: string[] } {
+  if (command === 'npx') {
+    return { command: resolveNpxPath({}), args: ['x', '--bun', ...normalizeNpxArgsForBundledBun(args)] };
+  }
+  return { command, args };
+}

--- a/tests/unit/acpBuiltinMcp.test.ts
+++ b/tests/unit/acpBuiltinMcp.test.ts
@@ -8,6 +8,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IMcpServer } from '../../src/common/config/storage';
 import { buildAcpSessionMcpServers } from '../../src/process/agent/acp/mcpSessionConfig';
 import { parseAgentCapabilities } from '../../src/common/types/acpTypes';
+import { resolveNpxPath } from '../../src/process/utils/shellEnv';
 
 describe('ACP built-in MCP session config - wayland_search_skills (C1)', () => {
   it('injects the seeded builtin search-skills entry into session/new with the correct stdio transport', () => {
@@ -224,12 +225,16 @@ describe('ACP custom MCP session config (#56)', () => {
 
     const result = buildAcpSessionMcpServers(servers, { stdio: true, http: false, sse: false });
 
+    // #827: a bare `npx` command is rewritten to Wayland's bundled Bun runtime
+    // (`bun x --bun ...`, npm-only flags like -y stripped) so tools actually
+    // load at session start on machines with no system npx (Windows). The #56
+    // guarantee — a custom server reaches Codex/Claude — is unchanged.
     expect(result).toEqual([
       {
         type: 'stdio',
         name: 'chrome-devtools',
-        command: 'npx',
-        args: ['-y', 'chrome-devtools-mcp@latest'],
+        command: resolveNpxPath({}),
+        args: ['x', '--bun', 'chrome-devtools-mcp@latest'],
         env: [],
       },
     ]);

--- a/tests/unit/mcpStdioResolve.test.ts
+++ b/tests/unit/mcpStdioResolve.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * #827 — a Playwright MCP server (`npx @playwright/mcp`) showed green in Settings
+ * but exposed zero tools in a live chat on Windows: the Settings probe rewrites
+ * `npx` → bundled Bun, but the session-injection path passed `npx` verbatim to
+ * the external ACP bridge, which can't resolve it on a machine with no system
+ * npx. These tests pin that every session-injection path now applies the same
+ * bundled-Bun rewrite the probe uses.
+ */
+import { describe, it, expect } from 'vitest';
+import type { IMcpServer } from '@/common/config/storage';
+import { resolveStdioMcpCommand } from '@process/utils/mcpStdioResolve';
+import { resolveNpxPath } from '@process/utils/shellEnv';
+import { McpConfig } from '@process/acp/session/McpConfig';
+import { buildAcpSessionMcpServers } from '@process/agent/acp/mcpSessionConfig';
+
+const BUN = resolveNpxPath({}); // env-agnostic: bundled bun path, or bare 'bun'/'bun.exe'
+
+describe('resolveStdioMcpCommand (#827)', () => {
+  it('rewrites npx to bundled Bun with `x --bun` and the package args', () => {
+    expect(resolveStdioMcpCommand('npx', ['@playwright/mcp'])).toEqual({
+      command: BUN,
+      args: ['x', '--bun', '@playwright/mcp'],
+    });
+  });
+
+  it('strips npm-only flags (-y/--yes/--prefer-offline) that bun x rejects', () => {
+    expect(resolveStdioMcpCommand('npx', ['-y', '@playwright/mcp', '--prefer-offline'])).toEqual({
+      command: BUN,
+      args: ['x', '--bun', '@playwright/mcp'],
+    });
+  });
+
+  it('passes a non-npx command through unchanged', () => {
+    expect(resolveStdioMcpCommand('node', ['server.js'])).toEqual({ command: 'node', args: ['server.js'] });
+    expect(resolveStdioMcpCommand('/usr/bin/my-mcp', [])).toEqual({ command: '/usr/bin/my-mcp', args: [] });
+  });
+});
+
+const npxServer = (): IMcpServer =>
+  ({
+    id: 'pw',
+    name: 'playwright',
+    enabled: true,
+    status: 'connected',
+    source: 'custom',
+    transport: { type: 'stdio', command: 'npx', args: ['-y', '@playwright/mcp'] },
+  }) as unknown as IMcpServer;
+
+describe('session injection rewrites npx (#827)', () => {
+  it('McpConfig.fromStorageConfig resolves an npx stdio server to bundled Bun', () => {
+    const [server] = McpConfig.fromStorageConfig([npxServer()]);
+    expect(server).toMatchObject({ name: 'playwright', command: BUN, args: ['x', '--bun', '@playwright/mcp'] });
+  });
+
+  it('buildAcpSessionMcpServers resolves an npx stdio server to bundled Bun', () => {
+    const [server] = buildAcpSessionMcpServers([npxServer()], { stdio: true, http: false, sse: false });
+    expect(server).toMatchObject({
+      type: 'stdio',
+      name: 'playwright',
+      command: BUN,
+      args: ['x', '--bun', '@playwright/mcp'],
+    });
+  });
+});

--- a/tests/unit/process/agent/acp/wcoreUserMcpInjection.test.ts
+++ b/tests/unit/process/agent/acp/wcoreUserMcpInjection.test.ts
@@ -18,6 +18,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { shouldInjectSessionMcpServer, buildWCoreUserStdioMcpServers } from '@process/agent/acp/mcpSessionConfig';
+import { resolveNpxPath } from '@process/utils/shellEnv';
 import type { IMcpServer } from '@/common/config/storage';
 
 const server = (over: Partial<IMcpServer>): IMcpServer =>
@@ -90,6 +91,22 @@ describe('buildWCoreUserStdioMcpServers', () => {
         env: [{ name: 'TOKEN', value: 't' }],
       },
     ]);
+  });
+
+  it('#827 rewrites an npx stdio connector to bundled Bun so wcore can spawn it (Windows, no system npx)', () => {
+    const playwright = server({
+      id: 'pw',
+      name: 'playwright',
+      status: undefined,
+      transport: { type: 'stdio', command: 'npx', args: ['-y', '@playwright/mcp'], env: {} },
+    });
+    const [out] = buildWCoreUserStdioMcpServers([playwright]);
+    expect(out).toMatchObject({
+      type: 'stdio',
+      name: 'playwright',
+      command: resolveNpxPath({}), // env-agnostic: bundled bun path, or bare 'bun'/'bun.exe'
+      args: ['x', '--bun', '@playwright/mcp'],
+    });
   });
 
   it('excludes builtins (handled by wcore via its own mechanisms)', () => {


### PR DESCRIPTION
A Playwright MCP server (`npx @playwright/mcp`) showed green in Settings
but exposed zero tools in a live chat on Windows. The Settings "Test
Connection" probe rewrites `npx` to the bundled Bun runtime, but the live
session-injection paths passed `npx` verbatim to the external ACP bridge,
whose spawn cannot resolve npx on a machine with no system Node - so the
MCP child never started and no tools loaded. Nothing re-validated
tools/list on the session path, so the failure was silent.

Route every stdio session-injection site through one shared helper,
`resolveStdioMcpCommand`, so the rewrite can never diverge from the probe
again. Applied at all three sites: McpConfig.fromStorageConfig,
buildAcpSessionMcpServers, and buildWCoreUserStdioMcpServers. The helper
lives in its own module so the many tests that vi.mock shellEnv keep the
export. Tier-A McpProtocol is left unchanged (its command/args use
distinct builtin-runtime conditions that a naive merge would regress).

refs #827
