### PR TITLE
chore(cowork): pull the Chat/Cowork toggle from the UI for this release

### DIFF
--- a/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/acp/AcpSendBox.tsx
@@ -5,7 +5,6 @@ import type { AcpBackend } from '@/common/types/acpTypes';
 import { uuid } from '@/common/utils';
 import AcpConfigSelector from '@/renderer/components/agent/AcpConfigSelector';
 import AgentModeSelector from '@/renderer/components/agent/AgentModeSelector';
-import CoworkToggle from '@/renderer/components/agent/CoworkToggle';
 import ContextUsageIndicator from '@/renderer/components/agent/ContextUsageIndicator';
 import CommandQueuePanel from '@/renderer/components/chat/CommandQueuePanel';
 import SendBox from '@/renderer/components/chat/sendbox';
@@ -430,7 +429,6 @@ Please check your local CLI tool authentication status`,
                 onModeChanged={isLeaderInTeam ? teamPermission?.propagateMode : undefined}
               />
             )}
-            <CoworkToggle workspace={workspacePath} size='mini' />
             <AcpConfigSelector
               conversationId={conversation_id}
               backend={backend}

--- a/src/renderer/pages/conversation/platforms/gemini/GeminiSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/gemini/GeminiSendBox.tsx
@@ -2,7 +2,6 @@ import { Shield } from 'lucide-react';
 import { ipcBridge } from '@/common';
 import { uuid } from '@/common/utils';
 import AgentModeSelector from '@/renderer/components/agent/AgentModeSelector';
-import CoworkToggle from '@/renderer/components/agent/CoworkToggle';
 import AgentSetupCard from '@/renderer/components/agent/AgentSetupCard';
 import ContextUsageIndicator from '@/renderer/components/agent/ContextUsageIndicator';
 import CommandQueuePanel from '@/renderer/components/chat/CommandQueuePanel';
@@ -472,7 +471,6 @@ const GeminiSendBox: React.FC<{
                 onModeChanged={isLeaderInTeam ? teamPermission?.propagateMode : undefined}
               />
             )}
-            <CoworkToggle workspace={workspacePath} size='mini' />
           </div>
         }
         sendButtonPrefix={

--- a/src/renderer/pages/conversation/platforms/wcore/WCoreSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/wcore/WCoreSendBox.tsx
@@ -8,7 +8,6 @@ import { Shield } from 'lucide-react';
 import { ipcBridge } from '@/common';
 import { uuid } from '@/common/utils';
 import AgentModeSelector from '@/renderer/components/agent/AgentModeSelector';
-import CoworkToggle from '@/renderer/components/agent/CoworkToggle';
 import ContextUsageIndicator from '@/renderer/components/agent/ContextUsageIndicator';
 import CommandQueuePanel from '@/renderer/components/chat/CommandQueuePanel';
 import SendBox from '@/renderer/components/chat/sendbox';
@@ -582,7 +581,6 @@ const WCoreSendBox: React.FC<{
               compactLabelPrefix={t('agentMode.permission')}
               hideCompactLabelPrefixOnMobile
             />
-            <CoworkToggle workspace={workspacePath} size='mini' />
           </div>
         }
         sendButtonPrefix={

--- a/src/renderer/pages/guid/GuidPage.tsx
+++ b/src/renderer/pages/guid/GuidPage.tsx
@@ -885,7 +885,6 @@ const GuidPage: React.FC = () => {
       files={guidInput.files}
       onFilesUploaded={guidInput.handleFilesUploaded}
       onSelectWorkspace={(dir) => guidInput.setDir(dir)}
-      workspace={guidInput.dir}
       modelSelectorNode={modelSelectorNode}
       selectedAgent={agentSelection.selectedAgent}
       effectiveModeAgent={agentSelection.currentEffectiveAgentInfo.agentType}

--- a/src/renderer/pages/guid/components/GuidActionRow.tsx
+++ b/src/renderer/pages/guid/components/GuidActionRow.tsx
@@ -11,7 +11,6 @@ import ComposerAddMenu, {
 } from '@/renderer/pages/conversation/components/composerMenu/ComposerAddMenu';
 import AgentModeSelector from '@/renderer/components/agent/AgentModeSelector';
 import AcpConfigSelector from '@/renderer/components/agent/AcpConfigSelector';
-import CoworkToggle from '@/renderer/components/agent/CoworkToggle';
 import { supportsModeSwitch, type AgentModeOption } from '@/renderer/utils/model/agentModes';
 import type { AcpSessionConfigOption } from '@/common/types/acpTypes';
 import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
@@ -30,8 +29,6 @@ type GuidActionRowProps = {
   files: string[];
   onFilesUploaded: (paths: string[]) => void;
   onSelectWorkspace: (dir: string) => void;
-  /** Currently selected workspace cwd (drives the Chat<->Cowork trust toggle, #671). */
-  workspace?: string;
 
   // Model selector node (rendered by parent)
   modelSelectorNode: React.ReactNode;
@@ -83,7 +80,6 @@ const GuidActionRow: React.FC<GuidActionRowProps> = ({
   files,
   onFilesUploaded,
   onSelectWorkspace,
-  workspace,
   modelSelectorNode,
   selectedAgent,
   effectiveModeAgent,
@@ -248,7 +244,6 @@ const GuidActionRow: React.FC<GuidActionRowProps> = ({
               hideCompactLabelPrefixOnMobile
             />
           )}
-          <CoworkToggle workspace={workspace} size='mini' />
           <AcpConfigSelector
             backend={configOptionsBackend}
             buttonClassName='guid-config-btn'


### PR DESCRIPTION
The Chat/Cowork toggle (#671) is being pulled from the composer for this
desktop release. The concept is being reworked into a stronger 'get shit done'
Cowork assistant in a future version, so shipping the current weak toggle would
only confuse. Removes the <CoworkToggle> render + import from GuidActionRow and
the acp/gemini/wcore send boxes, and drops the now-unused workspace prop from
GuidActionRow (+ its GuidPage caller). The CoworkToggle component and the
workspaceTrust backend are left intact/dormant for the future rework.
