### PR TITLE
TEMP F-01 verification A: docs-only PR must satisfy the required checks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,14 +70,14 @@ You are not prompting a chatbot. You are coworking with a system that remembers 
 
 Grab the latest build for your platform. No account, no sign-up. Every link opens the latest Releases page, where you pick the file for your platform.
 
-| Platform | Architecture | File |
-|----------|--------------|------|
-| **macOS** | Apple Silicon (M1 and up) | [.dmg](https://github.com/ferroxlabs/wayland/releases/latest) |
-| **macOS** | Intel | [.dmg](https://github.com/ferroxlabs/wayland/releases/latest) |
-| **Windows** | x64 | [.exe](https://github.com/ferroxlabs/wayland/releases/latest) |
-| **Windows** | ARM64 | [.exe](https://github.com/ferroxlabs/wayland/releases/latest) |
-| **Linux** | x64 (Debian / Ubuntu) | [.deb](https://github.com/ferroxlabs/wayland/releases/latest) |
-| **Linux** | ARM64 (Debian / Ubuntu) | [.deb](https://github.com/ferroxlabs/wayland/releases/latest) |
+| Platform    | Architecture              | File                                                          |
+| ----------- | ------------------------- | ------------------------------------------------------------- |
+| **macOS**   | Apple Silicon (M1 and up) | [.dmg](https://github.com/ferroxlabs/wayland/releases/latest) |
+| **macOS**   | Intel                     | [.dmg](https://github.com/ferroxlabs/wayland/releases/latest) |
+| **Windows** | x64                       | [.exe](https://github.com/ferroxlabs/wayland/releases/latest) |
+| **Windows** | ARM64                     | [.exe](https://github.com/ferroxlabs/wayland/releases/latest) |
+| **Linux**   | x64 (Debian / Ubuntu)     | [.deb](https://github.com/ferroxlabs/wayland/releases/latest) |
+| **Linux**   | ARM64 (Debian / Ubuntu)   | [.deb](https://github.com/ferroxlabs/wayland/releases/latest) |
 
 The installer bundles the Wayland-Core engine for your platform, so a clean install runs agents the moment you add a provider key.
 
@@ -211,19 +211,19 @@ Set your rules once and every agent follows them, no matter which CLI runs the t
 
 Wayland spawns each CLI in [ACP](https://agentclientprotocol.com) mode and you bring the CLI's own auth. The bundled Wayland-Core engine and Gemini run natively.
 
-| Agent | Command | Connect with |
-|:--|:--|:--|
-| <img src=".github/assets/logos/openclaw.svg" width="20" valign="middle"/> &nbsp;**OpenClaw** | gateway | OpenClaw account |
-| <img src=".github/assets/logos/hermes.svg" width="20" valign="middle"/> &nbsp;**Hermes** (Nous Research) | `hermes acp` | Hermes login |
-| <img src=".github/assets/logos/claude.svg" width="20" valign="middle"/> &nbsp;**Claude Code** | `claude` | Claude login or `ANTHROPIC_API_KEY` |
-| <img src=".github/assets/logos/cursor.png" width="20" valign="middle"/> &nbsp;**Cursor Agent** | `agent` | Cursor subscription |
-| <img src=".github/assets/logos/copilot.png" width="20" valign="middle"/> &nbsp;**GitHub Copilot** | `copilot` | Copilot subscription |
-| <img src=".github/assets/logos/codex.svg" width="20" valign="middle"/> &nbsp;**Codex** (OpenAI) | `codex` | ChatGPT auth or `OPENAI_API_KEY` |
-| <img src=".github/assets/logos/gemini.svg" width="20" valign="middle"/> &nbsp;**Gemini** (Google) | native | Google auth |
-| <img src=".github/assets/logos/goose.png" width="20" valign="middle"/> &nbsp;**Goose** (Block) | `goose acp` | provider key |
-| <img src=".github/assets/logos/qwen.svg" width="20" valign="middle"/> &nbsp;**Qwen Code** | `qwen` | Qwen auth |
-| <img src=".github/assets/logos/opencode.svg" width="20" valign="middle"/> &nbsp;**OpenCode** | `opencode` | provider key |
-| <img src=".github/assets/logos/kimi.svg" width="20" valign="middle"/> &nbsp;**Kimi** (Moonshot) | `kimi` | Kimi login |
+| Agent                                                                                                    | Command      | Connect with                        |
+| :------------------------------------------------------------------------------------------------------- | :----------- | :---------------------------------- |
+| <img src=".github/assets/logos/openclaw.svg" width="20" valign="middle"/> &nbsp;**OpenClaw**             | gateway      | OpenClaw account                    |
+| <img src=".github/assets/logos/hermes.svg" width="20" valign="middle"/> &nbsp;**Hermes** (Nous Research) | `hermes acp` | Hermes login                        |
+| <img src=".github/assets/logos/claude.svg" width="20" valign="middle"/> &nbsp;**Claude Code**            | `claude`     | Claude login or `ANTHROPIC_API_KEY` |
+| <img src=".github/assets/logos/cursor.png" width="20" valign="middle"/> &nbsp;**Cursor Agent**           | `agent`      | Cursor subscription                 |
+| <img src=".github/assets/logos/copilot.png" width="20" valign="middle"/> &nbsp;**GitHub Copilot**        | `copilot`    | Copilot subscription                |
+| <img src=".github/assets/logos/codex.svg" width="20" valign="middle"/> &nbsp;**Codex** (OpenAI)          | `codex`      | ChatGPT auth or `OPENAI_API_KEY`    |
+| <img src=".github/assets/logos/gemini.svg" width="20" valign="middle"/> &nbsp;**Gemini** (Google)        | native       | Google auth                         |
+| <img src=".github/assets/logos/goose.png" width="20" valign="middle"/> &nbsp;**Goose** (Block)           | `goose acp`  | provider key                        |
+| <img src=".github/assets/logos/qwen.svg" width="20" valign="middle"/> &nbsp;**Qwen Code**                | `qwen`       | Qwen auth                           |
+| <img src=".github/assets/logos/opencode.svg" width="20" valign="middle"/> &nbsp;**OpenCode**             | `opencode`   | provider key                        |
+| <img src=".github/assets/logos/kimi.svg" width="20" valign="middle"/> &nbsp;**Kimi** (Moonshot)          | `kimi`       | Kimi login                          |
 
 Plus **Factory Droid**, **Augment**, **CodeBuddy**, **Qoder**, **Kiro**, **Mistral Vibe**, **Snow**, and any custom ACP agent. 16 ACP CLI agents in all, plus native Gemini and the bundled Wayland-Core engine.
 
@@ -285,14 +285,14 @@ The CLI self-updates with `npm update -g @ferroxlabs/wayland-core`, independent 
 
 Wayland runs on your provider credentials. There is no required Wayland-hosted backend to chat.
 
-| What | Where | Notes |
-|---|---|---|
-| Anthropic key | `ANTHROPIC_API_KEY` or in-app | For a Claude subscription with no key, use the Claude Code backend and sign in with the `claude` CLI |
-| OpenAI key | `OPENAI_API_KEY` or in-app | Covers OpenAI-compatible endpoints (DeepSeek, Ollama, and more) |
-| Other providers | in-app | AWS Bedrock, Google Vertex, per-CLI auth for each ACP backend |
-| Flux Router | `FLUX_API_KEY` (`sk-flux-...`) | Optional. Only needed if you route through Flux |
-| Constitution | `~/.wayland/CONSTITUTION.md` | An editable rulebook prepended to every turn, with per-specialist overrides |
-| Data and memory | SQLite under your OS config dir | Your files, chats, and memory stay on disk |
+| What            | Where                           | Notes                                                                                                |
+| --------------- | ------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Anthropic key   | `ANTHROPIC_API_KEY` or in-app   | For a Claude subscription with no key, use the Claude Code backend and sign in with the `claude` CLI |
+| OpenAI key      | `OPENAI_API_KEY` or in-app      | Covers OpenAI-compatible endpoints (DeepSeek, Ollama, and more)                                      |
+| Other providers | in-app                          | AWS Bedrock, Google Vertex, per-CLI auth for each ACP backend                                        |
+| Flux Router     | `FLUX_API_KEY` (`sk-flux-...`)  | Optional. Only needed if you route through Flux                                                      |
+| Constitution    | `~/.wayland/CONSTITUTION.md`    | An editable rulebook prepended to every turn, with per-specialist overrides                          |
+| Data and memory | SQLite under your OS config dir | Your files, chats, and memory stay on disk                                                           |
 
 Engine key resolution order: `--api-key`, then config, then `API_KEY` env, then provider-specific env.
 

--- a/readme.md
+++ b/readme.md
@@ -326,3 +326,5 @@ A hosted **Wayland Pro** with expanded capabilities is on the way. The core you 
 The **code** is AGPL; the **name and logo** are trademarks. Fork freely, just give your fork its own name. You can always say it's "built on Wayland" or "compatible with Wayland." Full policy: [TRADEMARK.md](./TRADEMARK.md).
 
 <sub>Wayland is named after Wayland the Smith, the master craftsman of Norse and Germanic legend, the one who could forge anything. A tip of the hat to the Wayland display server protocol; different project, no affiliation.</sub>
+
+<!-- F-01 gate verification: docs-only diff. -->


### PR DESCRIPTION
Throwaway verification branch for Milestone F-01. Do not merge, do not review. It will be closed and deleted once the gate behaviour is recorded.

Case A of three: the diff is docs-only (readme.md), so the unit shards should not run and the three required Unit Tests checks should report green with the reason stated, while Code Quality still runs for real.