### PR TITLE
Pin Wayland Nano to the stable 0.1.0 release

### DIFF
--- a/src/common/types/acpTypes.ts
+++ b/src/common/types/acpTypes.ts
@@ -25,12 +25,20 @@ export const CODEBUDDY_ACP_BRIDGE_VERSION = '2.73.0';
 export const CODEBUDDY_ACP_NPX_PACKAGE = `@tencent-ai/codebuddy-code@${CODEBUDDY_ACP_BRIDGE_VERSION}`;
 
 /**
- * Wayland Nano's own npm distribution. PINNED DELIBERATELY: npm's `latest`
- * dist-tag still points at `0.1.0-alpha.0` while the release lives on `next`,
- * so a bare `npx waylandnano` silently installs the OLDER alpha. A pin is also
- * reproducible in a way a moving tag is not.
+ * Wayland Nano's own npm distribution. PINNED DELIBERATELY: a pin is
+ * reproducible in a way a moving dist-tag is not.
+ *
+ * Now on the STABLE release. `latest` used to point at `0.1.0-alpha.0` while
+ * the candidate sat on `next`, so a bare `npx waylandnano` installed the older
+ * alpha; `latest` is `0.1.0` as of 2026-08-15 and that hazard is gone, but the
+ * pin stays for reproducibility.
+ *
+ * Note the tarball ships `bin/wayland-nano.js` mode 0644. That does NOT affect
+ * us: we launch through `npx`, which runs the file via node's bin shim rather
+ * than exec'ing it. Verified against 0.1.0 - `npx waylandnano@0.1.0 --version`
+ * prints `wayland-nano 0.1.0`, and the `acp-host` subcommand below starts.
  */
-export const WNANO_NPM_VERSION = '0.1.0-rc.0';
+export const WNANO_NPM_VERSION = '0.1.0';
 export const WNANO_NPX_PACKAGE = `waylandnano@${WNANO_NPM_VERSION}`;
 
 /**


### PR DESCRIPTION
Moves `WNANO_NPM_VERSION` off the release candidate now that Nano has published
stable. This is the pre-tag action called out in
`.planning/HANDOFF-2026-08-15-RELEASE-READY.md` - without it, 0.12.0 ships
advertising Nano as a first-class built-in agent while pinned to an RC.

**The version is `0.1.0`, not `1.0`.** The registry has exactly three versions -
`0.1.0-alpha.0`, `0.1.0-rc.0`, `0.1.0` - and no 1.x. Stable published
2026-08-15T04:55Z.

`latest` now resolves to `0.1.0`, so the hazard the old comment described - a
bare `npx waylandnano` silently installing the older alpha because the release
sat on the `next` tag - is gone. The pin stays regardless, because a pin is
reproducible and a moving dist-tag is not.

## On the 0644 binary

The handoff flagged that the RC shipped `bin/wayland-nano.js` non-executable.
Stable still does. **It does not affect us, and the original worry was
misplaced:** Desktop launches through `npx`, which runs the file via node's bin
shim rather than exec'ing it, so the mode never comes into play.

Verified against the published artifact rather than reasoned about:
- `npx -y waylandnano@0.1.0 --version` prints `wayland-nano 0.1.0`
- the `acp-host` subcommand Desktop actually spawns starts and exits cleanly

## Verification

- `tsc --noEmit` clean, all prek hooks clean
- packaged build succeeds; pin confirmed compiled into both the main and
  renderer bundles as `WNANO_NPM_VERSION = "0.1.0"`
- 113 Nano/ACP-detection unit tests pass
- e2e app-launch + agent-settings-detection + guid-agent-selection: 19 passed,
  0 failed

No tag. Tagging stays a human action.
