### PR TITLE
fix(models): drop image + audio models from the chat picker

### DIFF
--- a/src/common/config/imageModels.ts
+++ b/src/common/config/imageModels.ts
@@ -48,6 +48,33 @@ export function isImageModelName(name: string): boolean {
   );
 }
 
+/**
+ * True when `name` looks like an audio / voice model id (text-to-speech,
+ * speech-to-text, transcription, voice synthesis). Case-insensitive. Like
+ * {@link isImageModelName} this exists because a new audio model too fresh for
+ * models.dev lands UNENRICHED with the default `kind: 'text'` and would slip
+ * through the Curator into the chat pickers (e.g. Flux Router's "Flux Voice"
+ * arms). Audio models belong to voice tooling, never the chat model dropdown.
+ */
+export function isAudioModelName(name: string): boolean {
+  const n = name.toLowerCase();
+  return (
+    n.includes('voice') ||
+    n.includes('audio') ||
+    n.includes('whisper') ||
+    n.includes('speech') ||
+    n.includes('transcri') || // transcribe / transcription
+    n.includes('elevenlabs') ||
+    n.includes('deepgram') ||
+    /\b(tts|stt)\b/.test(n)
+  );
+}
+
+/** True when a model id is a non-chat (image or audio) model by name. */
+export function isNonTextModelName(name: string): boolean {
+  return isImageModelName(name) || isAudioModelName(name);
+}
+
 /** A curated-floor rule: providers matching `test` get `models` as a baseline. */
 type CuratedRule = {
   /** Match on the legacy provider `platform` + `baseUrl` (host already lowered). */

--- a/src/process/providers/catalog/Curator.ts
+++ b/src/process/providers/catalog/Curator.ts
@@ -64,6 +64,7 @@
 
 import type { CatalogModel, CuratedModel } from '../types';
 import { FLUX_PROVIDER_ID, isFluxModelId } from '@/common/config/flux';
+import { isNonTextModelName } from '@/common/config/imageModels';
 import { CHATGPT_SUBSCRIPTION_PROVIDER_ID } from './chatgptSubscriptionModels';
 
 /**
@@ -170,7 +171,14 @@ export class Curator {
    * models together, newest-first; family order itself is not significant.
    */
   curate(catalog: CatalogModel[]): CuratedModel[] {
-    const textModels = catalog.filter((model) => model.kind === 'text');
+    // Chat pickers are text-only. `kind === 'text'` is not sufficient on its own:
+    // an image/audio model too new for models.dev lands UNENRICHED with the
+    // default `kind: 'text'` (e.g. Flux Router's "GPT Image *" / "Nano Banana" /
+    // "Flux Voice *" arms), so it would slip into the chat dropdown. Drop those
+    // by id/name too — image + audio models belong to their own tools, not chat.
+    const textModels = catalog.filter(
+      (model) => model.kind === 'text' && !isNonTextModelName(model.id) && !isNonTextModelName(model.displayName)
+    );
     const families = groupByFamily(textModels);
 
     // The reference date for the recency window - the catalog's newest

--- a/tests/unit/providers/curatorFluxException.test.ts
+++ b/tests/unit/providers/curatorFluxException.test.ts
@@ -107,7 +107,12 @@ describe('Curator flux hero-exception', () => {
       { ...fluxAuto, id: 'flux-voice', family: 'flux-voice', displayName: 'Flux Voice' },
       { ...fluxAuto, id: 'flux-voice-fast', family: 'flux-voice-fast', displayName: 'Flux Voice Fast' },
       // A real chat arm must survive alongside them.
-      { ...fluxAuto, id: 'perplexity/sonar-reasoning-pro', family: 'sonar', displayName: 'Flux Pinned Sonar Reasoning Pro' },
+      {
+        ...fluxAuto,
+        id: 'perplexity/sonar-reasoning-pro',
+        family: 'sonar',
+        displayName: 'Flux Pinned Sonar Reasoning Pro',
+      },
     ];
     const out = curator.curate(arms);
     expect(out.map((m) => m.id)).toEqual(['perplexity/sonar-reasoning-pro']);

--- a/tests/unit/providers/curatorFluxException.test.ts
+++ b/tests/unit/providers/curatorFluxException.test.ts
@@ -96,4 +96,20 @@ describe('Curator flux hero-exception', () => {
     // Routed models stay out of the Recommended zone (recommended: false).
     expect(curated?.recommended).toBe(false);
   });
+
+  it('drops unenriched image/audio flux-router arms from the chat picker (kind:text but not chattable)', () => {
+    // These land kind:'text' because models.dev has not enriched them, and the
+    // Flux all-on rule would otherwise force-enable them straight into the chat
+    // dropdown. Image + audio arms must never reach the chat picker.
+    const arms: CatalogModel[] = [
+      { ...fluxAuto, id: 'gpt-image-high', family: 'gpt-image-high', displayName: 'GPT Image High' },
+      { ...fluxAuto, id: 'nano-banana', family: 'nano-banana', displayName: 'Nano Banana' },
+      { ...fluxAuto, id: 'flux-voice', family: 'flux-voice', displayName: 'Flux Voice' },
+      { ...fluxAuto, id: 'flux-voice-fast', family: 'flux-voice-fast', displayName: 'Flux Voice Fast' },
+      // A real chat arm must survive alongside them.
+      { ...fluxAuto, id: 'perplexity/sonar-reasoning-pro', family: 'sonar', displayName: 'Flux Pinned Sonar Reasoning Pro' },
+    ];
+    const out = curator.curate(arms);
+    expect(out.map((m) => m.id)).toEqual(['perplexity/sonar-reasoning-pro']);
+  });
 });


### PR DESCRIPTION
Flux Router surfaces image (GPT Image *, Nano Banana) and audio (Flux Voice *)
arms in the chat model dropdown. The Curator filters kind:'text', but a model
too new for models.dev lands UNENRICHED with the default kind:'text', so these
non-chat arms slip through — and the Flux all-on rule (#880) force-enables them
straight into the picker.

Add an isAudioModelName detector (sibling to isImageModelName) plus a combined
isNonTextModelName, and filter the Curator's input by id AND displayName, so
unenriched image/audio arms are dropped from every chat picker regardless of
kind. They belong to the image/voice tools, never the chat dropdown.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
