### PR TITLE
fix(guid): Codex model pick shows 'Default Model' — resolve label from curated list

### DIFF
--- a/src/renderer/pages/guid/components/GuidModelSelector.tsx
+++ b/src/renderer/pages/guid/components/GuidModelSelector.tsx
@@ -424,14 +424,21 @@ const GuidModelSelector: React.FC<GuidModelSelectorProps> = ({
 
   const acpSelectedLabel = React.useMemo(() => {
     if (isFluxModelId(selectedAcpModel)) return FLUX_MODEL_DISPLAY[selectedAcpModel as FluxModelId];
+    // Resolve the label from the SAME unified list the dropdown renders
+    // (`acpModels` = live session cache when present, else the curated catalog).
+    // On a brand-new chat there is no spawned session yet, so
+    // `currentAcpCachedModelInfo` is null; looking only there left the button
+    // stuck on "Default Model" after picking e.g. gpt-5.6-sol for Codex, making
+    // the selection look like it did nothing. `acpModels` carries the curated
+    // rows, so the freshly-picked model resolves to its real label immediately.
     return (
-      currentAcpCachedModelInfo?.availableModels?.find((m) => m.id === selectedAcpModel)?.label ||
+      acpModels.find((m) => m.id === selectedAcpModel)?.label ||
       currentAcpCachedModelInfo?.currentModelLabel ||
       currentAcpCachedModelInfo?.currentModelId ||
       ''
     );
   }, [
-    currentAcpCachedModelInfo?.availableModels,
+    acpModels,
     currentAcpCachedModelInfo?.currentModelId,
     currentAcpCachedModelInfo?.currentModelLabel,
     selectedAcpModel,

--- a/tests/unit/renderer/guidModelSelector.dom.test.tsx
+++ b/tests/unit/renderer/guidModelSelector.dom.test.tsx
@@ -518,6 +518,30 @@ describe('GuidModelSelector home picker', () => {
     expect(screen.getByText('$')).toBeInTheDocument();
   });
 
+  it('labels the composer button from the curated set when a CLI model is picked with no session cache yet', async () => {
+    // Regression: on a brand-new Codex chat the ACP session cache is null, so the
+    // button label resolved only from `currentAcpCachedModelInfo` and fell back to
+    // "Default Model" even after the user picked gpt-5.6-sol — the selection looked
+    // like it did nothing. The label must resolve from the curated catalog (the
+    // same list the dropdown renders), so the pick shows immediately.
+    mockCuratedForAgent.mockResolvedValue([
+      curated({ id: 'gpt-5.6-sol', providerId: 'openai', displayName: 'GPT-5.6-Sol', family: 'GPT-5.6' }),
+      curated({ id: 'gpt-5.6-luna', providerId: 'openai', displayName: 'GPT-5.6-Luna', family: 'GPT-5.6' }),
+    ]);
+    render(
+      <GuidModelSelector
+        {...baseProps}
+        isGeminiMode={false}
+        agentKey='codex'
+        currentAcpCachedModelInfo={null}
+        selectedAcpModel='gpt-5.6-sol'
+      />
+    );
+
+    // The composer button (dropdown closed) reflects the pick, not the default.
+    expect(await screen.findByText('GPT-5.6-Sol')).toBeInTheDocument();
+  });
+
   it('passes the non-secret chat-start handle through to setCurrentModel (audit C4)', async () => {
     // The resolver hands back the NON-SECRET handle (platform + baseUrl +
     // account binding) - no decrypted key. The picker writes the binding into


### PR DESCRIPTION
Picking a model for a CLI agent (e.g. gpt-5.6-sol on Codex) from the new-chat
composer set the model correctly but the button label stayed 'Default Model',
so it looked like the click did nothing ('it won't let me select it').

Root cause: acpSelectedLabel resolved the display label only from
currentAcpCachedModelInfo.availableModels. On a brand-new chat no ACP session
has spawned yet, so that cache is null and the label came back empty, causing
the button to fall back to the default label. The dropdown itself renders from
the unified acpModels list (live cache OR curated catalog), so the picked model
was visible and selectable — only the button label was blind to it.

Fix: resolve acpSelectedLabel from the same acpModels list the dropdown uses,
so a freshly-picked curated model shows its real label immediately.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
