### PR TITLE
fix(models): newest-first picker order + Flux Router all models enabled

### DIFF
--- a/src/process/providers/catalog/Curator.ts
+++ b/src/process/providers/catalog/Curator.ts
@@ -63,7 +63,7 @@
  */
 
 import type { CatalogModel, CuratedModel } from '../types';
-import { isFluxModelId } from '@/common/config/flux';
+import { FLUX_PROVIDER_ID, isFluxModelId } from '@/common/config/flux';
 import { CHATGPT_SUBSCRIPTION_PROVIDER_ID } from './chatgptSubscriptionModels';
 
 /**
@@ -327,6 +327,16 @@ function curateOne(model: CatalogModel, rank: number, familyEligible: boolean): 
   // the rest of the flux-router catalog follows normal curation.
   if (isFluxModelId(model.id)) {
     return { ...model, recommended: false, enabled: true, role: 'flagship' };
+  }
+  // The rest of the Flux-router catalog (every model Flux can route to) is a
+  // curated, keyless virtual set like the tiers above. Flux Router users expect
+  // every routed model available out of the box, so force the whole provider
+  // `enabled` rather than letting normal rank-based curation leave most of it
+  // `enabled: false`. `recommended: false` keeps them in "More models" so they
+  // don't crowd the Recommended zone. Same class as the ollama / subscription
+  // unenriched-but-real sets below.
+  if (model.providerId === FLUX_PROVIDER_ID) {
+    return { ...model, recommended: false, enabled: true };
   }
   // The ChatGPT-subscription static catalog (GPT-5.x / Codex) is a curated,
   // unenriched virtual set just like the Flux tiers - there is no `/v1/models`

--- a/src/renderer/components/model/modelSelector/useModelSelectorViewModel.ts
+++ b/src/renderer/components/model/modelSelector/useModelSelectorViewModel.ts
@@ -20,6 +20,7 @@ import { useRecentlyUsedModels } from '@renderer/hooks/usage/useRecentlyUsedMode
 import { marqueeProviderRank } from '@renderer/utils/model/marquee';
 import { providerLabel } from '@renderer/components/onboarding/providerLabel';
 import { describeModel, fluxTierDescriptor, modelKey, priceTier } from './modelRowHelpers';
+import { sortModelsNewestFirst } from '@renderer/utils/model/modelOrder';
 import type { ModelRow, ModelSelectorViewModel, ModelZone } from './modelSelectorTypes';
 
 /** Backends whose config supports an effort/reasoning knob. */
