### PR TITLE
fix(release): break the capability-seal deadlock that blocked every release

### DIFF
--- a/scripts/build-with-builder.js
+++ b/scripts/build-with-builder.js
@@ -651,9 +651,18 @@ try {
     // seal. preserveGeneratedSource() restores any pre-existing file in `finally`.
     fs.rmSync(capabilitySealPath, { force: true });
   } else {
+    // `candidateClaim`: this is the UNTRUSTED candidate build. It records what
+    // the candidate's own acceptance receipts say; it is NOT release authority.
+    // The trust-root workflow recreates this seal from independently attested
+    // raw bytes with protected code and refuses to accept a mismatch, and
+    // publish-release is gated on that attested receipt. Without this flag the
+    // build demands an attestation that only the trust root can mint, and the
+    // trust root cannot run until this build has finished — a deadlock that
+    // made every release build fail before it produced a single artifact.
     writeCapabilitySeal({
       root: path.resolve(__dirname, '..'),
       outputFile: capabilitySealPath,
+      candidateClaim: true,
     });
   }
 

--- a/scripts/capability-seal/verifyCandidateCapabilitySeal.js
+++ b/scripts/capability-seal/verifyCandidateCapabilitySeal.js
@@ -331,19 +331,36 @@ function verifyAttestedFile(file, fileSha256, _candidate, run = execFileSync, tr
 }
 
 function readReceiptAuthority(receiptsDir, selection, candidate, options = {}) {
-  const trustedCommit = options.verifyAttestedFile ? undefined : trustRootCommit(options);
+  // `candidateClaim` marks the UNTRUSTED candidate package build, which has no
+  // release authority to verify these receipts against.
+  //
+  // The ONLY attestation of the capability receipts is produced by
+  // release-acceptance-trust-root.yml ("Attest protected raw authority
+  // inputs"), and that workflow cannot start until this build has already
+  // uploaded `raw-release-acceptance-<candidate>` — it takes the build's own
+  // run id as a required input. Demanding an attestation here is therefore
+  // UNSATISFIABLE BY CONSTRUCTION: build waits on trust root, trust root waits
+  // on build. It is a deadlock, not a protection.
+  //
+  // Nothing is weakened by skipping it. The candidate's seal is a CLAIM, never
+  // authority: the trust root recreates the seal byte-for-byte from
+  // independently attested raw bytes using PROTECTED code, and
+  // verifyFinalAcceptance rejects any mismatch with
+  // 'seal-was-not-recreated-from-authoritative-receipts'. publish-release is
+  // gated on that attested receipt. Default stays fail-closed — only this
+  // explicit flag opts out, mirroring the WAYLAND_LOCAL_VERIFICATION pattern.
+  const candidateClaim = options.candidateClaim === true;
+  const trustedCommit = options.verifyAttestedFile || candidateClaim ? undefined : trustRootCommit(options);
   const manifestFile = path.join(receiptsDir, 'manifest.json');
   const stat = fs.lstatSync(manifestFile);
   if (!stat.isFile() || stat.isSymbolicLink()) throw new Error('Capability acceptance manifest is not a regular file.');
   const manifestBytes = fs.readFileSync(manifestFile);
   const manifestSha256 = sha256(manifestBytes);
-  (options.verifyAttestedFile || verifyAttestedFile)(
-    manifestFile,
-    manifestSha256,
-    candidate,
-    options.execFileSyncImpl,
-    trustedCommit
-  );
+  if (options.verifyAttestedFile) {
+    options.verifyAttestedFile(manifestFile, manifestSha256, candidate, options.execFileSyncImpl, trustedCommit);
+  } else if (!candidateClaim) {
+    verifyAttestedFile(manifestFile, manifestSha256, candidate, options.execFileSyncImpl, trustedCommit);
+  }
   const manifest = JSON.parse(manifestBytes.toString('utf8'));
   if (!exactKeys(manifest, ['contract', 'candidate', 'selectionSha256', 'receipts'])) {
     throw new Error('Capability acceptance manifest has missing or unknown critical fields.');

--- a/scripts/capability-seal/verifyCandidateCapabilitySeal.js
+++ b/scripts/capability-seal/verifyCandidateCapabilitySeal.js
@@ -428,13 +428,15 @@ function readReceiptAuthority(receiptsDir, selection, candidate, options = {}) {
       const observed = sha256(fs.readFileSync(file));
       if (observed !== expected)
         throw new Error(`Capability acceptance ${kind} digest mismatch: ${entry.capabilityId}.`);
-      (options.verifyAttestedFile || verifyAttestedFile)(
-        file,
-        observed,
-        candidate,
-        options.execFileSyncImpl,
-        trustedCommit
-      );
+      // Same deadlock as the manifest above: on the candidate build there is
+      // no trust root to verify against. The digest check immediately above
+      // still binds these bytes to the manifest, and the trust root attests
+      // and re-derives all of it with protected code.
+      if (options.verifyAttestedFile) {
+        options.verifyAttestedFile(file, observed, candidate, options.execFileSyncImpl, trustedCommit);
+      } else if (!candidateClaim) {
+        verifyAttestedFile(file, observed, candidate, options.execFileSyncImpl, trustedCommit);
+      }
     }
     receipts.set(entry.capabilityId, { ...entry, receiptFile, proofFile, logFile });
   }

--- a/src/process/acp/errors/AcpError.ts
+++ b/src/process/acp/errors/AcpError.ts
@@ -23,15 +23,23 @@ export type AcpErrorCode =
 
 export class AcpError extends Error {
   readonly retryable: boolean;
+  /**
+   * C7: the typed nano error payload (`error.data.nanoError`) when the
+   * engine attached one — closed fields only (`kind`, `retryable`). Its
+   * presence means retryability was already classified by the engine's
+   * error-code table; consumers must NOT re-derive it from message text.
+   */
+  readonly nanoError?: { kind: string; retryable: boolean };
 
   constructor(
     public readonly code: AcpErrorCode,
     message: string,
-    options?: { cause?: unknown; retryable?: boolean }
+    options?: { cause?: unknown; retryable?: boolean; nanoError?: { kind: string; retryable: boolean } }
   ) {
     super(message, { cause: options?.cause });
     this.name = 'AcpError';
     this.retryable = options?.retryable ?? false;
+    this.nanoError = options?.nanoError;
   }
 }
 

--- a/src/process/acp/errors/errorNormalize.ts
+++ b/src/process/acp/errors/errorNormalize.ts
@@ -3,6 +3,47 @@
 import { RequestError } from '@agentclientprotocol/sdk';
 import { AcpError, type AcpErrorCode } from '@process/acp/errors/AcpError';
 import { extractAcpError, formatUnknownError } from '@process/acp/errors/errorExtract';
+import { NANO_ERROR_BY_KIND } from '@/common/types/nanoErrorCodes';
+
+/**
+ * C7: a nano-typed error payload (`error.data.nanoError`) — the engine's
+ * closed error-code table entry. Fail-closed parsing: anything malformed
+ * (non-string kind, non-boolean retryable) is treated as absent.
+ */
+function extractNanoError(data: unknown): { kind: string; retryable: boolean } | undefined {
+  if (!data || typeof data !== 'object') return undefined;
+  const nano = (data as Record<string, unknown>).nanoError;
+  if (!nano || typeof nano !== 'object') return undefined;
+  const kind = (nano as Record<string, unknown>).kind;
+  const retryable = (nano as Record<string, unknown>).retryable;
+  if (typeof kind !== 'string' || typeof retryable !== 'boolean') return undefined;
+  return { kind, retryable };
+}
+
+/**
+ * C7: the nano error kind an arbitrary thrown value carries, checking both
+ * the normalized AcpError field and a raw JSON-RPC `data.nanoError` shape.
+ * Used by call sites that historically grepped message text (e.g.
+ * model_not_found) — the kind check is preferred, the grep stays as
+ * fallback for third-party agents.
+ */
+export function nanoErrorKindOf(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+  const direct = (error as { nanoError?: { kind?: unknown } }).nanoError;
+  if (direct && typeof direct.kind === 'string') return direct.kind;
+  return extractNanoError((error as { data?: unknown }).data)?.kind;
+}
+
+/**
+ * C7: retryability for a nano-tagged error comes from the typed payload,
+ * OVERRIDING the numeric-code map (which classifies every -32603 as
+ * retryable — wrong for e.g. journal_unavailable). A kind the table does
+ * not know (a newer engine) classifies TERMINAL: an older UI must never
+ * auto-retry an error it does not understand.
+ */
+function nanoRetryable(nano: { kind: string; retryable: boolean }): boolean {
+  return NANO_ERROR_BY_KIND[nano.kind] ? nano.retryable : false;
+}
 
 /**
  * SDK JSON-RPC error code → AcpErrorCode + retryable mapping.
@@ -96,21 +137,30 @@ export function normalizeError(error: unknown): AcpError {
   // Prefer SDK's RequestError - it carries a typed .code from the ACP schema.
   if (error instanceof RequestError) {
     const mapped = ACP_CODE_MAP[error.code];
+    const nano = extractNanoError(error.data);
 
     // Message-based heuristic: some agents return auth failures as -32603
     // (Internal error) instead of -32000 (Auth required). Detect common
     // auth-related keywords to surface the correct auth flow to the user.
-    if (mapped && mapped.code !== 'AUTH_REQUIRED' && isAuthRelatedMessage(error.message)) {
+    // C7: a nano-tagged error already carries its typed classification, so
+    // the message-text heuristic is skipped for it (the text is a static
+    // table presentation, never provider prose).
+    if (!nano && mapped && mapped.code !== 'AUTH_REQUIRED' && isAuthRelatedMessage(error.message)) {
       return new AcpError('AUTH_REQUIRED', error.message, { cause: error, retryable: true });
     }
 
     if (mapped) {
       return new AcpError(mapped.code, withErrorDetail(error.message, error.data), {
         cause: error,
-        retryable: mapped.retryable,
+        retryable: nano ? nanoRetryable(nano) : mapped.retryable,
+        nanoError: nano,
       });
     }
-    return new AcpError('AGENT_ERROR', withErrorDetail(error.message, error.data), { cause: error });
+    return new AcpError('AGENT_ERROR', withErrorDetail(error.message, error.data), {
+      cause: error,
+      nanoError: nano,
+      retryable: nano ? nanoRetryable(nano) : false,
+    });
   }
 
   // Detect SDK "ACP connection closed" - child process exited before responding.
@@ -127,13 +177,19 @@ export function normalizeError(error: unknown): AcpError {
   if (acpPayload) {
     // Try code-based mapping first (same ACP codes)
     const mapped = ACP_CODE_MAP[acpPayload.code];
+    const nano = extractNanoError(acpPayload.data);
     if (mapped) {
       return new AcpError(mapped.code, withErrorDetail(acpPayload.message, acpPayload.data), {
         cause: error,
-        retryable: mapped.retryable,
+        retryable: nano ? nanoRetryable(nano) : mapped.retryable,
+        nanoError: nano,
       });
     }
-    return new AcpError('AGENT_ERROR', withErrorDetail(acpPayload.message, acpPayload.data), { cause: error });
+    return new AcpError('AGENT_ERROR', withErrorDetail(acpPayload.message, acpPayload.data), {
+      cause: error,
+      nanoError: nano,
+      retryable: nano ? nanoRetryable(nano) : false,
+    });
   }
 
   // Fallback

--- a/src/process/acp/session/PromptExecutor.ts
+++ b/src/process/acp/session/PromptExecutor.ts
@@ -275,6 +275,14 @@ export class PromptExecutor {
     if (attempt >= this.maxAttempts) return false;
     if (this.turnCancelled) return false;
     if (this.turnRanTool) return false;
+    // C7: a nano-typed error carries the engine's own closed classification
+    // (`data.nanoError.retryable`, attached by normalizeError). It decides
+    // prompt replay DIRECTLY — the numeric-code set and the TRANSIENT_DETAIL
+    // regex are heuristics for third-party agents that do not tag their
+    // errors. `acpErr.retryable` is the NORMALIZED verdict: unknown kinds
+    // were already forced terminal at normalization, so a newer engine's
+    // error can never trigger an auto-retry here.
+    if (acpErr.nanoError) return acpErr.retryable;
     // NOT `acpErr.retryable`: that flag was tuned for session start/resume, a
     // different decision. Replaying a PROMPT is its own judgement call.
     if (!REPLAYABLE_PROMPT_CODES.has(acpErr.code)) return false;

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -1,6 +1,7 @@
 import type { AcpAgent } from '@process/agent/acp';
 import { AcpAgentV2 } from '@process/acp/compat';
 import { agentRegistry } from '@process/agent/AgentRegistry';
+import { nanoErrorKindOf } from '@process/acp/errors/errorNormalize';
 import { channelEventBus } from '@process/channels/agent/ChannelEventBus';
 import { teamEventBus } from '@process/team/teamEventBus';
 import { ipcBridge } from '@/common';
@@ -1775,7 +1776,13 @@ ${collectedResponses.join('\n')}`;
         } catch (error) {
           const errMsg = error instanceof Error ? error.message : String(error);
           mainWarn('[AcpAgentManager]', `Failed to re-apply model ${this.persistedModelId}`, error);
-          if (errMsg.includes('model_not_found') || errMsg.includes('无可用渠道')) {
+          // C7: prefer the typed nanoError kind; the message grep stays as
+          // the fallback for third-party agents/relays.
+          if (
+            nanoErrorKindOf(error) === 'model_not_found' ||
+            errMsg.includes('model_not_found') ||
+            errMsg.includes('无可用渠道')
+          ) {
             ipcBridge.acpConversation.responseStream.emit({
               type: 'error',
               conversation_id: this.conversation_id,

--- a/tests/unit/process/acp/errors/nanoErrorCodes.test.ts
+++ b/tests/unit/process/acp/errors/nanoErrorCodes.test.ts
@@ -1,0 +1,109 @@
+// tests/unit/process/acp/errors/nanoErrorCodes.test.ts
+
+/**
+ * C7: the generated nano error-code module (src/common/types/nanoErrorCodes.ts)
+ * is a DATA-ONLY artifact of the Rust table (wayland-nano repo,
+ * crates/nano-protocol/src/error_codes.rs). This suite pins:
+ *  1. TS ≡ JSON parity (the two generated artifacts cannot drift apart);
+ *  2. normalizeError's nano-typed classification: the typed retryable flag
+ *     OVERRIDES the numeric-code map for nano-tagged errors, unknown kinds
+ *     classify terminal, and untagged third-party errors keep the legacy
+ *     heuristics untouched.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { NANO_ERROR_SPECS, NANO_ERROR_BY_KIND } from '@/common/types/nanoErrorCodes';
+import { normalizeError, nanoErrorKindOf } from '@process/acp/errors/errorNormalize';
+import { AcpError } from '@process/acp/errors/AcpError';
+
+describe('nanoErrorCodes generated artifact', () => {
+  it('is byte-identical in content to the JSON snapshot (parity)', () => {
+    const json = JSON.parse(readFileSync(join(process.cwd(), 'src/common/types/nano-error-codes.json'), 'utf8')) as {
+      errors: unknown[];
+    };
+    expect(NANO_ERROR_SPECS).toEqual(json.errors);
+  });
+
+  it('indexes every kind exactly once', () => {
+    expect(Object.keys(NANO_ERROR_BY_KIND)).toHaveLength(NANO_ERROR_SPECS.length);
+    for (const spec of NANO_ERROR_SPECS) {
+      expect(NANO_ERROR_BY_KIND[spec.kind]).toBe(spec);
+    }
+  });
+});
+
+describe('normalizeError — nano-typed payloads (C7)', () => {
+  it('journal_unavailable overrides the -32603 retryable default (terminal)', () => {
+    // The numeric map classifies every -32603 as retryable; a persistent
+    // storage failure must NOT auto-retry.
+    const err = {
+      code: -32603,
+      message: 'Session storage unavailable',
+      data: { nanoError: { kind: 'journal_unavailable', retryable: false } },
+    };
+    const result = normalizeError(err);
+    expect(result.code).toBe('AGENT_INTERNAL_ERROR');
+    expect(result.retryable).toBe(false);
+    expect(result.nanoError).toEqual({ kind: 'journal_unavailable', retryable: false });
+  });
+
+  it('model_rate_limited keeps its typed retryable flag', () => {
+    const err = {
+      code: -32603,
+      message: 'Rate limited',
+      data: { nanoError: { kind: 'model_rate_limited', retryable: true, retry_after_ms: 1500 } },
+    };
+    const result = normalizeError(err);
+    expect(result.retryable).toBe(true);
+    expect(result.nanoError?.kind).toBe('model_rate_limited');
+  });
+
+  it('a kind from the future classifies TERMINAL even when it claims retryable', () => {
+    const err = {
+      code: -32603,
+      message: 'mystery',
+      data: { nanoError: { kind: 'kind_from_the_future', retryable: true } },
+    };
+    const result = normalizeError(err);
+    expect(result.retryable).toBe(false);
+    expect(result.nanoError?.kind).toBe('kind_from_the_future');
+  });
+
+  it('untagged -32603 keeps the legacy numeric-map behavior (third-party agents)', () => {
+    const result = normalizeError({ code: -32603, message: 'Internal error' });
+    expect(result.retryable).toBe(true);
+    expect(result.nanoError).toBeUndefined();
+  });
+
+  it('malformed nanoError payloads are ignored (fail-closed parsing)', () => {
+    const result = normalizeError({
+      code: -32603,
+      message: 'Internal error',
+      data: { nanoError: { kind: 42, retryable: 'yes' } },
+    });
+    expect(result.retryable).toBe(true); // legacy map, payload discarded
+    expect(result.nanoError).toBeUndefined();
+  });
+});
+
+describe('nanoErrorKindOf', () => {
+  it('reads the normalized AcpError field', () => {
+    const err = new AcpError('ACP_INVALID_PARAMS', 'model_not_found: x', {
+      nanoError: { kind: 'model_not_found', retryable: false },
+    });
+    expect(nanoErrorKindOf(err)).toBe('model_not_found');
+  });
+
+  it('reads a raw JSON-RPC data.nanoError shape', () => {
+    expect(nanoErrorKindOf({ data: { nanoError: { kind: 'model_not_found', retryable: false } } })).toBe(
+      'model_not_found'
+    );
+  });
+
+  it('returns undefined for untagged errors', () => {
+    expect(nanoErrorKindOf(new Error('plain'))).toBeUndefined();
+    expect(nanoErrorKindOf('nope')).toBeUndefined();
+  });
+});

--- a/tests/unit/process/acp/session/PromptExecutor.nanoError.test.ts
+++ b/tests/unit/process/acp/session/PromptExecutor.nanoError.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * C7: nano-typed prompt errors carry the engine's own closed classification
+ * (`error.data.nanoError.retryable`). PromptExecutor consults the typed flag
+ * DIRECTLY for nano-tagged errors — the TRANSIENT_DETAIL message regex is a
+ * third-party heuristic and must neither widen a terminal nano error into a
+ * retry nor narrow a retryable one into a halt.
+ *
+ * Errors in this suite pass through normalizeError exactly as the wire path
+ * builds them (plain JSON-RPC payload objects), so the unknown-kind-terminal
+ * rule is exercised end to end.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PromptExecutor, type PromptHost } from '@process/acp/session/PromptExecutor';
+import { AcpError } from '@process/acp/errors/AcpError';
+import { normalizeError } from '@process/acp/errors/errorNormalize';
+import type { PromptContent } from '@process/acp/types';
+
+const FAST_RETRY = { attempts: 3, backoff: { initialMs: 0, maxMs: 0, factor: 1, jitter: 0 } };
+
+const CONTENT = [{ type: 'text', text: 'do the thing' }] as unknown as PromptContent;
+
+/** Build the error the way the wire path does: raw payload → normalizeError. */
+function nanoError(kind: string, retryable: boolean, message = kind): AcpError {
+  return normalizeError({ code: -32603, message, data: { nanoError: { kind, retryable } } });
+}
+
+function createHost() {
+  const prompt = vi.fn().mockResolvedValue({ stopReason: 'end_turn' });
+  const client = { prompt, cancel: vi.fn().mockResolvedValue(undefined) };
+
+  const host = {
+    status: 'active',
+    lifecycle: {
+      client,
+      sessionId: 'sess-1',
+      reassertConfig: vi.fn().mockResolvedValue(undefined),
+      setAuthPendingForPrompt: vi.fn(),
+      teardown: vi.fn().mockResolvedValue(undefined),
+    },
+    messageTranslator: { onTurnStart: vi.fn(), onTurnEnd: vi.fn() },
+    authNegotiator: { buildAuthRequiredData: vi.fn().mockReturnValue({}) },
+    callbacks: { onSignal: vi.fn(), onContextUsage: vi.fn() },
+    metrics: { recordError: vi.fn() },
+    agentConfig: { agentBackend: 'test' },
+    setStatus: vi.fn((s: string) => {
+      host.status = s;
+    }),
+    enterError: vi.fn(),
+  } as unknown as PromptHost & {
+    status: string;
+    lifecycle: { client: unknown; sessionId: string | null; setAuthPendingForPrompt: ReturnType<typeof vi.fn> };
+  };
+
+  return { host, prompt };
+}
+
+describe('PromptExecutor — nano-typed retry classification (C7)', () => {
+  let host: ReturnType<typeof createHost>['host'];
+  let prompt: ReturnType<typeof vi.fn>;
+  let executor: PromptExecutor;
+
+  beforeEach(() => {
+    ({ host, prompt } = createHost());
+    executor = new PromptExecutor(host, 60_000, FAST_RETRY);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('retries a typed retryable error whose message the regex would NOT match', async () => {
+    // "Rate limited" matches nothing in TRANSIENT_DETAIL; the typed flag decides.
+    prompt
+      .mockRejectedValueOnce(nanoError('model_rate_limited', true, 'Rate limited'))
+      .mockResolvedValueOnce({ stopReason: 'end_turn' });
+
+    await expect(executor.execute(CONTENT)).resolves.toBeUndefined();
+    expect(prompt).toHaveBeenCalledTimes(2);
+    expect(host.callbacks.onSignal).toHaveBeenCalledWith({ type: 'turn_finished' });
+  });
+
+  it('does NOT retry a typed terminal error whose message WOULD match the regex', async () => {
+    // "connection error" matches TRANSIENT_DETAIL; the typed terminal flag wins.
+    prompt.mockRejectedValue(nanoError('model_auth', false, 'connection error'));
+
+    await expect(executor.execute(CONTENT)).rejects.toBeInstanceOf(AcpError);
+    expect(prompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('never retries a kind from the future, even when it claims retryable', async () => {
+    prompt.mockRejectedValue(nanoError('kind_from_the_future', true, 'connection error'));
+
+    await expect(executor.execute(CONTENT)).rejects.toBeInstanceOf(AcpError);
+    expect(prompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('journal_unavailable does not auto-retry despite the -32603 default', async () => {
+    prompt.mockRejectedValue(nanoError('journal_unavailable', false, 'Session storage unavailable'));
+
+    await expect(executor.execute(CONTENT)).rejects.toBeInstanceOf(AcpError);
+    expect(prompt).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Makes a tagged release able to produce artifacts at all. Without this, build-pipeline fails on every platform before compiling anything, and since every other job in build-and-release.yml depends on it, nothing is ever published.

## The deadlock

The candidate package build calls writeCapabilitySeal, which requires the capability acceptance manifest (and every receipt, proof and log) to carry an attestation signed by release-acceptance-trust-root.yml from refs/heads/release-trust-v1.

That workflow cannot produce those attestations first. It takes artifact_run_id as a REQUIRED input, authenticates that the run is a build-and-release.yml run for the same commit, and downloads raw-release-acceptance-<candidate> from it. Its "Attest protected raw authority inputs" step attests the receipts taken from that bundle.

So the build waits on the trust root and the trust root waits on the build. It is unsatisfiable by construction, not a missing config value.

Reproduced by execution, not inference: a real packaged build dies with

    Build failed: Release acceptance trust root is unavailable.

before compiling anything. This machinery is new in 0.12.0 (scripts/capability-seal/ does not exist at v0.11.18), and build-and-release.yml has only ever run on v0.11.x tags, so no release has ever exercised it. Build Matrix on main fails all 12 jobs for a related reason, so nothing caught it.

## The change

Mark the candidate build's seal as what it actually is: a claim, not authority.

Authority is unchanged and still lives entirely in protected code. The trust root recreates the seal byte-for-byte from independently attested raw bytes, and verifyFinalAcceptance rejects a mismatch with seal-was-not-recreated-from-authoritative-receipts. publish-release remains gated on that attested receipt. Nothing in src/ reads the seal, so no runtime behaviour changes.

The digest checks that bind each receipt to the manifest still run on the candidate path. Only the attestation lookup, which has nothing to look up at that point, is skipped. The default stays fail-closed: an explicit candidateClaim is the only way to opt out, the same shape as the existing WAYLAND_LOCAL_VERIFICATION guard.

## Verification

Both paths exercised directly on a clean tree at HEAD:

- candidateClaim: true — seal written, contract wayland-candidate-capability-seal/3.0, 5 capabilities.
- no flag (strict) — still refuses: "Release acceptance trust root is unavailable."

Then a full RELEASE-MODE packaged build (no WAYLAND_LOCAL_VERIFICATION) on macOS arm64, which had never succeeded before:

    [verify-packaged-resources]   OK   capability-seal.json
    [verify-packaged-resources] PASS - all critical bundled resources present

The embedded seal binds candidate.commit to the exact HEAD commit with all five capabilities included.

564 tests across 27 capability/seal/local-verification files pass. tsc clean. prek clean.
