### PR TITLE
feat(agent): inject multi-provider credentials into wnano spawns (C8)

### DIFF
--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -26,7 +26,7 @@ import type {
   AcpSessionConfigOption,
 } from '@/common/types/acpTypes';
 import { ACP_BACKENDS_ALL, getCurrentWrapperVersion, getFluxCompat } from '@/common/types/acpTypes';
-import { isFluxModelId } from '@/common/config/flux';
+import { FLUX_MODEL_IDS, FLUX_PROVIDER_ID, isFluxModelId } from '@/common/config/flux';
 import { ExtensionRegistry } from '@process/extensions';
 import { getDatabase } from '@process/services/database';
 import { ProviderRepository } from '@process/providers/storage/ProviderRepository';
@@ -89,6 +89,15 @@ import { extractTextFromMessage, processCronInMessage } from './MessageMiddlewar
 import { ConversationTurnCompletionService } from './ConversationTurnCompletionService';
 import { resolveFluxRouting, type FluxRoutingResult, type RoutingDecision } from '@process/task/fluxRouting';
 import { readConnectedFluxKey } from '@process/connectors/fluxKey';
+import {
+  NANO_KNOWN_PROVIDER_IDS,
+  buildWaylandNanoProvidersPayload,
+  buildWnanoOAuthBearerEnv,
+  cleanupWnanoFluxKeyFile,
+  writeWnanoFluxKeyFile,
+  type WnanoOAuthBearerSource,
+  type WnanoProviderEntry,
+} from '@process/task/wnano';
 import type { McpConfigProjection } from '@process/acp/session/McpConfig';
 import { createMcpSessionState, type McpSessionBackend, type McpSessionState } from '@/common/mcp/sessionReceipt';
 import { createMcpSessionDigestKey } from '@process/services/mcpServices/mcpSessionTruthGate';
@@ -834,6 +843,17 @@ ${collectedResponses.join('\n')}`;
       }
     }
 
+    // wnano (C8 provider parity): advertise the connected provider set via
+    // WAYLAND_NANO_PROVIDERS and inject short-lived OAuth bearers. Merged at
+    // the same point as buildConnectedProviderEnv; an explicit custom-agent
+    // env var still wins over the auto-injected values.
+    if (data.backend === 'wnano') {
+      const wnanoEnv = await this.buildWnanoProvidersEnv();
+      for (const [key, value] of Object.entries(wnanoEnv)) {
+        if (!(key in mergedEnv)) mergedEnv[key] = value;
+      }
+    }
+
     // Native (non-Flux) codex spawns: point CODEX_HOME at a Wayland-scoped clone
     // of the user's ~/.codex so we can set the session sandbox mode WITHOUT ever
     // writing the user's own config.toml (#536). The clone copies their config
@@ -987,12 +1007,24 @@ ${collectedResponses.join('\n')}`;
     // resolved (its cached CLI model / configured preferred id) so the routing
     // decision honors the native model instead of blindly routing to Flux.
     const resolvedModelId = selectedModelId ? undefined : await this.resolveBackendModelId(backend);
+    // wnano (C8, Q4 ruling): hand the connected Flux key off as a FILE, never
+    // as FLUX_API_KEY. Written before the routing decision so the emitted
+    // FLUX_API_KEY_FILE points at a live file (atomic write, 0600 on POSIX /
+    // userData ACL on Windows, removed again in kill()). Best-effort: a failed
+    // write yields no path and the wnano arm falls back to 'native' so an
+    // ambient shell FLUX_API_KEY (the documented dev-only fallback) can flow.
+    let fluxKeyFilePath: string | undefined;
+    if (backend === 'wnano' && fluxKey) {
+      fluxKeyFilePath = await writeWnanoFluxKeyFile(app.getPath('userData'), this.conversation_id, fluxKey);
+      if (fluxKeyFilePath) this.wnanoFluxKeyFilePath = fluxKeyFilePath;
+    }
     return resolveFluxRouting({
       backend,
       selectedModelId,
       resolvedModelId,
       fluxConnected: Boolean(fluxKey),
       fluxKey,
+      fluxKeyFilePath,
       routeThroughFlux: Boolean(routeThroughFlux),
     });
   }
@@ -1024,6 +1056,102 @@ ${collectedResponses.join('\n')}`;
   /** The connected flux-router key, or undefined when not connected (R13 safety gate). */
   private async readFluxKey(): Promise<string | undefined> {
     return readConnectedFluxKey();
+  }
+
+  /**
+   * Path of the per-conversation FLUX_API_KEY_FILE written for the most recent
+   * wnano spawn, so kill() can remove it at teardown (C8 lifecycle cleanup).
+   */
+  private wnanoFluxKeyFilePath: string | undefined;
+
+  /**
+   * Build the wnano provider-parity env (C8, design §6.2/§6.3):
+   * `WAYLAND_NANO_PROVIDERS` (the bounded, secret-free advertisement payload)
+   * plus short-lived OAuth bearer vars for advertised OAuth providers. Empty
+   * when nothing is connected - Nano then falls back to Flux-only
+   * advertisement. Never throws; never logs credential material.
+   */
+  private async buildWnanoProvidersEnv(): Promise<Record<string, string>> {
+    const env: Record<string, string> = {};
+    try {
+      const db = await getDatabase();
+      const repo = new ProviderRepository(db.getDriver());
+      const connected = new Set(
+        repo
+          .listRegistryProviders()
+          .filter((provider) => provider.state === 'connected')
+          .map((provider) => provider.providerId)
+      );
+
+      const entries: WnanoProviderEntry[] = [];
+      for (const providerId of NANO_KNOWN_PROVIDER_IDS) {
+        if (!connected.has(providerId)) continue;
+        const stored = repo.getRegistryProviderCreds(providerId);
+        // Stored API-key creds carry the key under `key` (mirrors
+        // buildConnectedProviderEnv); for OAuth-connected xAI this is the
+        // current access token. `hasKey` is advisory UX metadata only.
+        const key = stored.status === 'ok' ? stored.creds.key : undefined;
+        const hasKey = typeof key === 'string' && key.length > 0;
+        // flux-router's model set is Desktop's fixed tier list; Nano owns the
+        // live Flux catalog itself. Every other provider advertises its
+        // persisted registry catalog plus any user-added custom model ids.
+        const models =
+          providerId === FLUX_PROVIDER_ID
+            ? [...FLUX_MODEL_IDS]
+            : [...repo.getRegistryCatalog(providerId).map((model) => model.id), ...repo.listCustomModels(providerId)];
+        entries.push({ provider: providerId, models, hasKey });
+      }
+
+      const payload = buildWaylandNanoProvidersPayload(entries);
+      if (!payload) return env;
+      env.WAYLAND_NANO_PROVIDERS = payload;
+      Object.assign(env, await this.buildWnanoOAuthBearerEnv(entries.map((entry) => entry.provider)));
+    } catch (err) {
+      mainWarn('[AcpAgentManager]', 'buildWnanoProvidersEnv failed', err);
+    }
+    return env;
+  }
+
+  /**
+   * Short-lived OAuth bearer env for wnano spawns (C8, Q1(b) ruling). Desktop
+   * owns refresh; Nano receives the ACCESS token only, plus non-secret expiry
+   * metadata. Refresh tokens are never injected. v1 wires xAI only - the only
+   * Desktop OAuth provider in Nano's known id set (chatgpt-subscription is not
+   * in the set and needs the deferred Responses wire anyway).
+   */
+  private async buildWnanoOAuthBearerEnv(advertisedProviderIds: readonly string[]): Promise<Record<string, string>> {
+    if (!advertisedProviderIds.includes('xai')) return {};
+    try {
+      // Dynamic imports avoid the OAuth module-init cycle (same pattern as the
+      // McpService import in loadCodexSessionMcpServers).
+      const [{ loadXaiTokens }, { xaiRefreshToken }] = await Promise.all([
+        import('@process/onboarding/xaiTokenStore'),
+        import('@process/onboarding/xaiOAuth'),
+      ]);
+      const db = await getDatabase();
+      const repo = new ProviderRepository(db.getDriver());
+      const source: WnanoOAuthBearerSource = {
+        nanoProviderId: 'xai',
+        load: async () => {
+          const stored = await loadXaiTokens();
+          if (!stored?.refreshToken) return null; // API-key-connected xAI: no OAuth bundle
+          const creds = repo.getRegistryProviderCreds('xai');
+          const key = creds.status === 'ok' ? creds.creds.key : undefined;
+          const accessToken = typeof key === 'string' && key.length > 0 ? key : undefined;
+          return { accessToken, expiresAtMs: stored.expiresAt };
+        },
+        refresh: async () => {
+          // xaiRefreshToken prefers the engine-rotated bundle (#391), so this
+          // never races Wayland Core's single-use refresh-token rotation.
+          const result = await xaiRefreshToken();
+          return result.ok;
+        },
+      };
+      return await buildWnanoOAuthBearerEnv(advertisedProviderIds, [source]);
+    } catch (err) {
+      mainWarn('[AcpAgentManager]', 'buildWnanoOAuthBearerEnv failed', err);
+      return {};
+    }
   }
 
   /**
@@ -2632,6 +2760,14 @@ ${collectedResponses.join('\n')}`;
   async kill(_reason?: AgentKillReason): Promise<void> {
     this.flushBufferedStreamTextMessages();
     this.flushThinkingToDb(undefined, 'done');
+
+    // C8: remove the per-conversation FLUX_API_KEY_FILE handoff written for
+    // wnano spawns (lifecycle cleanup). Best-effort; never blocks teardown.
+    if (this.wnanoFluxKeyFilePath) {
+      const keyFile = this.wnanoFluxKeyFilePath;
+      this.wnanoFluxKeyFilePath = undefined;
+      await cleanupWnanoFluxKeyFile(keyFile);
+    }
 
     const BACKEND_SHUTDOWN_TIMEOUT_MS = 12_000;
 

--- a/src/process/task/fluxRouting.ts
+++ b/src/process/task/fluxRouting.ts
@@ -92,6 +92,18 @@ export const RESPONSES_FLUX_BACKENDS = ['codex'] as const;
 export const SCOPED_HOME_FLUX_BACKENDS = ['hermes'] as const;
 
 /**
+ * Backends that receive the connected Flux key via a key FILE handoff (C8
+ * provider parity, Q4 ruling) instead of a `FLUX_API_KEY` env var. wnano
+ * (Wayland Nano) resolves its Flux credential as `FLUX_API_KEY` ->
+ * `FLUX_TEST_KEY` -> the file named by `FLUX_API_KEY_FILE`. Desktop writes the
+ * connected key to a per-conversation file under userData (atomic, 0600 on
+ * POSIX / userData ACL on Windows, cleaned up at teardown) and injects the
+ * PATH - never the secret. `FLUX_API_KEY` stays a documented manual/dev-only
+ * fallback for non-Desktop launches; Desktop never emits it.
+ */
+export const FILE_HANDOFF_FLUX_BACKENDS = ['wnano'] as const;
+
+/**
  * Native codex/OpenAI key vars stripped before a flux-routed codex spawn, so it
  * never also carries the user's native credentials (mutual exclusivity).
  * FLUX_API_KEY is deliberately NOT here.
@@ -126,6 +138,13 @@ export type FluxRoutingContext = {
   resolvedModelId?: string;
   fluxConnected: boolean;
   fluxKey: string | undefined;
+  /**
+   * Absolute path of the Desktop-written Flux key file (FILE_HANDOFF backends
+   * only). AcpAgentManager writes the connected key to this file before
+   * computing the routing decision; the path - never the key - is what the
+   * routing result emits as `FLUX_API_KEY_FILE`.
+   */
+  fluxKeyFilePath?: string;
   routeThroughFlux: boolean;
 };
 
