### PR TITLE
fix(ui): Codex backend icon renders as solid white circle on dark theme

### DIFF
--- a/src/renderer/utils/model/agentLogo.ts
+++ b/src/renderer/utils/model/agentLogo.ts
@@ -93,8 +93,14 @@ export function getAgentLogo(agent: string | undefined | null): string | null {
  * them to a clean white silhouette on dark. Colored brand logos (claude, gemini,
  * codebuddy, hermes, nanobot, openclaw, vibe) are deliberately excluded so their
  * brand colour is never flattened.
+ *
+ * `codex` is intentionally NOT in this set: its asset is a two-tone mark (a white
+ * disc with a black `>_` glyph + ring), not a single-color silhouette. Flattening
+ * it with `brightness(0)` collapses the disc and glyph to one black shape, which
+ * `invert(1)` then turns into a featureless solid-white circle. The native asset
+ * already reads on dark (white disc carries its own contrast), so it needs no filter.
  */
-const MONOCHROME_DARK_AGENT_LOGOS = new Set(['codex', 'copilot', 'goose', 'auggie', 'kimi', 'grok']);
+const MONOCHROME_DARK_AGENT_LOGOS = new Set(['copilot', 'goose', 'auggie', 'kimi', 'grok']);
 
 /**
  * On the dark theme, whether this agent's logo needs forcing to a white

--- a/tests/unit/agentLogo.test.ts
+++ b/tests/unit/agentLogo.test.ts
@@ -28,7 +28,7 @@ describe('agentLogo', () => {
 
     it('forces monochrome/currentColor logos to a white silhouette on dark theme', () => {
       setTheme('dark');
-      for (const b of ['codex', 'copilot', 'goose', 'auggie', 'kimi']) {
+      for (const b of ['copilot', 'goose', 'auggie', 'kimi', 'grok']) {
         expect(agentLogoDarkFilter(b)).toBe('brightness(0) invert(1)');
       }
     });
@@ -40,6 +40,13 @@ describe('agentLogo', () => {
       }
     });
 
+    it('does not filter the two-tone codex mark on dark (its white disc self-contrasts)', () => {
+      // codex.svg is a white disc + black `>_` glyph, not a single-color
+      // silhouette; brightness(0) invert(1) would flatten it to a white circle.
+      setTheme('dark');
+      expect(agentLogoDarkFilter('codex')).toBeUndefined();
+    });
+
     it('applies no filter on the light theme (monochrome logos are visible)', () => {
       setTheme('light');
       expect(agentLogoDarkFilter('codex')).toBeUndefined();
@@ -48,7 +55,7 @@ describe('agentLogo', () => {
 
     it('is case-insensitive and safe for unknown/empty input', () => {
       setTheme('dark');
-      expect(agentLogoDarkFilter('Codex')).toBe('brightness(0) invert(1)');
+      expect(agentLogoDarkFilter('Copilot')).toBe('brightness(0) invert(1)');
       expect(agentLogoDarkFilter('unknown')).toBeUndefined();
       expect(agentLogoDarkFilter(undefined)).toBeUndefined();
     });


### PR DESCRIPTION
The dark-theme logo filter (brightness(0) invert(1)) is only valid for
single-color silhouette marks. codex.svg is two-tone — a white disc with a
black >_ glyph and ring — so the filter flattened both layers to one black
shape and then inverted it into a featureless solid-white circle in the agent
pill bar. The native asset already carries its own contrast on dark, so remove
codex from the monochrome set and let it render unfiltered.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
