### PR TITLE
feat(acp): nano error table — 59 kinds (P4 fix round)

### DIFF
--- a/src/common/types/nano-error-codes.json
+++ b/src/common/types/nano-error-codes.json
@@ -297,6 +297,22 @@
       "wireCode": -32603
     },
     {
+      "hint": "The saved rules.toml denies this command; edit or remove the rule",
+      "kind": "shell_rule_denied",
+      "retryable": false,
+      "surface": "tool_card",
+      "title": "Denied by a shell rule",
+      "wireCode": -32603
+    },
+    {
+      "hint": "Fix or remove rules.toml (strict TOML, owner-only permissions)",
+      "kind": "rule_file_invalid",
+      "retryable": false,
+      "surface": "tool_card",
+      "title": "Shell rules file is invalid or insecurely configured; running with no saved rules",
+      "wireCode": -32603
+    },
+    {
       "hint": "Start a new session or narrow the task",
       "kind": "budget_exhausted",
       "retryable": false,

--- a/src/common/types/nanoErrorCodes.ts
+++ b/src/common/types/nanoErrorCodes.ts
@@ -39,6 +39,8 @@ export type NanoErrorKind =
   | 'approval_denied'
   | 'pty_session_gone'
   | 'review_parse_failed'
+  | 'shell_rule_denied'
+  | 'rule_file_invalid'
   | 'budget_exhausted'
   | 'budget_exceeded'
   | 'no_progress'
@@ -367,6 +369,22 @@ export const NANO_ERROR_SPECS: readonly NanoErrorSpec[] = [
     retryable: false,
     title: 'The review finished but its report couldn\'t be parsed',
     hint: '',
+  },
+  {
+    kind: 'shell_rule_denied',
+    surface: 'tool_card',
+    wireCode: -32603,
+    retryable: false,
+    title: 'Denied by a shell rule',
+    hint: 'The saved rules.toml denies this command; edit or remove the rule',
+  },
+  {
+    kind: 'rule_file_invalid',
+    surface: 'tool_card',
+    wireCode: -32603,
+    retryable: false,
+    title: 'Shell rules file is invalid or insecurely configured; running with no saved rules',
+    hint: 'Fix or remove rules.toml (strict TOML, owner-only permissions)',
   },
   {
     kind: 'budget_exhausted',


### PR DESCRIPTION
The P4 fix round (merged at wayland-nano@2246092) added two error kinds: shell_rule_denied and rule_file_invalid. This regenerates the Desktop mirror to the 59-kind surface. Generated by gen_error_table — do not hand-edit. Supersedes #954's 57-kind table.