### PR TITLE
fix(wcore): route OpenAI-family fallback to OAuth when sub connected

### DIFF
--- a/src/process/agent/wcore/envBuilder.ts
+++ b/src/process/agent/wcore/envBuilder.ts
@@ -204,8 +204,15 @@ export function isOpenAIFamilyModelId(modelId: string | undefined): boolean {
  * Map provider name to wcore provider name.
  *
  * Platform values: 'custom' | 'new-api' | 'gemini' | 'gemini-vertex-ai' | 'anthropic' | 'bedrock'
+ *
+ * `chatGptSubscriptionAvailable` is the caller's auth-availability signal (true
+ * when a ChatGPT-subscription OAuth token is present in `~/.codex/auth.json`).
+ * It ONLY influences the OpenAI-family-off-Anthropic guard below: it picks the
+ * keyless `openai-chatgpt` surface over the API-key `openai` surface for a
+ * model that would otherwise wrongly hit Anthropic. Every other routing arm is
+ * unaffected.
  */
-function mapProvider(model: TProviderWithModel): WCoreProvider {
+function mapProvider(model: TProviderWithModel, chatGptSubscriptionAvailable: boolean): WCoreProvider {
   // ChatGPT subscription (OAuth): route to the engine's native slug so it drives
   // the ChatGPT backend + reads the token from ~/.codex/auth.json, instead of
   // collapsing to `--provider openai` against api.openai.com (#243).
@@ -257,12 +264,22 @@ function mapProvider(model: TProviderWithModel): WCoreProvider {
   // every wcore spawn funnels through here). Routing it to `--provider anthropic`
   // yields the reported `400 invalid_request_error` with an Anthropic-shaped
   // error envelope ("The 'gpt-5.6-sol' model does not exist"). Re-bind such an
-  // OpenAI-family id to the OpenAI surface. This runs AFTER the ChatGPT-
+  // OpenAI-family id to an OpenAI-compatible surface. This runs AFTER the ChatGPT-
   // subscription / catalog / engine-native / openai-chatgpt precedence above,
   // so those correct routings are never overridden; a real `claude-*` id never
   // matches {@link isOpenAIFamilyModelId}, so genuine Anthropic routing stands.
+  //
+  // AUTH-AWARE fallback: the engine serves these models on BOTH the API-key
+  // `openai` surface (needs OPENAI_API_KEY) AND the keyless `openai-chatgpt`
+  // ChatGPT-OAuth surface (token from ~/.codex/auth.json). A user with only a
+  // ChatGPT subscription (no OpenAI API key) would hit "No API key found" on the
+  // `openai` surface, so when the subscription's OAuth is available we prefer the
+  // keyless surface. The preference holds even if the user ALSO has an API key
+  // (keyless has no per-token cost - the #555 subscription-preference rationale),
+  // so it works for a sub-only user and a both-connected user alike. With no sub
+  // connected we return `openai` - unchanged behavior for API-key users.
   if (mapped === 'anthropic' && isOpenAIFamilyModelId(model.useModel)) {
-    return 'openai';
+    return chatGptSubscriptionAvailable ? CHATGPT_SUBSCRIPTION_ENGINE_PROVIDER : 'openai';
   }
   return mapped;
 }
@@ -411,6 +428,17 @@ export function buildSpawnConfig(
      * standalone CLI would for that session id. The `model` argument is ignored.
      */
     rawEngine?: boolean;
+    /**
+     * True when a ChatGPT subscription's OAuth is available for keyless inference
+     * (the caller resolved it from `~/.codex/auth.json` - the same store the
+     * engine reads for `--provider openai-chatgpt`). Consumed ONLY by
+     * {@link mapProvider}'s OpenAI-family-off-Anthropic guard: an OpenAI-family
+     * model that would wrongly hit the Anthropic surface routes to the keyless
+     * `openai-chatgpt` surface when this is true (so a sub-only user needs no
+     * OpenAI API key), and to the API-key `openai` surface otherwise. Every other
+     * routing arm ignores this flag. Defaults to false (API-key behavior).
+     */
+    chatGptSubscriptionAvailable?: boolean;
   }
 ): {
   args: string[];
@@ -459,7 +487,7 @@ export function buildSpawnConfig(
     return { args, env: {}, projectConfig: '', resolvedMaxTokens: undefined, missingRequiredApiKey: false };
   }
 
-  const provider = mapProvider(model);
+  const provider = mapProvider(model, options.chatGptSubscriptionAvailable ?? false);
   const env: Record<string, string> = {};
   const args: string[] = ['--json-stream', '--provider', provider, '--model', model.useModel];
 

--- a/src/process/agent/wcore/index.ts
+++ b/src/process/agent/wcore/index.ts
@@ -26,6 +26,7 @@ import {
   type VaultPassphraseDelivery,
 } from './envBuilder';
 import { ProfileIsolationError, resolveActiveConfigDir } from './profilePaths';
+import { readCodexAuthFile } from '@process/onboarding/codexAuthFile';
 import { getToolKeyStore } from './toolKeyStore';
 import { hydrateModelForSpawn } from '@process/providers/ipc/modelRegistryIpc';
 import { killChild } from '@process/agent/acp/utils';
@@ -299,6 +300,26 @@ export class WCoreAgent {
     // (it uses the engine's own config.toml), so skip the lookup there.
     const spawnModel = this.options.rawEngineMode ? this.options.model : await hydrateModelForSpawn(this.options.model);
 
+    // Auth-aware surface selection (#865 follow-up): an OpenAI-family model that
+    // would wrongly inherit the Anthropic surface can be served keyless via the
+    // engine's `openai-chatgpt` provider when a ChatGPT subscription is connected,
+    // so a sub-only user (no OpenAI API key) is never dead-ended on "No API key
+    // found". We detect a live subscription by the presence of a ChatGPT OAuth
+    // token in `~/.codex/auth.json` - the SAME store the engine reads for that
+    // provider, so this signal is authoritative for "the keyless spawn will work".
+    // Skipped in raw-engine mode (which ignores the model entirely). The read is
+    // best-effort and must NEVER abort the spawn: on any failure we fall back to
+    // false (the API-key surface), so a transient/unavailable auth store degrades
+    // to unchanged behavior rather than breaking init.
+    let chatGptSubscriptionAvailable = false;
+    if (!this.options.rawEngineMode) {
+      try {
+        chatGptSubscriptionAvailable = (await readCodexAuthFile()) !== null;
+      } catch {
+        chatGptSubscriptionAvailable = false;
+      }
+    }
+
     const { args, env, projectConfig, resolvedMaxTokens, missingRequiredApiKey, requiredKeyEnvVar } = buildSpawnConfig(
       spawnModel,
       {
@@ -309,6 +330,7 @@ export class WCoreAgent {
         sessionId: this.options.sessionId,
         resume: this.options.resume,
         rawEngine: this.options.rawEngineMode,
+        chatGptSubscriptionAvailable,
       }
     );
 

--- a/tests/unit/wcoreEnvBuilder.authAwareSurface.test.ts
+++ b/tests/unit/wcoreEnvBuilder.authAwareSurface.test.ts
@@ -1,0 +1,128 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildSpawnConfig } from '../../src/process/agent/wcore/envBuilder';
+import type { TProviderWithModel } from '../../src/common/config/storage';
+
+// #865 follow-up: the OpenAI-family-off-Anthropic guard hard-returned `openai`,
+// which needs an OPENAI_API_KEY. A customer with a ChatGPT subscription (OAuth)
+// but NO OpenAI API key would then hit "No API key found". The engine serves
+// these models on BOTH surfaces: `-p openai -m gpt-5.6-sol` (API key) AND
+// `-p openai-chatgpt -m gpt-5.6-sol` (keyless ChatGPT-OAuth, token from
+// ~/.codex/auth.json). The guard's fallback is now auth-aware: prefer the keyless
+// `openai-chatgpt` surface when a ChatGPT subscription is connected, else fall
+// back to the API-key `openai` surface (unchanged behavior for key users).
+
+function makeModel(platform: string, useModel: string, extra: Partial<TProviderWithModel> = {}): TProviderWithModel {
+  return {
+    id: 'test-provider',
+    platform,
+    name: 'Test Provider',
+    baseUrl: '',
+    apiKey: 'test-key',
+    useModel,
+    ...extra,
+  };
+}
+
+/** The value passed after `--provider` in the spawn args. */
+function providerArg(args: string[]): string | undefined {
+  const i = args.indexOf('--provider');
+  return i === -1 ? undefined : args[i + 1];
+}
+
+describe('mapProvider - auth-aware OpenAI-family fallback (ChatGPT subscription)', () => {
+  const workspace = '/tmp/test-workspace';
+
+  // The reported catalog-only models plus representative siblings. Each would
+  // otherwise inherit `platform: 'anthropic'` (the stale-default bug).
+  const openaiFamily = [
+    'gpt-5.6-sol',
+    'gpt-5.6-luna',
+    'gpt-5.6-terra',
+    'gpt-4o',
+    'gpt-5.1',
+    'o3-mini',
+    'chatgpt-4o-latest',
+  ];
+
+  for (const model of openaiFamily) {
+    it(`routes ${model} to openai-chatgpt (keyless) when a ChatGPT subscription is connected`, () => {
+      const { args, env, missingRequiredApiKey } = buildSpawnConfig(makeModel('anthropic', model), {
+        workspace,
+        chatGptSubscriptionAvailable: true,
+      });
+      expect(providerArg(args)).toBe('openai-chatgpt');
+      // Keyless: no key env var, no --base-url, and NOT flagged as missing-key.
+      expect(env.OPENAI_API_KEY).toBeUndefined();
+      expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+      expect(args).not.toContain('--base-url');
+      expect(missingRequiredApiKey).toBe(false);
+    });
+
+    it(`routes ${model} to openai (API key) when NO ChatGPT subscription is connected`, () => {
+      const { args, env } = buildSpawnConfig(makeModel('anthropic', model), {
+        workspace,
+        chatGptSubscriptionAvailable: false,
+      });
+      expect(providerArg(args)).toBe('openai');
+      expect(env.OPENAI_API_KEY).toBe('test-key');
+      expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    });
+  }
+
+  it('prefers the keyless openai-chatgpt surface even when an API key is ALSO configured (Sean: has both)', () => {
+    // Model carries a real apiKey AND the sub is connected -> keyless wins, and
+    // the key is NOT presented (no per-token cost; the #555 rationale).
+    const { args, env, missingRequiredApiKey } = buildSpawnConfig(
+      makeModel('anthropic', 'gpt-5.6-sol', { apiKey: 'sk-real-openai-key' }),
+      { workspace, chatGptSubscriptionAvailable: true }
+    );
+    expect(providerArg(args)).toBe('openai-chatgpt');
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+    expect(missingRequiredApiKey).toBe(false);
+  });
+
+  it('sub-only user (no OpenAI API key) is NOT dead-ended: routes keyless, missingRequiredApiKey=false (cplagz)', () => {
+    const { args, env, missingRequiredApiKey } = buildSpawnConfig(
+      makeModel('anthropic', 'gpt-5.6-sol', { apiKey: '' }),
+      { workspace, chatGptSubscriptionAvailable: true }
+    );
+    expect(providerArg(args)).toBe('openai-chatgpt');
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+    expect(missingRequiredApiKey).toBe(false);
+  });
+
+  it('defaults to the openai API-key surface when the flag is omitted (back-compat)', () => {
+    const { args } = buildSpawnConfig(makeModel('anthropic', 'gpt-5.6-sol'), { workspace });
+    expect(providerArg(args)).toBe('openai');
+  });
+
+  it('a genuine claude-* model stays on anthropic even when a ChatGPT subscription is connected', () => {
+    for (const claude of ['claude-opus-4-8', 'claude-sonnet-4-6', 'claude-haiku-4', 'claude-3-opus']) {
+      const { args, env } = buildSpawnConfig(makeModel('anthropic', claude), {
+        workspace,
+        chatGptSubscriptionAvailable: true,
+      });
+      expect(providerArg(args)).toBe('anthropic');
+      expect(env.ANTHROPIC_API_KEY).toBe('test-key');
+    }
+  });
+
+  it('a normal openai-platform gpt model is unaffected by the sub flag (control)', () => {
+    // platform 'openai' never maps to 'anthropic', so the guard never fires -
+    // an explicitly configured OpenAI API-key provider stays on `openai`.
+    for (const sub of [true, false]) {
+      const { args, env } = buildSpawnConfig(makeModel('openai', 'gpt-5.6-sol'), {
+        workspace,
+        chatGptSubscriptionAvailable: sub,
+      });
+      expect(providerArg(args)).toBe('openai');
+      expect(env.OPENAI_API_KEY).toBe('test-key');
+    }
+  });
+});

--- a/tests/unit/wcoreStderrSurfacing.test.ts
+++ b/tests/unit/wcoreStderrSurfacing.test.ts
@@ -38,6 +38,10 @@ vi.mock('@process/providers/ipc/modelRegistryIpc', () => ({
 }));
 const killChildMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 vi.mock('@process/agent/acp/utils', () => ({ killChild: killChildMock }));
+// start() reads the ChatGPT OAuth token file (real fs I/O) to pick the keyless
+// provider surface; mock it so the read resolves on a microtask (the spawn flush
+// below only spins microtasks) and never touches the real ~/.codex/auth.json.
+vi.mock('@process/onboarding/codexAuthFile', () => ({ readCodexAuthFile: vi.fn().mockResolvedValue(null) }));
 
 import { WCoreAgent } from '@process/agent/wcore';
 import type { WCoreAgentOptions } from '@process/agent/wcore';


### PR DESCRIPTION
The anthropic-surface guard (#865) hard-returned openai, which needs OPENAI_API_KEY - a ChatGPT-subscription-only user with no key still hit 'No API key found'. Make the fallback auth-aware: when a ChatGPT OAuth token is present (~/.codex/auth.json, the same store the engine reads for --provider openai-chatgpt) prefer the keyless openai-chatgpt surface; otherwise openai. Prefer OAuth even when a key also exists (keyless, per #555). claude-* and explicit openai-platform routing unchanged. Makes gpt-5.6-sol/luna/terra usable whether the customer has a key, a sub, or both.
