### PR TITLE
fix(wcore): route OpenAI-family models off the Anthropic surface

### DIFF
--- a/src/process/agent/wcore/envBuilder.ts
+++ b/src/process/agent/wcore/envBuilder.ts
@@ -184,6 +184,23 @@ function isChatGptSubscription(model: TProviderWithModel): boolean {
 }
 
 /**
+ * True when `modelId` is unmistakably an OpenAI-family model id — the GPT line
+ * (`gpt-*`, which includes the brand-new catalog-only `gpt-5.6-sol` /
+ * `gpt-5.6-luna` / `gpt-5.6-terra`), the o-series reasoning models
+ * (`o1`/`o3`/`o4`…), or a ChatGPT alias (`chatgpt-*`). These are served by
+ * OpenAI (`api.openai.com`) or the ChatGPT backend — NEVER by the native
+ * Anthropic surface (`api.anthropic.com`, which only speaks `claude-*`).
+ *
+ * Used purely as a defense-in-depth guard in {@link mapProvider}: a genuine
+ * Anthropic model id (`claude-*`, `claude-opus-*`, …) never matches this test,
+ * so real Anthropic routing is untouched.
+ */
+export function isOpenAIFamilyModelId(modelId: string | undefined): boolean {
+  if (!modelId) return false;
+  return /^(?:gpt-|chatgpt-|o\d)/i.test(modelId.trim());
+}
+
+/**
  * Map provider name to wcore provider name.
  *
  * Platform values: 'custom' | 'new-api' | 'gemini' | 'gemini-vertex-ai' | 'anthropic' | 'bedrock'
@@ -229,7 +246,25 @@ function mapProvider(model: TProviderWithModel): WCoreProvider {
     custom: 'openai',
     'new-api': 'openai',
   };
-  return mapping[model.platform] ?? 'openai';
+  const mapped = mapping[model.platform] ?? 'openai';
+
+  // Defense-in-depth: the native Anthropic surface (`api.anthropic.com`) can
+  // only serve Anthropic `claude-*` models. A brand-new OpenAI-family model
+  // that exists only in the models.dev catalog cache (e.g. `gpt-5.6-sol`) is
+  // NOT owned by any configured OpenAI provider, so on selection it inherits
+  // the agent's current/default `platform` — which is `'anthropic'` for a
+  // Claude-default agent (normal chat, and equally in Teams/Workflows, since
+  // every wcore spawn funnels through here). Routing it to `--provider anthropic`
+  // yields the reported `400 invalid_request_error` with an Anthropic-shaped
+  // error envelope ("The 'gpt-5.6-sol' model does not exist"). Re-bind such an
+  // OpenAI-family id to the OpenAI surface. This runs AFTER the ChatGPT-
+  // subscription / catalog / engine-native / openai-chatgpt precedence above,
+  // so those correct routings are never overridden; a real `claude-*` id never
+  // matches {@link isOpenAIFamilyModelId}, so genuine Anthropic routing stands.
+  if (mapped === 'anthropic' && isOpenAIFamilyModelId(model.useModel)) {
+    return 'openai';
+  }
+  return mapped;
 }
 
 const GEMINI_OPENAI_COMPAT_PATH = '/v1beta/openai';

--- a/tests/unit/wcoreEnvBuilder.anthropicSurface.test.ts
+++ b/tests/unit/wcoreEnvBuilder.anthropicSurface.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildSpawnConfig, isOpenAIFamilyModelId } from '../../src/process/agent/wcore/envBuilder';
+import type { TProviderWithModel } from '../../src/common/config/storage';
+
+// A brand-new OpenAI model (gpt-5.6-sol / -luna / -terra) exists only in the
+// models.dev catalog cache and is NOT owned by any configured OpenAI provider,
+// so on selection it inherits the agent's current/default `platform`. For a
+// Claude-default agent that platform is `'anthropic'`, which used to route the
+// model to `--provider anthropic` -> the reported
+// `400 invalid_request_error: "The 'gpt-5.6-sol' model does not exist"` with an
+// Anthropic-shaped error envelope. The native Anthropic surface only serves
+// `claude-*`; an OpenAI-family id must resolve to an OpenAI-compatible surface.
+
+function makeModel(platform: string, useModel: string, extra: Partial<TProviderWithModel> = {}): TProviderWithModel {
+  return {
+    id: 'test-provider',
+    platform,
+    name: 'Test Provider',
+    baseUrl: '',
+    apiKey: 'test-key',
+    useModel,
+    ...extra,
+  };
+}
+
+/** The value passed after `--provider` in the spawn args. */
+function providerArg(args: string[]): string | undefined {
+  const i = args.indexOf('--provider');
+  return i === -1 ? undefined : args[i + 1];
+}
+
+describe('mapProvider - OpenAI-family models never route to the Anthropic surface', () => {
+  const workspace = '/tmp/test-workspace';
+
+  // The exact reported models plus representative siblings. Even when the
+  // incoming platform is 'anthropic' (the stale-default bug), the spawn must
+  // resolve to an OpenAI-compatible surface, never `anthropic`.
+  const openaiFamily = [
+    'gpt-5.6-sol',
+    'gpt-5.6-luna',
+    'gpt-5.6-terra',
+    'gpt-4o',
+    'gpt-5.1',
+    'o3-mini',
+    'chatgpt-4o-latest',
+  ];
+
+  for (const model of openaiFamily) {
+    it(`routes ${model} to openai (NOT anthropic) even when platform='anthropic'`, () => {
+      const { args } = buildSpawnConfig(makeModel('anthropic', model), { workspace });
+      expect(providerArg(args)).toBe('openai');
+      expect(args).not.toContain('anthropic');
+    });
+  }
+
+  it('routes gpt-5.6-sol to openai and sets OPENAI_API_KEY (not ANTHROPIC_API_KEY)', () => {
+    const { args, env } = buildSpawnConfig(makeModel('anthropic', 'gpt-5.6-sol'), { workspace });
+    expect(providerArg(args)).toBe('openai');
+    expect(env.OPENAI_API_KEY).toBe('test-key');
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+  });
+
+  it('leaves a genuine anthropic model on the anthropic surface', () => {
+    const { args, env } = buildSpawnConfig(makeModel('anthropic', 'claude-opus-4-8'), { workspace });
+    expect(providerArg(args)).toBe('anthropic');
+    expect(env.ANTHROPIC_API_KEY).toBe('test-key');
+  });
+
+  it('leaves other anthropic model ids (sonnet/haiku) on the anthropic surface', () => {
+    for (const claude of ['claude-sonnet-4-6', 'claude-haiku-4', 'claude-3-opus']) {
+      const { args } = buildSpawnConfig(makeModel('anthropic', claude), { workspace });
+      expect(providerArg(args)).toBe('anthropic');
+    }
+  });
+
+  it('a normal openai-platform gpt model is unaffected (control)', () => {
+    const { args } = buildSpawnConfig(makeModel('openai', 'gpt-5.6-sol'), { workspace });
+    expect(providerArg(args)).toBe('openai');
+  });
+});
+
+describe('isOpenAIFamilyModelId', () => {
+  it('matches the reported gpt-5.6 catalog models', () => {
+    expect(isOpenAIFamilyModelId('gpt-5.6-sol')).toBe(true);
+    expect(isOpenAIFamilyModelId('gpt-5.6-luna')).toBe(true);
+    expect(isOpenAIFamilyModelId('gpt-5.6-terra')).toBe(true);
+  });
+
+  it('matches gpt / o-series / chatgpt families', () => {
+    expect(isOpenAIFamilyModelId('gpt-4o')).toBe(true);
+    expect(isOpenAIFamilyModelId('o1')).toBe(true);
+    expect(isOpenAIFamilyModelId('o3-mini')).toBe(true);
+    expect(isOpenAIFamilyModelId('chatgpt-4o-latest')).toBe(true);
+    expect(isOpenAIFamilyModelId('GPT-5.6-Sol')).toBe(true); // case-insensitive
+  });
+
+  it('does NOT match Anthropic claude ids', () => {
+    expect(isOpenAIFamilyModelId('claude-opus-4-8')).toBe(false);
+    expect(isOpenAIFamilyModelId('claude-sonnet-4-6')).toBe(false);
+    expect(isOpenAIFamilyModelId('claude-haiku-4')).toBe(false);
+    expect(isOpenAIFamilyModelId('claude-3-opus')).toBe(false);
+  });
+
+  it('does NOT match unrelated ids or empty input', () => {
+    expect(isOpenAIFamilyModelId('gemini-2.5-pro')).toBe(false);
+    expect(isOpenAIFamilyModelId('grok-4')).toBe(false);
+    expect(isOpenAIFamilyModelId(undefined)).toBe(false);
+    expect(isOpenAIFamilyModelId('')).toBe(false);
+  });
+});


### PR DESCRIPTION
A brand-new OpenAI model that exists only in the models.dev catalog (e.g. gpt-5.6-sol/luna/terra) is not owned by any configured OpenAI provider, so on selection it inherits the agent's default platform (anthropic for a Claude-default agent). mapProvider then returned --provider anthropic, and the native Anthropic surface 400s a non-Claude model ('The gpt-5.6-sol model does not exist', Anthropic-shaped envelope). Guard: an OpenAI-family model id (gpt-/chatgpt-/o-series) that would map to anthropic is re-bound to openai, after the existing subscription/catalog/native precedence so correct routings stand and real claude-* models are untouched. Covers chat, Teams and Workflows (single wcore spawn chokepoint).