@@ -149,8 +168,33 @@ export function resolveFluxRouting(ctx: FluxRoutingContext): FluxRoutingResult {
   const isAnthropic = (ANTHROPIC_FLUX_BACKENDS as readonly string[]).includes(ctx.backend);
   const isResponses = (RESPONSES_FLUX_BACKENDS as readonly string[]).includes(ctx.backend);
   const isScopedHome = (SCOPED_HOME_FLUX_BACKENDS as readonly string[]).includes(ctx.backend);
-  if (!isOpenAi && !isAnthropic && !isResponses && !isScopedHome) return UNKNOWN();
+  const isFileHandoff = (FILE_HANDOFF_FLUX_BACKENDS as readonly string[]).includes(ctx.backend);
+  if (!isOpenAi && !isAnthropic && !isResponses && !isScopedHome && !isFileHandoff) return UNKNOWN();
   if (!ctx.fluxConnected || !ctx.fluxKey) return NATIVE();
+
+  if (isFileHandoff) {
+    // wnano does its OWN per-provider routing + credential resolution, so the
+    // handoff is unconditional (not gated on the selected model or the global
+    // toggle): every wnano spawn gets the connected Flux key whenever one
+    // exists, independent of which provider's model the chat is bound to.
+    //
+    // Mutual exclusivity, wnano-style: the connected key (via the file) must
+    // win over a stale shell-exported FLUX_API_KEY/FLUX_TEST_KEY, exactly as
+    // the other arms strip native keys so their flux surface wins. Native
+    // PROVIDER keys (OPENAI_API_KEY, ...) are deliberately NOT stripped here -
+    // unlike the surface arms, wnano consumes them as its multi-provider
+    // credentials (C8: WAYLAND_NANO_PROVIDERS + buildConnectedProviderEnv).
+    //
+    // Without a written key file (write failed / no path) there is nothing to
+    // hand off: fall back to 'native' so Nano can still pick up an ambient
+    // FLUX_API_KEY from the user's shell (the documented dev-only fallback).
+    if (!ctx.fluxKeyFilePath) return NATIVE();
+    return {
+      routing: 'flux',
+      env: { FLUX_API_KEY_FILE: ctx.fluxKeyFilePath },
+      stripKeys: ['FLUX_API_KEY', 'FLUX_TEST_KEY'],
+    };
+  }
 
   // L3 (R5 rule 1: an explicit per-chat pick wins). The picker feeds explicit
   // model ids per chat - a flux-* alias OR a native model id. When there is no

--- a/src/process/task/wnano/fluxKeyFile.ts
+++ b/src/process/task/wnano/fluxKeyFile.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * `FLUX_API_KEY_FILE` handoff for wnano (Wayland Nano) spawns (C8 provider
+ * parity, design §6.1 / Q4 ruling).
+ *
+ * Nano resolves its Flux credential as `FLUX_API_KEY` -> `FLUX_TEST_KEY` ->
+ * the file named by `FLUX_API_KEY_FILE`. Desktop NEVER emits `FLUX_API_KEY`
+ * (it stays a documented manual/dev-only fallback for non-Desktop launches);
+ * instead it writes the connected Flux key to a per-conversation file under
+ * userData and hands Nano the PATH - never the secret - via the env var.
+ *
+ * Guarantees (mirroring `codexAuthFile.ts`):
+ *  - ATOMIC write: write to a temp sibling, then rename over the target.
+ *  - Mode 0600 on POSIX. On Windows POSIX mode bits are fiction, so the
+ *    guarantee there is the userData directory ACL (which is already
+ *    user-scoped); no POSIX-style bit check is attempted on Windows.
+ *  - Lifecycle cleanup: the file is deleted when the spawn/agent is torn down
+ *    (AcpAgentManager.kill).
+ *  - The key value is NEVER logged - these functions return paths/booleans
+ *    only and swallow write errors so a failed handoff degrades to Nano's
+ *    ambient-env fallback instead of crashing the spawn.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/** Subdirectory under userData holding the per-conversation Flux key files. */
+const WNANO_KEY_DIR = 'wnano';
+
+/**
+ * Absolute path of the Flux key file for one wnano conversation. The
+ * conversation id is filename-sanitized so each concurrent wnano spawn gets
+ * its own file and one teardown can never delete another spawn's credential.
+ */
+export function wnanoFluxKeyFilePath(userDataDir: string, conversationId: string): string {
+  const safeId = conversationId.replace(/[^A-Za-z0-9_-]/g, '_') || 'default';
+  return path.join(userDataDir, WNANO_KEY_DIR, `flux-api-key-${safeId}`);
+}
+
+/**
+ * Atomically write the connected Flux key to its handoff file (dir 0o700,
+ * file 0o600 on POSIX; userData directory ACL on Windows) and return the
+ * absolute path to inject as `FLUX_API_KEY_FILE`. Returns `undefined` on any
+ * failure. Never throws, never logs the key.
+ */
+export async function writeWnanoFluxKeyFile(
+  userDataDir: string,
+  conversationId: string,
+  fluxKey: string
+): Promise<string | undefined> {
+  if (fluxKey.length === 0) return undefined;
+  try {
+    const file = wnanoFluxKeyFilePath(userDataDir, conversationId);
+    await fs.promises.mkdir(path.dirname(file), { recursive: true, mode: 0o700 });
+    const tmp = `${file}.tmp-${process.pid}`;
+    await fs.promises.writeFile(tmp, fluxKey, { mode: 0o600 });
+    await fs.promises.rename(tmp, file);
+    // rename preserves the temp file's mode, but chmod again defensively in
+    // case an existing target's perms lingered on some platforms.
+    await fs.promises.chmod(file, 0o600);
+    return file;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Best-effort deletion of a handoff file at spawn/agent teardown. Never
+ * throws - a leftover file is inert (userData-scoped, 0600) and is overwritten
+ * atomically on the next spawn of the same conversation.
+ */
+export async function cleanupWnanoFluxKeyFile(filePath: string): Promise<void> {
+  try {
+    await fs.promises.rm(filePath, { force: true });
+  } catch {
+    // Already gone / unlink failed - nothing to do.
+  }
+}

--- a/src/process/task/wnano/index.ts
+++ b/src/process/task/wnano/index.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * wnano (Wayland Nano) spawn support: the Desktop half of C8 provider parity.
+ * See `C8-provider-parity-design.md` §5-§8 for the env contract these modules
+ * implement (`FLUX_API_KEY_FILE`, `WAYLAND_NANO_PROVIDERS`,
+ * `WAYLAND_NANO_OAUTH_BEARER_*`).
+ */
+
+export {
+  NANO_KNOWN_PROVIDER_IDS,
+  WNANO_PROVIDERS_MAX_BYTES,
+  WNANO_PROVIDERS_MAX_ENTRIES,
+  WNANO_PROVIDERS_MAX_ID_CHARS,
+  WNANO_PROVIDERS_MAX_MODELS_PER_PROVIDER,
+  buildWaylandNanoProvidersPayload,
+  type NanoKnownProviderId,
+  type WnanoProviderEntry,
+} from './providersPayload';
+export { cleanupWnanoFluxKeyFile, wnanoFluxKeyFilePath, writeWnanoFluxKeyFile } from './fluxKeyFile';
+export {
+  WNANO_OAUTH_REFRESH_THRESHOLD_SECS,
+  buildWnanoOAuthBearerEnv,
+  normalizeWnanoBearerEnvSuffix,
+  type WnanoOAuthBearerSnapshot,
+  type WnanoOAuthBearerSource,
+} from './oauthBearer';

--- a/src/process/task/wnano/oauthBearer.ts
+++ b/src/process/task/wnano/oauthBearer.ts
@@ -1,0 +1,130 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Short-lived OAuth bearer injection for wnano (Wayland Nano) spawns (C8
+ * provider parity, design §6.3 / Q1(b) ruling).
+ *
+ * Desktop owns every OAuth flow and token store; Nano NEVER reads
+ * `~/.codex/auth.json` or `$WAYLAND_HOME/oauth/xai.json`, never sees a refresh
+ * token, and never writes a token store. At spawn time, for each connected
+ * OAuth provider that is advertised in the `WAYLAND_NANO_PROVIDERS` payload,
+ * Desktop refreshes the access token ONLY when its remaining lifetime is below
+ * {@link WNANO_OAUTH_REFRESH_THRESHOLD_SECS} (avoids refresh churn) and injects:
+ *
+ *  - `WAYLAND_NANO_OAUTH_BEARER_<NORMALIZED_ID>` - the ACCESS token only.
+ *  - `WAYLAND_NANO_OAUTH_BEARER_<NORMALIZED_ID>_EXPIRES_AT_UNIX_SECS` - the
+ *    non-secret expiry, so Nano can pre-fail with `oauth_expired` instead of
+ *    dispatching a doomed turn.
+ *
+ * `NORMALIZED_ID` is the provider id uppercased with every char outside
+ * [A-Z0-9] replaced by `_` (e.g. `google-gemini` -> `GOOGLE_GEMINI`).
+ *
+ * v1 reach: `xai` is the only wired source (the only Desktop OAuth provider in
+ * Nano's known id set; ChatGPT's `chatgpt-subscription` id is not in the set
+ * and needs the deferred Responses wire anyway). xAI also keeps working via
+ * the `XAI_API_KEY` that `buildConnectedProviderEnv` already injects - the
+ * bearer is the expiry-aware path on top.
+ */
+
+/** Refresh the access token at spawn only when fewer than this many seconds remain. */
+export const WNANO_OAUTH_REFRESH_THRESHOLD_SECS = 600;
+
+/** A read of a provider's current OAuth credential. Never carries the refresh token. */
+export type WnanoOAuthBearerSnapshot = {
+  /** The current short-lived access token (secret). */
+  accessToken?: string;
+  /** Epoch MILLISECONDS when the access token expires. */
+  expiresAtMs?: number;
+};
+
+/**
+ * One OAuth-backed credential source, wired by the caller to Desktop's token
+ * stores. Dependencies are injected so the decision logic stays pure/testable.
+ */
+export type WnanoOAuthBearerSource = {
+  /** Provider id exactly as advertised in the `WAYLAND_NANO_PROVIDERS` payload. */
+  nanoProviderId: string;
+  /** Read the current access token + expiry. Null/absent fields = no usable credential. */
+  load: () => Promise<WnanoOAuthBearerSnapshot | null>;
+  /**
+   * Exchange the stored refresh token for a fresh access token and persist it.
+   * Resolves true when a fresh token was obtained (a subsequent `load()` must
+   * reflect it); false on any failure. Never rejects.
+   */
+  refresh: () => Promise<boolean>;
+};
+
+/** Map a provider id onto its bearer env-var suffix: uppercase, [^A-Z0-9] -> '_'. */
+export function normalizeWnanoBearerEnvSuffix(providerId: string): string {
+  return providerId.toUpperCase().replace(/[^A-Z0-9]/g, '_');
+}
+
+/**
+ * Build the bearer env for a wnano spawn. Only sources whose provider id is
+ * advertised in the payload are considered. A source emits nothing when it has
+ * no access token, when its expiry is unknown (the expiry metadata is part of
+ * the contract, so an unbounded token is never injected), or when a required
+ * refresh fails - the spawn proceeds and Nano fails closed at dispatch time.
+ * Two sources normalizing to the same env suffix are a config bug: the first
+ * wins and the colliding source is skipped (never a silently overwritten var).
+ * Never throws; never logs token material.
+ */
+export async function buildWnanoOAuthBearerEnv(
+  advertisedProviderIds: readonly string[],
+  sources: readonly WnanoOAuthBearerSource[],
+  nowMs: number = Date.now()
+): Promise<Record<string, string>> {
+  const advertised = new Set(advertisedProviderIds);
+  const usedSuffixes = new Set<string>();
+  // Only advertised providers are considered. Two sources normalizing to the
+  // same env suffix are a config bug: the first wins and the colliding source
+  // is skipped (never a silently overwritten var).
+  const eligible = sources.filter((source) => {
+    if (!advertised.has(source.nanoProviderId)) return false;
+    const suffix = normalizeWnanoBearerEnvSuffix(source.nanoProviderId);
+    if (usedSuffixes.has(suffix)) return false;
+    usedSuffixes.add(suffix);
+    return true;
+  });
+
+  const parts = await Promise.all(eligible.map((source) => buildSourceBearerEnv(source, nowMs)));
+  return Object.assign({}, ...parts);
+}
+
+/**
+ * Resolve one source's bearer env. Emits nothing when the source has no
+ * access token, when its expiry is unknown (the expiry metadata is part of the
+ * contract, so an unbounded token is never injected), or when a required
+ * refresh fails - the spawn proceeds and Nano fails closed at dispatch time.
+ * Never throws; never logs token material.
+ */
+async function buildSourceBearerEnv(source: WnanoOAuthBearerSource, nowMs: number): Promise<Record<string, string>> {
+  try {
+    let snapshot = await source.load();
+    if (!snapshot?.accessToken) return {};
+
+    const remainingSecs = snapshot.expiresAtMs !== undefined ? (snapshot.expiresAtMs - nowMs) / 1000 : undefined;
+    if (remainingSecs !== undefined && remainingSecs < WNANO_OAUTH_REFRESH_THRESHOLD_SECS) {
+      if (!(await source.refresh())) return {};
+      snapshot = await source.load();
+      if (!snapshot?.accessToken) return {};
+    }
+
+    // The expiry metadata is contractual: never inject a bearer whose expiry
+    // Desktop cannot state (Nano would be unable to pre-fail on expiry).
+    if (snapshot.expiresAtMs === undefined) return {};
+
+    const suffix = normalizeWnanoBearerEnvSuffix(source.nanoProviderId);
+    return {
+      [`WAYLAND_NANO_OAUTH_BEARER_${suffix}`]: snapshot.accessToken,
+      [`WAYLAND_NANO_OAUTH_BEARER_${suffix}_EXPIRES_AT_UNIX_SECS`]: String(Math.floor(snapshot.expiresAtMs / 1000)),
+    };
+  } catch {
+    // A failing source must never abort the spawn - skip it.
+    return {};
+  }
+}

--- a/src/process/task/wnano/providersPayload.ts
+++ b/src/process/task/wnano/providersPayload.ts
@@ -1,0 +1,126 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Builder for the `WAYLAND_NANO_PROVIDERS` env payload injected into every
+ * wnano (Wayland Nano) spawn (C8 provider parity, design §5/§6.2).
+ *
+ * The payload is a JSON array of `{ provider, models, hasKey }` telling Nano
+ * which providers to advertise and route. It is UNTRUSTED-adjacent metadata:
+ *
+ *  - It carries NO secrets and NO endpoint/routing fields. Entries are rebuilt
+ *    from scratch with exactly the three contract keys, so a `baseUrl`,
+ *    `apiPath`, env-var name, or any other field on an input entry can never
+ *    leak into the serialized payload. Endpoint authority is solely Nano's
+ *    vendored catalog table.
+ *  - Provider ids are constrained to Nano's known set
+ *    ({@link NANO_KNOWN_PROVIDER_IDS}); anything else is dropped.
+ *  - Bounds mirror Nano's validation limits exactly: <= 64 entries, <= 256
+ *    model ids per provider, <= 128 chars per id, <= 32 KiB serialized.
+ *    Overflow is dropped/trimmed DETERMINISTICALLY (never exceeded).
+ *  - Model ids are deduplicated (first occurrence wins) and the output order
+ *    is deterministic: Nano's known-set order for providers, input order for
+ *    each provider's models.
+ *
+ * `hasKey` is advisory UX metadata only (Nano re-resolves real credentials at
+ * `set_model`/dispatch time and never trusts this flag).
+ */
+
+/** Provider ids Nano's vendored catalog table knows (v1 scope, design §2/Q3). */
+export const NANO_KNOWN_PROVIDER_IDS = [
+  'flux-router',
+  'anthropic',
+  'openai',
+  'openrouter',
+  'groq',
+  'mistral',
+  'deepseek',
+  'together',
+  'fireworks',
+  'perplexity',
+  'cohere',
+  'cerebras',
+  'xai',
+  'moonshot',
+  'nvidia',
+  'minimax',
+  'google-gemini',
+] as const;
+
+export type NanoKnownProviderId = (typeof NANO_KNOWN_PROVIDER_IDS)[number];
+
+/** One candidate entry gathered from Desktop's model registry. */
+export type WnanoProviderEntry = {
+  provider: string;
+  models: string[];
+  hasKey: boolean;
+};
+
+/** Hard bounds mirrored from Nano's payload validation (design §5). */
+export const WNANO_PROVIDERS_MAX_ENTRIES = 64;
+export const WNANO_PROVIDERS_MAX_MODELS_PER_PROVIDER = 256;
+export const WNANO_PROVIDERS_MAX_ID_CHARS = 128;
+export const WNANO_PROVIDERS_MAX_BYTES = 32 * 1024;
+
+const KNOWN_ID_SET: ReadonlySet<string> = new Set(NANO_KNOWN_PROVIDER_IDS);
+
+/**
+ * Serialize the bounded `WAYLAND_NANO_PROVIDERS` payload for a wnano spawn.
+ * Returns `undefined` when no entry survives sanitization (the env var is then
+ * simply not injected, and Nano falls back to Flux-only advertisement).
+ * Pure - no I/O, no secrets.
+ */
+export function buildWaylandNanoProvidersPayload(entries: readonly WnanoProviderEntry[]): string | undefined {
+  const byProvider = new Map<string, WnanoProviderEntry>();
+  for (const entry of entries) {
+    if (!KNOWN_ID_SET.has(entry.provider)) continue;
+    // First occurrence wins - keeps the output independent of duplicate input.
+    if (!byProvider.has(entry.provider)) byProvider.set(entry.provider, entry);
+  }
+
+  // Deterministic order: Nano's known-set order, not input/enumeration order.
+  const sanitized: WnanoProviderEntry[] = [];
+  for (const providerId of NANO_KNOWN_PROVIDER_IDS) {
+    if (sanitized.length >= WNANO_PROVIDERS_MAX_ENTRIES) break;
+    const entry = byProvider.get(providerId);
+    if (!entry) continue;
+    sanitized.push({ provider: entry.provider, models: sanitizeModelIds(entry.models), hasKey: entry.hasKey });
+  }
+
+  // Serialized-size bound: drop trailing providers first; if a single provider
+  // still exceeds the cap, trim its model list from the end. Deterministic.
+  while (sanitized.length > 0) {
+    if (Buffer.byteLength(JSON.stringify(sanitized), 'utf8') <= WNANO_PROVIDERS_MAX_BYTES) break;
+    const last = sanitized[sanitized.length - 1];
+    if (sanitized.length === 1 && last.models.length > 0) {
+      last.models.pop();
+    } else {
+      sanitized.pop();
+    }
+  }
+
+  if (sanitized.length === 0) return undefined;
+  return JSON.stringify(sanitized);
+}
+
+/**
+ * Keep only usable model ids: non-empty strings of <= 128 chars, deduplicated
+ * (first wins), capped at 256 per provider.
+ */
+function sanitizeModelIds(models: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const model of models) {
+    if (out.length >= WNANO_PROVIDERS_MAX_MODELS_PER_PROVIDER) break;
+    if (typeof model !== 'string') continue;
+    const id = model.trim();
+    if (id.length === 0 || id.length > WNANO_PROVIDERS_MAX_ID_CHARS) continue;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+  }
+  return out;
+}

--- a/tests/unit/AcpModelSelectorWnanoColonId.dom.test.tsx
+++ b/tests/unit/AcpModelSelectorWnanoColonId.dom.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * C8 Q2 build condition: `<provider>:<model>` colon ids (e.g.
+ * `openai:gpt-5.6-terra`) must round-trip through the ACP model picker
+ * untouched - advertise -> render -> select -> `session/set_model` echo -
+ * while the picker displays the human-friendly `name`. wnano advertises
+ * non-Flux models with namespaced ids so its Rust side can route
+ * unambiguously; Desktop must never parse, split, or rewrite them.
+ */
+
+import React from 'react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const ipcMock = vi.hoisted(() => ({
+  getModelInfo: vi.fn(),
+  setModel: vi.fn(),
+  onResponseStream: vi.fn(() => () => {}),
+  getModelConfig: vi.fn().mockResolvedValue([]),
+  curatedForAgent: vi.fn().mockResolvedValue([]),
+  queryRecentlyUsedModels: vi.fn().mockResolvedValue([]),
+  registryList: vi.fn().mockResolvedValue([]),
+  registryListChanged: vi.fn(() => () => {}),
+  conversationGet: vi.fn().mockResolvedValue(null),
+  conversationUpdate: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    acpConversation: {
+      getModelInfo: { invoke: ipcMock.getModelInfo },
+      setModel: { invoke: ipcMock.setModel },
+      responseStream: { on: ipcMock.onResponseStream },
+    },
+    mode: {
+      getModelConfig: { invoke: ipcMock.getModelConfig },
+    },
+    usage: {
+      queryRecentlyUsedModels: { invoke: ipcMock.queryRecentlyUsedModels },
+    },
+    conversation: {
+      get: { invoke: ipcMock.conversationGet },
+      update: { invoke: ipcMock.conversationUpdate },
+    },
+  },
+}));
+
+vi.mock('@/common/adapter/ipcBridge', () => ({
+  modelRegistry: {
+    list: { invoke: ipcMock.registryList },
+    listChanged: { on: ipcMock.registryListChanged },
+    curatedForAgent: { invoke: ipcMock.curatedForAgent },
+  },
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('@/common/config/storage', () => ({
+  ConfigStorage: {
+    get: vi.fn().mockResolvedValue(null),
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | { defaultValue?: string }) => {
+      if (typeof fallback === 'string') return fallback || key;
+      if (fallback && typeof fallback === 'object' && fallback.defaultValue) return fallback.defaultValue;
+      return key;
+    },
+  }),
+}));
+
+vi.mock('swr', () => ({
+  default: () => ({ data: [], error: undefined, mutate: vi.fn() }),
+}));
+
+import AcpModelSelector from '../../src/renderer/components/agent/AcpModelSelector';
+
+const COLON_ID = 'openai:gpt-5.6-terra';
+const COLON_LABEL = 'GPT-5.6 Terra (OpenAI)';
+
+/** The models block wnano advertises on session/new: bare Flux id + colon ids. */
+const WNANO_MODEL_INFO = {
+  currentModelId: 'flux-auto',
+  currentModelLabel: 'Flux Auto',
+  availableModels: [
+    { id: 'flux-auto', label: 'Flux Auto' },
+    { id: COLON_ID, label: COLON_LABEL },
+    { id: 'anthropic:claude-opus-4-8', label: 'Claude Opus 4.8 (Anthropic)' },
+  ],
+  canSwitch: true,
+  source: 'models',
+  sourceDetail: 'wnano',
+};
+
+describe('AcpModelSelector wnano colon-id round-trip (C8 Q2)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ipcMock.getModelConfig.mockResolvedValue([]);
+    ipcMock.registryList.mockResolvedValue([]);
+    ipcMock.getModelInfo.mockResolvedValue({ success: true, data: { modelInfo: WNANO_MODEL_INFO } });
+    // The agent echoes the pick back unchanged (session/set_model response).
+    ipcMock.setModel.mockResolvedValue({
+      success: true,
+      data: { modelInfo: { ...WNANO_MODEL_INFO, currentModelId: COLON_ID, currentModelLabel: COLON_LABEL } },
+    });
+  });
+
+  it('sends session/set_model with the exact colon id, untouched', async () => {
+    render(<AcpModelSelector conversationId='conv-wnano' backend='wnano' />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/Flux Auto/).length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(screen.getByRole('button'));
+    await waitFor(() => {
+      expect(screen.getByText(COLON_LABEL)).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText(COLON_LABEL));
+
+    await waitFor(() => {
+      expect(ipcMock.setModel).toHaveBeenCalledWith({ conversationId: 'conv-wnano', modelId: COLON_ID });
+    });
+  });
+
+  it('displays the human-friendly name, not the raw colon id', async () => {
+    render(<AcpModelSelector conversationId='conv-wnano' backend='wnano' />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/Flux Auto/).length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(screen.getByRole('button'));
+    await waitFor(() => {
+      expect(screen.getByText(COLON_LABEL)).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText(COLON_LABEL));
+
+    // After the agent echoes the pick, the friendly label is what renders -
+    // the raw colon id never becomes the visible label.
+    await waitFor(() => {
+      expect(screen.getAllByText(new RegExp(COLON_LABEL.replace(/[()]/g, (c) => `\\${c}`))).length).toBeGreaterThan(0);
+    });
+    expect(screen.queryByText(COLON_ID)).toBeNull();
+  });
+
+  it('renders every advertised colon id as a selectable row (ids never parsed or split)', async () => {
+    render(<AcpModelSelector conversationId='conv-wnano' backend='wnano' />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/Flux Auto/).length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(screen.getByRole('button'));
+    await waitFor(() => {
+      expect(screen.getByText(COLON_LABEL)).toBeTruthy();
+      expect(screen.getByText('Claude Opus 4.8 (Anthropic)')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText('Claude Opus 4.8 (Anthropic)'));
+
+    await waitFor(() => {
+      expect(ipcMock.setModel).toHaveBeenCalledWith({
+        conversationId: 'conv-wnano',
+        modelId: 'anthropic:claude-opus-4-8',
+      });
+    });
+  });
+});

--- a/tests/unit/task/wnano/fluxKeyFile.test.ts
+++ b/tests/unit/task/wnano/fluxKeyFile.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { cleanupWnanoFluxKeyFile, wnanoFluxKeyFilePath, writeWnanoFluxKeyFile } from '@process/task/wnano';
+
+const SYNTHETIC_KEY = 'sk-flux-SYNTHETIC-test-key';
+
+let userDataDir: string | undefined;
+
+async function makeUserDataDir(): Promise<string> {
+  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'wnano-keyfile-test-'));
+  userDataDir = dir;
+  return dir;
+}
+
+afterEach(async () => {
+  if (userDataDir) {
+    await fs.promises.rm(userDataDir, { recursive: true, force: true });
+    userDataDir = undefined;
+  }
+});
+
+describe('wnano FLUX_API_KEY_FILE handoff (C8 Q4)', () => {
+  it('writes the key under userData and returns the absolute path to inject', async () => {
+    const dir = await makeUserDataDir();
+    const file = await writeWnanoFluxKeyFile(dir, 'conv-1', SYNTHETIC_KEY);
+    expect(file).toBe(wnanoFluxKeyFilePath(dir, 'conv-1'));
+    expect(path.isAbsolute(file!)).toBe(true);
+    await expect(fs.promises.readFile(file!, 'utf8')).resolves.toBe(SYNTHETIC_KEY);
+  });
+
+  it('writes atomically: no temp sibling is left behind after the rename', async () => {
+    const dir = await makeUserDataDir();
+    const file = (await writeWnanoFluxKeyFile(dir, 'conv-1', SYNTHETIC_KEY))!;
+    const siblings = await fs.promises.readdir(path.dirname(file));
+    expect(siblings).toEqual([path.basename(file)]);
+  });
+
+  it('overwrites a stale key file atomically on respawn', async () => {
+    const dir = await makeUserDataDir();
+    await writeWnanoFluxKeyFile(dir, 'conv-1', 'sk-flux-STALE');
+    const file = (await writeWnanoFluxKeyFile(dir, 'conv-1', SYNTHETIC_KEY))!;
+    await expect(fs.promises.readFile(file, 'utf8')).resolves.toBe(SYNTHETIC_KEY);
+  });
+
+  it('is mode 0600 on POSIX (Windows relies on the userData directory ACL instead)', async () => {
+    if (process.platform === 'win32') {
+      // POSIX mode bits are fiction on Windows; the guarantee there is the
+      // user-scoped userData directory ACL, so there is no bit check to run.
+      return;
+    }
+    const dir = await makeUserDataDir();
+    const file = (await writeWnanoFluxKeyFile(dir, 'conv-1', SYNTHETIC_KEY))!;
+    const mode = (await fs.promises.stat(file)).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it('gives each conversation its own file (one teardown cannot strand another spawn)', async () => {
+    const dir = await makeUserDataDir();
+    const a = (await writeWnanoFluxKeyFile(dir, 'conv-a', 'sk-flux-A'))!;
+    const b = (await writeWnanoFluxKeyFile(dir, 'conv-b', 'sk-flux-B'))!;
+    expect(a).not.toBe(b);
+    await cleanupWnanoFluxKeyFile(a);
+    await expect(fs.promises.access(a)).rejects.toThrow();
+    await expect(fs.promises.readFile(b, 'utf8')).resolves.toBe('sk-flux-B');
+  });
+
+  it('sanitizes hostile conversation ids into a safe file name inside userData', async () => {
+    const dir = await makeUserDataDir();
+    const file = (await writeWnanoFluxKeyFile(dir, '../../etc/evil', SYNTHETIC_KEY))!;
+    expect(path.dirname(file)).toBe(path.join(dir, 'wnano'));
+  });
+
+  it('cleanup removes the file at teardown and never throws on a missing file', async () => {
+    const dir = await makeUserDataDir();
+    const file = (await writeWnanoFluxKeyFile(dir, 'conv-1', SYNTHETIC_KEY))!;
+    await cleanupWnanoFluxKeyFile(file);
+    await expect(fs.promises.access(file)).rejects.toThrow();
+    await expect(cleanupWnanoFluxKeyFile(file)).resolves.toBeUndefined();
+  });
+
+  it('refuses an empty key and never creates a file for it', async () => {
+    const dir = await makeUserDataDir();
+    await expect(writeWnanoFluxKeyFile(dir, 'conv-1', '')).resolves.toBeUndefined();
+    expect(fs.existsSync(wnanoFluxKeyFilePath(dir, 'conv-1'))).toBe(false);
+  });
+
+  it('returns undefined (never throws) when the target directory is not writable', async () => {
+    const dir = await makeUserDataDir();
+    // A regular file where the key directory must be created forces the write to fail.
+    await fs.promises.writeFile(path.join(dir, 'wnano'), 'occupied');
+    await expect(writeWnanoFluxKeyFile(dir, 'conv-1', SYNTHETIC_KEY)).resolves.toBeUndefined();
+  });
+});

--- a/tests/unit/task/wnano/fluxRoutingWnano.test.ts
+++ b/tests/unit/task/wnano/fluxRoutingWnano.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { resolveFluxRouting, FILE_HANDOFF_FLUX_BACKENDS } from '@process/task/fluxRouting';
+
+const ctx = (over = {}) => ({
+  backend: 'wnano',
+  selectedModelId: undefined,
+  fluxConnected: true,
+  fluxKey: 'sk-flux-test',
+  fluxKeyFilePath: '/userdata/wnano/flux-api-key-conv-1',
+  routeThroughFlux: false,
+  ...over,
+});
+
+describe('resolveFluxRouting wnano arm (C8 FLUX_API_KEY_FILE handoff)', () => {
+  it('emits FLUX_API_KEY_FILE (the path, never the secret)', () => {
+    const out = resolveFluxRouting(ctx());
+    expect(out.routing).toBe('flux');
+    expect(out.env).toEqual({ FLUX_API_KEY_FILE: '/userdata/wnano/flux-api-key-conv-1' });
+  });
+
+  it('never emits FLUX_API_KEY, even though a connected key exists', () => {
+    const out = resolveFluxRouting(ctx());
+    expect(out.env.FLUX_API_KEY).toBeUndefined();
+    expect(JSON.stringify(out.env)).not.toContain('sk-flux-test');
+  });
+
+  it('strips ambient FLUX_API_KEY/FLUX_TEST_KEY so the connected key file wins (mutual exclusivity)', () => {
+    const out = resolveFluxRouting(ctx());
+    expect(out.stripKeys).toContain('FLUX_API_KEY');
+    expect(out.stripKeys).toContain('FLUX_TEST_KEY');
+  });
+
+  it('does NOT strip native provider keys - wnano consumes them as its multi-provider credentials', () => {
+    const out = resolveFluxRouting(ctx());
+    expect(out.stripKeys).not.toContain('OPENAI_API_KEY');
+    expect(out.stripKeys).not.toContain('ANTHROPIC_API_KEY');
+    expect(out.stripKeys).not.toContain('XAI_API_KEY');
+  });
+
+  it('hands off unconditionally: a non-flux model pick and toggle off still get the file', () => {
+    const out = resolveFluxRouting(ctx({ selectedModelId: 'openai:gpt-5.6-terra', routeThroughFlux: false }));
+    expect(out.routing).toBe('flux');
+    expect(out.env.FLUX_API_KEY_FILE).toBe('/userdata/wnano/flux-api-key-conv-1');
+  });
+
+  it('keeps the routing decision stable across model switches (no respawn churn)', () => {
+    const fluxModel = resolveFluxRouting(ctx({ selectedModelId: 'flux-auto' }));
+    const colonModel = resolveFluxRouting(ctx({ selectedModelId: 'anthropic:claude-opus-4-8' }));
+    expect(fluxModel.routing).toBe('flux');
+    expect(colonModel.routing).toBe(fluxModel.routing);
+  });
+
+  it('falls back to native when the key file could not be written (ambient-env fallback)', () => {
+    const out = resolveFluxRouting(ctx({ fluxKeyFilePath: undefined }));
+    expect(out.routing).toBe('native');
+    expect(out.env).toEqual({});
+    expect(out.stripKeys).toEqual([]);
+  });
+
+  it('stays native when flux is not connected (ambient FLUX_API_KEY dev fallback flows)', () => {
+    const out = resolveFluxRouting(ctx({ fluxConnected: false, fluxKey: undefined }));
+    expect(out.routing).toBe('native');
+    expect(out.env).toEqual({});
+    expect(out.stripKeys).toEqual([]);
+  });
+
+  it('registers wnano in the file-handoff backend set', () => {
+    expect(FILE_HANDOFF_FLUX_BACKENDS).toContain('wnano');
+  });
+});

--- a/tests/unit/task/wnano/oauthBearer.test.ts
+++ b/tests/unit/task/wnano/oauthBearer.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  WNANO_OAUTH_REFRESH_THRESHOLD_SECS,
+  buildWnanoOAuthBearerEnv,
+  normalizeWnanoBearerEnvSuffix,
+  type WnanoOAuthBearerSource,
+} from '@process/task/wnano';
+
+const NOW_MS = 1_800_000_000_000;
+
+const source = (over: Partial<WnanoOAuthBearerSource> & { nanoProviderId?: string } = {}) => ({
+  nanoProviderId: 'xai',
+  load: vi.fn(async () => ({ accessToken: 'xai-access-synthetic', expiresAtMs: NOW_MS + 3_600_000 })),
+  refresh: vi.fn(async () => true),
+  ...over,
+});
+
+describe('normalizeWnanoBearerEnvSuffix', () => {
+  it('uppercases and replaces every char outside [A-Z0-9] with underscore', () => {
+    expect(normalizeWnanoBearerEnvSuffix('google-gemini')).toBe('GOOGLE_GEMINI');
+    expect(normalizeWnanoBearerEnvSuffix('xai')).toBe('XAI');
+    expect(normalizeWnanoBearerEnvSuffix('flux-router')).toBe('FLUX_ROUTER');
+  });
+});
+
+describe('buildWnanoOAuthBearerEnv (C8 Q1b bearer injection)', () => {
+  it('injects the access token + expiry metadata for an advertised OAuth provider', async () => {
+    const env = await buildWnanoOAuthBearerEnv(['xai'], [source()], NOW_MS);
+    expect(env.WAYLAND_NANO_OAUTH_BEARER_XAI).toBe('xai-access-synthetic');
+    expect(env.WAYLAND_NANO_OAUTH_BEARER_XAI_EXPIRES_AT_UNIX_SECS).toBe(
+      String(Math.floor((NOW_MS + 3_600_000) / 1000))
+    );
+  });
+
+  it('does NOT refresh when the token is fresh (>= 600s remaining)', async () => {
+    const src = source();
+    await buildWnanoOAuthBearerEnv(['xai'], [src], NOW_MS);
+    expect(src.refresh).not.toHaveBeenCalled();
+  });
+
+  it('refreshes at spawn when fewer than 600s remain, then injects the fresh token', async () => {
+    const src = source({
+      load: vi
+        .fn()
+        .mockResolvedValueOnce({ accessToken: 'stale-token', expiresAtMs: NOW_MS + 300_000 })
+        .mockResolvedValueOnce({ accessToken: 'fresh-token', expiresAtMs: NOW_MS + 3_600_000 }),
+    });
+    const env = await buildWnanoOAuthBearerEnv(['xai'], [src], NOW_MS);
+    expect(src.refresh).toHaveBeenCalledTimes(1);
+    expect(env.WAYLAND_NANO_OAUTH_BEARER_XAI).toBe('fresh-token');
+    expect(env.WAYLAND_NANO_OAUTH_BEARER_XAI_EXPIRES_AT_UNIX_SECS).toBe(
+      String(Math.floor((NOW_MS + 3_600_000) / 1000))
+    );
+  });
+
+  it('treats exactly-600s-remaining as fresh enough (threshold is strictly-below)', async () => {
+    const src = source({
+      load: vi.fn(async () => ({
+        accessToken: 'borderline-token',
+        expiresAtMs: NOW_MS + WNANO_OAUTH_REFRESH_THRESHOLD_SECS * 1000,
+      })),
+    });
+    const env = await buildWnanoOAuthBearerEnv(['xai'], [src], NOW_MS);
+    expect(src.refresh).not.toHaveBeenCalled();
+    expect(env.WAYLAND_NANO_OAUTH_BEARER_XAI).toBe('borderline-token');
+  });
+
+  it('never emits a refresh token - only the access token and expiry metadata', async () => {
+    const src = source({
+      load: vi.fn(async () => ({
+        accessToken: 'xai-access-synthetic',
+        expiresAtMs: NOW_MS + 3_600_000,
+        refreshToken: 'xai-refresh-SHOULD-NEVER-LEAK',
+      })),
+    });
+    const env = await buildWnanoOAuthBearerEnv(['xai'], [src], NOW_MS);
+    expect(JSON.stringify(env)).not.toContain('xai-refresh-SHOULD-NEVER-LEAK');
+    expect(Object.keys(env).toSorted()).toEqual([
+      'WAYLAND_NANO_OAUTH_BEARER_XAI',
+      'WAYLAND_NANO_OAUTH_BEARER_XAI_EXPIRES_AT_UNIX_SECS',
+    ]);
+  });
+
+  it('emits nothing for a provider that is not advertised in the payload', async () => {
+    const src = source();
+    const env = await buildWnanoOAuthBearerEnv(['openai'], [src], NOW_MS);
+    expect(env).toEqual({});
+    expect(src.load).not.toHaveBeenCalled();
+  });
+
+  it('emits nothing when the source has no access token', async () => {
+    const env = await buildWnanoOAuthBearerEnv(['xai'], [source({ load: vi.fn(async () => null) })], NOW_MS);
+    expect(env).toEqual({});
+  });
+
+  it('emits nothing when the expiry is unknown (expiry metadata is contractual)', async () => {
+    const src = source({ load: vi.fn(async () => ({ accessToken: 'xai-access-synthetic' })) });
+    const env = await buildWnanoOAuthBearerEnv(['xai'], [src], NOW_MS);
+    expect(env).toEqual({});
+    expect(src.refresh).not.toHaveBeenCalled();
+  });
+
+  it('emits nothing when a required refresh fails (spawn proceeds; Nano fails closed at dispatch)', async () => {
+    const src = source({
+      load: vi.fn(async () => ({ accessToken: 'stale-token', expiresAtMs: NOW_MS + 60_000 })),
+      refresh: vi.fn(async () => false),
+    });
+    const env = await buildWnanoOAuthBearerEnv(['xai'], [src], NOW_MS);
+    expect(env).toEqual({});
+  });
+
+  it('survives a throwing source without aborting the spawn env build', async () => {
+    const broken = source({ load: vi.fn(async () => Promise.reject(new Error('store corrupt'))) });
+    const env = await buildWnanoOAuthBearerEnv(['xai'], [broken], NOW_MS);
+    expect(env).toEqual({});
+  });
+
+  it('skips a second source whose normalized env suffix collides with the first', async () => {
+    const first = source({ nanoProviderId: 'google-gemini' });
+    const colliding = source({
+      nanoProviderId: 'google_gemini',
+      load: vi.fn(async () => ({ accessToken: 'colliding-token', expiresAtMs: NOW_MS + 3_600_000 })),
+    });
+    const env = await buildWnanoOAuthBearerEnv(['google-gemini', 'google_gemini'], [first, colliding], NOW_MS);
+    expect(env.WAYLAND_NANO_OAUTH_BEARER_GOOGLE_GEMINI).toBe('xai-access-synthetic');
+    expect(colliding.load).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/task/wnano/providersPayload.test.ts
+++ b/tests/unit/task/wnano/providersPayload.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import {
+  NANO_KNOWN_PROVIDER_IDS,
+  WNANO_PROVIDERS_MAX_BYTES,
+  WNANO_PROVIDERS_MAX_ENTRIES,
+  WNANO_PROVIDERS_MAX_ID_CHARS,
+  WNANO_PROVIDERS_MAX_MODELS_PER_PROVIDER,
+  buildWaylandNanoProvidersPayload,
+} from '@process/task/wnano';
+
+const parse = (json: string | undefined) => (json ? (JSON.parse(json) as unknown[]) : undefined);
+
+const fatModels = (prefix: string) => Array.from({ length: 200 }, (_, i) => `${prefix}-${'x'.repeat(100)}${i}`);
+
+describe('buildWaylandNanoProvidersPayload (C8 WAYLAND_NANO_PROVIDERS)', () => {
+  it('serializes the exact {provider, models, hasKey} schema', () => {
+    const payload = parse(
+      buildWaylandNanoProvidersPayload([{ provider: 'openai', models: ['gpt-5.6-terra'], hasKey: true }])
+    );
+    expect(payload).toEqual([{ provider: 'openai', models: ['gpt-5.6-terra'], hasKey: true }]);
+  });
+
+  it('never emits endpoint/routing fields, even when the input carries them', () => {
+    const hostile = {
+      provider: 'openai',
+      models: ['gpt-5.6-terra'],
+      hasKey: true,
+      base_url: 'https://evil.example/v1',
+      wire: 'responses',
+      api_path: '/chat/completions',
+      env_var: 'SK_SECRET',
+      apiKey: 'sk-live-secret',
+    };
+    const payload = parse(buildWaylandNanoProvidersPayload([hostile])) as Array<Record<string, unknown>>;
+    expect(Object.keys(payload[0]).toSorted()).toEqual(['hasKey', 'models', 'provider']);
+    expect(JSON.stringify(payload)).not.toContain('evil.example');
+    expect(JSON.stringify(payload)).not.toContain('sk-live-secret');
+  });
+
+  it('excludes provider ids outside Nano known set', () => {
+    const payload = parse(
+      buildWaylandNanoProvidersPayload([
+        { provider: 'not-a-nano-provider', models: ['m1'], hasKey: true },
+        { provider: 'groq', models: ['llama-4'], hasKey: false },
+      ])
+    );
+    expect(payload).toEqual([{ provider: 'groq', models: ['llama-4'], hasKey: false }]);
+  });
+
+  it('returns undefined when no entry survives (no env var is injected)', () => {
+    expect(buildWaylandNanoProvidersPayload([])).toBeUndefined();
+    expect(
+      buildWaylandNanoProvidersPayload([{ provider: 'unknown-thing', models: ['m'], hasKey: true }])
+    ).toBeUndefined();
+  });
+
+  it('orders providers deterministically by Nano known-set order, not input order', () => {
+    const payload = parse(
+      buildWaylandNanoProvidersPayload([
+        { provider: 'xai', models: ['grok-4'], hasKey: true },
+        { provider: 'openai', models: ['gpt-5.6-terra'], hasKey: true },
+        { provider: 'flux-router', models: ['flux-auto'], hasKey: true },
+      ])
+    ) as Array<{ provider: string }>;
+    expect(payload.map((entry) => entry.provider)).toEqual(['flux-router', 'openai', 'xai']);
+    expect(payload.map((entry) => entry.provider)).toEqual(
+      ['flux-router', 'openai', 'xai'].toSorted(
+        (a, b) => NANO_KNOWN_PROVIDER_IDS.indexOf(a as never) - NANO_KNOWN_PROVIDER_IDS.indexOf(b as never)
+      )
+    );
+  });
+
+  it('dedupes model ids, first occurrence wins, preserving order', () => {
+    const payload = parse(
+      buildWaylandNanoProvidersPayload([{ provider: 'openai', models: ['a', 'b', 'a', 'c', 'b'], hasKey: true }])
+    ) as Array<{ models: string[] }>;
+    expect(payload[0].models).toEqual(['a', 'b', 'c']);
+  });
+
+  it('drops blank and over-128-char model ids', () => {
+    const tooLong = 'm'.repeat(WNANO_PROVIDERS_MAX_ID_CHARS + 1);
+    const atLimit = 'm'.repeat(WNANO_PROVIDERS_MAX_ID_CHARS);
+    const payload = parse(
+      buildWaylandNanoProvidersPayload([
+        { provider: 'openai', models: ['', '   ', tooLong, atLimit, 'ok'], hasKey: true },
+      ])
+    ) as Array<{ models: string[] }>;
+    expect(payload[0].models).toEqual([atLimit, 'ok']);
+  });
+
+  it('caps models per provider at 256', () => {
+    const models = Array.from({ length: WNANO_PROVIDERS_MAX_MODELS_PER_PROVIDER + 50 }, (_, i) => `m${i}`);
+    const payload = parse(buildWaylandNanoProvidersPayload([{ provider: 'openai', models, hasKey: true }])) as Array<{
+      models: string[];
+    }>;
+    expect(payload[0].models).toHaveLength(WNANO_PROVIDERS_MAX_MODELS_PER_PROVIDER);
+    expect(payload[0].models[0]).toBe('m0');
+  });
+
+  it('caps entries at 64 (first duplicate provider occurrence wins)', () => {
+    // Only 17 known ids exist, so the entry cap is exercised via duplicates:
+    // duplicates collapse to one entry and never multiply past the cap.
+    const entries = Array.from({ length: 100 }, () => ({
+      provider: 'openai',
+      models: ['gpt-5.6-terra'],
+      hasKey: true,
+    }));
+    const payload = parse(buildWaylandNanoProvidersPayload(entries)) as unknown[];
+    expect(payload).toHaveLength(1);
+    expect(payload.length).toBeLessThanOrEqual(WNANO_PROVIDERS_MAX_ENTRIES);
+  });
+
+  it('never exceeds 32 KiB serialized: trailing providers are dropped first', () => {
+    const payload = buildWaylandNanoProvidersPayload([
+      { provider: 'flux-router', models: ['flux-auto'], hasKey: true },
+      { provider: 'openai', models: fatModels('openai'), hasKey: true },
+      { provider: 'anthropic', models: fatModels('anthropic'), hasKey: true },
+    ]);
+    expect(payload).toBeDefined();
+    expect(Buffer.byteLength(payload!, 'utf8')).toBeLessThanOrEqual(WNANO_PROVIDERS_MAX_BYTES);
+    const parsed = parse(payload) as Array<{ provider: string; models: string[] }>;
+    // The small leading provider survives; size pressure is absorbed from the end.
+    expect(parsed[0]).toEqual({ provider: 'flux-router', models: ['flux-auto'], hasKey: true });
+    expect(parsed.length).toBeLessThan(3);
+  });
+
+  it('trims a single oversize provider model list from the end rather than exceeding the cap', () => {
+    // 124-char prefix + up-to-3-char index stays under the 128-char id limit
+    // while 256 of them exceed 32 KiB serialized, forcing the trim path.
+    const models = Array.from({ length: WNANO_PROVIDERS_MAX_MODELS_PER_PROVIDER }, (_, i) => `${'y'.repeat(124)}${i}`);
+    const payload = buildWaylandNanoProvidersPayload([{ provider: 'openai', models, hasKey: true }]);
+    expect(payload).toBeDefined();
+    expect(Buffer.byteLength(payload!, 'utf8')).toBeLessThanOrEqual(WNANO_PROVIDERS_MAX_BYTES);
+    const parsed = parse(payload) as Array<{ provider: string; models: string[] }>;
+    expect(parsed[0].provider).toBe('openai');
+    expect(parsed[0].models.length).toBeGreaterThan(0);
+    expect(parsed[0].models.length).toBeLessThan(models.length);
+  });
+});


### PR DESCRIPTION
## Summary

Desktop half of **C8 multi-provider parity** for `wnano` (design: `shared/reviews/panel-tui/C8-provider-parity-design.md` §6/§7, Desktop bullets of §9; §5 payload invariants and §8 security invariants honored). Today `resolveFluxRouting` returns `'unknown'` for wnano, so no Flux credential flows at all. This PR adds the full injection arm:

- **`FLUX_API_KEY_FILE` handoff (Q4)** — a new `wnano` arm in `resolveFluxRouting` emits the PATH (never the secret) of a per-conversation key file that Desktop writes under userData: atomic temp-then-rename (mirrors `codexAuthFile.ts`), mode 0600 on POSIX (Windows relies on the userData directory ACL — documented, no POSIX bit checks there), deleted in `kill()` at teardown, key value never logged. Mutual exclusivity, wnano-style: ambient `FLUX_API_KEY`/`FLUX_TEST_KEY` are stripped so the connected key wins; Desktop never emits `FLUX_API_KEY` (it stays the documented manual/dev-only fallback for non-Desktop launches). Unlike the surface arms, native provider keys are deliberately NOT stripped — Nano consumes them as its multi-provider credentials. The handoff is unconditional (not gated on the model pick or the routeThroughFlux toggle), so routing stays stable across `set_model` switches and no respawn churn is introduced.
- **`WAYLAND_NANO_PROVIDERS` payload (§6.2)** — injected at the same merge point as `buildConnectedProviderEnv`. JSON array `[{provider, models, hasKey}]`: no secrets, no endpoint/routing fields (entries are rebuilt with exactly the three contract keys), provider ids constrained to Nano's known set, deduped (first wins), deterministic order (known-set order), bounded to ≤64 entries / ≤256 models per provider / ≤128 chars per id / ≤32 KiB serialized with deterministic drop-trailing-then-trim. `hasKey` is advisory only. Models come from the connected providers' persisted model-registry catalogs (`getRegistryCatalog` + custom model ids); `flux-router` advertises Desktop's fixed tier list (Nano owns the live Flux catalog itself). **Note:** the brief pointed at `providerCatalog.generated.json` as the model source, but that file carries no model lists (and none of Nano's 17 known ids) — the registry catalog is the only Desktop source of per-provider model ids for connected providers.
- **OAuth bearer injection (Q1b)** — for each advertised OAuth provider, refresh at spawn ONLY when <600s remain (no churn), inject the ACCESS token only as `WAYLAND_NANO_OAUTH_BEARER_<NORMALIZED_ID>` plus non-secret `..._EXPIRES_AT_UNIX_SECS`. Refresh tokens are never injected; a bearer with unknown expiry is never emitted (the expiry metadata is contractual). v1 wires **xai only** — the only Desktop OAuth provider in Nano's known id set (`chatgpt-subscription` is not in the set and needs the deferred Responses wire); refresh goes through `xaiRefreshToken()`, which prefers the engine-rotated bundle (#391), so there is no refresh-token rotation race.

Nothing else changes: the wnano registry entry, picker, and mode table already fit (§6.4). `WAYLAND_HOME` is not passed (struck proposal).

## Test plan

- [x] `tests/unit/task/wnano/fluxRoutingWnano.test.ts` — wnano arm: `FLUX_API_KEY_FILE` emitted, `FLUX_API_KEY` never emitted, ambient flux keys stripped, provider keys kept, unconditional handoff, stable routing across model switches, native fallback when unconnected/unwritable
- [x] `tests/unit/task/wnano/providersPayload.test.ts` — schema exactness, hostile endpoint/secret fields never emitted, unknown ids excluded, dedup, deterministic known-set order, all four bounds enforced (64/256/128/32 KiB)
- [x] `tests/unit/task/wnano/oauthBearer.test.ts` — access-token-only env, refresh called <600s / not called when fresh / boundary at exactly 600s, no refresh token in env, expiry metadata emitted, unknown-expiry skip, refresh-failure skip, suffix normalization + collision guard
- [x] `tests/unit/task/wnano/fluxKeyFile.test.ts` — atomic write (no temp sibling left), 0600 on POSIX (skip on Windows), per-conversation isolation, hostile-id sanitization, teardown cleanup, failure paths never throw
- [x] `tests/unit/AcpModelSelectorWnanoColonId.dom.test.tsx` — **Q2 build condition**: `openai:gpt-5.6-terra` / `anthropic:claude-opus-4-8` round-trip through the picker (advertise → render → select → `set_model` echo with the exact colon id), friendly `name` displayed instead of the raw id
- [x] `bunx vitest run tests/unit/task/ tests/unit/AcpModelSelector*.dom.test.tsx` — 12 files, 115 passed / 1 skipped
- [x] `bun run typecheck` (tsc --noEmit) — clean
- [x] `bunx oxlint` + `oxfmt --check` on all touched files — clean
- [x] Full `bunx vitest run` — 15697 passed, 61 failed in 7 files; **all 61 failures reproduce on the pristine base branch** (host-specific: EPERM on `~/.wayland-server` storage, `ERR_DLOPEN_FAILED` native module, recovery/wcore suites). Zero new failures from this PR.

**CI note:** Desktop CI red is PRE-EXISTING (constitution-fs pin) — documented in the design §6 and deliberately not fixed here.

**Base branch:** `feature/wayland-nano`, stacked on the wnano chain exactly like #951 (wnano does not exist on `main` yet).