### PR TITLE
fix(windows): clean protocol + start-on-boot registry on uninstall

### DIFF
--- a/resources/windows-installer-arm64.nsh
+++ b/resources/windows-installer-arm64.nsh
@@ -35,3 +35,40 @@ FunctionEnd
   nsExec::Exec `powershell -NoProfile -ExecutionPolicy Bypass -Command "$$d = '$INSTDIR'; $$self = $9; Get-Process -ErrorAction SilentlyContinue | Where-Object { $$_.Id -ne $$self -and $$_.Path -and $$_.Path.ToLower().StartsWith($$d.ToLower()) } | Stop-Process -Force -ErrorAction SilentlyContinue"`
   Sleep 1500
 !macroend
+
+; #490: the running app writes per-user (HKCU) registry entries at runtime that
+; electron-builder's uninstaller never removes, so they outlive an uninstall:
+;   1. the `wayland://` deep-link handler - app.setAsDefaultProtocolClient(
+;      PROTOCOL_SCHEME) in src/index.ts writes HKCU\Software\Classes\wayland on
+;      every launch (DeleteRegKey removes the key and its shell\open\command tree).
+;   2. the start-on-boot entry - app.setLoginItemSettings (the start-on-boot toggle
+;      in applicationBridge.ts) writes HKCU\...\CurrentVersion\Run. Electron names
+;      that value with the app's AppUserModelID; this app never calls
+;      setAppUserModelId, so Electron falls back to its default `electron.app.<Name>`
+;      = electron.app.Wayland. Disabling autostart additionally leaves a binary
+;      "disabled" marker under ...\Explorer\StartupApproved\Run under the same name.
+;
+; customUnInstall is electron-builder's uninstall hook (same mechanism as
+; customUnInit above). Remove all three so an uninstall leaves no per-user residue.
+; DeleteRegKey / DeleteRegValue are silent no-ops when the entry is absent, so this
+; is safe whether or not the user ever set the deep-link default or enabled autostart.
+;
+; CAVEAT (perMachine: true): the app writes these under the HKCU of whichever user
+; ran it, but a per-machine uninstaller runs elevated, so HKCU here is the elevating
+; admin's hive. Residue under OTHER users' hives on a multi-user machine is not
+; reachable without enumerating every loaded profile (out of scope); this cleans the
+; common single-user case. (Keep in sync with windows-installer-x64.nsh.)
+!macro customUnInstall
+  ; Only scrub on a GENUINE uninstall. electron-builder runs the OLD version's
+  ; uninstaller in update mode on every app update (uninstallOldVersion ->
+  ; ExecWait ... /KEEP_APP_DATA --updated), and this hook fires there too. Deleting
+  ; the start-on-boot value on an update would silently disable autostart with no
+  ; self-heal - setStartOnBootEnabled only re-runs via the one-time first-run
+  ; defaults or the user's Settings toggle - so gate every removal on a real
+  ; uninstall via ${isUpdated}, matching the template's own file-removal gating.
+  ${IfNot} ${isUpdated}
+    DeleteRegKey HKCU "Software\Classes\wayland"
+    DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Run" "electron.app.Wayland"
+    DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run" "electron.app.Wayland"
+  ${EndIf}
+!macroend

--- a/resources/windows-installer-x64.nsh
+++ b/resources/windows-installer-x64.nsh
@@ -45,3 +45,40 @@ FunctionEnd
   nsExec::Exec `powershell -NoProfile -ExecutionPolicy Bypass -Command "$$d = '$INSTDIR'; $$self = $9; Get-Process -ErrorAction SilentlyContinue | Where-Object { $$_.Id -ne $$self -and $$_.Path -and $$_.Path.ToLower().StartsWith($$d.ToLower()) } | Stop-Process -Force -ErrorAction SilentlyContinue"`
   Sleep 1500
 !macroend
