### PR TITLE
feat(acp): consume nano typed errors (data.nanoError) end to end

### DIFF
--- a/src/process/acp/errors/AcpError.ts
+++ b/src/process/acp/errors/AcpError.ts
@@ -23,15 +23,23 @@ export type AcpErrorCode =
 
 export class AcpError extends Error {
   readonly retryable: boolean;
+  /**
+   * C7: the typed nano error payload (`error.data.nanoError`) when the
+   * engine attached one — closed fields only (`kind`, `retryable`). Its
+   * presence means retryability was already classified by the engine's
+   * error-code table; consumers must NOT re-derive it from message text.
+   */
+  readonly nanoError?: { kind: string; retryable: boolean };
 
   constructor(
     public readonly code: AcpErrorCode,
     message: string,
-    options?: { cause?: unknown; retryable?: boolean }
+    options?: { cause?: unknown; retryable?: boolean; nanoError?: { kind: string; retryable: boolean } }
   ) {
     super(message, { cause: options?.cause });
     this.name = 'AcpError';
     this.retryable = options?.retryable ?? false;
+    this.nanoError = options?.nanoError;
   }
 }
 

--- a/src/process/acp/errors/errorNormalize.ts
+++ b/src/process/acp/errors/errorNormalize.ts
@@ -3,6 +3,47 @@
 import { RequestError } from '@agentclientprotocol/sdk';
 import { AcpError, type AcpErrorCode } from '@process/acp/errors/AcpError';
 import { extractAcpError, formatUnknownError } from '@process/acp/errors/errorExtract';
