### PR TITLE
fix(codex): migrate to @agentclientprotocol/codex-acp App Server adapter

### DIFF
--- a/src/common/types/acpTypes.ts
+++ b/src/common/types/acpTypes.ts
@@ -8,8 +8,13 @@
 // the LATEST published version of each bridge via bridgeVersionResolver (so new
 // models/features land automatically); these pins are used only when the npm
 // registry is unreachable. Keep them at a recent known-good version.
-export const CODEX_ACP_BRIDGE_VERSION = '0.9.5';
-export const CODEX_ACP_NPX_PACKAGE = `@zed-industries/codex-acp@${CODEX_ACP_BRIDGE_VERSION}`;
+// Codex uses the actively-maintained App-Server adapter, NOT the retired
+// @zed-industries/codex-acp (which statically embedded codex-core rust-v0.137.0
+// and so version-gated out of new models like gpt-5.6-sol). The new adapter
+// drives the live `codex app-server`, so it tracks the current Codex release and
+// new models work automatically. Zed handed the project off here on 2026-06-22.
+export const CODEX_ACP_BRIDGE_VERSION = '1.1.2';
+export const CODEX_ACP_NPX_PACKAGE = `@agentclientprotocol/codex-acp@${CODEX_ACP_BRIDGE_VERSION}`;
 
 export const CLAUDE_ACP_BRIDGE_VERSION = '0.44.0';
 export const CLAUDE_ACP_NPX_PACKAGE = `@agentclientprotocol/claude-agent-acp@${CLAUDE_ACP_BRIDGE_VERSION}`;