+
+; #490: the running app writes per-user (HKCU) registry entries at runtime that
+; electron-builder's uninstaller never removes, so they outlive an uninstall:
+;   1. the `wayland://` deep-link handler - app.setAsDefaultProtocolClient(
+;      PROTOCOL_SCHEME) in src/index.ts writes HKCU\Software\Classes\wayland on
+;      every launch (DeleteRegKey removes the key and its shell\open\command tree).
+;   2. the start-on-boot entry - app.setLoginItemSettings (the start-on-boot toggle
+;      in applicationBridge.ts) writes HKCU\...\CurrentVersion\Run. Electron names
+;      that value with the app's AppUserModelID; this app never calls
+;      setAppUserModelId, so Electron falls back to its default `electron.app.<Name>`
+;      = electron.app.Wayland. Disabling autostart additionally leaves a binary
+;      "disabled" marker under ...\Explorer\StartupApproved\Run under the same name.
+;
+; customUnInstall is electron-builder's uninstall hook (same mechanism as
+; customUnInit above). Remove all three so an uninstall leaves no per-user residue.
+; DeleteRegKey / DeleteRegValue are silent no-ops when the entry is absent, so this
+; is safe whether or not the user ever set the deep-link default or enabled autostart.
+;
+; CAVEAT (perMachine: true): the app writes these under the HKCU of whichever user
+; ran it, but a per-machine uninstaller runs elevated, so HKCU here is the elevating
+; admin's hive. Residue under OTHER users' hives on a multi-user machine is not
+; reachable without enumerating every loaded profile (out of scope); this cleans the
+; common single-user case. (Keep in sync with windows-installer-arm64.nsh.)
+!macro customUnInstall
+  ; Only scrub on a GENUINE uninstall. electron-builder runs the OLD version's
+  ; uninstaller in update mode on every app update (uninstallOldVersion ->
+  ; ExecWait ... /KEEP_APP_DATA --updated), and this hook fires there too. Deleting
+  ; the start-on-boot value on an update would silently disable autostart with no
+  ; self-heal - setStartOnBootEnabled only re-runs via the one-time first-run
+  ; defaults or the user's Settings toggle - so gate every removal on a real
+  ; uninstall via ${isUpdated}, matching the template's own file-removal gating.
+  ${IfNot} ${isUpdated}
+    DeleteRegKey HKCU "Software\Classes\wayland"
+    DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Run" "electron.app.Wayland"
+    DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run" "electron.app.Wayland"
+  ${EndIf}
+!macroend

