### PR TITLE
fix(routing): keep native models off Flux in team/workflow spawns

### DIFF
--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -856,13 +856,47 @@ ${collectedResponses.join('\n')}`;
   private async computeFluxRouting(backend: string, selectedModelId: string | undefined): Promise<FluxRoutingResult> {
     const fluxKey = await this.readFluxKey();
     const routeThroughFlux = (await ProcessConfig.get('system.routeThroughFlux')) ?? false;
+    // Belt-and-suspenders for team + workflow spawns: they frequently arrive with
+    // NO explicit model (team_spawn_agent is usually called with no model), so the
+    // spawn's `currentModelId` is undefined. Without a resolved model, the global
+    // routeThroughFlux toggle would default the spawn to Flux and 400 a backend
+    // that natively runs the customer's model (codex on gpt-5.6-sol via an OpenAI
+    // key OR a ChatGPT subscription). Fall back to the model this backend itself
+    // resolved (its cached CLI model / configured preferred id) so the routing
+    // decision honors the native model instead of blindly routing to Flux.
+    const resolvedModelId = selectedModelId ? undefined : await this.resolveBackendModelId(backend);
     return resolveFluxRouting({
       backend,
       selectedModelId,
+      resolvedModelId,
       fluxConnected: Boolean(fluxKey),
       fluxKey,
       routeThroughFlux: Boolean(routeThroughFlux),
     });
+  }
+
+  /**
+   * The model id this backend resolved from its OWN provider identity when a
+   * spawn carries no explicit pick: the CLI's last-cached model, else the
+   * configured preferred model. Mirrors TeamSessionService.resolvePreferredAcpModelId
+   * (preferred first, then cached) so the routing choke point sees the same native
+   * model the spawn path would thread. Best-effort: any read failure yields
+   * undefined and the caller falls back to the routeThroughFlux default.
+   */
+  private async resolveBackendModelId(backend: string): Promise<string | undefined> {
+    try {
+      const acpConfig = await ProcessConfig.get('acp.config');
+      const preferred = (acpConfig as Record<string, { preferredModelId?: string } | undefined> | undefined)?.[backend]
+        ?.preferredModelId;
+      if (typeof preferred === 'string' && preferred.trim().length > 0) return preferred.trim();
+
+      const cachedModels = await ProcessConfig.get('acp.cachedModels');
+      const cached = cachedModels?.[backend]?.currentModelId;
+      if (typeof cached === 'string' && cached.trim().length > 0) return cached.trim();
+    } catch (err) {
+      mainWarn('[AcpAgentManager]', 'resolveBackendModelId failed', err);
+    }
+    return undefined;
   }
 
   /** The connected flux-router key, or undefined when not connected (R13 safety gate). */

--- a/src/process/task/fluxRouting.ts
+++ b/src/process/task/fluxRouting.ts
@@ -111,6 +111,19 @@ export type RoutingDecision = 'flux' | 'native' | 'unknown';
 export type FluxRoutingContext = {
   backend: string;
   selectedModelId: string | undefined;
+  /**
+   * A concrete model id resolved from the backend's OWN provider identity
+   * (its last-used / cached / configured-preferred model) for spawns that carry
+   * no explicit per-spawn pick. Belt-and-suspenders for team + workflow spawns:
+   * team_spawn_agent is usually called with no explicit model, so `selectedModelId`
+   * arrives `undefined`. A known native model here PINS the spawn native so the
+   * global `routeThroughFlux` toggle can NEVER force a backend that natively runs
+   * the customer's model (e.g. codex on `gpt-5.6-sol` via an OpenAI API key OR a
+   * ChatGPT subscription) onto the Flux surface - Flux 400s "the '<model>' model
+   * does not exist" for a non-Flux id. Absent for a truly modelless spawn, where
+   * the toggle's default role (route unmodeled chats through Flux) still applies.
+   */
+  resolvedModelId?: string;
   fluxConnected: boolean;
   fluxKey: string | undefined;
   routeThroughFlux: boolean;
@@ -139,15 +152,23 @@ export function resolveFluxRouting(ctx: FluxRoutingContext): FluxRoutingResult {
   if (!isOpenAi && !isAnthropic && !isResponses && !isScopedHome) return UNKNOWN();
   if (!ctx.fluxConnected || !ctx.fluxKey) return NATIVE();
 
-  // L3 (R5 rule 1: an explicit per-chat pick wins). The picker now feeds explicit
-  // model ids per chat - a flux-* alias OR a native model id. Decision:
-  //  - flux model id selected            -> flux (always).
-  //  - non-flux (native) model id chosen -> native; the global toggle does NOT
-  //    override an explicit native pick (e.g. picking Opus 4.8 stays native even
-  //    when "Route all agents through Flux" is on).
-  //  - no model selected + toggle on      -> flux (the toggle's default role: it
-  //    only routes chats that have no explicit per-chat model).
-  const wantsFlux = isFluxModelId(ctx.selectedModelId) || (ctx.routeThroughFlux && !ctx.selectedModelId);
+  // L3 (R5 rule 1: an explicit per-chat pick wins). The picker feeds explicit
+  // model ids per chat - a flux-* alias OR a native model id. When there is no
+  // explicit per-spawn pick (team/workflow spawns frequently arrive with none),
+  // fall back to the model the backend resolved from its OWN provider identity
+  // (`resolvedModelId`) so a native model the customer actually runs is honored.
+  // Decision, on the effective (explicit-or-resolved) model id:
+  //  - flux model id                     -> flux (always).
+  //  - non-flux (native) model id        -> native; the global toggle does NOT
+  //    override a native model, explicit OR resolved (e.g. picking Opus 4.8, or a
+  //    codex teammate on gpt-5.6-sol, stays native even when "Route all agents
+  //    through Flux" is on). This is the guard that keeps a concrete non-flux
+  //    model off the Flux surface (which 400s it) even when selectedModelId is
+  //    absent but the backend's resolved identity is a native model.
+  //  - no model at all + toggle on        -> flux (the toggle's default role: it
+  //    only routes spawns that have no model, explicit or resolved).
+  const effectiveModelId = ctx.selectedModelId ?? ctx.resolvedModelId;
+  const wantsFlux = isFluxModelId(effectiveModelId) || (ctx.routeThroughFlux && !effectiveModelId);
   if (!wantsFlux) return NATIVE();
 
   if (isScopedHome) {

--- a/tests/unit/task/fluxRouting.test.ts
+++ b/tests/unit/task/fluxRouting.test.ts
@@ -105,6 +105,36 @@ describe('resolveFluxRouting', () => {
   it('stays native when no model is selected and the toggle is off', () => {
     expect(resolveFluxRouting(ctx({ selectedModelId: undefined, routeThroughFlux: false })).routing).toBe('native');
   });
+
+  // resolvedModelId: the backend's OWN native identity when a team/workflow spawn
+  // carries no explicit pick. A concrete native model here must PIN native so the
+  // toggle can never route it to Flux (which 400s a non-flux id). #555-adjacent.
+  it('keeps a resolved native model native even with the toggle on + no explicit pick (codex/gpt-5.6-sol)', () => {
+    // The exact team/workflow failure: no explicit selectedModelId, toggle ON, but
+    // the codex backend natively runs gpt-5.6-sol (OpenAI key OR ChatGPT sub).
+    const out = resolveFluxRouting(
+      ctx({ backend: 'codex', selectedModelId: undefined, resolvedModelId: 'gpt-5.6-sol', routeThroughFlux: true })
+    );
+    expect(out.routing).toBe('native');
+  });
+  it('an explicit flux pick still wins over a resolved native model', () => {
+    const out = resolveFluxRouting(
+      ctx({ selectedModelId: 'flux-auto', resolvedModelId: 'gpt-5.6-sol', routeThroughFlux: false })
+    );
+    expect(out.routing).toBe('flux');
+  });
+  it('routes flux when the resolved model is itself a flux id (toggle off)', () => {
+    const out = resolveFluxRouting(
+      ctx({ selectedModelId: undefined, resolvedModelId: 'flux-auto', routeThroughFlux: false })
+    );
+    expect(out.routing).toBe('flux');
+  });
+  it('still defaults to flux when there is genuinely no model (explicit or resolved) + toggle on', () => {
+    const out = resolveFluxRouting(
+      ctx({ backend: 'codex', selectedModelId: undefined, resolvedModelId: undefined, routeThroughFlux: true })
+    );
+    expect(out.routing).toBe('flux');
+  });
   it('lists only the empirically-proven env-routable backends (qwen, goose)', () => {
     // Verified 2026-06-05 against a live capture server: qwen + goose route
     // flux-auto through Flux via R13-safe env injection. opencode/qoder need the
@@ -153,10 +183,14 @@ describe('resolveFluxRouting', () => {
     expect(out.stripKeys).toContain('DEEPSEEK_API_KEY');
   });
   it('keeps hermes native when an explicit native model is picked even with the toggle on', () => {
-    const out = resolveFluxRouting(ctx({ backend: 'hermes', selectedModelId: 'anthropic/claude-opus-4.6', routeThroughFlux: true }));
+    const out = resolveFluxRouting(
+      ctx({ backend: 'hermes', selectedModelId: 'anthropic/claude-opus-4.6', routeThroughFlux: true })
+    );
     expect(out.routing).toBe('native');
   });
   it('keeps hermes native when flux is not connected', () => {
-    expect(resolveFluxRouting(ctx({ backend: 'hermes', fluxConnected: false, fluxKey: undefined })).routing).toBe('native');
+    expect(resolveFluxRouting(ctx({ backend: 'hermes', fluxConnected: false, fluxKey: undefined })).routing).toBe(
+      'native'
+    );
   });
 });

--- a/tests/unit/task/fluxRoutingResolvedModel.test.ts
+++ b/tests/unit/task/fluxRoutingResolvedModel.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * AcpAgentManager.computeFluxRouting - native-model belt-and-suspenders.
+ *
+ * The team/workflow failure (#555-adjacent): a spawn arrives with NO explicit
+ * model (team_spawn_agent is usually called with no model), the global
+ * `system.routeThroughFlux` toggle is ON, and the backend (codex) natively runs
+ * the customer's OpenAI model (gpt-5.6-sol via an OpenAI API key OR a ChatGPT
+ * subscription). Without a resolved model the toggle forced the spawn to Flux,
+ * which 400s "the 'gpt-5.6-sol' model does not exist". computeFluxRouting now
+ * falls back to the backend's OWN resolved model (cached CLI model / configured
+ * preferred id) so the routing decision stays `native`.
+ *
+ * Mirrors fluxRoutingRespawn.test.ts's bare-manager (Object.create) pattern, but
+ * exercises the REAL computeFluxRouting, stubbing only the flux-key seam and the
+ * ProcessConfig reads.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// AcpAgentManager pulls a large process-side graph; the database module is the
+// only hard dependency its top-level imports need here.
+vi.mock('@process/services/database', () => ({ getDatabase: vi.fn() }));
+
+// Hoisted so the vi.mock factory (also hoisted) can reference it safely.
+const { mockGet } = vi.hoisted(() => ({ mockGet: vi.fn() }));
+vi.mock('@process/utils/initStorage', () => ({
+  ProcessConfig: { get: mockGet, getConfig: vi.fn(() => ({})) },
+}));
+
+import AcpAgentManager from '@process/task/AcpAgentManager';
+
+type RoutingResult = { routing: 'flux' | 'native' | 'unknown' };
+
+/** ProcessConfig.get stub driven by a per-test config map. */
+function stubConfig(map: {
+  routeThroughFlux?: boolean;
+  cachedModels?: Record<string, { currentModelId?: string }>;
+  acpConfig?: Record<string, { preferredModelId?: string }>;
+}): void {
+  mockGet.mockImplementation((key: string) => {
+    switch (key) {
+      case 'system.routeThroughFlux':
+        return Promise.resolve(map.routeThroughFlux ?? false);
+      case 'acp.cachedModels':
+        return Promise.resolve(map.cachedModels ?? {});
+      case 'acp.config':
+        return Promise.resolve(map.acpConfig ?? {});
+      default:
+        return Promise.resolve(undefined);
+    }
+  });
+}
+
+/** Bare AcpAgentManager with the flux key seam stubbed to a connected key. */
+function bareManager(): { manager: AcpAgentManager } {
+  const manager = Object.create(AcpAgentManager.prototype) as AcpAgentManager;
+  const m = manager as unknown as Record<string, unknown>;
+  m.readFluxKey = vi.fn().mockResolvedValue('sk-flux-test');
+  return { manager };
+}
+
+const compute = (manager: AcpAgentManager, backend: string, selectedModelId: string | undefined) =>
+  (
+    manager as unknown as {
+      computeFluxRouting: (b: string, s: string | undefined) => Promise<RoutingResult>;
+    }
+  ).computeFluxRouting(backend, selectedModelId);
+
+describe('AcpAgentManager.computeFluxRouting - resolved-native-model guard', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('routes native when a team/workflow spawn has no model but codex cached gpt-5.6-sol (toggle ON)', async () => {
+    stubConfig({ routeThroughFlux: true, cachedModels: { codex: { currentModelId: 'gpt-5.6-sol' } } });
+    const { manager } = bareManager();
+    expect((await compute(manager, 'codex', undefined)).routing).toBe('native');
+  });
+
+  it('routes native from the configured preferred model when there is no cached model (toggle ON)', async () => {
+    stubConfig({ routeThroughFlux: true, acpConfig: { codex: { preferredModelId: 'gpt-5.6-sol' } } });
+    const { manager } = bareManager();
+    expect((await compute(manager, 'codex', undefined)).routing).toBe('native');
+  });
+
+  it('routes native for an explicit non-flux pick even with the toggle ON (threaded model)', async () => {
+    stubConfig({ routeThroughFlux: true });
+    const { manager } = bareManager();
+    expect((await compute(manager, 'codex', 'gpt-5.6-sol')).routing).toBe('native');
+  });
+
+  it('still routes to Flux when the spawn has genuinely no model (no pick, no cache) + toggle ON', async () => {
+    stubConfig({ routeThroughFlux: true });
+    const { manager } = bareManager();
+    expect((await compute(manager, 'codex', undefined)).routing).toBe('flux');
+  });
+
+  it('does NOT consult the backend identity when an explicit model is passed', async () => {
+    stubConfig({ routeThroughFlux: true, cachedModels: { codex: { currentModelId: 'gpt-5.6-sol' } } });
+    const { manager } = bareManager();
+    await compute(manager, 'codex', 'gpt-5.6-sol');
+    // acp.cachedModels / acp.config are only read on the no-explicit-model path.
+    expect(mockGet).not.toHaveBeenCalledWith('acp.cachedModels');
+    expect(mockGet).not.toHaveBeenCalledWith('acp.config');
+  });
+});


### PR DESCRIPTION
Team/workflow spawns reach computeFluxRouting with currentModelId undefined, so with system.routeThroughFlux ON a native OpenAI model (gpt-5.6-sol/luna/terra) defaulted to the Flux surface, which 400s a non-Flux model id. Resolve the backend's own model identity (acp.config preferredModelId, then cachedModels) as a fallback so a concrete native model pins the spawn native across teams, workflows, and chat. An explicit flux-* pick still routes flux; a truly modelless spawn still honors the toggle.