--- a/src/process/agent/acp/acpConnectors.ts
+++ b/src/process/agent/acp/acpConnectors.ts
@@ -192,15 +192,16 @@ export function ensureMinNodeVersion(
       const sep = isWindows ? ';' : ':';
       cleanEnv.PATH = suitableBinDir + sep + (cleanEnv.PATH || '');
 
-      // Verify the corrected PATH actually resolves to a good node (npx uses the same PATH)
+      // Verify the corrected PATH actually resolves to a good node (npx uses the
+      // same PATH). We only care that this does not throw — the version output
+      // itself is unused, so it is not captured.
       try {
-        const correctedVersion = execFileSync(isWindows ? 'node.exe' : 'node', ['--version'], {
+        execFileSync(isWindows ? 'node.exe' : 'node', ['--version'], {
           env: cleanEnv,
           encoding: 'utf-8',
           timeout: 5000,
           stdio: ['pipe', 'pipe', 'pipe'],
-        }).trim();
-        // Version auto-corrected silently
+        });
       } catch {
         console.warn(`[ACP] PATH corrected with ${suitableBinDir} but node verification failed - proceeding anyway`);
       }

--- a/src/process/agent/acp/acpConnectors.ts
+++ b/src/process/agent/acp/acpConnectors.ts
@@ -80,75 +80,6 @@ function parseWindowsCliPath(cliPath: string): { command: string; inlineArgs: st
   return { command: parts[0] ?? '', inlineArgs: parts.slice(1) };
 }
 
-function resolveCodexAcpPlatformPackage(): string | null {
-  if (process.platform === 'win32') {
-    if (process.arch === 'x64') {
-      return '@zed-industries/codex-acp-win32-x64';
-    }
-
-    if (process.arch === 'arm64') {
-      return '@zed-industries/codex-acp-win32-arm64';
-    }
-  }
-
-  if (process.platform === 'linux') {
-    if (process.arch === 'x64') {
-      return '@zed-industries/codex-acp-linux-x64';
-    }
-
-    if (process.arch === 'arm64') {
-      return '@zed-industries/codex-acp-linux-arm64';
-    }
-  }
-
-  if (process.platform === 'darwin') {
-    if (process.arch === 'x64') {
-      return '@zed-industries/codex-acp-darwin-x64';
-    }
-
-    if (process.arch === 'arm64') {
-      return '@zed-industries/codex-acp-darwin-arm64';
-    }
-  }
-
-  return null;
-}
-
-function resolveCodexAcpPlatformPackageSpecifier(packageName: string): string {
-  return `${packageName}@${CODEX_ACP_BRIDGE_VERSION}`;
-}
-
-function resolvePreferredCodexAcpPlatformPackage(): string | null {
-  const packageName = resolveCodexAcpPlatformPackage();
-  return packageName ? resolveCodexAcpPlatformPackageSpecifier(packageName) : null;
-}
-
-function shouldPreferDirectCodexAcpPackage(): boolean {
-  return process.platform === 'win32' || process.platform === 'linux';
-}
-
-function extractCodexPlatformPackageFromError(errorMessage: string): string | null {
-  const packageMatch = errorMessage.match(/Cannot find package '(@zed-industries\/codex-acp-[^']+)'/i);
-  if (packageMatch) {
-    return packageMatch[1];
-  }
-
-  const binaryMatch = errorMessage.match(/Failed to locate (@zed-industries\/codex-acp-[^\s]+) binary/i);
-  if (binaryMatch) {
-    return binaryMatch[1];
-  }
-
-  return null;
-}
-
-function isCodexMetaPackageOptionalDependencyError(errorMessage: string): boolean {
-  return (
-    errorMessage.includes('optional dependency was not installed') ||
-    (errorMessage.includes('@zed-industries/codex-acp') &&
-      /ERR_MODULE_NOT_FOUND|Cannot find package|Failed to locate .* binary/i.test(errorMessage))
-  );
-}
-
 // ── Environment helpers ─────────────────────────────────────────────
 
 /**
@@ -827,72 +758,20 @@ export function connectCodex(
   customEnv?: Record<string, string>
 ): Promise<void> {
   return (async () => {
-    const codexPlatformPackage = resolvePreferredCodexAcpPlatformPackage();
-    // Resolve the latest published codex-acp at spawn time (fallback to the
-    // pinned CODEX_ACP_NPX_PACKAGE offline).
+    // @agentclientprotocol/codex-acp is a single pure-JS stdio ACP agent (no
+    // per-platform binary sub-packages like the retired Zed bridge had), so we
+    // resolve the latest published version once and launch it via npx — no
+    // platform-package candidate list or optional-dependency retry dance.
+    // Fallback to the pinned CODEX_ACP_NPX_PACKAGE when the registry is offline.
     const codexAcpPackage = await resolveBridgePackage(CODEX_ACP_NPX_PACKAGE);
-    const preferDirectPackage = codexPlatformPackage !== null && shouldPreferDirectCodexAcpPackage();
-    const codexPackageCandidates = preferDirectPackage
-      ? [codexPlatformPackage, codexAcpPackage]
-      : [codexAcpPackage, ...(codexPlatformPackage ? [codexPlatformPackage] : [])];
-
-    let lastError: Error | null = null;
-
-    for (const [index, npxPackage] of codexPackageCandidates.entries()) {
-      try {
-        await connectNpxBackend({
-          backend: 'codex',
-          npxPackage,
-          prepareFn: () => prepareCodex(npxPackage),
-          workingDir,
-          ...hooks,
-          customEnv,
-        });
-        return;
-      } catch (error) {
-        lastError = error instanceof Error ? error : new Error(String(error));
-
-        const fallbackPackageName = extractCodexPlatformPackageFromError(lastError.message);
-        const fallbackPackage = fallbackPackageName
-          ? resolveCodexAcpPlatformPackageSpecifier(fallbackPackageName)
-          : null;
-        const canRetryWithPlatformPackage =
-          index === 0 &&
-          !preferDirectPackage &&
-          codexPlatformPackage !== null &&
-          npxPackage === codexAcpPackage &&
-          isCodexMetaPackageOptionalDependencyError(lastError.message);
-        const hasRemainingCandidates = index < codexPackageCandidates.length - 1;
-
-        await hooks.cleanup();
-
-        if (canRetryWithPlatformPackage) {
-          if (fallbackPackage && !codexPackageCandidates.includes(fallbackPackage)) {
-            codexPackageCandidates.push(fallbackPackage);
-          }
-
-          mainWarn(
-            '[ACP codex]',
-            `Meta bridge package failed to install its platform binary, retrying with direct package: ${codexPlatformPackage}`,
-            lastError.message
-          );
-          continue;
-        }
-
-        if (hasRemainingCandidates) {
-          mainWarn(
-            '[ACP codex]',
-            `Bridge package failed, retrying alternate package: ${npxPackage}`,
-            lastError.message
-          );
-          continue;
-        }
-
-        throw lastError;
-      }
-    }
-
-    throw lastError ?? new Error('Failed to start codex ACP bridge');
+    await connectNpxBackend({
+      backend: 'codex',
+      npxPackage: codexAcpPackage,
+      prepareFn: () => prepareCodex(codexAcpPackage),
+      workingDir,
+      ...hooks,
+      customEnv,
+    });
   })();
 }
 

--- a/src/process/resources/assistant/cli-setup/cli-setup.md
+++ b/src/process/resources/assistant/cli-setup/cli-setup.md
@@ -26,7 +26,7 @@ Then run the environment diagnostics from the `cli-setup` skill (which of the fi
 Wayland drives each backend over ACP (Agent Client Protocol). The launch differs per CLI, and two of them have real traps:
 
 - **Claude Code** has NO native ACP. Bare `claude` will not work as an ACP backend; it needs an adapter (for example `@zed-industries/claude-code-acp`). Explain this when setting up Claude Code, and flag it if a Claude backend will not connect.
-- **Codex** connects through the codex-acp bridge, which wraps the installed `codex` (must be on PATH).
+- **Codex** connects through the `@agentclientprotocol/codex-acp` App Server adapter, which Wayland launches automatically. It drives a bundled compatible `codex` (or the one at `CODEX_PATH`), so a separate `codex` on PATH is not required.
 - **Kimi** uses `kimi acp`, but the default coding model needs OAuth (`kimi login`), not just an API key. A key alone returns AUTH_REQUIRED. This is the number-one Kimi failure.
 - **OpenCode** uses `opencode acp` and is bring-your-own-key.
 - **Qwen** uses `qwen --acp`.

--- a/src/process/resources/skills/cli-setup/SKILL.md
+++ b/src/process/resources/skills/cli-setup/SKILL.md
@@ -60,7 +60,7 @@ Two engine-level facts to keep in mind: Claude Code needs an external ACP adapte
 
 ## Codex (command: `codex`), OpenAI
 
-**Install:** `npm install -g @openai/codex`, or `brew install --cask codex`. Self-update: `codex update`. The ACP bridge `@zed-industries/codex-acp` is separate and requires `codex` on PATH.
+**Install:** `npm install -g @openai/codex`, or `brew install --cask codex`. Self-update: `codex update`. Wayland's ACP adapter is `@agentclientprotocol/codex-acp` (the App Server adapter — the retired `@zed-industries/codex-acp` embedded a frozen codex-core and version-gated out of new models). It bundles a compatible `codex`, so a PATH install is optional; set `CODEX_PATH` to force a specific binary.
 
 **Auth (via `codex login`, NOT `codex auth`):**
 - ChatGPT sign-in (Plus/Pro/Team/Enterprise quota): `codex login` (browser); headless `codex login --device-auth`.
@@ -72,7 +72,7 @@ Two engine-level facts to keep in mind: Claude Code needs an external ACP adapte
 
 **Top gotchas:** it is `codex login`, not `codex auth`; codex-acp needs `codex` on PATH; the spawn environment must carry `~/.codex/auth.json` (consistent HOME) or `OPENAI_API_KEY`; ChatGPT login fails headless without `--device-auth`; API-key billing is at API rates.
 
-**Docs:** https://github.com/openai/codex · https://developers.openai.com/codex/auth · bridge https://github.com/zed-industries/codex-acp
+**Docs:** https://github.com/openai/codex · https://developers.openai.com/codex/auth · adapter https://github.com/agentclientprotocol/codex-acp
 
 ---
 

--- a/src/process/resources/skills/cli-setup/SKILL.md
+++ b/src/process/resources/skills/cli-setup/SKILL.md
@@ -45,6 +45,7 @@ Two engine-level facts to keep in mind: Claude Code needs an external ACP adapte
 **Install:** `curl -fsSL https://claude.ai/install.sh | bash` (macOS/Linux/WSL, auto-updates). Windows PowerShell: `irm https://claude.ai/install.ps1 | iex`. Also `brew install --cask claude-code` (no auto-update) or `npm install -g @anthropic-ai/claude-code` (Node 18+). Never `sudo npm -g`. The native installer lands `claude` in `~/.local/bin`, so confirm that is on PATH.
 
 **Auth (two paths):**
+
 - Subscription (Pro/Max/Team/Enterprise), recommended: `claude auth login` (browser OAuth). Headless long-lived token: `claude setup-token`. The free Claude.ai plan does NOT include Claude Code.
 - API key (Console pay-as-you-go): `claude auth login --console`, or `export ANTHROPIC_API_KEY=sk-ant-...`.
 
@@ -63,6 +64,7 @@ Two engine-level facts to keep in mind: Claude Code needs an external ACP adapte
 **Install:** `npm install -g @openai/codex`, or `brew install --cask codex`. Self-update: `codex update`. Wayland's ACP adapter is `@agentclientprotocol/codex-acp` (the App Server adapter — the retired `@zed-industries/codex-acp` embedded a frozen codex-core and version-gated out of new models). It bundles a compatible `codex`, so a PATH install is optional; set `CODEX_PATH` to force a specific binary.
 
 **Auth (via `codex login`, NOT `codex auth`):**
+
 - ChatGPT sign-in (Plus/Pro/Team/Enterprise quota): `codex login` (browser); headless `codex login --device-auth`.
 - API key (API rates): `printenv OPENAI_API_KEY | codex login --with-api-key`, or `codex login` and pick the API-key option. Stored in `~/.codex/auth.json`.
 
@@ -81,6 +83,7 @@ Two engine-level facts to keep in mind: Claude Code needs an external ACP adapte
 **Install:** `uv tool install kimi-cli` (package `kimi-cli`, binary `kimi`; needs `uv`; pin Python with `--python 3.14` if needed). Lands `~/.local/bin/kimi`.
 
 **Auth (the number-one trap: OAuth required, not an API key):**
+
 - `kimi login` (browser OAuth) writes `~/.kimi/credentials/kimi-code.json`. The default model `kimi-code/kimi-for-coding` uses the `managed:kimi-code` provider, which is satisfied ONLY by this OAuth login.
 - A static Moonshot `sk-...` key authenticates only the separate `managed:moonshot-ai` provider. A key alone will NOT make `kimi acp` work with the default coding model: the server returns AUTH_REQUIRED. To use the default model, you must run `kimi login`.
 
@@ -101,6 +104,7 @@ This is SST's `sst/opencode` (npm package `opencode-ai`), not the unrelated Go p
 **Install:** `curl -fsSL https://opencode.ai/install | bash`, or `npm install -g opencode-ai`, or `brew install opencode`. Detect by PATH/binary presence, not by package manager (brew may report "not installed" when it was installed via npm).
 
 **Auth / providers (BYOK):**
+
 - Interactive: `opencode auth login` (writes `~/.local/share/opencode/auth.json`); `-p <provider> -m <method>` to skip prompts.
 - Env vars: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`/`GOOGLE_GENERATIVE_AI_API_KEY`, `GROQ_API_KEY`, and the AWS/Azure/Vertex sets.
 - Config `~/.config/opencode/opencode.json`: provider blocks with `apiKey: "{env:VAR}"` interpolation plus `baseURL`/`headers` (the `baseURL` override is how you point OpenCode at a proxy or router).
@@ -122,6 +126,7 @@ A Gemini-CLI fork for Qwen3-Coder. Package `@qwen-code/qwen-code`.
 **Install:** `npm install -g @qwen-code/qwen-code@latest`, or `brew install qwen-code`. Node 20+. Shares Gemini-CLI's settings/extensions/MCP architecture.
 
 **Auth (the Qwen OAuth free tier was discontinued in April 2026, so do not lead with it):**
+
 - `qwen auth api-key` (BYOK, recommended: DashScope/OpenAI/Anthropic/Gemini).
 - `qwen auth coding-plan` (Alibaba Cloud Coding Plan; endpoint `https://coding.dashscope.aliyuncs.com/v1`).
 - `qwen auth openrouter`.

--- a/tests/unit/acpConnectors.test.ts
+++ b/tests/unit/acpConnectors.test.ts
@@ -487,15 +487,15 @@ describe('spawnGenericBackend - detached process group', () => {
   });
 });
 
+function setPlatform(platform: NodeJS.Platform, arch: string): void {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  Object.defineProperty(process, 'arch', { value: arch, configurable: true });
+}
+
 describe('connectCodex - App Server adapter package', () => {
   let originalPlatform: PropertyDescriptor | undefined;
   let originalArch: PropertyDescriptor | undefined;
   const mockChild = { unref: vi.fn() };
-
-  const setPlatform = (platform: NodeJS.Platform, arch: string) => {
-    Object.defineProperty(process, 'platform', { value: platform, configurable: true });
-    Object.defineProperty(process, 'arch', { value: arch, configurable: true });
-  };
 
   beforeEach(() => {
     originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');

--- a/tests/unit/acpConnectors.test.ts
+++ b/tests/unit/acpConnectors.test.ts
@@ -390,11 +390,15 @@ describe('connectClaude - detached process group', () => {
     const setup = vi.fn().mockResolvedValue(undefined);
     const cleanup = vi.fn().mockResolvedValue(undefined);
 
-    await connectClaude('/cwd', { setup, cleanup }, {
-      ANTHROPIC_BASE_URL: 'https://api.fluxrouter.ai/anthropic',
-      ANTHROPIC_AUTH_TOKEN: 'sk-flux-key',
-      ANTHROPIC_MODEL: 'flux-auto',
-    });
+    await connectClaude(
+      '/cwd',
+      { setup, cleanup },
+      {
+        ANTHROPIC_BASE_URL: 'https://api.fluxrouter.ai/anthropic',
+        ANTHROPIC_AUTH_TOKEN: 'sk-flux-key',
+        ANTHROPIC_MODEL: 'flux-auto',
+      }
+    );
 
     expect(mockSpawn).toHaveBeenCalledWith(
       '/bundled/bun',
@@ -483,16 +487,19 @@ describe('spawnGenericBackend - detached process group', () => {
   });
 });
 
-describe('connectCodex - Windows package selection', () => {
+describe('connectCodex - App Server adapter package', () => {
   let originalPlatform: PropertyDescriptor | undefined;
   let originalArch: PropertyDescriptor | undefined;
   const mockChild = { unref: vi.fn() };
 
+  const setPlatform = (platform: NodeJS.Platform, arch: string) => {
+    Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+    Object.defineProperty(process, 'arch', { value: arch, configurable: true });
+  };
+
   beforeEach(() => {
     originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
     originalArch = Object.getOwnPropertyDescriptor(process, 'arch');
-    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
-    Object.defineProperty(process, 'arch', { value: 'x64', configurable: true });
     mockExecFileSync.mockImplementation(() => 'v20.10.0\n' as never);
     mockSpawn.mockReturnValue(mockChild as unknown as ReturnType<typeof spawn>);
     mockFsPromises.readdir.mockRejectedValue(new Error('cache not found'));
@@ -509,178 +516,45 @@ describe('connectCodex - Windows package selection', () => {
     vi.clearAllMocks();
   });
 
-  it('uses the direct Windows platform package first with bundled bun', async () => {
-    const hooks = {
-      setup: vi.fn(async () => {}),
-      cleanup: vi.fn(async () => {}),
-    };
+  // The App-Server adapter (@agentclientprotocol/codex-acp) is a single pure-JS
+  // package with NO per-platform binary sub-packages, so every OS/arch launches
+  // the exact same specifier via bundled bun. (resolveBridgePackage is mocked to
+  // echo the pinned fallback, so we assert against CODEX_ACP_NPX_PACKAGE.)
+  it.each([
+    ['win32', 'x64', 'C:\\cwd'],
+    ['linux', 'x64', '/cwd'],
+    ['darwin', 'arm64', '/cwd'],
+  ])('launches the meta App Server adapter on %s/%s (no platform sub-package)', async (platform, arch, cwd) => {
+    setPlatform(platform as NodeJS.Platform, arch);
+    const hooks = { setup: vi.fn(async () => {}), cleanup: vi.fn(async () => {}) };
 
-    await connectCodex('C:\\cwd', hooks);
+    await connectCodex(cwd, hooks);
 
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
     const [command, args] = mockSpawn.mock.calls[0];
     // SEC-ACP-04: bundled bun is spawned directly (shell: false), no chcp prefix.
     expect(command).toBe('/bundled/bun');
     expect(args).toContain('x');
     expect(args).toContain('--bun');
-    expect(args).toContain('@zed-industries/codex-acp-win32-x64@0.9.5');
+    expect(args).toContain('@agentclientprotocol/codex-acp@1.1.2');
+    // The retired Zed bridge (and its per-platform binaries) is never referenced.
+    expect((args as string[]).some((a) => typeof a === 'string' && a.includes('@zed-industries/codex-acp'))).toBe(
+      false
+    );
   });
 
-  it('uses the direct Windows platform package first when startup succeeds', async () => {
-    const hooks = {
-      setup: vi.fn(async () => {}),
-      cleanup: vi.fn(async () => {}),
-    };
-
-    await connectCodex('C:\\cwd', hooks);
-
-    const [, args] = mockSpawn.mock.calls[0];
-    expect(args).toContain('@zed-industries/codex-acp-win32-x64@0.9.5');
-    expect(args).not.toContain('@zed-industries/codex-acp@0.9.5');
-    expect(mockChild.unref).not.toHaveBeenCalled();
-  });
-
-  it('falls back to the meta package when the direct Windows platform package times out', async () => {
+  it('makes a single spawn attempt and cleans up on startup failure (no platform-package retry)', async () => {
+    setPlatform('darwin', 'arm64');
     const hooks = {
       setup: vi.fn(async () => {
-        const [, args] = mockSpawn.mock.calls.at(-1) ?? [];
-        if (Array.isArray(args) && args.includes('@zed-industries/codex-acp-win32-x64@0.9.5')) {
-          throw new Error('Request initialize timed out after 60 seconds');
-        }
+        throw new Error('Request initialize timed out after 60 seconds');
       }),
       cleanup: vi.fn(async () => {}),
     };
 
-    await connectCodex('C:\\cwd', hooks);
-
-    const firstCallArgs = mockSpawn.mock.calls[0]?.[1];
-    const secondCallArgs = mockSpawn.mock.calls[1]?.[1];
-
-    expect(firstCallArgs).toContain('@zed-industries/codex-acp-win32-x64@0.9.5');
-    expect(secondCallArgs).toContain('@zed-industries/codex-acp@0.9.5');
-  });
-});
-
-describe('connectCodex - Linux package selection', () => {
-  let originalPlatform: PropertyDescriptor | undefined;
-  let originalArch: PropertyDescriptor | undefined;
-  const mockChild = { unref: vi.fn() };
-
-  beforeEach(() => {
-    originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
-    originalArch = Object.getOwnPropertyDescriptor(process, 'arch');
-    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
-    Object.defineProperty(process, 'arch', { value: 'x64', configurable: true });
-    mockExecFileSync.mockImplementation(() => 'v20.10.0\n' as never);
-    mockSpawn.mockReturnValue(mockChild as unknown as ReturnType<typeof spawn>);
-    mockFsPromises.readdir.mockRejectedValue(new Error('cache not found'));
-    mockFsPromises.stat.mockRejectedValue(new Error('not found'));
-  });
-
-  afterEach(() => {
-    if (originalPlatform) {
-      Object.defineProperty(process, 'platform', originalPlatform);
-    }
-    if (originalArch) {
-      Object.defineProperty(process, 'arch', originalArch);
-    }
-    vi.clearAllMocks();
-  });
-
-  it('uses the direct Linux platform package first with bundled bun', async () => {
-    const hooks = {
-      setup: vi.fn(async () => {}),
-      cleanup: vi.fn(async () => {}),
-    };
-
-    await connectCodex('/cwd', hooks);
-
-    const [command, args] = mockSpawn.mock.calls[0];
-    expect(command).toBe('/bundled/bun');
-    expect(args).toContain('x');
-    expect(args).toContain('--bun');
-    expect(args).toContain('@zed-industries/codex-acp-linux-x64@0.9.5');
-  });
-
-  it('uses the direct Linux platform package first when startup succeeds', async () => {
-    const hooks = {
-      setup: vi.fn(async () => {}),
-      cleanup: vi.fn(async () => {}),
-    };
-
-    await connectCodex('/cwd', hooks);
-
-    const [, args] = mockSpawn.mock.calls[0];
-    expect(args).toContain('@zed-industries/codex-acp-linux-x64@0.9.5');
-    expect(args).not.toContain('@zed-industries/codex-acp@0.9.5');
-    expect(mockChild.unref).not.toHaveBeenCalled();
-  });
-
-  it('falls back to the meta package when the direct Linux platform package times out', async () => {
-    const hooks = {
-      setup: vi.fn(async () => {
-        const [, args] = mockSpawn.mock.calls.at(-1) ?? [];
-        if (Array.isArray(args) && args.includes('@zed-industries/codex-acp-linux-x64@0.9.5')) {
-          throw new Error('Request initialize timed out after 60 seconds');
-        }
-      }),
-      cleanup: vi.fn(async () => {}),
-    };
-
-    await connectCodex('/cwd', hooks);
-
-    const firstCallArgs = mockSpawn.mock.calls[0]?.[1];
-    const secondCallArgs = mockSpawn.mock.calls[1]?.[1];
-
-    expect(firstCallArgs).toContain('@zed-industries/codex-acp-linux-x64@0.9.5');
-    expect(secondCallArgs).toContain('@zed-industries/codex-acp@0.9.5');
-  });
-});
-
-describe('connectCodex - Darwin optional dependency fallback', () => {
-  let originalPlatform: PropertyDescriptor | undefined;
-  let originalArch: PropertyDescriptor | undefined;
-
-  beforeEach(() => {
-    originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
-    originalArch = Object.getOwnPropertyDescriptor(process, 'arch');
-    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
-    Object.defineProperty(process, 'arch', { value: 'x64', configurable: true });
-    mockExecFileSync.mockImplementation(() => 'v20.10.0\n' as never);
-    mockSpawn.mockReturnValue({ unref: vi.fn() } as unknown as ReturnType<typeof spawn>);
-    mockFsPromises.readdir.mockRejectedValue(new Error('cache not found'));
-    mockFsPromises.stat.mockRejectedValue(new Error('not found'));
-  });
-
-  afterEach(() => {
-    if (originalPlatform) {
-      Object.defineProperty(process, 'platform', originalPlatform);
-    }
-    if (originalArch) {
-      Object.defineProperty(process, 'arch', originalArch);
-    }
-    vi.clearAllMocks();
-  });
-
-  it('retries with the direct Darwin platform package when the meta package misses its optional binary', async () => {
-    const hooks = {
-      setup: vi.fn(async () => {
-        const [, args] = mockSpawn.mock.calls.at(-1) ?? [];
-        if (Array.isArray(args) && args.includes('@zed-industries/codex-acp@0.9.5')) {
-          throw new Error(
-            "Error resolving package: Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@zed-industries/codex-acp-darwin-x64' imported from /tmp/codex-acp.js\n" +
-              'Failed to locate @zed-industries/codex-acp-darwin-x64 binary. This usually means the optional dependency was not installed.'
-          );
-        }
-      }),
-      cleanup: vi.fn(async () => {}),
-    };
-
-    await connectCodex('/cwd', hooks);
-
-    const firstCallArgs = mockSpawn.mock.calls[0]?.[1];
-    const secondCallArgs = mockSpawn.mock.calls[1]?.[1];
-
-    expect(firstCallArgs).toContain('@zed-industries/codex-acp@0.9.5');
-    expect(secondCallArgs).toContain('@zed-industries/codex-acp-darwin-x64@0.9.5');
+    await expect(connectCodex('/cwd', hooks)).rejects.toThrow(/timed out/);
+    // No candidate-fallback list anymore: one spawn, then propagate.
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(hooks.cleanup).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
gpt-5.6-sol (and other new models) failed under the Codex agent with a 400
'requires a newer version of Codex'. Root cause: Wayland launched the retired
@zed-industries/codex-acp bridge, which statically embeds codex-core
rust-v0.137.0 and makes the model API call itself — so OpenAI version-gated it
out of new models. codex-cli has no native ACP mode, so we can't point at the
user's installed codex directly. Zed handed the project off (2026-06-22) to the
App Server adapter.

Fix: switch the codex bridge to @agentclientprotocol/codex-acp (v1.1.2), which
starts the live 'codex app-server' and translates ACP<->Codex. It bundles
@openai/codex@0.144.4 (sol-capable) and tracks current Codex releases, so new
models work automatically; the runtime resolver still auto-picks the latest.
The adapter is a single pure-JS package with no per-platform binary
sub-packages, so the Zed-specific platform-package selection and
optional-dependency retry logic is removed; connectNpxBackend already handles
cleanup and bunx-cache retries. Docs updated to the new adapter.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