--- a/tests/unit/windowsUninstallRegistryCleanup.test.ts
+++ b/tests/unit/windowsUninstallRegistryCleanup.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * #490: the Windows uninstaller left two per-user (HKCU) registry residues the
+ * running app writes at runtime - the `wayland://` protocol handler
+ * (setAsDefaultProtocolClient) and the start-on-boot Run entry
+ * (setLoginItemSettings) - because electron-builder's `customUnInstall` hook was
+ * never defined. NSIS scripts are not unit-runnable here, so this parses both
+ * arch include files and pins that the cleanup directives exist, target the exact
+ * keys the app writes, and stay byte-identical between x64 and arm64.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const ROOT = path.resolve(__dirname, '../..');
+const NSH_FILES = ['resources/windows-installer-x64.nsh', 'resources/windows-installer-arm64.nsh'];
+
+/** Extract the body between `!macro customUnInstall` and its `!macroend`. */
+function customUnInstallBody(nsh: string): string | null {
+  const m = nsh.match(/!macro\s+customUnInstall\b([\s\S]*?)!macroend/);
+  return m ? m[1] : null;
+}
+
+describe('#490 Windows uninstaller registry cleanup', () => {
+  const bodies = NSH_FILES.map((rel) => ({
+    rel,
+    body: customUnInstallBody(fs.readFileSync(path.join(ROOT, rel), 'utf-8')),
+  }));
+
+  it.each(bodies)('$rel defines a customUnInstall macro', ({ body }) => {
+    expect(body).not.toBeNull();
+  });
+
+  // Line-anchored (multiline) so a commented-out `; DeleteReg...` cannot false-pass.
+  it.each(bodies)('$rel removes the wayland:// protocol handler key', ({ body }) => {
+    // DeleteRegKey removes the whole HKCU\Software\Classes\wayland tree
+    // (URL Protocol value + shell\open\command) written every launch.
+    expect(body).toMatch(/^\s*DeleteRegKey\s+HKCU\s+"Software\\Classes\\wayland"/m);
+  });
+
+  it.each(bodies)('$rel removes the start-on-boot Run value + StartupApproved marker', ({ body }) => {
+    // Electron names the Run value with the app's AppUserModelID; with no
+    // setAppUserModelId call it defaults to electron.app.<Name> = electron.app.Wayland.
+    expect(body).toMatch(
+      /^\s*DeleteRegValue\s+HKCU\s+"Software\\Microsoft\\Windows\\CurrentVersion\\Run"\s+"electron\.app\.Wayland"/m
+    );
+    expect(body).toMatch(
+      /^\s*DeleteRegValue\s+HKCU\s+"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\StartupApproved\\Run"\s+"electron\.app\.Wayland"/m
+    );
+  });
+
+  it.each(bodies)('$rel gates all removals on a genuine uninstall (not --updated)', ({ body }) => {
+    // electron-builder reruns the old uninstaller in update mode on every app
+    // update, and customUnInstall fires there too. The deletions MUST sit inside
+    // ${IfNot} ${isUpdated} ... ${EndIf}, or an update silently wipes the
+    // start-on-boot entry (which has no self-heal). Guard the gate, not just presence.
+    expect(body).toMatch(
+      /\$\{IfNot\}\s+\$\{isUpdated\}[\s\S]*DeleteRegValue[\s\S]*CurrentVersion\\Run[\s\S]*\$\{EndIf\}/
+    );
+  });
+
+  it('keeps the customUnInstall body identical across x64 and arm64 (no arch drift)', () => {
+    const [x64, arm64] = bodies.map((b) => b.body);
+    expect(x64).toBe(arm64);
+  });
+
+  it('the cleaned protocol scheme matches PROTOCOL_SCHEME in source (rename guard)', () => {
+    const deepLink = fs.readFileSync(path.join(ROOT, 'src/process/utils/deepLink.ts'), 'utf-8');
+    const scheme = deepLink.match(/PROTOCOL_SCHEME\s*=\s*'([^']+)'/)?.[1];
+    expect(scheme).toBe('wayland');
+    // If the scheme is ever renamed, the .nsh DeleteRegKey below must move with it.
+    for (const { body } of bodies) {
+      expect(body).toContain(`Software\\Classes\\${scheme}`);
+    }
+  });
+});


### PR DESCRIPTION
The NSIS uninstaller left two per-user (HKCU) registry residues behind
because electron-builder's `customUnInstall` hook was never defined. The
running app writes both at runtime, so an uninstall could never reach them:

  1. the `wayland://` deep-link handler - setAsDefaultProtocolClient writes
     HKCU\Software\Classes\wayland on every launch.
  2. the start-on-boot entry - setLoginItemSettings writes HKCU\...\Run under
     the app's AppUserModelID. The app never calls setAppUserModelId, so
     Electron uses its default electron.app.Wayland; disabling autostart also
     leaves a StartupApproved marker under the same name.

Define customUnInstall in both arch include files to DeleteRegKey the
protocol tree and DeleteRegValue the Run + StartupApproved entries. Gate all
removals behind ${IfNot} ${isUpdated}: electron-builder reruns the old
uninstaller in update mode on every app update and this hook fires there too,
so an unguarded delete would silently disable autostart (which has no
self-heal) on each update. Both arch bodies are identical and a test parses
the .nsh files to pin the directives, the update gate, and their sync (NSIS
is not unit-runnable). Per-machine uninstall reaches only the elevating
user's HKCU; the multi-user limitation is documented.

refs #490