+import { NANO_ERROR_BY_KIND } from '@/common/types/nanoErrorCodes';
+
+/**
+ * C7: a nano-typed error payload (`error.data.nanoError`) — the engine's
+ * closed error-code table entry. Fail-closed parsing: anything malformed
+ * (non-string kind, non-boolean retryable) is treated as absent.
+ */
+function extractNanoError(data: unknown): { kind: string; retryable: boolean } | undefined {
+  if (!data || typeof data !== 'object') return undefined;
+  const nano = (data as Record<string, unknown>).nanoError;
+  if (!nano || typeof nano !== 'object') return undefined;
+  const kind = (nano as Record<string, unknown>).kind;
+  const retryable = (nano as Record<string, unknown>).retryable;
+  if (typeof kind !== 'string' || typeof retryable !== 'boolean') return undefined;
+  return { kind, retryable };
+}
+
+/**
+ * C7: the nano error kind an arbitrary thrown value carries, checking both
+ * the normalized AcpError field and a raw JSON-RPC `data.nanoError` shape.
+ * Used by call sites that historically grepped message text (e.g.
+ * model_not_found) — the kind check is preferred, the grep stays as
+ * fallback for third-party agents.
+ */
+export function nanoErrorKindOf(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+  const direct = (error as { nanoError?: { kind?: unknown } }).nanoError;
+  if (direct && typeof direct.kind === 'string') return direct.kind;
+  return extractNanoError((error as { data?: unknown }).data)?.kind;
+}
+
+/**
+ * C7: retryability for a nano-tagged error comes from the typed payload,
+ * OVERRIDING the numeric-code map (which classifies every -32603 as
+ * retryable — wrong for e.g. journal_unavailable). A kind the table does
+ * not know (a newer engine) classifies TERMINAL: an older UI must never
+ * auto-retry an error it does not understand.
+ */
+function nanoRetryable(nano: { kind: string; retryable: boolean }): boolean {
+  return NANO_ERROR_BY_KIND[nano.kind] ? nano.retryable : false;
+}
 
 /**
  * SDK JSON-RPC error code → AcpErrorCode + retryable mapping.
@@ -96,21 +137,30 @@ export function normalizeError(error: unknown): AcpError {
   // Prefer SDK's RequestError - it carries a typed .code from the ACP schema.
   if (error instanceof RequestError) {
     const mapped = ACP_CODE_MAP[error.code];
+    const nano = extractNanoError(error.data);
 
     // Message-based heuristic: some agents return auth failures as -32603
     // (Internal error) instead of -32000 (Auth required). Detect common
     // auth-related keywords to surface the correct auth flow to the user.
-    if (mapped && mapped.code !== 'AUTH_REQUIRED' && isAuthRelatedMessage(error.message)) {
+    // C7: a nano-tagged error already carries its typed classification, so
+    // the message-text heuristic is skipped for it (the text is a static
+    // table presentation, never provider prose).
+    if (!nano && mapped && mapped.code !== 'AUTH_REQUIRED' && isAuthRelatedMessage(error.message)) {
       return new AcpError('AUTH_REQUIRED', error.message, { cause: error, retryable: true });
     }
 
     if (mapped) {
       return new AcpError(mapped.code, withErrorDetail(error.message, error.data), {
         cause: error,
-        retryable: mapped.retryable,
+        retryable: nano ? nanoRetryable(nano) : mapped.retryable,
+        nanoError: nano,
       });
     }
-    return new AcpError('AGENT_ERROR', withErrorDetail(error.message, error.data), { cause: error });
+    return new AcpError('AGENT_ERROR', withErrorDetail(error.message, error.data), {
+      cause: error,
+      nanoError: nano,
+      retryable: nano ? nanoRetryable(nano) : false,
+    });
   }
 
   // Detect SDK "ACP connection closed" - child process exited before responding.
@@ -127,13 +177,19 @@ export function normalizeError(error: unknown): AcpError {
   if (acpPayload) {
     // Try code-based mapping first (same ACP codes)
     const mapped = ACP_CODE_MAP[acpPayload.code];
+    const nano = extractNanoError(acpPayload.data);
     if (mapped) {
       return new AcpError(mapped.code, withErrorDetail(acpPayload.message, acpPayload.data), {
         cause: error,
-        retryable: mapped.retryable,
+        retryable: nano ? nanoRetryable(nano) : mapped.retryable,
+        nanoError: nano,
       });
     }
-    return new AcpError('AGENT_ERROR', withErrorDetail(acpPayload.message, acpPayload.data), { cause: error });
+    return new AcpError('AGENT_ERROR', withErrorDetail(acpPayload.message, acpPayload.data), {
+      cause: error,
+      nanoError: nano,
+      retryable: nano ? nanoRetryable(nano) : false,
+    });
   }
 
   // Fallback

--- a/src/process/acp/session/PromptExecutor.ts
+++ b/src/process/acp/session/PromptExecutor.ts
@@ -275,6 +275,14 @@ export class PromptExecutor {
     if (attempt >= this.maxAttempts) return false;
     if (this.turnCancelled) return false;
     if (this.turnRanTool) return false;
+    // C7: a nano-typed error carries the engine's own closed classification
+    // (`data.nanoError.retryable`, attached by normalizeError). It decides
+    // prompt replay DIRECTLY — the numeric-code set and the TRANSIENT_DETAIL
+    // regex are heuristics for third-party agents that do not tag their
+    // errors. `acpErr.retryable` is the NORMALIZED verdict: unknown kinds
+    // were already forced terminal at normalization, so a newer engine's
+    // error can never trigger an auto-retry here.
+    if (acpErr.nanoError) return acpErr.retryable;
     // NOT `acpErr.retryable`: that flag was tuned for session start/resume, a
     // different decision. Replaying a PROMPT is its own judgement call.
     if (!REPLAYABLE_PROMPT_CODES.has(acpErr.code)) return false;

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -1,6 +1,7 @@
 import type { AcpAgent } from '@process/agent/acp';
 import { AcpAgentV2 } from '@process/acp/compat';
 import { agentRegistry } from '@process/agent/AgentRegistry';
+import { nanoErrorKindOf } from '@process/acp/errors/errorNormalize';
 import { channelEventBus } from '@process/channels/agent/ChannelEventBus';
 import { teamEventBus } from '@process/team/teamEventBus';
 import { ipcBridge } from '@/common';
@@ -1775,7 +1776,13 @@ ${collectedResponses.join('\n')}`;
         } catch (error) {
           const errMsg = error instanceof Error ? error.message : String(error);
           mainWarn('[AcpAgentManager]', `Failed to re-apply model ${this.persistedModelId}`, error);
-          if (errMsg.includes('model_not_found') || errMsg.includes('无可用渠道')) {
+          // C7: prefer the typed nanoError kind; the message grep stays as
+          // the fallback for third-party agents/relays.
+          if (
+            nanoErrorKindOf(error) === 'model_not_found' ||
+            errMsg.includes('model_not_found') ||
+            errMsg.includes('无可用渠道')
+          ) {
             ipcBridge.acpConversation.responseStream.emit({
               type: 'error',
               conversation_id: this.conversation_id,

--- a/tests/unit/process/acp/errors/nanoErrorCodes.test.ts
+++ b/tests/unit/process/acp/errors/nanoErrorCodes.test.ts
@@ -1,0 +1,109 @@
+// tests/unit/process/acp/errors/nanoErrorCodes.test.ts
+
+/**
+ * C7: the generated nano error-code module (src/common/types/nanoErrorCodes.ts)
+ * is a DATA-ONLY artifact of the Rust table (wayland-nano repo,
+ * crates/nano-protocol/src/error_codes.rs). This suite pins:
+ *  1. TS ≡ JSON parity (the two generated artifacts cannot drift apart);
+ *  2. normalizeError's nano-typed classification: the typed retryable flag
+ *     OVERRIDES the numeric-code map for nano-tagged errors, unknown kinds
+ *     classify terminal, and untagged third-party errors keep the legacy
+ *     heuristics untouched.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { NANO_ERROR_SPECS, NANO_ERROR_BY_KIND } from '@/common/types/nanoErrorCodes';
+import { normalizeError, nanoErrorKindOf } from '@process/acp/errors/errorNormalize';
+import { AcpError } from '@process/acp/errors/AcpError';
+
+describe('nanoErrorCodes generated artifact', () => {
+  it('is byte-identical in content to the JSON snapshot (parity)', () => {
+    const json = JSON.parse(readFileSync(join(process.cwd(), 'src/common/types/nano-error-codes.json'), 'utf8')) as {
+      errors: unknown[];
+    };
+    expect(NANO_ERROR_SPECS).toEqual(json.errors);
+  });
+
+  it('indexes every kind exactly once', () => {
+    expect(Object.keys(NANO_ERROR_BY_KIND)).toHaveLength(NANO_ERROR_SPECS.length);
+    for (const spec of NANO_ERROR_SPECS) {
+      expect(NANO_ERROR_BY_KIND[spec.kind]).toBe(spec);
+    }
+  });
+});
+
+describe('normalizeError — nano-typed payloads (C7)', () => {
+  it('journal_unavailable overrides the -32603 retryable default (terminal)', () => {
+    // The numeric map classifies every -32603 as retryable; a persistent
+    // storage failure must NOT auto-retry.
+    const err = {
+      code: -32603,
+      message: 'Session storage unavailable',
+      data: { nanoError: { kind: 'journal_unavailable', retryable: false } },
+    };
+    const result = normalizeError(err);
+    expect(result.code).toBe('AGENT_INTERNAL_ERROR');
+    expect(result.retryable).toBe(false);
+    expect(result.nanoError).toEqual({ kind: 'journal_unavailable', retryable: false });
+  });
+
+  it('model_rate_limited keeps its typed retryable flag', () => {
+    const err = {
+      code: -32603,
+      message: 'Rate limited',
+      data: { nanoError: { kind: 'model_rate_limited', retryable: true, retry_after_ms: 1500 } },
+    };
+    const result = normalizeError(err);
+    expect(result.retryable).toBe(true);
+    expect(result.nanoError?.kind).toBe('model_rate_limited');
+  });
+
+  it('a kind from the future classifies TERMINAL even when it claims retryable', () => {
+    const err = {
+      code: -32603,
+      message: 'mystery',
+      data: { nanoError: { kind: 'kind_from_the_future', retryable: true } },
+    };
+    const result = normalizeError(err);
+    expect(result.retryable).toBe(false);
+    expect(result.nanoError?.kind).toBe('kind_from_the_future');
+  });
+
+  it('untagged -32603 keeps the legacy numeric-map behavior (third-party agents)', () => {
+    const result = normalizeError({ code: -32603, message: 'Internal error' });
+    expect(result.retryable).toBe(true);
+    expect(result.nanoError).toBeUndefined();
+  });
+
+  it('malformed nanoError payloads are ignored (fail-closed parsing)', () => {
+    const result = normalizeError({
+      code: -32603,
+      message: 'Internal error',
+      data: { nanoError: { kind: 42, retryable: 'yes' } },
+    });
+    expect(result.retryable).toBe(true); // legacy map, payload discarded
+    expect(result.nanoError).toBeUndefined();
+  });
+});
+
+describe('nanoErrorKindOf', () => {
+  it('reads the normalized AcpError field', () => {
+    const err = new AcpError('ACP_INVALID_PARAMS', 'model_not_found: x', {
+      nanoError: { kind: 'model_not_found', retryable: false },
+    });
+    expect(nanoErrorKindOf(err)).toBe('model_not_found');
+  });
+
+  it('reads a raw JSON-RPC data.nanoError shape', () => {
+    expect(nanoErrorKindOf({ data: { nanoError: { kind: 'model_not_found', retryable: false } } })).toBe(
+      'model_not_found'
+    );
+  });
+
+  it('returns undefined for untagged errors', () => {
+    expect(nanoErrorKindOf(new Error('plain'))).toBeUndefined();
+    expect(nanoErrorKindOf('nope')).toBeUndefined();
+  });
+});

--- a/tests/unit/process/acp/session/PromptExecutor.nanoError.test.ts
+++ b/tests/unit/process/acp/session/PromptExecutor.nanoError.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * C7: nano-typed prompt errors carry the engine's own closed classification
+ * (`error.data.nanoError.retryable`). PromptExecutor consults the typed flag
+ * DIRECTLY for nano-tagged errors — the TRANSIENT_DETAIL message regex is a
+ * third-party heuristic and must neither widen a terminal nano error into a
+ * retry nor narrow a retryable one into a halt.
+ *
+ * Errors in this suite pass through normalizeError exactly as the wire path
+ * builds them (plain JSON-RPC payload objects), so the unknown-kind-terminal
+ * rule is exercised end to end.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PromptExecutor, type PromptHost } from '@process/acp/session/PromptExecutor';
+import { AcpError } from '@process/acp/errors/AcpError';
+import { normalizeError } from '@process/acp/errors/errorNormalize';
+import type { PromptContent } from '@process/acp/types';
+
+const FAST_RETRY = { attempts: 3, backoff: { initialMs: 0, maxMs: 0, factor: 1, jitter: 0 } };
+
+const CONTENT = [{ type: 'text', text: 'do the thing' }] as unknown as PromptContent;
+
+/** Build the error the way the wire path does: raw payload → normalizeError. */
+function nanoError(kind: string, retryable: boolean, message = kind): AcpError {
+  return normalizeError({ code: -32603, message, data: { nanoError: { kind, retryable } } });
+}
+
+function createHost() {
+  const prompt = vi.fn().mockResolvedValue({ stopReason: 'end_turn' });
+  const client = { prompt, cancel: vi.fn().mockResolvedValue(undefined) };
+
+  const host = {
+    status: 'active',
+    lifecycle: {
+      client,
+      sessionId: 'sess-1',
+      reassertConfig: vi.fn().mockResolvedValue(undefined),
+      setAuthPendingForPrompt: vi.fn(),
+      teardown: vi.fn().mockResolvedValue(undefined),
+    },
+    messageTranslator: { onTurnStart: vi.fn(), onTurnEnd: vi.fn() },
+    authNegotiator: { buildAuthRequiredData: vi.fn().mockReturnValue({}) },
+    callbacks: { onSignal: vi.fn(), onContextUsage: vi.fn() },
+    metrics: { recordError: vi.fn() },
+    agentConfig: { agentBackend: 'test' },
+    setStatus: vi.fn((s: string) => {
+      host.status = s;
+    }),
+    enterError: vi.fn(),
+  } as unknown as PromptHost & {
+    status: string;
+    lifecycle: { client: unknown; sessionId: string | null; setAuthPendingForPrompt: ReturnType<typeof vi.fn> };
+  };
+
+  return { host, prompt };
+}
+
+describe('PromptExecutor — nano-typed retry classification (C7)', () => {
+  let host: ReturnType<typeof createHost>['host'];
+  let prompt: ReturnType<typeof vi.fn>;
+  let executor: PromptExecutor;
+
+  beforeEach(() => {
+    ({ host, prompt } = createHost());
+    executor = new PromptExecutor(host, 60_000, FAST_RETRY);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('retries a typed retryable error whose message the regex would NOT match', async () => {
+    // "Rate limited" matches nothing in TRANSIENT_DETAIL; the typed flag decides.
+    prompt
+      .mockRejectedValueOnce(nanoError('model_rate_limited', true, 'Rate limited'))
+      .mockResolvedValueOnce({ stopReason: 'end_turn' });
+
+    await expect(executor.execute(CONTENT)).resolves.toBeUndefined();
+    expect(prompt).toHaveBeenCalledTimes(2);
+    expect(host.callbacks.onSignal).toHaveBeenCalledWith({ type: 'turn_finished' });
+  });
+
+  it('does NOT retry a typed terminal error whose message WOULD match the regex', async () => {
+    // "connection error" matches TRANSIENT_DETAIL; the typed terminal flag wins.
+    prompt.mockRejectedValue(nanoError('model_auth', false, 'connection error'));
+
+    await expect(executor.execute(CONTENT)).rejects.toBeInstanceOf(AcpError);
+    expect(prompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('never retries a kind from the future, even when it claims retryable', async () => {
+    prompt.mockRejectedValue(nanoError('kind_from_the_future', true, 'connection error'));
+
+    await expect(executor.execute(CONTENT)).rejects.toBeInstanceOf(AcpError);
+    expect(prompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('journal_unavailable does not auto-retry despite the -32603 default', async () => {
+    prompt.mockRejectedValue(nanoError('journal_unavailable', false, 'Session storage unavailable'));
+
+    await expect(executor.execute(CONTENT)).rejects.toBeInstanceOf(AcpError);
+    expect(prompt).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Lands the one genuinely unmerged piece of the Nano stack: end-to-end consumption of the engine's typed error payload (data.nanoError).

## What this is

PRs #950-#953 were a stacked chain on feature/wayland-nano, whose content main already absorbed via the #956 squash. Verified by cherry-picking each onto main:

- #950 - already on main.
- #952 - cherry-pick produced an EMPTY patch. Fully landed. Superseded.
- #953 commit 1 of 2 ("regenerate nano error table") - DROPPED. Main's generated table has 59 error kinds; that commit's table has 40 and contributes zero kinds main lacks. Applying it would have DELETED 19 kinds. The two generated files here are byte-identical to main.
- #953 commit 2 of 2 - this PR.
- #951 (bundling) - NOT included. See below.

## Why #951 is not here

The packaged-build gate (verifyWNanoRuntime in scripts/verify-packaged-resources.js) requires publisherVerified === true, which needs a signed SLSA provenance attestation for the wayland-nano release assets. All five v0.1.0 assets return HTTP 404 for attestations. The same check against wayland-core v0.13.0 succeeds and its sourceDigest matches its policy entry, so the method is sound and the negative is real.

prepareWaylandNano is wired into build-with-builder.js with requireVerified: true, and its checksum manifest ships as an unfilled placeholder with DEFAULT_WNANO_VERSION = 'latest'. Confirmed by execution that it throws: 'Strict wayland-nano preparation requires an exact pinned release tag; "latest" is forbidden.' Landing it as-is would break the release build. Filling it honestly requires attested wayland-nano releases upstream. Nano continues to launch via npx waylandnano@0.1.0.

## Verification

- Full unit suite: 17,638 passed, 154 skipped. The single failure (AcpSession.brokenBridge, a spawn-count assertion) reproduces only under machine load 30+ and passes 4/4 on four separate isolated runs. The change is provably inert on that path: every new branch is gated on data.nanoError being present, and retryable already defaulted to false.
- tsc: no errors.
- prek (all hooks, diff-scoped): pass.
- New tests: 14 passing across nanoErrorCodes and PromptExecutor.nanoError.

## Behaviour

A nano-typed error's own retryable flag decides prompt replay directly, instead of the numeric-code heuristic that classified every -32603 as retryable. An unknown kind from a newer engine classifies terminal, so an older UI can never auto-retry an error it does not understand. Malformed payloads parse fail-closed and fall back to existing behaviour.
