### PR TITLE
TEMP F-01 verification B/C: mixed PR with a failing test must go red

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -326,3 +326,7 @@ A hosted **Wayland Pro** with expanded capabilities is on the way. The core you 
 The **code** is AGPL; the **name and logo** are trademarks. Fork freely, just give your fork its own name. You can always say it's "built on Wayland" or "compatible with Wayland." Full policy: [TRADEMARK.md](./TRADEMARK.md).
 
 <sub>Wayland is named after Wayland the Smith, the master craftsman of Norse and Germanic legend, the one who could forge anything. A tip of the hat to the Wayland display server protocol; different project, no affiliation.</sub>
+
+<!-- F-01 gate verification: docs-only diff. -->
+
+<!-- F-01 gate verification: mixed diff. -->

--- a/tests/unit/gateTruthDeliberateFailure.test.ts
+++ b/tests/unit/gateTruthDeliberateFailure.test.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// TEMPORARY - F-01 gate verification only. This test fails on purpose to prove a
+// required "Unit Tests (<os>)" check reports RED on a mixed PR. Delete with the
+// verification branch.
+import { describe, expect, it } from 'vitest';
+
+describe('F-01 gate verification', () => {
+  it('fails on purpose so the required check must go red', () => {
+    expect('gate').toBe('bypassed');
+  });
+});


### PR DESCRIPTION
Throwaway verification branch for Milestone F-01. Do not merge, do not review. It will be closed and deleted once the gate behaviour is recorded.

Cases B and C of three. The diff is mixed (readme.md plus a deliberately failing unit test), which is exactly the shape that satisfied the old required checks with zero tests run.

Opened as a DRAFT first to record case C: a draft must not report green required checks. Then it gets marked ready for review to record case B: a required Unit Tests check must report red while a unit test is failing.