### PR TITLE
fix(codex): confirm selected model in header; stop silent-clearing usable subscription models

### DIFF
--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -1449,12 +1449,20 @@ ${collectedResponses.join('\n')}`;
       // so DO NOT clear it as "unavailable" and DO NOT re-send it via set_model
       // (the claude bridge rejects an unlisted id). The env already selected it.
       const isFluxOnFluxBackend = isFluxModelId(this.persistedModelId) && Boolean(getFluxCompat(this.options.backend));
+      // Codex's session capabilities enumerate a narrower model list than the
+      // account can actually use: gpt-5.6-sol/luna/terra come from the live
+      // codex/models catalog the picker reads, but the codex-acp session/new
+      // response drops them. Silently clearing the user's pick then stranded the
+      // header on "Select Model" and ran the default model. Treat the backend as
+      // the source of truth for codex — attempt the switch and let set_model
+      // succeed or surface an honest "falling back" error (handled below).
+      const trustBackendModel = this.options.backend === 'codex';
       if (isFluxOnFluxBackend) {
         // Keep persistedModelId as-is; the env carries the route.
-      } else if (!isModelAvailable) {
+      } else if (!isModelAvailable && !trustBackendModel) {
         mainWarn('[AcpAgentManager]', `Persisted model ${this.persistedModelId} is not in available models, clearing`);
         this.persistedModelId = null;
-      } else if (currentInfo?.currentModelId !== this.persistedModelId) {
+      } else if (!isModelAvailable || currentInfo?.currentModelId !== this.persistedModelId) {
         try {
           await this.agent.setModelByConfigOption(this.persistedModelId);
         } catch (error) {

--- a/src/renderer/pages/conversation/components/ChatConversation.tsx
+++ b/src/renderer/pages/conversation/components/ChatConversation.tsx
@@ -552,7 +552,8 @@ const ChatConversation: React.FC<{
       );
     }
     if (conversation.type === 'codex') {
-      return <AcpModelSelector conversationId={conversation.id} />;
+      const extra = conversation.extra as { backend?: string; currentModelId?: string };
+      return <AcpModelSelector conversationId={conversation.id} initialModelId={extra.currentModelId} />;
     }
     return <GeminiModelSelector disabled={true} />;
   }, [conversation, isGeminiConversation, isWCoreConversation]);

--- a/tests/unit/acpAgentManagerSetModelDurable.test.ts
+++ b/tests/unit/acpAgentManagerSetModelDurable.test.ts
@@ -221,3 +221,58 @@ describe('AcpAgentManager.setModel durable persistence (codex / ACP)', () => {
     expect(agent.setModelByConfigOption).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * restorePersistedState: codex's session/new capabilities enumerate a narrower
+ * model list than the account can use (gpt-5.6-sol/luna/terra come from the live
+ * codex/models catalog the picker reads, but the session drops them). Clearing the
+ * pick when it is absent from that list stranded the conversation header on
+ * "Select Model" and silently ran the default. For codex we now attempt the switch
+ * instead of clearing; other backends keep the strict clear.
+ */
+type RestoreInternals = {
+  agent: { getModelInfo: ReturnType<typeof vi.fn>; setModelByConfigOption: ReturnType<typeof vi.fn> };
+  persistedModelId: string | null;
+  restorePersistedState: () => Promise<void>;
+};
+
+function enumeratingAgent() {
+  // Advertises only gpt-5 — the user's gpt-5.6-terra pick is NOT in the list.
+  return {
+    getModelInfo: vi.fn(() => ({
+      currentModelId: 'gpt-5',
+      currentModelLabel: 'GPT-5',
+      availableModels: [{ id: 'gpt-5', label: 'GPT-5' }],
+      canSwitch: true,
+      source: 'models' as const,
+    })),
+    setModelByConfigOption: vi.fn(() => Promise.resolve(null)),
+  };
+}
+
+describe('AcpAgentManager.restorePersistedState (unenumerated subscription models)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('codex: keeps a pick absent from the session list and attempts the switch (no silent clear)', async () => {
+    const manager = makeManager('codex', { withAgent: enumeratingAgent() });
+    const internals = manager as unknown as RestoreInternals;
+    internals.persistedModelId = 'gpt-5.6-terra';
+
+    await internals.restorePersistedState();
+
+    // The pick survives (header can confirm it) and the backend was asked to switch.
+    expect(internals.persistedModelId).toBe('gpt-5.6-terra');
+    expect(internals.agent.setModelByConfigOption).toHaveBeenCalledWith('gpt-5.6-terra');
+  });
+
+  it('non-codex: still clears a pick the session does not advertise (strict, no switch attempt)', async () => {
+    const manager = makeManager('qwen', { withAgent: enumeratingAgent() });
+    const internals = manager as unknown as RestoreInternals;
+    internals.persistedModelId = 'legacy-only-model';
+
+    await internals.restorePersistedState();
+
+    expect(internals.persistedModelId).toBeNull();
+    expect(internals.agent.setModelByConfigOption).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Codex's codex-acp session/new capabilities enumerate a narrower model list
than the account can actually use: gpt-5.6-sol/luna/terra come from the live
codex/models catalog the picker reads, but the session enumeration drops them.
restorePersistedState() then cleared the user's pick as 'unavailable', stranding
the conversation header on 'Select Model' and silently running the default model.

- AcpAgentManager.restorePersistedState: for codex, attempt the switch via
  setModelByConfigOption instead of clearing. set_model succeeds (the account can
  serve it) so AcpAgentV2.getModelInfo's existing override overlay names it in the
  header; a genuine rejection surfaces the existing honest 'falling back' error
  instead of a silent blank. Other backends keep the strict clear.
- ChatConversation: seed the codex header selector with the conversation's
  currentModelId (parity with the acp path) so it shows the model on load.
- Tests: pin codex keeps-and-switches vs non-codex still-clears.