@@ -120,7 +121,10 @@ export function useModelSelectorViewModel(backend: string, activeModelKey?: stri
     // is connected AND whose per-model toggle is on (`enabled`). Disabled /
     // disconnected-vendor models are HIDDEN, not greyed - never show a model you
     // cannot choose. Flux virtual ids are handled separately (the hero + zone).
-    const base = curated.filter((m) => !isFluxModelId(m.id) && m.enabled);
+    // Newest-first so the "More models" zone (and any provider grouping derived
+    // from it) shows e.g. GPT-5.6 above 5.5 above 5.4 instead of the catalog
+    // store's ascending alphabetical order.
+    const base = sortModelsNewestFirst(curated.filter((m) => !isFluxModelId(m.id) && m.enabled));
     const empty = base.length === 0 && !fluxConnected;
 
     if (empty) {

--- a/src/renderer/pages/guid/components/GuidModelSelector.tsx
+++ b/src/renderer/pages/guid/components/GuidModelSelector.tsx
@@ -21,6 +21,7 @@ import { resolveAgentScope } from '@/renderer/pages/settings/AgentSettings/agent
 import { iconColors } from '@/renderer/styles/colors';
 import FluxRouterMark from '@/renderer/components/icons/FluxRouterMark';
 import { getModelDisplayLabel } from '@/renderer/utils/model/agentLogo';
+import { sortModelsNewestFirst } from '@/renderer/utils/model/modelOrder';
 import { formatAcpModelDisplayLabel, getAcpModelSourceLabel } from '@/renderer/utils/model/modelSource';
 import type { AcpModelInfo } from '../types';
 import React from 'react';
@@ -417,9 +418,12 @@ const GuidModelSelector: React.FC<GuidModelSelectorProps> = ({
   // identically to a cached entry. This is what kills the cold-start dead-end.
   const acpModels = React.useMemo<AcpModelInfo['availableModels']>(() => {
     if (currentAcpCachedModelInfo?.availableModels?.length) {
-      return currentAcpCachedModelInfo.availableModels;
+      return sortModelsNewestFirst(currentAcpCachedModelInfo.availableModels);
     }
-    return (curated ?? []).map((m) => ({ id: m.id, label: m.displayName }));
+    // Sort the curated rows (which carry releaseDate) newest-first BEFORE mapping
+    // to `{id,label}`, so the picker shows e.g. GPT-5.6 above 5.5 above 5.4
+    // instead of the catalog store's ascending alphabetical order.
+    return sortModelsNewestFirst(curated ?? []).map((m) => ({ id: m.id, label: m.displayName }));
   }, [currentAcpCachedModelInfo?.availableModels, curated]);
 
   const acpSelectedLabel = React.useMemo(() => {

--- a/src/renderer/utils/model/modelOrder.ts
+++ b/src/renderer/utils/model/modelOrder.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Model picker ordering — newest first.
+ *
+ * The subscription / CLI catalogs (e.g. the ChatGPT-subscription GPT-5.x set)
+ * carry no models.dev `releaseDate`, so the catalog store's default
+ * alphabetical `sortByDisplayName` left the picker ascending — `GPT-5.4` above
+ * `GPT-5.6`. Users expect the newest models on top. This comparator sorts
+ * newest-first by (1) release date when present, then (2) a parsed version
+ * number (`5.6` > `5.5` > `5.4`), and otherwise leaves items in their existing
+ * relative order (return 0 → a stable sort preserves the alphabetical grouping,
+ * so `GPT-5.6-Luna`/`-Sol`/`-Terra` stay alphabetical *within* the 5.6 tier).
+ */
+
+type OrderableModel = { id: string; label?: string; displayName?: string; releaseDate?: string };
+
+/**
+ * Parse the leading semantic version-ish number from a model label/id.
+ * `"GPT-5.6-Sol"` / `"gpt-5.6-sol"` → `5.6`, `"GPT-5.4-Mini"` → `5.4`,
+ * `"Claude Sonnet 4.5"` → `4.5`. Returns `null` when there is no `X.Y` (or bare
+ * integer) number to key on (e.g. `"sonnet"`), so unversioned ids keep their
+ * original order instead of being forced to the front or back arbitrarily.
+ */
+export function parseModelVersion(text: string): number | null {
+  const match = text.match(/(\d+(?:\.\d+)?)/);
+  return match ? Number.parseFloat(match[1]) : null;
+}
+
+/** Text used to key a model's version — prefer the human label, then id. */
+function versionText(model: OrderableModel): string {
+  return model.label || model.displayName || model.id;
+}
+
+/**
+ * Comparator for `Array.prototype.sort` / `toSorted` that orders models
+ * newest-first. Stable-safe: equal-rank models return 0 and keep their input
+ * order. Pass to `list.slice().sort(compareModelsNewestFirst)`.
+ */
+export function compareModelsNewestFirst(a: OrderableModel, b: OrderableModel): number {
+  // 1. Release date, newest first. '' (undated) sorts after any real date.
+  const ad = a.releaseDate ?? '';
+  const bd = b.releaseDate ?? '';
+  if (ad !== bd) return bd.localeCompare(ad);
+
+  // 2. Parsed version, highest first. A versioned id outranks an unversioned one.
+  const av = parseModelVersion(versionText(a));
+  const bv = parseModelVersion(versionText(b));
+  if (av !== null && bv !== null) {
+    if (av !== bv) return bv - av;
+  } else if (av !== null || bv !== null) {
+    return av !== null ? -1 : 1;
+  }
+
+  // 3. Otherwise preserve input order (stable sort → keeps alphabetical grouping).
+  return 0;
+}
+
+/** Convenience: return a new newest-first-sorted array (does not mutate input). */
+export function sortModelsNewestFirst<T extends OrderableModel>(models: readonly T[]): T[] {
+  return models.slice().sort(compareModelsNewestFirst);
+}

--- a/tests/unit/providers/curatorFluxException.test.ts
+++ b/tests/unit/providers/curatorFluxException.test.ts
@@ -43,7 +43,13 @@ describe('Curator flux hero-exception', () => {
     // lands enabled:false and disappears from the WCore picker entirely.
     const ollama: CatalogModel[] = [
       { ...fluxAuto, id: 'qwen3:32b', providerId: 'ollama-local', family: 'qwen3', displayName: 'qwen3:32b' },
-      { ...fluxAuto, id: 'hf.co/Jackrong/Qwen3.5-27B', providerId: 'ollama-local', family: 'hf.co/Jackrong/Qwen3.5-27B', displayName: 'Qwen3.5 27B' },
+      {
+        ...fluxAuto,
+        id: 'hf.co/Jackrong/Qwen3.5-27B',
+        providerId: 'ollama-local',
+        family: 'hf.co/Jackrong/Qwen3.5-27B',
+        displayName: 'Qwen3.5 27B',
+      },
     ];
     const out = curator.curate(ollama);
     expect(out.filter((m) => m.enabled)).toHaveLength(2);
@@ -57,17 +63,26 @@ describe('Curator flux hero-exception', () => {
     // hiding the whole provider from the picker. Same class as Ollama/flux.
     const sakana: CatalogModel[] = [
       { ...fluxAuto, id: 'fugu', providerId: 'sakana', family: 'fugu', displayName: 'fugu', enriched: false },
-      { ...fluxAuto, id: 'fugu-ultra', providerId: 'sakana', family: 'fugu-ultra', displayName: 'fugu-ultra', enriched: false },
+      {
+        ...fluxAuto,
+        id: 'fugu-ultra',
+        providerId: 'sakana',
+        family: 'fugu-ultra',
+        displayName: 'fugu-ultra',
+        enriched: false,
+      },
     ];
     const out = curator.curate(sakana);
     expect(out.filter((m) => m.enabled)).toHaveLength(2);
     expect(out.every((m) => m.recommended === false)).toBe(true);
   });
 
-  it('does NOT force-enable a non-tier flux-router model (only the tier aliases are hero)', () => {
-    // The real flux-router catalog returns 40+ branded route models; only the
-    // four tier aliases should get the hero exception, the rest follow normal
-    // curation (an unenriched non-tier route stays disabled).
+  it('force-enables non-tier flux-router route models too (Flux Router → all models on)', () => {
+    // The real flux-router catalog returns 40+ branded route models. Flux Router
+    // users expect every routed model available out of the box, so the whole
+    // provider is force-enabled — not just the four tier aliases. (Previously an
+    // unenriched non-tier route fell through to normal curation and stayed
+    // disabled, hiding it from the picker.)
     const route: CatalogModel = {
       ...fluxAuto,
       id: 'anthropic/claude-opus-4-6',
@@ -76,6 +91,9 @@ describe('Curator flux hero-exception', () => {
       enriched: false,
     };
     const out = curator.curate([route]);
-    expect(out.find((m) => m.id === 'anthropic/claude-opus-4-6')?.enabled).toBe(false);
+    const curated = out.find((m) => m.id === 'anthropic/claude-opus-4-6');
+    expect(curated?.enabled).toBe(true);
+    // Routed models stay out of the Recommended zone (recommended: false).
+    expect(curated?.recommended).toBe(false);
   });
 });

--- a/tests/unit/renderer/modelOrder.test.ts
+++ b/tests/unit/renderer/modelOrder.test.ts
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { compareModelsNewestFirst, parseModelVersion, sortModelsNewestFirst } from '@/renderer/utils/model/modelOrder';
+
+describe('parseModelVersion', () => {
+  it('extracts the leading version number from labels and ids', () => {
+    expect(parseModelVersion('GPT-5.6-Sol')).toBe(5.6);
+    expect(parseModelVersion('gpt-5.6-sol')).toBe(5.6);
+    expect(parseModelVersion('GPT-5.4-Mini')).toBe(5.4);
+    expect(parseModelVersion('GPT-5.5')).toBe(5.5);
+    expect(parseModelVersion('Claude Sonnet 4.5')).toBe(4.5);
+  });
+
+  it('returns null when there is no version number', () => {
+    expect(parseModelVersion('sonnet')).toBeNull();
+    expect(parseModelVersion('Default')).toBeNull();
+  });
+});
+
+describe('sortModelsNewestFirst', () => {
+  it('orders the ChatGPT-subscription GPT set newest-version-first (Sean bug: was ascending)', () => {
+    // The catalog store hands these over alphabetically ascending (5.4 first)
+    // because they carry no releaseDate. The picker must show 5.6 on top.
+    const input = [
+      { id: 'gpt-5.4', label: 'GPT-5.4' },
+      { id: 'gpt-5.4-mini', label: 'GPT-5.4-Mini' },
+      { id: 'gpt-5.5', label: 'GPT-5.5' },
+      { id: 'gpt-5.6-luna', label: 'GPT-5.6-Luna' },
+      { id: 'gpt-5.6-sol', label: 'GPT-5.6-Sol' },
+      { id: 'gpt-5.6-terra', label: 'GPT-5.6-Terra' },
+    ];
+    expect(sortModelsNewestFirst(input).map((m) => m.label)).toEqual([
+      'GPT-5.6-Luna',
+      'GPT-5.6-Sol',
+      'GPT-5.6-Terra',
+      'GPT-5.5',
+      'GPT-5.4',
+      'GPT-5.4-Mini',
+    ]);
+  });
+
+  it('keeps alphabetical grouping stable within the same version tier', () => {
+    const input = [
+      { id: 'gpt-5.6-terra', label: 'GPT-5.6-Terra' },
+      { id: 'gpt-5.6-luna', label: 'GPT-5.6-Luna' },
+      { id: 'gpt-5.6-sol', label: 'GPT-5.6-Sol' },
+    ];
+    // Stable: input order preserved within the 5.6 tier (caller pre-sorts A→Z).
+    expect(sortModelsNewestFirst(input).map((m) => m.label)).toEqual(['GPT-5.6-Terra', 'GPT-5.6-Luna', 'GPT-5.6-Sol']);
+  });
+
+  it('prefers an explicit releaseDate over the parsed version', () => {
+    const input = [
+      { id: 'old-9', label: 'Old 9.9', releaseDate: '2024-01-01' },
+      { id: 'new-1', label: 'New 1.0', releaseDate: '2026-06-01' },
+    ];
+    expect(sortModelsNewestFirst(input).map((m) => m.id)).toEqual(['new-1', 'old-9']);
+  });
+
+  it('leaves unversioned CLI ids (sonnet/haiku) in their original order', () => {
+    const input = [
+      { id: 'sonnet', label: 'Sonnet' },
+      { id: 'haiku', label: 'Haiku' },
+      { id: 'opus', label: 'Opus' },
+    ];
+    expect(sortModelsNewestFirst(input).map((m) => m.id)).toEqual(['sonnet', 'haiku', 'opus']);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [
+      { id: 'gpt-5.4', label: 'GPT-5.4' },
+      { id: 'gpt-5.6', label: 'GPT-5.6' },
+    ];
+    const copy = [...input];
+    sortModelsNewestFirst(input);
+    expect(input).toEqual(copy);
+  });
+
+  it('is a stable no-op comparator for equal-rank pairs', () => {
+    expect(compareModelsNewestFirst({ id: 'a', label: 'x' }, { id: 'b', label: 'y' })).toBe(0);
+  });
+});


### PR DESCRIPTION
Two model-picker fixes:

1. Ordering — the picker listed GPT-5.4 above 5.6 (ascending). The
   subscription/CLI catalogs carry no models.dev releaseDate, so the catalog
   store's alphabetical sortByDisplayName won and put older versions on top.
   Add a shared newest-first comparator (releaseDate desc, then parsed version
   desc, stable otherwise) and apply it to the Codex/ACP picker (GuidModelSelector)
   and the shared in-chat flyout (useModelSelectorViewModel). GPT-5.6 now sorts
   above 5.5 above 5.4, alphabetical within a tier.

2. Flux Router all-on — curateOne only force-enabled the four Flux tier aliases;
   the rest of the flux-router catalog fell through to rank-based curation and
   mostly landed enabled:false. Force the whole flux-router provider enabled
   (recommended:false so routed models stay in 'More models'), so a Flux Router
   user has every routed model available out of the box.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
