### PR TITLE
fix(ui): conversation view crashes on null offsetParent from CoworkToggle tooltip

### DIFF
--- a/src/renderer/components/agent/CoworkToggle.tsx
+++ b/src/renderer/components/agent/CoworkToggle.tsx
@@ -71,6 +71,13 @@ const CoworkToggle: React.FC<CoworkToggleProps> = ({ workspace, size = 'small', 
 
   if (!workspace) return null;
 
+  // The Radio.Group is wrapped in a stable <span> so Arco's Trigger anchors its
+  // popup to a plain DOM node that stays mounted across composer re-renders.
+  // Anchoring directly to Radio.Group let `findDOMNode` return null mid-render
+  // (e.g. when the selected model is cleared and the send-box subtree churns),
+  // and Arco's `getPopupStyle` then dereferenced `null.offsetParent` — crashing
+  // the whole conversation view with "Cannot read properties of null". The span
+  // is always present while this toggle is mounted, so the anchor never vanishes.
   return (
     <Tooltip
       content={
@@ -85,17 +92,19 @@ const CoworkToggle: React.FC<CoworkToggleProps> = ({ workspace, size = 'small', 
             )
       }
     >
-      <Radio.Group
-        type='button'
-        size={size}
-        value={level}
-        onChange={handleChange}
-        className={className}
-        disabled={saving}
-      >
-        <Radio value='chat'>{t('agentMode.chat', 'Chat')}</Radio>
-        <Radio value='cowork'>{t('agentMode.cowork', 'Cowork')}</Radio>
-      </Radio.Group>
+      <span className='inline-flex'>
+        <Radio.Group
+          type='button'
+          size={size}
+          value={level}
+          onChange={handleChange}
+          className={className}
+          disabled={saving}
+        >
+          <Radio value='chat'>{t('agentMode.chat', 'Chat')}</Radio>
+          <Radio value='cowork'>{t('agentMode.cowork', 'Cowork')}</Radio>
+        </Radio.Group>
+      </span>
     </Tooltip>
   );
 };


### PR DESCRIPTION
Opening a Codex (ACP) conversation with a workspace crashed the entire
conversation view with 'Cannot read properties of null (reading offsetParent)'.

Root cause: CoworkToggle wraps its Radio.Group directly in an Arco <Tooltip>.
Arco's Trigger anchors the popup via findDOMNode(rootDOMRef). When the send-box
subtree churns (e.g. the selected model is cleared because Codex does not
advertise it), the Radio.Group's DOM is transiently detached while the Trigger
instance is still mounted, so its unmount guard does not fire. getPopupStyle
then reads offsetParent on the null root element and throws, tripping the
ErrorBoundary for the whole chat.

Fix: wrap Radio.Group in a stable <span>. Arco anchors to the span, which stays
mounted for the toggle's lifetime, so the popup target never vanishes mid-render.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
