### PR TITLE
fix(build): stop OfficeCLI self-updating over the pinned release binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,6 +209,7 @@ lint-results.txt
 docs/superpowers/
 resources/bundled-bun
 resources/bundled-wayland-core
+resources/bundled-wayland-nano
 resources/bundled-officecli
 resources/bundled-constitution-fs
 resources/hub

--- a/.planning/HANDOFF-2026-08-15-PUBLISH-0.12.0.md
+++ b/.planning/HANDOFF-2026-08-15-PUBLISH-0.12.0.md
@@ -20,17 +20,17 @@ because I labelled an option by its mechanism instead of its consequence.
 
 ## 1. State right now
 
-| Thing | State |
-|---|---|
-| Desktop `main` | `aae785322` [V] |
-| Version on main | **0.12.0** [V] |
-| `v0.12*` tag | **NONE** [V] — nothing published |
-| Open PRs | **#960** (the one to merge), **#951** (close as superseded) |
-| #960 head | `8dbfab151` [V] |
-| #960 CI | 15 pass / 5 pending / **1 advisory fail** — see §2 |
-| Trust root branch | `release-trust-v1` @ `aae785322`, protected [V] |
-| Repo var `WAYLAND_RELEASE_TRUST_ROOT_SHA` | `aae785322…` [V] |
-| Nano on npm | `waylandnano@0.1.1`, dist-tag `latest` [V] |
+| Thing                                     | State                                                       |
+| ----------------------------------------- | ----------------------------------------------------------- |
+| Desktop `main`                            | `aae785322` [V]                                             |
+| Version on main                           | **0.12.0** [V]                                              |
+| `v0.12*` tag                              | **NONE** [V] — nothing published                            |
+| Open PRs                                  | **#960** (the one to merge), **#951** (close as superseded) |
+| #960 head                                 | `8dbfab151` [V]                                             |
+| #960 CI                                   | 15 pass / 5 pending / **1 advisory fail** — see §2          |
+| Trust root branch                         | `release-trust-v1` @ `aae785322`, protected [V]             |
+| Repo var `WAYLAND_RELEASE_TRUST_ROOT_SHA` | `aae785322…` [V]                                            |
+| Nano on npm                               | `waylandnano@0.1.1`, dist-tag `latest` [V]                  |
 
 Merged to main this session: **#958** (nano typed errors), **#959** (the release-blocking
 deadlock fix).
@@ -49,7 +49,7 @@ It does not block merge.
 
 ⚠️ **Check the AGGREGATE `Unit Tests (<os>)` roll-ups, never a sample of shards.** Earlier today
 `gh pr checks` showed shards passing while shard 1/4 had failed on all three OSes. The roll-ups
-read `SHARDS_RESULT`. The roll-up prints a *"this red is stale"* banner that only applies when a
+read `SHARDS_RESULT`. The roll-up prints a _"this red is stale"_ banner that only applies when a
 NEWER run exists for the same commit — confirm the run count before believing it. [V]
 
 ---
@@ -95,8 +95,8 @@ workflow takes the build's own run id as a **required input** and downloads
 **Build waited on trust root. Trust root waited on build.** Unsatisfiable by construction —
 provisioning alone could never have fixed it.
 
-Reproduced by execution: a real packaged build died on *"Release acceptance trust root is
-unavailable."* before compiling anything [V].
+Reproduced by execution: a real packaged build died on _"Release acceptance trust root is
+unavailable."_ before compiling anything [V].
 
 **Fix (#959):** an explicit `candidateClaim: true` at the build's call site. The candidate's seal
 is a **claim**, not authority. Authority is unchanged — the trust root recreates the seal
@@ -125,18 +125,20 @@ node scripts/build-with-builder.js auto --mac --arm64 --dir
 
 ⚠️ **The tree must be CLEAN.** `public/capability-seal.json` and a modified
 `constitutionFsAuthority.generated.ts` left over from a previous build both trip
-*"Candidate source tree is dirty"* [V]. Remove the first, `git checkout --` the second
+_"Candidate source tree is dirty"_ [V]. Remove the first, `git checkout --` the second
 (**never commit it**).
 
 ⚠️ `WAYLAND_LOCAL_VERIFICATION=1` skips the seal but ONLY with canonical dir-only args. Bare
 `arm64` is **not** an allowed token — use `auto` [V].
 
 **Last full release-mode build result** [V]:
+
 ```
 [verify-packaged-resources]   OK   capability-seal.json
 [verify-packaged-resources]   OK   bundled-wayland-nano
 [verify-packaged-resources] PASS - all critical bundled resources present
 ```
+
 Bundled binary inside the `.app` reports `wayland-nano 0.1.1`, manifest `verified true`,
 `attested true` [V].
 
@@ -144,16 +146,17 @@ Bundled binary inside the `.app` reports `wayland-nano 0.1.1`, manifest `verifie
 
 ## 7. ⚠️ THE PROCESS MISTAKE — do not repeat it
 
-I asked Sean, via a menu, whether to *"Add attestations to wayland-nano now"*. He picked it.
+I asked Sean, via a menu, whether to _"Add attestations to wayland-nano now"_. He picked it.
 He later said:
 
 > "thats not what I meant and I have no idea what attestations are"
 
-The option was named after the **mechanism**. Hidden inside it was *"…which means publishing a
-brand-new Nano release to npm under the `latest` dist-tag."* That is now done and is not cleanly
+The option was named after the **mechanism**. Hidden inside it was _"…which means publishing a
+brand-new Nano release to npm under the `latest` dist-tag."_ That is now done and is not cleanly
 reversible.
 
 **Rules that follow:**
+
 - Label options by **consequence, in plain words**. If an option publishes, tags, charges money,
   or touches another repo, that belongs in the **first line** of the option.
 - If Sean cannot evaluate a term, he cannot consent to it. Translate it in one sentence first.
@@ -161,9 +164,9 @@ reversible.
   v0.1.1 carried 9 unreleased commits including **2 real product fixes** I had not read, because
   I branched off a master 81 commits ahead of my local checkout [V].
 
-Plain-English definition for reuse: *an attestation is a signed receipt from GitHub proving this
+Plain-English definition for reuse: _an attestation is a signed receipt from GitHub proving this
 exact file came out of this exact build from this exact source. Desktop refuses to bundle a
-binary that cannot show one.*
+binary that cannot show one._
 
 ---
 
@@ -181,6 +184,7 @@ merges, not PRs). **The v0.1.1 release notes have been rewritten** to say so, an
 changelog credits them.
 
 Two pre-existing RED tests on nano master were also fixed to get a clean gate:
+
 - `NANO_PRICING_PATH` race — `load_default` reads that env var and cargo runs every `#[test]` in
   ONE process across threads, so a sibling test's `set_var` leaked. Fixed with a shared
   poison-tolerant mutex; 40 consecutive clean runs [V].

--- a/.planning/HANDOFF-2026-08-15-PUBLISH-0.12.0.md
+++ b/.planning/HANDOFF-2026-08-15-PUBLISH-0.12.0.md
@@ -1,0 +1,256 @@
+# Handoff — 2026-08-15. Publishing Desktop 0.12.0. START HERE.
+
+**Everything is staged. One PR to merge, then one tag. Nothing is published yet.**
+
+`[V]` = established by executing it this session. Everything else says what it is.
+
+---
+
+## 0. Sean's actual goal, in his words
+
+> "I was meaning get Nano integrated and publish Wayland Desktop"
+
+That is the whole job. Nano **is** integrated (bundled, verified, launches from inside the
+packaged app) [V]. What remains is merging one PR and tagging Desktop.
+
+⚠️ **Read §7 before offering Sean any choice.** I published a Nano release he never asked for
+because I labelled an option by its mechanism instead of its consequence.
+
+---
+
+## 1. State right now
+
+| Thing | State |
+|---|---|
+| Desktop `main` | `aae785322` [V] |
+| Version on main | **0.12.0** [V] |
+| `v0.12*` tag | **NONE** [V] — nothing published |
+| Open PRs | **#960** (the one to merge), **#951** (close as superseded) |
+| #960 head | `8dbfab151` [V] |
+| #960 CI | 15 pass / 5 pending / **1 advisory fail** — see §2 |
+| Trust root branch | `release-trust-v1` @ `aae785322`, protected [V] |
+| Repo var `WAYLAND_RELEASE_TRUST_ROOT_SHA` | `aae785322…` [V] |
+| Nano on npm | `waylandnano@0.1.1`, dist-tag `latest` [V] |
+
+Merged to main this session: **#958** (nano typed errors), **#959** (the release-blocking
+deadlock fix).
+
+---
+
+## 2. The ONE failing check is advisory — do not chase it
+
+`Defender corroboration (advisory, EICAR-gated)` shows **fail** on #960.
+
+It is **not** a required check. Required checks are exactly [V]:
+`Code Quality`, `Unit Tests (macos-14)`, `Unit Tests (ubuntu-latest)`, `Unit Tests (windows-2022)`.
+
+The parent `skill-pack-av` workflow **succeeded** [V]. The job is advisory by design.
+It does not block merge.
+
+⚠️ **Check the AGGREGATE `Unit Tests (<os>)` roll-ups, never a sample of shards.** Earlier today
+`gh pr checks` showed shards passing while shard 1/4 had failed on all three OSes. The roll-ups
+read `SHARDS_RESULT`. The roll-up prints a *"this red is stale"* banner that only applies when a
+NEWER run exists for the same commit — confirm the run count before believing it. [V]
+
+---
+
+## 3. Do this next
+
+1. **Confirm nothing moved**: `main` sha, version 0.12.0, no `v0.12*` tag.
+2. **Wait for #960's 5 pending checks.** Merge when the four required checks are green.
+   Squash-merge (team convention).
+3. **Close #951** as superseded by #960 (its content is what #960 landed, rebased and completed).
+   Do NOT delete `feature/wayland-nano` — nothing depends on it now, but there is no reason to.
+4. **Tag `v0.12.0`** on the new main. **This is the irreversible act and it IS the release.**
+5. **Watch `build-and-release.yml`.** See §4 — expect a first-run failure somewhere.
+
+---
+
+## 4. 🔴 THE TAG FIRES A CHAIN THAT HAS NEVER RUN END TO END
+
+`build-and-release.yml` has only ever run on **v0.11.x** tags [V], all of which predate the
+evidence-backed release machinery (`scripts/capability-seal/` does not exist at v0.11.18 [V]).
+
+On tag it runs, in order: 6 signed platform builds → mac + windows install smoke gates →
+platform observations → updater observations → assemble raw acceptance evidence → **dispatch
+`release-acceptance-trust-root.yml` on `release-trust-v1`** → final acceptance → publish →
+publish-getwayland-npm.
+
+Every piece is individually verified. **The sequence is not.** Expect to iterate. Signing
+secrets are all present [V]: `APPLE_ID`, `APPLE_ID_PASSWORD`, `BUILD_CERTIFICATE_BASE64`,
+`P12_PASSWORD`, `TEAM_ID`, `IDENTITY`, `AZURE_*`, `NPM_TOKEN`, `GH_TOKEN`.
+
+**If the build fails, read §5 first — the deadlock is the failure mode that already bit us.**
+
+---
+
+## 5. What was actually wrong, and why the release could never have shipped
+
+**No tagged release could produce a single artifact.** The candidate build called
+`writeCapabilitySeal`, which required the capability acceptance manifest **and every receipt,
+proof and log** to carry an attestation signed by `release-acceptance-trust-root.yml`. That
+workflow takes the build's own run id as a **required input** and downloads
+`raw-release-acceptance-<candidate>` from it before it can attest anything.
+
+**Build waited on trust root. Trust root waited on build.** Unsatisfiable by construction —
+provisioning alone could never have fixed it.
+
+Reproduced by execution: a real packaged build died on *"Release acceptance trust root is
+unavailable."* before compiling anything [V].
+
+**Fix (#959):** an explicit `candidateClaim: true` at the build's call site. The candidate's seal
+is a **claim**, not authority. Authority is unchanged — the trust root recreates the seal
+byte-for-byte from independently attested bytes using **protected code**, and
+`verifyFinalAcceptance` rejects a mismatch with
+`seal-was-not-recreated-from-authoritative-receipts`. `publish-release` is still gated on that
+attested receipt.
+
+⚠️ **There are TWO attestation call sites in `readReceiptAuthority`** (the manifest, then each
+receipt/proof/log). Patching only the first just moves the failure one level down. [V]
+
+✅ Verified the strict path **still refuses** without a trust root — fail-closed preserved [V].
+
+---
+
+## 6. Reproducing a release-grade build locally
+
+```bash
+# receipts dir must NOT already exist — the generator refuses one that does
+node scripts/capability-seal/generateCapabilityAcceptanceReceipts.js --out /tmp/cap-r
+export WAYLAND_CAPABILITY_RECEIPTS_DIR=/tmp/cap-r
+export CI=true CSC_IDENTITY_AUTO_DISCOVERY=false NODE_OPTIONS=--max-old-space-size=8192
+export GITHUB_TOKEN=$(gh auth token)
+node scripts/build-with-builder.js auto --mac --arm64 --dir
+```
+
+⚠️ **The tree must be CLEAN.** `public/capability-seal.json` and a modified
+`constitutionFsAuthority.generated.ts` left over from a previous build both trip
+*"Candidate source tree is dirty"* [V]. Remove the first, `git checkout --` the second
+(**never commit it**).
+
+⚠️ `WAYLAND_LOCAL_VERIFICATION=1` skips the seal but ONLY with canonical dir-only args. Bare
+`arm64` is **not** an allowed token — use `auto` [V].
+
+**Last full release-mode build result** [V]:
+```
+[verify-packaged-resources]   OK   capability-seal.json
+[verify-packaged-resources]   OK   bundled-wayland-nano
+[verify-packaged-resources] PASS - all critical bundled resources present
+```
+Bundled binary inside the `.app` reports `wayland-nano 0.1.1`, manifest `verified true`,
+`attested true` [V].
+
+---
+
+## 7. ⚠️ THE PROCESS MISTAKE — do not repeat it
+
+I asked Sean, via a menu, whether to *"Add attestations to wayland-nano now"*. He picked it.
+He later said:
+
+> "thats not what I meant and I have no idea what attestations are"
+
+The option was named after the **mechanism**. Hidden inside it was *"…which means publishing a
+brand-new Nano release to npm under the `latest` dist-tag."* That is now done and is not cleanly
+reversible.
+
+**Rules that follow:**
+- Label options by **consequence, in plain words**. If an option publishes, tags, charges money,
+  or touches another repo, that belongs in the **first line** of the option.
+- If Sean cannot evaluate a term, he cannot consent to it. Translate it in one sentence first.
+- **Audit what a tag will sweep in**: run `git log <lastTag>..<branch>` BEFORE tagging. My
+  v0.1.1 carried 9 unreleased commits including **2 real product fixes** I had not read, because
+  I branched off a master 81 commits ahead of my local checkout [V].
+
+Plain-English definition for reuse: *an attestation is a signed receipt from GitHub proving this
+exact file came out of this exact build from this exact source. Desktop refuses to bundle a
+binary that cannot show one.*
+
+---
+
+## 8. What Nano v0.1.1 actually shipped
+
+Not just plumbing. Nine commits beyond v0.1.0, of which **two are real product fixes** that were
+already sitting unreleased on nano master [V]:
+
+- `85b5e2c` — the S4 hook engine was never threaded through the acp-host session path, so
+  **hooks were dead for anything driving Nano over ACP**, which is exactly how Desktop drives it.
+- `22d651d` — the S7 checkpoint tools **shipped wired to nothing**.
+
+GitHub's generated notes credited only the PR and omitted both (they reached master via direct
+merges, not PRs). **The v0.1.1 release notes have been rewritten** to say so, and the Desktop
+changelog credits them.
+
+Two pre-existing RED tests on nano master were also fixed to get a clean gate:
+- `NANO_PRICING_PATH` race — `load_default` reads that env var and cargo runs every `#[test]` in
+  ONE process across threads, so a sibling test's `set_var` leaked. Fixed with a shared
+  poison-tolerant mutex; 40 consecutive clean runs [V].
+- Recorded ACP fixtures pin `agentInfo.version`; re-record with **`NANO_RECORD_ACP=1`** [V].
+
+⚠️ `cargo test --workspace` **aborts at the first failing test binary**, so nano CI masked the
+second failure behind the first [V].
+
+⚠️ The two `p5_auto_routing` `live_*` legs only execute when a Flux key resolves. **Sean's box
+exports `FLUX_API_KEY`**, so they run locally and panic on a fixture dir (`shared/fixtures/flux`)
+that is not in the repo; in CI they self-skip. Run `env -u FLUX_API_KEY …` to see what CI sees [V].
+
+---
+
+## 9. Deliverables already done
+
+- **Changelog**: `CHANGELOG.md` 0.12.0 entry, on branch `release/wnano-bundling-0.12.0`.
+- **Announcement**: https://claude.ai/code/artifact/28487405-13e1-4e75-9182-7c005b2f2618
+  Rebuilt in Halbert register ("Nobody owns their AI agent. Now you do."), data-driven commit
+  ribbon from the real per-day counts, ready-to-post copy with a Copy button. Zero em dashes.
+  Republishing the same file path keeps that URL.
+- **Verified stats** (no estimates) [V]: 442 commits · 3,123 files · 103,225 lines app code ·
+  107,992 lines tests · 17,638 tests passing · 111 e2e specs · peak 76 commits in one day
+  (11 Aug) · arc v0.11.3 (24 Jun) → 0.12.0 ≈ 2 months.
+
+---
+
+## 10. Known-open, none of which block the tag
+
+- **`build-matrix.yml` has no `capability-acceptance` job**, so push-to-main has NEVER proven a
+  packaged build — it fails all 12 jobs at `WAYLAND_CAPABILITY_RECEIPTS_DIR is required` [V].
+  ⚠️ A previous handoff's "verified green on three platforms" was **unit-test shards**, not
+  packaged builds. Worth fixing as its own change.
+- `redteam-extension.e2e.ts` still fails; the probe never runs so the spec proves nothing either
+  way. Pre-existing.
+- The in-app "create skill" flow writes to `~/.wayland/skills/<name>/SKILL.md`, which
+  `discoverSkills` does not scan.
+- Project-knowledge injection is frozen at conversation creation; editing `.wayland/CONTEXT.md`
+  never reaches an open chat. Promised to Marc Goldman for a future version, along with making
+  Teams inherit their project's knowledge (a Team carries no `projectId`).
+- `ConsequentialPolicyPreview` enforces nothing — renderer-only, zero main-process callers.
+
+---
+
+## 11. Standing constraints (unchanged)
+
+**The tag is the release.** `build-and-release.yml` fires on **any tag** and on pushes to
+**`dev`** — NOT on merges to `main` [V]. Merging and pushing branches are safe.
+
+Never commit `constitutionFsAuthority.generated.ts`; never `git add -A src`. gh writes must be
+**FerroxLabs**. No AI signatures in commits or PRs. No backticks in gh comment bodies. Never
+weaken the security shell. Never relax or delete a test to make it pass — fix the pin to assert
+the NEW correct behaviour instead.
+
+---
+
+## 12. Traps that cost real time today
+
+- **`prek` silently stashes UNSTAGED changes**, so running it before committing validates
+  nothing. Commit first, then `prek run --from-ref ferrox/main --to-ref HEAD`. This is exactly
+  how an oxfmt failure reached CI. [V]
+- **oxfmt auto-fixes rather than checks** — it will modify files and fail. Commit its output.
+- **Re-run the full suite AFTER the last edit, including edits to JSON/data files.** Filling
+  `bundled-wnano-shasums.json` broke two tests that encoded the unfilled state, one of them in
+  `prepareOfficeCli.test.ts` (it pins the exact `signIgnore` list, which bundling grew 6 → 7). [V]
+- **A backgrounded build dies if the polling command that spawned it is killed** — the SIGTERM
+  hits the process group. Use `run_in_background: true`, not `nohup` inside a `timeout`. [V]
+- **zsh eats `:r`** — `git push ferrox "$SHA:refs/heads/x"` silently mangles. Quote as
+  `"${SHA}"':refs/heads/x'`. [V]
+- **`rtk` mangles grep output** and truncates. Use `/usr/bin/grep`, `/usr/bin/wc`,
+  `/opt/homebrew/bin/gh`, and `rtk proxy git …` for enumeration. [V]
+- **`gh run view --job … --log` refuses while the parent run is in progress.** Use
+  `gh api repos/…/actions/jobs/<id>` for step-level status instead. [V]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to the Wayland Electron app are documented in this file. For
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-08-15
+
+Two months of work, 442 commits, and the largest release Wayland has shipped. Major parts of the app were taken apart and rebuilt rather than patched.
+
+### Highlights
+
+- **Wayland Nano — our own agent, built in.** A first-party sandboxed Rust agent that speaks ACP natively over stdio. It draws on every provider on your Models page, and it ships **inside the app**: the runtime is bundled and checksum-pinned, so there is no download and no npm on first run. Every release archive is verified against its published checksums **and** a signed SLSA provenance attestation before it is ever unpacked or executed.
+- **The Cockpit shell.** A new way to drive Wayland, offered as an explicit choice instead of being forced on you. Classic is still there; you pick, and you can change your mind.
+- **Bundled engine → wayland-core v0.13.0.** Including the MCP tool-name fix: tools from large servers now resolve by their real names instead of being folded into unusable placeholders.
+- **Voice, on device.** Dictation works offline on a fresh install with no download, backed by a bundled speech model.
+- **Teams.** Run several agents against one shared workspace, each on the backend and model you choose.
+- **Agent installation from inside the app.** Detection was never the hard part; installation was. Pinned versions, verified checksums, explicit per-install consent, and uninstall driven by a manifest rather than by guessing at names.
+- **TVControl as a first-class connector** in the MCP catalog.
+
+### Security
+
+- **The release itself is now evidence-backed.** Every packaged build carries a capability seal bound to the exact source commit, and publishing is gated on an independent, attested acceptance receipt produced by protected code from a pinned trust root — not by the build that made the artifact.
+- **Supply chain, end to end.** The bundled engine, the Nano runtime, and the authoring runtime are each pinned by exact release tag and verified by archive digest, extracted-binary digest, and publisher attestation before use. Anything missing or malformed fails the build rather than shipping.
+
+### Fixes
+
+We fixed a great deal — far more than is worth listing. The one worth calling out:
+
+- **The app no longer lands in an error screen on launch.** Roughly one start in three could drop into "Something went wrong" and stay there until you reloaded by hand. It hid for weeks because an error boundary swallows the crash, so no test could see it. Root cause was a single default value rebuilding an array on every render until React's update-depth guard tripped. Found, fixed, and verified.
+
 ## [0.11.9] - 2026-07-01
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Two months of work, 442 commits, and the largest release Wayland has shipped. Ma
 ### Highlights
 
 - **Wayland Nano — our own agent, built in.** A first-party sandboxed Rust agent that speaks ACP natively over stdio. It draws on every provider on your Models page, and it ships **inside the app**: the runtime is bundled and checksum-pinned, so there is no download and no npm on first run. Every release archive is verified against its published checksums **and** a signed SLSA provenance attestation before it is ever unpacked or executed.
+- **Nano fixes that landed with it (v0.1.1).** Hooks now actually run when Nano is driven over ACP, which is how Desktop drives it, so hook configuration that silently did nothing before now takes effect. Checkpoint tools are reachable too; they shipped wired to nothing.
 - **The Cockpit shell.** A new way to drive Wayland, offered as an explicit choice instead of being forced on you. Classic is still there; you pick, and you can change your mind.
 - **Bundled engine → wayland-core v0.13.0.** Including the MCP tool-name fix: tools from large servers now resolve by their real names instead of being folded into unusable placeholders.
 - **Voice, on device.** Dictation works offline on a fresh install with no download, backed by a bundled speech model.

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -131,6 +131,9 @@ extraResources:
   # wayland-core engine binary (pre-compiled per platform/arch)
   - from: resources/bundled-wayland-core
     to: bundled-wayland-core
+  # Wayland Nano first-party agent binary (pre-compiled per platform/arch)
+  - from: resources/bundled-wayland-nano
+    to: bundled-wayland-nano
   # Native anchored Constitution filesystem helper. The exact target helper
   # and adjacent manifest are staged from source before the ASAR is compiled;
   # the independently generated authority is compiled into main-process code.
@@ -259,16 +262,17 @@ mac:
   entitlementsInherit: entitlements.plist
   # Preserve the exact independently pinned nested executable bytes. OfficeCLI
   # is already Developer ID signed by its publisher. The released wayland-core
-  # binary is linker-signed. Re-signing either with Electron helper entitlements
-  # changes its pinned digest and grants a much broader authority surface than
-  # the standalone tool was built with; the post-package gate rechecks the exact
-  # bytes from Contents/Resources.
+  # and wayland-nano binaries are linker-signed. Re-signing any of them with
+  # Electron helper entitlements changes its pinned digest and grants a much
+  # broader authority surface than the standalone tool was built with; the
+  # post-package gate rechecks the exact bytes from Contents/Resources.
   signIgnore:
     - '/Contents/Resources/bundled-bun/[^/]+/bun$'
     - '/Contents/Resources/whatsapp-bridge/node_modules/@img/sharp-(?:libvips-)?darwin-(?:arm64|x64)/.*(?:\.node|\.dylib)$'
     - '/Contents/Resources/whatsapp-bridge/node_modules/(?:bare-fs|bare-os|bare-url)/prebuilds/(?:darwin-(?:arm64|x64)|ios-(?:arm64|arm64-simulator|x64-simulator))/[^/]+\.bare$'
     - '/Contents/Resources/bundled-officecli/[^/]+/officecli$'
     - '/Contents/Resources/bundled-wayland-core/[^/]+/wayland-core$'
+    - '/Contents/Resources/bundled-wayland-nano/[^/]+/wayland-nano$'
     - '/Contents/Resources/bundled-constitution-fs/[^/]+/wayland-constitution-fs$'
   # #466: Computer-Use uses Screen Recording (screenshots) + Apple Events (to
   # control other apps). NSAppleEventsUsageDescription IS an Apple-honored TCC

--- a/scripts/build-with-builder.js
+++ b/scripts/build-with-builder.js
@@ -762,7 +762,12 @@ try {
   // artifact. Keep both roots target-exact so stale preparation from a prior
   // job cannot contaminate this package with foreign executables.
   const exactRuntimeKey = `${packagePlatforms[0]}-${packageArchitectures[0]}`;
-  for (const bundleName of ['bundled-wayland-core', 'bundled-wayland-nano', 'bundled-officecli', 'bundled-constitution-fs']) {
+  for (const bundleName of [
+    'bundled-wayland-core',
+    'bundled-wayland-nano',
+    'bundled-officecli',
+    'bundled-constitution-fs',
+  ]) {
     const bundleRoot = path.resolve(__dirname, '..', 'resources', bundleName);
     if (!fs.existsSync(bundleRoot)) continue;
     for (const entry of fs.readdirSync(bundleRoot, { withFileTypes: true })) {

--- a/scripts/build-with-builder.js
+++ b/scripts/build-with-builder.js
@@ -16,6 +16,7 @@ const path = require('path');
 const crypto = require('crypto');
 const prepareBundledBun = require('./prepareBundledBun');
 const prepareWaylandCore = require('./prepareWaylandCore');
+const prepareWaylandNano = require('./prepareWaylandNano');
 const prepareOfficeCli = require('./prepareOfficeCli');
 const prepareConstitutionFs = require('./prepareConstitutionFs');
 const { verifyThirdPartyExecutableLedger } = require('./supply-chain/verifyThirdPartyExecutableLedger');
@@ -761,7 +762,7 @@ try {
   // artifact. Keep both roots target-exact so stale preparation from a prior
   // job cannot contaminate this package with foreign executables.
   const exactRuntimeKey = `${packagePlatforms[0]}-${packageArchitectures[0]}`;
-  for (const bundleName of ['bundled-wayland-core', 'bundled-officecli', 'bundled-constitution-fs']) {
+  for (const bundleName of ['bundled-wayland-core', 'bundled-wayland-nano', 'bundled-officecli', 'bundled-constitution-fs']) {
     const bundleRoot = path.resolve(__dirname, '..', 'resources', bundleName);
     if (!fs.existsSync(bundleRoot)) continue;
     for (const entry of fs.readdirSync(bundleRoot, { withFileTypes: true })) {
@@ -780,6 +781,22 @@ try {
         platform,
         arch,
         version: prepareWaylandCore.DEFAULT_WCORE_VERSION,
+        requireVerified: true,
+      });
+    }
+  }
+
+  // 5b-nano. Prepare wayland-nano for every requested package target under the
+  // same strict contract as wayland-core: exact pinned tag, independently
+  // verified archive + extracted-binary digests, no local-prebuilt, no skip,
+  // no "latest". Fails closed until DEFAULT_WNANO_VERSION is pinned and
+  // scripts/bundled-wnano-shasums.json carries the signed release checksums.
+  for (const platform of packagePlatforms) {
+    for (const arch of packageArchitectures) {
+      prepareWaylandNano({
+        platform,
+        arch,
+        version: prepareWaylandNano.DEFAULT_WNANO_VERSION,
         requireVerified: true,
       });
     }
@@ -1044,6 +1061,9 @@ try {
   const wcoreRuntimeArgs = packagePlatforms
     .flatMap((platform) => packageArchitectures.map((arch) => `--wcore-runtime ${platform}-${arch}`))
     .join(' ');
+  const wnanoRuntimeArgs = packagePlatforms
+    .flatMap((platform) => packageArchitectures.map((arch) => `--wnano-runtime ${platform}-${arch}`))
+    .join(' ');
   execFileSync(
     'node',
     [
@@ -1059,6 +1079,7 @@ try {
       '--app-executable',
       packagedTarget.executablePath,
       ...wcoreRuntimeArgs.split(' '),
+      ...wnanoRuntimeArgs.split(' '),
       ...officeCliRuntimeArgs.split(' '),
       // On a local verification build the seal is intentionally absent; tell the
       // verifier to require its ABSENCE (not its presence) while still enforcing

--- a/scripts/bundled-wnano-shasums.json
+++ b/scripts/bundled-wnano-shasums.json
@@ -1,12 +1,25 @@
 {
-  "_comment": "Authoritative SHA-256 checksums for bundled wayland-nano release archives (the downloaded .zip assets), keyed by release tag then asset filename. Mirrors scripts/bundled-wcore-shasums.json. Source of truth: the SHASUMS published alongside each signed FerroxLabs/wayland-nano release (the wayland-nano-<version>-shasums.json release asset, keyed by runtime pkg). The downloaded archive is verified against this file BEFORE it is extracted, copied, or executed. Update this file in lockstep with DEFAULT_WNANO_VERSION in scripts/prepareWaylandNano.js and regenerate on every agent version bump.",
-  "_ownerAction": "FILL ON FIRST RELEASE. No wayland-nano GitHub release assets exist yet, so this manifest intentionally has NO tag entries: every lookup fails closed (missing tag -> hard error, never a verification skip). When the first signed FerroxLabs/wayland-nano release lands, add one entry per tag shaped like the schema below, then pin DEFAULT_WNANO_VERSION to that exact tag in scripts/prepareWaylandNano.js and add the matching publisher-attestation policy to scripts/supply-chain/publisher-attestations.json in the SAME commit. Schema per tag: \"v0.1.0\": { \"wayland-nano-0.1.0-darwin-arm64.zip\": { \"archiveSha256\": \"sha256:<64 hex from the release shasums asset>\", \"binarySha256\": \"sha256:<64 hex of the extracted wayland-nano executable>\" }, ... }. Archive hashes come from the release's wayland-nano-<version>-shasums.json asset (keys darwin-arm64/darwin-x64/linux-arm64/linux-x64/win32-x64 map to assets wayland-nano-<version>-<key>.zip); binarySha256 is computed by extracting the verified zip and hashing the wayland-nano[.exe] inside - strict builds refuse a manifest that asserts only its own archive digest. Assets are named with the UNPREFIXED version (no 'v') while the manifest key and download URL use the 'v'-prefixed tag. There is NO win32-arm64 asset - the release workflow does not build one. Placeholder or malformed values are rejected as 'Malformed or placeholder SHA-256' and fail closed.",
-  "_fillOnReleaseExample": {
-    "v0.1.0": {
-      "wayland-nano-0.1.0-darwin-arm64.zip": {
-        "archiveSha256": "sha256:PENDING-fill-from-release-shasums-asset",
-        "binarySha256": "sha256:PENDING-hash-of-extracted-verified-binary"
-      }
+  "_comment": "Authoritative SHA-256 checksums for bundled wayland-nano release archives, keyed by release tag then asset filename. Mirrors scripts/bundled-wcore-shasums.json. Source of truth: the wayland-nano-<version>-shasums.json asset published alongside each signed FerroxLabs/wayland-nano release. Every archive is verified against this file BEFORE it is extracted, copied, or executed, and binarySha256 is the digest of the executable inside the verified archive. Update in lockstep with DEFAULT_WNANO_VERSION in scripts/prepareWaylandNano.js and the matching entry in scripts/supply-chain/publisher-attestations.json. Assets use the UNPREFIXED version; the manifest key and download URL use the 'v'-prefixed tag. There is no win32-arm64 asset.",
+  "v0.1.1": {
+    "wayland-nano-0.1.1-darwin-arm64.zip": {
+      "archiveSha256": "sha256:474e288a54ce59d83a6e7f0d185e7826e85fcf7307303fc337571e0a89a3653a",
+      "binarySha256": "sha256:73b6e5eac67eecb50e762fe45d8d5d608556d370932f9ac034802c6437ebeacf"
+    },
+    "wayland-nano-0.1.1-darwin-x64.zip": {
+      "archiveSha256": "sha256:c1a09855bdc929c6533717b369f351154cc26d9ebe5f955c046bc4a0beacf5e2",
+      "binarySha256": "sha256:81938e87c719f7aa0a6057656e4d51120dacccd647ff19acdac881e1e896026a"
+    },
+    "wayland-nano-0.1.1-linux-arm64.zip": {
+      "archiveSha256": "sha256:a5a182b06cf677853bd8d15b72cfd9bde13f03b04d80596a1384528f94358ad5",
+      "binarySha256": "sha256:09bdf86898205d1620613ef8ce1911c1bf90a8d20932ca33db62b3eb5521b207"
+    },
+    "wayland-nano-0.1.1-linux-x64.zip": {
+      "archiveSha256": "sha256:d46d09eb63d8e8680f3c60e1f941e527bf292bec747ccd1194b0038d14faf9d7",
+      "binarySha256": "sha256:0a099038989bf0979dc46b405e9669513a32198a8898d93da0c81c3d6b25e008"
+    },
+    "wayland-nano-0.1.1-win32-x64.zip": {
+      "archiveSha256": "sha256:2326ab956b3c06dc6e6eba40ca54c7153fa95696f4fb645f9537607fbb4a763d",
+      "binarySha256": "sha256:bb3854ce7ec7918ebb44297618ab87d2d91d2f0eea6b3fad65ae9b874ba5b5be"
     }
   }
 }

--- a/scripts/bundled-wnano-shasums.json
+++ b/scripts/bundled-wnano-shasums.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "Authoritative SHA-256 checksums for bundled wayland-nano release archives (the downloaded .zip assets), keyed by release tag then asset filename. Mirrors scripts/bundled-wcore-shasums.json. Source of truth: the SHASUMS published alongside each signed FerroxLabs/wayland-nano release (the wayland-nano-<version>-shasums.json release asset, keyed by runtime pkg). The downloaded archive is verified against this file BEFORE it is extracted, copied, or executed. Update this file in lockstep with DEFAULT_WNANO_VERSION in scripts/prepareWaylandNano.js and regenerate on every agent version bump.",
+  "_ownerAction": "FILL ON FIRST RELEASE. No wayland-nano GitHub release assets exist yet, so this manifest intentionally has NO tag entries: every lookup fails closed (missing tag -> hard error, never a verification skip). When the first signed FerroxLabs/wayland-nano release lands, add one entry per tag shaped like the schema below, then pin DEFAULT_WNANO_VERSION to that exact tag in scripts/prepareWaylandNano.js and add the matching publisher-attestation policy to scripts/supply-chain/publisher-attestations.json in the SAME commit. Schema per tag: \"v0.1.0\": { \"wayland-nano-0.1.0-darwin-arm64.zip\": { \"archiveSha256\": \"sha256:<64 hex from the release shasums asset>\", \"binarySha256\": \"sha256:<64 hex of the extracted wayland-nano executable>\" }, ... }. Archive hashes come from the release's wayland-nano-<version>-shasums.json asset (keys darwin-arm64/darwin-x64/linux-arm64/linux-x64/win32-x64 map to assets wayland-nano-<version>-<key>.zip); binarySha256 is computed by extracting the verified zip and hashing the wayland-nano[.exe] inside - strict builds refuse a manifest that asserts only its own archive digest. Assets are named with the UNPREFIXED version (no 'v') while the manifest key and download URL use the 'v'-prefixed tag. There is NO win32-arm64 asset - the release workflow does not build one. Placeholder or malformed values are rejected as 'Malformed or placeholder SHA-256' and fail closed.",
+  "_fillOnReleaseExample": {
+    "v0.1.0": {
+      "wayland-nano-0.1.0-darwin-arm64.zip": {
+        "archiveSha256": "sha256:PENDING-fill-from-release-shasums-asset",
+        "binarySha256": "sha256:PENDING-hash-of-extracted-verified-binary"
+      }
+    }
+  }
+}

--- a/scripts/prepareOfficeCli.js
+++ b/scripts/prepareOfficeCli.js
@@ -358,13 +358,33 @@ function assertContractOutputs(versionOutput, topLevelHelp, formatHelp, watchHel
   return { contract: `${contract.contract}/${contract.major}.${contract.minor}`, release: contract.release };
 }
 
+// OfficeCLI ships a background self-updater that is ON by default: it resolves the
+// moving `latest` release and swaps its own binary in place on a subsequent run.
+// That silently replaces the exact bytes this script just digest-verified, and it
+// broke every platform of the 0.12.0 release build (Windows reported 1.0.144 against
+// a pinned 1.0.136; macOS and Linux crashed mid-swap inside ApplyPendingUpdate).
+// Every invocation of the bundled binary therefore runs against an isolated config
+// home with autoUpdate disabled, so the contract and smoke checks exercise the
+// pinned artifact rather than whatever upstream published most recently.
+function withUpdatesDisabled() {
+  const configHome = fs.mkdtempSync(path.join(os.tmpdir(), 'wayland-officecli-home-'));
+  fs.mkdirSync(path.join(configHome, '.officecli'), { recursive: true });
+  fs.writeFileSync(
+    path.join(configHome, '.officecli', 'config.json'),
+    `${JSON.stringify({ autoUpdate: false, log: false }, null, 2)}\n`
+  );
+  return { ...process.env, HOME: configHome, USERPROFILE: configHome };
+}
+
 function verifyExecutableContract(binaryPath) {
   const contract = loadContract();
+  const env = withUpdatesDisabled();
   const run = (args) =>
     execFileSync(binaryPath, args, {
       encoding: 'utf8',
       timeout: 10_000,
       stdio: ['ignore', 'pipe', 'pipe'],
+      env,
     });
   const formatHelp = Object.fromEntries(
     Object.keys(contract.requiredElements).map((format) => [format, run(['help', format])])
@@ -379,12 +399,14 @@ function verifyExecutableSmoke(binaryPath) {
     xlsx: path.join(tempDir, 'proof.xlsx'),
     pptx: path.join(tempDir, 'proof.pptx'),
   };
+  const env = withUpdatesDisabled();
   const run = (args) =>
     execFileSync(binaryPath, args, {
       encoding: 'utf8',
       timeout: 15_000,
       maxBuffer: 2 * 1024 * 1024,
       stdio: ['ignore', 'pipe', 'pipe'],
+      env,
     });
 
   try {

--- a/scripts/prepareWaylandNano.js
+++ b/scripts/prepareWaylandNano.js
@@ -213,7 +213,7 @@ function verifyArchiveChecksum(archivePath, expectedHex, assetName, tag) {
 // packaging fails closed until DEFAULT_WNANO_VERSION is pinned to an exact
 // release tag here and scripts/bundled-wnano-shasums.json is filled in the
 // same commit. Override with WNANO_VERSION=... when bumping.
-const DEFAULT_WNANO_VERSION = 'latest';
+const DEFAULT_WNANO_VERSION = 'v0.1.1';
 
 function getVersion() {
   return (process.env.WNANO_VERSION || DEFAULT_WNANO_VERSION).trim();

--- a/scripts/prepareWaylandNano.js
+++ b/scripts/prepareWaylandNano.js
@@ -711,6 +711,7 @@ prepareWaylandNano.DEFAULT_WNANO_VERSION = DEFAULT_WNANO_VERSION;
 prepareWaylandNano.SHASUMS_FILE = SHASUMS_FILE;
 prepareWaylandNano.getAssetName = getAssetName;
 prepareWaylandNano.loadExpectedProvenance = loadExpectedProvenance;
+prepareWaylandNano.normalizeSha256 = normalizeSha256;
 prepareWaylandNano.normalizeExactReleaseTag = normalizeExactReleaseTag;
 prepareWaylandNano.pruneRuntimeDirectory = pruneRuntimeDirectory;
 

--- a/scripts/prepareWaylandNano.js
+++ b/scripts/prepareWaylandNano.js
@@ -1,0 +1,727 @@
+/**
+ * Prepare wayland-nano binary for Electron packaging.
+ *
+ * Resolution order:
+ *  0. Dev-only calls may use a pre-placed unverified local binary. Strict
+ *     package builds never treat extracted cache bytes as publisher authority;
+ *     they authenticate the exact release archive before publishing.
+ *  1. GitHub release download (requires WNANO_VERSION or defaults to "latest"),
+ *     SHA-256 verified before extract/copy/execute.
+ *
+ * Output: resources/bundled-wayland-nano/{platform}-{arch}/wayland-nano[.exe]
+ *
+ * Env (DEV ONLY - IGNORED for skipping verification on release/CI builds):
+ *      WNANO_USE_LOCAL=1      trust a pre-placed binary on a dev build;
+ *      WNANO_FORCE_DOWNLOAD=1 always re-download (ignore a pre-placed binary);
+ *      WNANO_ALLOW_UNVERIFIED=1 (historical) does NOT downgrade a release build.
+ *   On a release/CI build these never bypass SHA-256 verification - the build
+ *   either verifies a present local binary or downloads-and-verifies, else fails
+ *   closed.
+ *
+ * Pattern follows prepareWaylandCore.js.
+ */
+
+const { execSync, execFileSync } = require('child_process');
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { verifyPublisherAttestation } = require('./supply-chain/verifyPublisherAttestation');
+
+const GITHUB_OWNER = 'FerroxLabs';
+const GITHUB_REPO = 'wayland-nano';
+const BUNDLE_CONTRACT = 'wayland-nano-bundle/1.0';
+const BUNDLE_GENERATOR = 'prepareWaylandNano/1';
+
+// Authoritative per-platform SHA-256 manifest for the downloaded release
+// archives. Supply-chain guard (UPD-03): every release build must fetch the
+// pinned tag's asset and verify its SHA-256 against this file before the
+// archive is extracted, copied, or - critically - executed (`--version`).
+// Mirrors scripts/bundled-wcore-shasums.json. Bump in lockstep with the tag.
+const SHASUMS_FILE = path.resolve(__dirname, 'bundled-wnano-shasums.json');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function ensureDirectory(dirPath) {
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true });
+  }
+}
+
+function removeDirectorySafe(dirPath) {
+  fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+function pruneRuntimeDirectory(dirPath, allowedNames) {
+  const allowed = new Set(allowedNames);
+  if (!fs.existsSync(dirPath)) return;
+  for (const entry of fs.readdirSync(dirPath, { withFileTypes: true })) {
+    if (allowed.has(entry.name)) continue;
+    fs.rmSync(path.join(dirPath, entry.name), { recursive: true, force: true });
+  }
+}
+
+function copyFileSafe(sourcePath, targetPath) {
+  ensureDirectory(path.dirname(targetPath));
+  fs.copyFileSync(sourcePath, targetPath);
+}
+
+function ensureExecutableMode(filePath) {
+  if (process.platform === 'win32') return;
+  try {
+    fs.chmodSync(filePath, 0o755);
+  } catch {}
+}
+
+function writeJson(filePath, payload) {
+  fs.writeFileSync(filePath, JSON.stringify(payload, null, 2) + '\n', 'utf-8');
+}
+
+function getBinaryName(platform) {
+  return platform === 'win32' ? 'wayland-nano.exe' : 'wayland-nano';
+}
+
+function readJsonSafe(filePath) {
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Detect a release/CI build. When true the supply-chain guard is mandatory:
+ * every bundled agent binary MUST have a verified SHA-256, and the WNANO_*
+ * trust/bypass env vars are IGNORED for the purpose of skipping verification.
+ *
+ * Signals (any one is sufficient):
+ *  - process.env.CI                  - standard CI marker (GitHub Actions etc.)
+ *  - process.env.npm_config_production / NODE_ENV=production - prod install/build
+ *  - electron-builder release context - set by electron-builder during a build
+ *    (npm_lifecycle_event starts with dist/build/make/package, or a publish run).
+ *  - WNANO_REQUIRE_VERIFIED=1         - explicit opt-in to the strict path.
+ *
+ * IMPORTANT (RT-B6-06): WNANO_ALLOW_UNVERIFIED must NOT be able to flip this to
+ * false. A genuine release/CI build stays a release build regardless of that
+ * env var, so it can never downgrade itself into trusting an unverified binary.
+ */
+function isReleaseBuild() {
+  const lifecycle = (process.env.npm_lifecycle_event || '').toLowerCase();
+  const builderRelease =
+    /^(dist|build|make|package)/.test(lifecycle) ||
+    process.env.EP_PRE_RELEASE === 'true' ||
+    process.env.PUBLISH_FOR_PULL_REQUEST === 'true';
+  return (
+    process.env.CI === '1' ||
+    process.env.CI === 'true' ||
+    process.env.WNANO_REQUIRE_VERIFIED === '1' ||
+    process.env.NODE_ENV === 'production' ||
+    process.env.npm_config_production === 'true' ||
+    builderRelease
+  );
+}
+
+/**
+ * Resolve the expected SHA-256 (lowercase hex, no prefix) for a given release
+ * tag + asset from bundled-wnano-shasums.json. Throws when the manifest is
+ * missing, the tag/asset entry is absent, or the value is malformed - callers
+ * decide whether that aborts (release) or downgrades to skip (dev).
+ */
+function normalizeSha256(raw, label) {
+  const hex = String(raw || '')
+    .replace(/^sha256:/i, '')
+    .trim()
+    .toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(hex)) {
+    throw new Error(`Malformed or placeholder SHA-256 for ${label}: ${raw || '<missing>'}.`);
+  }
+  return hex;
+}
+
+function loadExpectedProvenance(tag, assetName, { requireBinary = false } = {}) {
+  const manifest = readJsonSafe(SHASUMS_FILE);
+  if (!manifest) {
+    throw new Error(
+      `Missing SHA-256 manifest at ${SHASUMS_FILE}. ` +
+        `Cannot verify bundled wayland-nano integrity (supply-chain guard).`
+    );
+  }
+
+  const tagEntry = manifest[tag];
+  if (!tagEntry || typeof tagEntry !== 'object') {
+    throw new Error(
+      `No SHA-256 entries for wayland-nano tag "${tag}" in ${SHASUMS_FILE}. ` +
+        `Add the per-platform archive checksums from the signed release before building.`
+    );
+  }
+
+  const raw = tagEntry[assetName];
+  if (!raw || (typeof raw !== 'string' && typeof raw !== 'object')) {
+    throw new Error(`No SHA-256 entry for asset "${assetName}" under tag "${tag}" in ${SHASUMS_FILE}.`);
+  }
+
+  const archiveSha256 = normalizeSha256(
+    typeof raw === 'string' ? raw : raw.archiveSha256,
+    `archive "${assetName}" (tag "${tag}") in ${SHASUMS_FILE}`
+  );
+  const binarySha256 =
+    typeof raw === 'object' && raw.binarySha256
+      ? normalizeSha256(raw.binarySha256, `binary from "${assetName}" (tag "${tag}") in ${SHASUMS_FILE}`)
+      : null;
+  if (requireBinary && !binarySha256) {
+    throw new Error(
+      `No independently pinned extracted-binary SHA-256 for "${assetName}" (tag "${tag}") in ${SHASUMS_FILE}. ` +
+        `A strict package cannot trust a manifest that asserts its own binary digest.`
+    );
+  }
+  return { archiveSha256, binarySha256 };
+}
+
+function loadExpectedShaForAsset(tag, assetName) {
+  return loadExpectedProvenance(tag, assetName).archiveSha256;
+}
+
+function computeFileSha256(filePath) {
+  const hash = crypto.createHash('sha256');
+  hash.update(fs.readFileSync(filePath));
+  return hash.digest('hex');
+}
+
+/**
+ * Verify the downloaded archive against its pinned SHA-256 BEFORE it is
+ * extracted, copied, or executed. Aborts on mismatch - never ships or runs an
+ * unverified agent binary.
+ */
+function verifyArchiveChecksum(archivePath, expectedHex, assetName, tag) {
+  const actualHex = computeFileSha256(archivePath);
+  if (actualHex !== expectedHex) {
+    throw new Error(
+      `wayland-nano archive checksum mismatch for ${assetName} (tag ${tag}). ` +
+        `Expected sha256=${expectedHex}, got sha256=${actualHex}. ` +
+        `Refusing to extract or execute this binary; aborting bundled wayland-nano preparation.`
+    );
+  }
+}
+
+// Default version. The agent release stream lives at FerroxLabs/wayland-nano;
+// unlike wayland-core there is no pinned tag yet - the first release assets
+// are published alongside this integration, so the default resolves "latest"
+// for dev builds. Strict package builds REJECT "latest" (see below), so
+// packaging fails closed until DEFAULT_WNANO_VERSION is pinned to an exact
+// release tag here and scripts/bundled-wnano-shasums.json is filled in the
+// same commit. Override with WNANO_VERSION=... when bumping.
+const DEFAULT_WNANO_VERSION = 'latest';
+
+function getVersion() {
+  return (process.env.WNANO_VERSION || DEFAULT_WNANO_VERSION).trim();
+}
+
+function normalizeExactReleaseTag(version) {
+  const tag = version.startsWith('v') ? version : `v${version}`;
+  if (!/^v\d+\.\d+\.\d+(?:-[0-9A-Za-z]+(?:\.[0-9A-Za-z]+)*)?$/.test(tag)) {
+    throw new Error(`Invalid wayland-nano release tag "${version}"; expected an exact vMAJOR.MINOR.PATCH tag.`);
+  }
+  return tag;
+}
+
+// ---------------------------------------------------------------------------
+// Source resolvers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the actual version tag when "latest" is requested.
+ * Uses GitHub API via `gh` CLI (needs GH_TOKEN in CI) or falls back to
+ * `curl` with an optional Authorization header (GITHUB_TOKEN / GH_TOKEN).
+ */
+function resolveLatestTag() {
+  const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || '';
+
+  // 1. Try gh CLI (honours GH_TOKEN automatically)
+  try {
+    const out = execSync(`gh api repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases/latest --jq .tag_name`, {
+      encoding: 'utf-8',
+      timeout: 15000,
+    }).trim();
+    if (out) return out;
+  } catch {
+    // gh CLI not available or no token - fall back to curl
+  }
+
+  // 2. Curl with optional token to avoid rate-limit 403
+  try {
+    const authArgs = token ? ['-H', `Authorization: token ${token}`] : [];
+    const args = ['-fsSL', ...authArgs, `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases/latest`];
+    const out = execFileSync('curl', args, { encoding: 'utf-8', timeout: 15000 });
+    const tag = JSON.parse(out).tag_name;
+    if (tag) return tag;
+  } catch {
+    // network issue or rate-limited
+  }
+
+  return null;
+}
+
+/**
+ * 1. Download from GitHub releases
+ *
+ * wayland-nano release assets are named after the unprefixed npm version and
+ * the npm package's runtime key, one zip per platform (the release workflow
+ * publishes no Windows ARM64 target):
+ *   wayland-nano-0.1.0-darwin-arm64.zip
+ */
+function getAssetName(platform, arch, tag) {
+  const runtimeKey = `${platform}-${arch}`;
+  const supported = new Set(['darwin-arm64', 'darwin-x64', 'linux-arm64', 'linux-x64', 'win32-x64']);
+  if (!supported.has(runtimeKey)) return null;
+  const version = tag.startsWith('v') ? tag.slice(1) : tag;
+  return `wayland-nano-${version}-${runtimeKey}.zip`;
+}
+
+function getDownloadUrl(assetName, tag) {
+  return `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/releases/download/${tag}/${assetName}`;
+}
+
+/**
+ * Try downloading via authed `gh release download` first when the URL looks
+ * like a GitHub release asset. This handles private repos (where anonymous
+ * curl gets a 404) without requiring users to plumb GITHUB_TOKEN manually.
+ * Returns true on success; false to signal the caller should fall through.
+ */
+function tryGhRelease(url, outputPath) {
+  const ghMatch = /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/releases\/download\/([^/]+)\/([^/]+)$/.exec(url);
+  if (!ghMatch) return false;
+  const [, owner, repo, tag, asset] = ghMatch;
+  try {
+    execFileSync('gh', ['--version'], { stdio: 'ignore', timeout: 5000 });
+  } catch {
+    return false;
+  }
+  try {
+    const tmpDir = path.dirname(outputPath);
+    execFileSync(
+      'gh',
+      ['release', 'download', tag, '--repo', `${owner}/${repo}`, '--pattern', asset, '--dir', tmpDir, '--clobber'],
+      { timeout: 120000, stdio: ['ignore', 'pipe', 'pipe'] }
+    );
+    const ghOut = path.join(tmpDir, asset);
+    if (ghOut !== outputPath && fs.existsSync(ghOut)) {
+      fs.renameSync(ghOut, outputPath);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function downloadFile(url, outputPath) {
+  console.log(`  Downloading wayland-nano from ${url}`);
+  if (tryGhRelease(url, outputPath)) return;
+  if (process.platform === 'win32') {
+    const ps = `$ProgressPreference='SilentlyContinue'; Invoke-WebRequest -Uri '${url.replace(/'/g, "''")}' -OutFile '${outputPath.replace(/'/g, "''")}'`;
+    execFileSync('powershell', ['-NoProfile', '-NonInteractive', '-Command', ps], { timeout: 120000 });
+    return;
+  }
+  try {
+    execFileSync('curl', ['-L', '--fail', '--silent', '--show-error', '-o', outputPath, url], { timeout: 120000 });
+  } catch {
+    execFileSync('wget', ['-q', '-O', outputPath, url], { timeout: 120000 });
+  }
+}
+
+function extractArchive(archivePath, outputDir, platform) {
+  ensureDirectory(outputDir);
+  if (platform === 'win32' || archivePath.endsWith('.zip')) {
+    if (platform === 'win32') {
+      const ps = `Expand-Archive -LiteralPath '${archivePath.replace(/'/g, "''")}' -DestinationPath '${outputDir.replace(/'/g, "''")}' -Force`;
+      execFileSync('powershell', ['-NoProfile', '-NonInteractive', '-Command', ps]);
+    } else {
+      execFileSync('unzip', ['-o', archivePath, '-d', outputDir]);
+    }
+  } else {
+    execFileSync('tar', ['-xzf', archivePath, '-C', outputDir]);
+  }
+}
+
+function findBinaryInDir(dir, binaryName) {
+  // Search recursively for the binary
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isFile() && entry.name === binaryName) return fullPath;
+    if (entry.isDirectory()) {
+      const found = findBinaryInDir(fullPath, binaryName);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+function downloadAndExtract(platform, arch, tag, { requireBinaryPin = false } = {}) {
+  const assetName = getAssetName(platform, arch, tag);
+  if (!assetName) {
+    throw new Error(`Unsupported wayland-nano target: ${platform}-${arch}`);
+  }
+
+  const url = getDownloadUrl(assetName, tag);
+  const tempDir = path.join(os.tmpdir(), 'aionui-wayland-nano', tag, `${platform}-${arch}`);
+  const archivePath = path.join(tempDir, assetName);
+  const extractDir = path.join(tempDir, 'extracted');
+
+  // Resolve the expected hash BEFORE downloading so a missing/placeholder
+  // entry aborts without ever touching the network result.
+  const expected = loadExpectedProvenance(tag, assetName, { requireBinary: requireBinaryPin });
+
+  removeDirectorySafe(tempDir);
+  ensureDirectory(tempDir);
+
+  downloadFile(url, archivePath);
+  // Supply-chain gate: verify the downloaded archive before extract/copy/exec.
+  verifyArchiveChecksum(archivePath, expected.archiveSha256, assetName, tag);
+  const publisherAttestation = requireBinaryPin
+    ? verifyPublisherAttestation({
+        artifactPath: archivePath,
+        assetName,
+        releaseTag: tag,
+        expectedSha256: expected.archiveSha256,
+      })
+    : null;
+  extractArchive(archivePath, extractDir, platform);
+
+  const binaryName = getBinaryName(platform);
+  const binaryPath = findBinaryInDir(extractDir, binaryName);
+  if (!binaryPath) {
+    throw new Error(`Binary ${binaryName} not found in downloaded archive`);
+  }
+
+  const binarySha256 = computeFileSha256(binaryPath);
+  if (expected.binarySha256 && binarySha256 !== expected.binarySha256) {
+    throw new Error(
+      `wayland-nano extracted binary checksum mismatch for ${assetName} (tag ${tag}). ` +
+        `Expected sha256=${expected.binarySha256}, got sha256=${binarySha256}. ` +
+        `Refusing to bundle an archive whose extracted executable is not independently pinned.`
+    );
+  }
+
+  return {
+    binaryPath,
+    tempDir,
+    url,
+    assetName,
+    archiveSha256: expected.archiveSha256,
+    binarySha256,
+    publisherAttestation,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function verifiedBundleManifest({
+  platform,
+  arch,
+  tag,
+  sourceType,
+  assetName,
+  archiveSha256,
+  binaryName,
+  binarySha256,
+  publisherAttestation,
+}) {
+  return {
+    contract: BUNDLE_CONTRACT,
+    generator: BUNDLE_GENERATOR,
+    platform,
+    arch,
+    releaseTag: tag,
+    version: tag,
+    generatedAt: new Date().toISOString(),
+    sourceType,
+    verified: Boolean(publisherAttestation),
+    source: {
+      owner: GITHUB_OWNER,
+      repository: GITHUB_REPO,
+      url: getDownloadUrl(assetName, tag),
+      asset: assetName,
+      archiveSha256: `sha256:${archiveSha256}`,
+    },
+    binary: {
+      name: binaryName,
+      sha256: `sha256:${binarySha256}`,
+    },
+    publisherAttestation: publisherAttestation || null,
+    files: [binaryName],
+    skipped: false,
+  };
+}
+
+function prepareWaylandNano(options = {}) {
+  const projectRoot = path.resolve(__dirname, '..');
+  const platform = options.platform || process.platform;
+  // Support cross-compilation: WNANO_ARCH > npm_config_target_arch > process.arch
+  const arch = options.arch || process.env.WNANO_ARCH || process.env.npm_config_target_arch || process.arch;
+  const runtimeKey = `${platform}-${arch}`;
+  const version = String(options.version || getVersion()).trim();
+  const strict = options.requireVerified === true || isReleaseBuild();
+  const skipRequested = process.env.WNANO_SKIP === '1' || process.env.WAYLAND_NANO_SKIP === '1';
+
+  // Honor an explicit skip - same pattern as wayland-core. Used by CI test
+  // matrices and forks that do not need the bundled agent. IMPORTANT: there is
+  // NO runtime download fallback - a build made with WNANO_SKIP=1 ships WITHOUT
+  // the agent, so the Wayland-Nano backend falls back to a `wayland-nano`
+  // binary on the user's PATH in that build.
+  // Release builds must NOT set this.
+  if (skipRequested && strict) {
+    throw new Error(
+      `Strict wayland-nano preparation for ${runtimeKey} cannot honor WNANO_SKIP/WAYLAND_NANO_SKIP; ` +
+        `a package must contain an independently verified agent binary.`
+    );
+  }
+  if (skipRequested) {
+    const targetDir = path.join(projectRoot, 'resources', 'bundled-wayland-nano', runtimeKey);
+    ensureDirectory(targetDir);
+    writeJson(path.join(targetDir, 'manifest.json'), {
+      contract: BUNDLE_CONTRACT,
+      generator: BUNDLE_GENERATOR,
+      platform,
+      arch,
+      releaseTag: version,
+      version,
+      generatedAt: new Date().toISOString(),
+      sourceType: 'none',
+      verified: false,
+      source: {},
+      files: [],
+      skipped: true,
+      reason: 'WNANO_SKIP=1 set; agent NOT bundled (PATH fallback only). Test/matrix builds only.',
+    });
+    console.log(
+      `  wayland-nano skip requested (WNANO_SKIP=1); wrote skip manifest at resources/bundled-wayland-nano/${runtimeKey}/manifest.json`
+    );
+    return { prepared: false, reason: 'env_skip' };
+  }
+
+  // Resolve the actual version tag - asset filenames include the version.
+  // If "latest" can't be resolved (e.g. FerroxLabs/wayland-nano has no
+  // published releases yet), fall through to the skip-manifest path below
+  // instead of throwing. The comment at "Not found - write skip manifest"
+  // describes the intended behavior; this preserves it.
+  let tag;
+  if (version === 'latest') {
+    if (strict) {
+      throw new Error('Strict wayland-nano preparation requires an exact pinned release tag; "latest" is forbidden.');
+    }
+    const resolved = resolveLatestTag();
+    if (!resolved) {
+      console.warn('  Could not resolve latest wayland-nano release tag; falling back to skip manifest.');
+      const targetDir = path.join(projectRoot, 'resources', 'bundled-wayland-nano', runtimeKey);
+      ensureDirectory(targetDir);
+      writeJson(path.join(targetDir, 'manifest.json'), {
+        contract: BUNDLE_CONTRACT,
+        generator: BUNDLE_GENERATOR,
+        platform,
+        arch,
+        releaseTag: 'unresolved',
+        version: 'unresolved',
+        generatedAt: new Date().toISOString(),
+        sourceType: 'none',
+        verified: false,
+        source: {},
+        files: [],
+        skipped: true,
+        reason: 'Failed to resolve latest tag (likely no GitHub releases published yet).',
+      });
+      return { prepared: false, reason: 'unresolved_latest' };
+    }
+    tag = resolved;
+    console.log(`Resolved wayland-nano "latest" → ${tag}`);
+  } else {
+    tag = normalizeExactReleaseTag(version);
+  }
+
+  const targetDir = path.join(projectRoot, 'resources', 'bundled-wayland-nano', runtimeKey);
+  const binaryName = getBinaryName(platform);
+  const targetBinaryPath = path.join(targetDir, binaryName);
+  const assetName = getAssetName(platform, arch, tag);
+  if (!assetName) {
+    throw new Error(`Unsupported wayland-nano target: ${runtimeKey}`);
+  }
+  const expected = loadExpectedProvenance(tag, assetName, { requireBinary: strict });
+  const forceDownload = process.env.WNANO_FORCE_DOWNLOAD === '1';
+
+  console.log(`Preparing wayland-nano for ${runtimeKey} (version: ${tag})`);
+
+  // A strict build may reuse exact bytes only because the extracted executable
+  // digest is independently pinned beside the archive digest. The old manifest
+  // is deliberately ignored: a local or self-asserted manifest is not authority.
+  const hasPreplaced = fs.existsSync(targetBinaryPath) && fs.lstatSync(targetBinaryPath).isFile();
+  if (hasPreplaced && !forceDownload) {
+    const binarySha256 = computeFileSha256(targetBinaryPath);
+    if (strict && binarySha256 === expected.binarySha256) {
+      // The publisher attestation covers the release archive, not this extracted
+      // executable. A digest-matching local cache therefore cannot prove
+      // publisher authority by itself; strict builds re-fetch and authenticate
+      // the exact archive before publishing any bytes.
+      console.warn(
+        `  Strict build: independently pinned wayland-nano cache for ${runtimeKey} lacks archive-bound publisher ` +
+          `authentication; downloading and verifying the signed release asset.`
+      );
+    } else if (!strict) {
+      pruneRuntimeDirectory(targetDir, [binaryName]);
+      ensureExecutableMode(targetBinaryPath);
+      let binaryVersion = tag;
+      try {
+        binaryVersion = execFileSync(targetBinaryPath, ['--version'], { encoding: 'utf-8', timeout: 5000 }).trim();
+      } catch {}
+      writeJson(path.join(targetDir, 'manifest.json'), {
+        contract: BUNDLE_CONTRACT,
+        generator: BUNDLE_GENERATOR,
+        platform,
+        arch,
+        releaseTag: tag,
+        version: binaryVersion,
+        generatedAt: new Date().toISOString(),
+        sourceType: 'local-prebuilt',
+        verified: false,
+        source: {
+          note: 'Dev-only pre-placed binary. It is not eligible for packaged-resource acceptance.',
+        },
+        binary: { name: binaryName, sha256: `sha256:${binarySha256}` },
+        files: [binaryName],
+        skipped: false,
+      });
+      console.log(
+        `  Using dev-only pre-placed wayland-nano: resources/bundled-wayland-nano/${runtimeKey}/${binaryName} ` +
+          `[source=local-prebuilt verified=false binarySha256=${binarySha256.slice(0, 12)}...]`
+      );
+      return { prepared: true, dir: targetDir, sourceType: 'local-prebuilt', verified: false };
+    } else {
+      console.warn(
+        `  Strict build: pre-placed wayland-nano at resources/bundled-wayland-nano/${runtimeKey}/${binaryName} ` +
+          `does not match the independently pinned extracted-binary digest; downloading the exact release asset instead.`
+      );
+    }
+  }
+
+  removeDirectorySafe(targetDir);
+  ensureDirectory(targetDir);
+
+  let sourcePath = null;
+  let sourceType = 'none';
+  let sourceDetail = {};
+  let tempDir = null;
+  let archiveSha256 = null;
+  let binarySha256 = null;
+  let publisherAttestation = null;
+
+  // 1. Download from GitHub releases (archive is SHA-256 verified inside
+  //    downloadAndExtract BEFORE it is extracted, copied, or executed).
+  if (!sourcePath) {
+    try {
+      const result = downloadAndExtract(platform, arch, tag, { requireBinaryPin: strict });
+      sourcePath = result.binaryPath;
+      tempDir = result.tempDir;
+      sourceType = 'download';
+      sourceDetail = { url: result.url, asset: result.assetName };
+      archiveSha256 = result.archiveSha256;
+      binarySha256 = result.binarySha256;
+      publisherAttestation = result.publisherAttestation;
+      console.log(
+        `  Downloaded + verified from GitHub releases ` +
+          `(archiveSha256=${archiveSha256} binarySha256=${binarySha256})`
+      );
+    } catch (error) {
+      // On release builds a failed download OR a failed/missing checksum must
+      // abort - never silently ship an agent-less or unverified installer.
+      if (strict) {
+        if (tempDir) removeDirectorySafe(tempDir);
+        throw new Error(
+          `Release build cannot prepare a verified wayland-nano for ${runtimeKey} (tag ${tag}): ${error.message}`
+        );
+      }
+      console.warn(`  Download failed: ${error.message}`);
+    }
+  }
+
+  // Write result
+  if (sourcePath) {
+    copyFileSafe(sourcePath, targetBinaryPath);
+    ensureExecutableMode(targetBinaryPath);
+
+    const copiedBinarySha256 = computeFileSha256(targetBinaryPath);
+    if (copiedBinarySha256 !== binarySha256) {
+      if (tempDir) removeDirectorySafe(tempDir);
+      throw new Error(
+        `wayland-nano binary changed while publishing ${runtimeKey}: ` +
+          `expected sha256=${binarySha256}, got sha256=${copiedBinarySha256}`
+      );
+    }
+
+    const manifest = verifiedBundleManifest({
+      platform,
+      arch,
+      tag,
+      sourceType,
+      assetName: sourceDetail.asset,
+      archiveSha256,
+      binaryName,
+      binarySha256,
+      publisherAttestation,
+    });
+    if (!strict && !expected.binarySha256) manifest.verified = false;
+
+    writeJson(path.join(targetDir, 'manifest.json'), manifest);
+    console.log(
+      `  Bundled wayland-nano prepared: resources/bundled-wayland-nano/${runtimeKey}/${binaryName} [source=${sourceType}]`
+    );
+
+    if (tempDir) removeDirectorySafe(tempDir);
+    return { prepared: true, dir: targetDir, sourceType, verified: manifest.verified };
+  }
+
+  // Not found - write skip manifest (non-fatal, like wayland-core)
+  const manifest = {
+    contract: BUNDLE_CONTRACT,
+    generator: BUNDLE_GENERATOR,
+    platform,
+    arch,
+    releaseTag: tag,
+    version: tag,
+    generatedAt: new Date().toISOString(),
+    sourceType: 'none',
+    verified: false,
+    source: {},
+    files: [],
+    skipped: true,
+    reason: 'wayland-nano binary not found (ensure GitHub release exists)',
+  };
+
+  writeJson(path.join(targetDir, 'manifest.json'), manifest);
+  console.warn(`  wayland-nano not found - skipping bundle (agent will fall back to PATH in packaged app)`);
+  return { prepared: false, reason: 'not_found' };
+}
+
+module.exports = prepareWaylandNano;
+prepareWaylandNano.BUNDLE_CONTRACT = BUNDLE_CONTRACT;
+prepareWaylandNano.BUNDLE_GENERATOR = BUNDLE_GENERATOR;
+prepareWaylandNano.DEFAULT_WNANO_VERSION = DEFAULT_WNANO_VERSION;
+prepareWaylandNano.SHASUMS_FILE = SHASUMS_FILE;
+prepareWaylandNano.getAssetName = getAssetName;
+prepareWaylandNano.loadExpectedProvenance = loadExpectedProvenance;
+prepareWaylandNano.normalizeExactReleaseTag = normalizeExactReleaseTag;
+prepareWaylandNano.pruneRuntimeDirectory = pruneRuntimeDirectory;
+
+// Allow standalone invocation: `node scripts/prepareWaylandNano.js`.
+// build-with-builder.js requires the module and calls the function directly;
+// this runner makes the script independently executable (and testable).
+if (require.main === module) {
+  try {
+    prepareWaylandNano();
+  } catch (error) {
+    console.error(`prepareWaylandNano failed: ${error.message}`);
+    process.exit(1);
+  }
+}

--- a/scripts/supply-chain/publisher-attestations.json
+++ b/scripts/supply-chain/publisher-attestations.json
@@ -36,6 +36,18 @@
       "predicateType": "https://slsa.dev/provenance/v1",
       "oidcIssuer": "https://token.actions.githubusercontent.com",
       "runner": "github-hosted"
+    },
+    {
+      "id": "wayland-nano-v0.1.1-release",
+      "status": "active",
+      "releaseTag": "v0.1.1",
+      "repository": "FerroxLabs/wayland-nano",
+      "signerWorkflow": "FerroxLabs/wayland-nano/.github/workflows/release.yml",
+      "sourceRef": "refs/tags/v0.1.1",
+      "sourceDigest": "466f030db615038919d6f367e2b7f0354ac73f06",
+      "predicateType": "https://slsa.dev/provenance/v1",
+      "oidcIssuer": "https://token.actions.githubusercontent.com",
+      "runner": "github-hosted"
     }
   ]
 }

--- a/scripts/verify-packaged-resources.js
+++ b/scripts/verify-packaged-resources.js
@@ -15,6 +15,7 @@
  * Usage:
  *   node scripts/verify-packaged-resources.js [--out <dir>]
  *     --wcore-runtime <platform-arch> [--wcore-runtime ...]
+ *     --wnano-runtime <platform-arch> [--wnano-runtime ...]
  *     --officecli-runtime <platform-arch> [--officecli-runtime ...]
  *   (defaults to ./out, electron-builder's directories.output)
  *
@@ -28,6 +29,7 @@ const path = require('path');
 const crypto = require('crypto');
 const { execFileSync } = require('child_process');
 const prepareWaylandCore = require('./prepareWaylandCore');
+const prepareWaylandNano = require('./prepareWaylandNano');
 const prepareOfficeCli = require('./prepareOfficeCli');
 const bundledBunShasums = require('./bundled-bun-shasums.json');
 const bundledBunBinaries = require('./bundled-bun-binaries.json');
@@ -47,6 +49,7 @@ const REQUIRED = [
   { rel: 'skills-library', critical: true, kind: 'skill-pack' },
   { rel: 'bundled-workflows', critical: true, kind: 'skill-pack' },
   { rel: 'bundled-wayland-core', critical: true, kind: 'wcore-bundle' },
+  { rel: 'bundled-wayland-nano', critical: true, kind: 'wnano-bundle' },
   { rel: 'bundled-officecli', critical: true, kind: 'officecli-bundle' },
   {
     rel: 'managed-cli-shims/officecli',
@@ -431,6 +434,89 @@ function verifyWCoreBundle(bundleDir, requiredRuntimes, authority = prepareWayla
   const packagedRuntimes = entries.map((entry) => entry.name).sort();
   if (JSON.stringify(packagedRuntimes) !== JSON.stringify([...requiredRuntimes].sort())) return false;
   return packagedRuntimes.every((runtime) => verifyWCoreRuntime(bundleDir, runtime, authority));
+}
+
+// Mirrors verifyWCoreRuntime for the bundled wayland-nano agent. The policy
+// selector is injectable because, unlike wayland-core, the first
+// FerroxLabs/wayland-nano publisher-attestation policy only exists once the
+// first signed release lands - tests substitute their own until then.
+function verifyWNanoRuntime(bundleDir, runtimeKey, authority = prepareWaylandNano, policySelector = selectPolicy) {
+  const [platform, arch] = runtimeKey.split('-');
+  const binaryName = platform === 'win32' ? 'wayland-nano.exe' : 'wayland-nano';
+  const runtimeDir = path.join(bundleDir, runtimeKey);
+  const manifestPath = path.join(runtimeDir, 'manifest.json');
+  const binaryPath = path.join(runtimeDir, binaryName);
+  if (!isNonEmpty(manifestPath, 'file') || !isNonEmpty(binaryPath, 'file')) return false;
+  const runtimeEntries = fs.readdirSync(runtimeDir, { withFileTypes: true });
+  const expectedRuntimeFiles = [binaryName, 'manifest.json'].sort();
+  if (
+    JSON.stringify(runtimeEntries.map((entry) => entry.name).sort()) !== JSON.stringify(expectedRuntimeFiles) ||
+    runtimeEntries.some((entry) => !entry.isFile())
+  ) {
+    return false;
+  }
+
+  const metadata = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const releaseTag = authority.DEFAULT_WNANO_VERSION;
+  const assetName = authority.getAssetName(platform, arch, releaseTag);
+  if (!assetName) return false;
+  const expected = authority.loadExpectedProvenance(releaseTag, assetName, { requireBinary: true });
+  const actualBinarySha256 = sha256File(binaryPath);
+  const manifestArchiveSha256 = String(metadata.source?.archiveSha256 || '')
+    .replace(/^sha256:/i, '')
+    .toLowerCase();
+  const manifestBinarySha256 = String(metadata.binary?.sha256 || '')
+    .replace(/^sha256:/i, '')
+    .toLowerCase();
+  const expectedUrl = `https://github.com/FerroxLabs/wayland-nano/releases/download/${releaseTag}/${assetName}`;
+  const publisher = metadata.publisherAttestation;
+  const publisherPolicy = policySelector(releaseTag);
+  const publisherVerified =
+    publisher?.contract === PUBLISHER_CONTRACT &&
+    publisher?.policyId === publisherPolicy.id &&
+    publisher?.repository === publisherPolicy.repository &&
+    publisher?.signerWorkflow === publisherPolicy.signerWorkflow &&
+    publisher?.sourceRef === publisherPolicy.sourceRef &&
+    publisher?.sourceDigest === publisherPolicy.sourceDigest &&
+    publisher?.predicateType === publisherPolicy.predicateType &&
+    publisher?.runner === publisherPolicy.runner &&
+    publisher?.asset === assetName &&
+    publisher?.sha256 === `sha256:${expected.archiveSha256}` &&
+    publisher?.verified === true;
+
+  return (
+    metadata.contract === authority.BUNDLE_CONTRACT &&
+    metadata.generator === authority.BUNDLE_GENERATOR &&
+    metadata.platform === platform &&
+    metadata.arch === arch &&
+    metadata.releaseTag === releaseTag &&
+    metadata.version === releaseTag &&
+    ['download', 'verified-cache'].includes(metadata.sourceType) &&
+    metadata.verified === true &&
+    publisherVerified &&
+    metadata.skipped === false &&
+    metadata.source?.owner === 'FerroxLabs' &&
+    metadata.source?.repository === 'wayland-nano' &&
+    metadata.source?.url === expectedUrl &&
+    metadata.source?.asset === assetName &&
+    manifestArchiveSha256 === expected.archiveSha256 &&
+    metadata.binary?.name === binaryName &&
+    manifestBinarySha256 === expected.binarySha256 &&
+    actualBinarySha256 === expected.binarySha256 &&
+    JSON.stringify(metadata.files) === JSON.stringify([binaryName])
+  );
+}
+
+function verifyWNanoBundle(bundleDir, requiredRuntimes, authority = prepareWaylandNano, policySelector = selectPolicy) {
+  if (!fs.statSync(bundleDir).isDirectory()) return false;
+  const entries = fs.readdirSync(bundleDir, { withFileTypes: true });
+  if (entries.length === 0) return false;
+  if (entries.some((entry) => !entry.isDirectory() || !/^(darwin|linux|win32)-(x64|arm64)$/.test(entry.name))) {
+    return false;
+  }
+  const packagedRuntimes = entries.map((entry) => entry.name).sort();
+  if (JSON.stringify(packagedRuntimes) !== JSON.stringify([...requiredRuntimes].sort())) return false;
+  return packagedRuntimes.every((runtime) => verifyWNanoRuntime(bundleDir, runtime, authority, policySelector));
 }
 
 function hasNonHiddenRegularFile(dir) {
@@ -861,7 +947,10 @@ function isNonEmpty(
   verifyOfficeCliDarwinSignature = (binaryPath) => officeCliAuthority.verifyDarwinPublisherSignature(binaryPath),
   constitutionFsAuthority,
   verifyConstitutionFsDarwinSignature,
-  verifyCandidateCapabilitySeal = verifyCapabilitySeal
+  verifyCandidateCapabilitySeal = verifyCapabilitySeal,
+  requiredWNanoRuntimes = [],
+  wnanoAuthority = prepareWaylandNano,
+  wnanoPolicySelector = selectPolicy
 ) {
   try {
     if (kind === 'constitution-fs-bundle' && targetPlatform === 'win32') {
@@ -882,6 +971,9 @@ function isNonEmpty(
     if (!st.isDirectory()) return false;
     if (kind === 'wcore-bundle') {
       return verifyWCoreBundle(p, requiredWCoreRuntimes, wcoreAuthority);
+    }
+    if (kind === 'wnano-bundle') {
+      return verifyWNanoBundle(p, requiredWNanoRuntimes, wnanoAuthority, wnanoPolicySelector);
     }
     if (kind === 'officecli-bundle') {
       const entries = fs.readdirSync(p, { withFileTypes: true });
@@ -979,6 +1071,8 @@ function verifyPackagedResources(options = {}) {
   const cwd = options.cwd || process.cwd();
   const logger = options.logger || console;
   const wcoreAuthority = options.wcoreAuthority || prepareWaylandCore;
+  const wnanoAuthority = options.wnanoAuthority || prepareWaylandNano;
+  const wnanoPolicySelector = options.wnanoPolicySelector || selectPolicy;
   const voiceAuthority = options.voiceAuthority || voiceModelPinnedRelease;
   const bunAuthority = options.bunAuthority || bundledBunBinaries;
   const modelsAuthority = options.modelsAuthority || modelsDevSnapshotPin;
@@ -999,6 +1093,7 @@ function verifyPackagedResources(options = {}) {
   const { platform: targetPlatform, arch: targetArch } = parseTarget(argv);
   const requiredOfficeCliRuntimes = parseRequiredRuntimes(argv, '--officecli-runtime', 'OfficeCLI');
   const requiredWCoreRuntimes = parseRequiredRuntimes(argv, '--wcore-runtime', 'wayland-core');
+  const requiredWNanoRuntimes = parseRequiredRuntimes(argv, '--wnano-runtime', 'wayland-nano');
   // Local verification builds (`build-with-builder.js` with WAYLAND_LOCAL_VERIFICATION=1
   // + `--dir`) intentionally OMIT the release capability seal. When this flag is set we
   // require the seal to be ABSENT (not present-and-valid) — enforcing omit-not-forge —
@@ -1007,9 +1102,10 @@ function verifyPackagedResources(options = {}) {
   const expectedRuntime = `${targetPlatform}-${targetArch}`;
   if (
     JSON.stringify(requiredOfficeCliRuntimes) !== JSON.stringify([expectedRuntime]) ||
-    JSON.stringify(requiredWCoreRuntimes) !== JSON.stringify([expectedRuntime])
+    JSON.stringify(requiredWCoreRuntimes) !== JSON.stringify([expectedRuntime]) ||
+    JSON.stringify(requiredWNanoRuntimes) !== JSON.stringify([expectedRuntime])
   ) {
-    throw new Error(`${TAG} Core and OfficeCLI runtime declarations must exactly match ${expectedRuntime}`);
+    throw new Error(`${TAG} Core, Nano and OfficeCLI runtime declarations must exactly match ${expectedRuntime}`);
   }
   const explicitResourceDir = parseSingleArg(argv, '--resources-dir', false);
   const explicitExecutable = parseSingleArg(argv, '--app-executable', false);
@@ -1087,7 +1183,10 @@ function verifyPackagedResources(options = {}) {
         verifyOfficeCliDarwinSignature,
         constitutionFsAuthority,
         verifyConstitutionFsDarwinSignature,
-        verifyCandidateCapabilitySeal
+        verifyCandidateCapabilitySeal,
+        requiredWNanoRuntimes,
+        wnanoAuthority,
+        wnanoPolicySelector
       );
       if (ok) {
         logger.log(`${TAG}   OK   ${req.rel}`);
@@ -1131,6 +1230,8 @@ module.exports = {
   verifyConstitutionFsBundle,
   verifyWCoreBundle,
   verifyWCoreRuntime,
+  verifyWNanoBundle,
+  verifyWNanoRuntime,
 };
 
 if (require.main === module) {

--- a/src/common/types/acpTypes.ts
+++ b/src/common/types/acpTypes.ts
@@ -478,8 +478,10 @@ export const ACP_BACKENDS_ALL: Record<AcpBackendAll, AcpBackendConfig> = {
     fluxCompat: 'setup',
   },
   // Wayland Nano: first-party sandboxed Rust agent. Always listed in the agent
-  // registry (AgentRegistry.createWNanoAgent); spawns via cliCommand when the
-  // binary is on PATH. Speaks ACP natively over stdio via the `acp-host`
+  // registry (AgentRegistry.createWNanoAgent); AcpAgentManager resolves the
+  // verified bundled binary first (resolveWNanoBinary: userData override →
+  // bundled-wayland-nano → dev resources), falling back to cliCommand on PATH.
+  // Speaks ACP natively over stdio via the `acp-host`
   // subcommand (bare `wayland-nano` prints usage and exits 2 — live-proven B1).
   wnano: {
     id: 'wnano',

--- a/src/common/types/acpTypes.ts
+++ b/src/common/types/acpTypes.ts
@@ -38,7 +38,7 @@ export const CODEBUDDY_ACP_NPX_PACKAGE = `@tencent-ai/codebuddy-code@${CODEBUDDY
  * than exec'ing it. Verified against 0.1.0 - `npx waylandnano@0.1.0 --version`
  * prints `wayland-nano 0.1.0`, and the `acp-host` subcommand below starts.
  */
-export const WNANO_NPM_VERSION = '0.1.0';
+export const WNANO_NPM_VERSION = '0.1.1';
 export const WNANO_NPX_PACKAGE = `waylandnano@${WNANO_NPM_VERSION}`;
 
 /**

--- a/src/process/agent/AgentRegistry.ts
+++ b/src/process/agent/AgentRegistry.ts
@@ -110,8 +110,10 @@ class AgentRegistry {
   /**
    * Wayland Nano is a first-party built-in ACP agent: always listed (like
    * Wayland Core) even when its `wayland-nano` binary is not on PATH yet.
-   * No cliPath here - AcpAgentManager falls back to
-   * ACP_BACKENDS_ALL.wnano.cliCommand at spawn time.
+   * No cliPath here - AcpAgentManager first tries the verified bundled
+   * binary via resolveWNanoBinary (userData override → bundled resource →
+   * dev resources), then falls back to ACP_BACKENDS_ALL.wnano.cliCommand
+   * (PATH) at spawn time.
    */
   private createWNanoAgent(): AcpDetectedAgent {
     return {

--- a/src/process/agent/acp/acpConnectors.ts
+++ b/src/process/agent/acp/acpConnectors.ts
@@ -303,11 +303,14 @@ export function createGenericSpawnConfig(
     spawnCommand = command;
     spawnArgs = [...inlineArgs, ...effectiveAcpArgs];
   } else {
-    // Unix: simple command or path. If cliPath contains spaces (e.g., "goose acp"),
-    // parse into command + inline args.
-    const parts = cliPath.split(/\s+/);
-    spawnCommand = parts[0];
-    spawnArgs = [...parts.slice(1), ...effectiveAcpArgs];
+    // Unix: simple command or path. Parse with the same helper as the Windows
+    // branch so a quoted executable path containing spaces (e.g. a bundled
+    // wayland-nano resolved under a userData dir like "Application Support")
+    // stays a single token; unquoted cliPaths still split into command +
+    // inline args ("goose acp"). No shell is invoked either way.
+    const { command, inlineArgs } = parseWindowsCliPath(cliPath);
+    spawnCommand = command;
+    spawnArgs = [...inlineArgs, ...effectiveAcpArgs];
   }
 
   const options: SpawnOptions = {

--- a/src/process/agent/wnano/binaryResolver.ts
+++ b/src/process/agent/wnano/binaryResolver.ts
@@ -1,0 +1,146 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+/**
+ * Binary names to look for, in priority order:
+ *  1. `wayland-nano`  - primary, written by `prepareWaylandNano.js` and
+ *     published by the agent's release workflow.
+ *  2. `wnano`         - convenience symlink users may have created.
+ */
+const BINARY_CANDIDATES: readonly string[] = ['wayland-nano', 'wnano'];
+
+/**
+ * Subdirectory under `userData` where an in-app agent updater would install a
+ * newer wayland-nano, by runtime key (`<platform>-<arch>`). Checked BEFORE the
+ * bundled binary so a user-accepted update supersedes the version shipped with
+ * the app. Mirrors `WCORE_OVERRIDE_SUBDIR` in the wcore resolver.
+ */
+export const WNANO_OVERRIDE_SUBDIR = 'wayland-nano-overrides';
+
+function withPlatformExt(name: string): string {
+  return process.platform === 'win32' ? `${name}.exe` : name;
+}
+
+/**
+ * The user-data override dir (`<userData>/wayland-nano-overrides`), or `null`
+ * when Electron's `app` is unavailable (e.g. unit tests). Lazily `require`d so
+ * importing this module outside Electron (test runner) never throws.
+ */
+function userDataOverrideDir(): string | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, global-require
+    const electron = require('electron') as { app?: { getPath?: (n: string) => string } };
+    const dir = electron.app?.getPath?.('userData');
+    return dir ? join(dir, WNANO_OVERRIDE_SUBDIR) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Primary binary name (used for the bundled-resource lookup filename).
+ * Iteration over `BINARY_CANDIDATES` happens at the call site for the
+ * bundled and PATH searches.
+ */
+function getBinaryName(): string {
+  return withPlatformExt(BINARY_CANDIDATES[0]);
+}
+
+function lookupOnPath(name: string): string | null {
+  // Use execFileSync (no shell) so the binary-name candidate cannot be
+  // interpreted as shell syntax - `BINARY_CANDIDATES` is compile-time
+  // constant today but defensive coding prevents future drift.
+  const finder = process.platform === 'win32' ? 'where' : 'which';
+  try {
+    const result = execFileSync(finder, [name], { encoding: 'utf-8', timeout: 5000 }).trim();
+    if (result && existsSync(result)) return result;
+  } catch {
+    // not found in PATH
+  }
+  return null;
+}
+
+/**
+ * Resolve the wayland-nano agent binary path.
+ * Search order:
+ *  0. User-installed override (in-app update) under userData.
+ *  1. Bundled with app (production resourcesPath) - tries each `BINARY_CANDIDATES` filename.
+ *  2. Project-root resources/bundled-wayland-nano/ (dev mode) - mirrors the
+ *     wcore resolution so `bun start` finds the same binary the packaged
+ *     build does.
+ *  3. System PATH - tries each `BINARY_CANDIDATES` name in order.
+ */
+export function resolveWNanoBinary(): string | null {
+  const runtimeKey = `${process.platform}-${process.arch}`;
+
+  // 0. User-installed override (in-app agent update) - checked FIRST so an
+  //    accepted update supersedes the bundled binary without a full app update.
+  const overrideDir = userDataOverrideDir();
+  if (overrideDir) {
+    for (const candidate of BINARY_CANDIDATES) {
+      const override = join(overrideDir, runtimeKey, withPlatformExt(candidate));
+      if (existsSync(override)) return override;
+    }
+  }
+
+  // 1. Bundled binary (production) - same layout as bundled-wayland-core
+  const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath;
+  if (resourcesPath) {
+    for (const candidate of BINARY_CANDIDATES) {
+      const bundled = join(resourcesPath, 'bundled-wayland-nano', runtimeKey, withPlatformExt(candidate));
+      if (existsSync(bundled)) return bundled;
+    }
+  }
+
+  // 2. Dev-mode project-root fallback. In dev, `process.resourcesPath` points
+  //    at Electron's own resources dir, not ours - so step 1 misses our
+  //    prepared binary. Check project-root resources/ directly.
+  for (const candidate of BINARY_CANDIDATES) {
+    const devBundled = join(process.cwd(), 'resources', 'bundled-wayland-nano', runtimeKey, withPlatformExt(candidate));
+    if (existsSync(devBundled)) return devBundled;
+  }
+
+  // 3. System PATH - try each candidate in priority order.
+  for (const candidate of BINARY_CANDIDATES) {
+    const found = lookupOnPath(candidate);
+    if (found) return found;
+  }
+
+  return null;
+}
+
+export function isWNanoAvailable(): boolean {
+  return resolveWNanoBinary() !== null;
+}
+
+/**
+ * Detect wayland-nano availability and version for settings UI.
+ */
+export function detectWNano(): {
+  available: boolean;
+  version?: string;
+  path?: string;
+} {
+  const binaryPath = resolveWNanoBinary();
+  if (!binaryPath) return { available: false };
+
+  try {
+    const version = execFileSync(binaryPath, ['--version'], {
+      encoding: 'utf-8',
+      timeout: 5000,
+    }).trim();
+    return { available: true, version, path: binaryPath };
+  } catch {
+    return { available: true, path: binaryPath };
+  }
+}
+
+// Internal - exported for tests.
+export { BINARY_CANDIDATES, getBinaryName };

--- a/src/process/agent/wnano/index.ts
+++ b/src/process/agent/wnano/index.ts
@@ -1,0 +1,7 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { WNANO_OVERRIDE_SUBDIR, detectWNano, isWNanoAvailable, resolveWNanoBinary } from './binaryResolver';

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -2,6 +2,7 @@ import type { AcpAgent } from '@process/agent/acp';
 import { AcpAgentV2 } from '@process/acp/compat';
 import { agentRegistry } from '@process/agent/AgentRegistry';
 import { nanoErrorKindOf } from '@process/acp/errors/errorNormalize';
+import { resolveWNanoBinary } from '@process/agent/wnano/binaryResolver';
 import { channelEventBus } from '@process/channels/agent/ChannelEventBus';
 import { teamEventBus } from '@process/team/teamEventBus';
 import { ipcBridge } from '@/common';
@@ -1281,6 +1282,16 @@ ${collectedResponses.join('\n')}`;
     let customArgs: string[] | undefined;
     if (backendConfig?.acpArgs) {
       customArgs = backendConfig.acpArgs;
+    }
+
+    // Wayland Nano prefers the verified bundled binary (userData override →
+    // bundled resource → dev resources) over a bare PATH lookup. Quote a
+    // resolved path containing whitespace so createGenericSpawnConfig keeps
+    // the executable a single token (macOS userData lives under
+    // "Application Support"); the spawn config unquotes it without a shell.
+    if (!cliPath && data.backend === 'wnano') {
+      const resolved = resolveWNanoBinary();
+      if (resolved) cliPath = /\s/.test(resolved) ? `"${resolved}"` : resolved;
     }
 
     // If cliPath is not configured, fall back to the backend's own launcher.

--- a/tests/unit/acpConnectors.test.ts
+++ b/tests/unit/acpConnectors.test.ts
@@ -414,6 +414,26 @@ describe('createGenericSpawnConfig - Windows path handling', () => {
     });
   });
 
+  it('parses a quoted Unix path with spaces into a bare command, no shell', () => {
+    setLinuxPlatform();
+    // A bundled-binary path resolved under a userData dir (macOS
+    // "Application Support") arrives quoted from AcpAgentManager; it must
+    // survive as a single argv token instead of splitting on the space.
+    const config = createGenericSpawnConfig(
+      '"/Users/x/Library/Application Support/Wayland/wayland-nano-overrides/linux-arm64/wayland-nano"',
+      '/cwd',
+      ['acp-host'],
+      undefined,
+      { PATH: '/usr/bin' }
+    );
+
+    expect(config.command).toBe(
+      '/Users/x/Library/Application Support/Wayland/wayland-nano-overrides/linux-arm64/wayland-nano'
+    );
+    expect(config.args).toEqual(['acp-host']);
+    expect(config.options).toMatchObject({ shell: false });
+  });
+
   it('splits npx package into command and args (no chcp prefix for npx path)', () => {
     const config = createGenericSpawnConfig('npx @pkg/cli', '/cwd', ['--acp'], undefined, { PATH: '/usr/bin' });
 

--- a/tests/unit/prepareOfficeCli.test.ts
+++ b/tests/unit/prepareOfficeCli.test.ts
@@ -293,8 +293,13 @@ describe('prepareOfficeCli supply-chain contract', () => {
       '/Contents/Resources/whatsapp-bridge/node_modules/(?:bare-fs|bare-os|bare-url)/prebuilds/(?:darwin-(?:arm64|x64)|ios-(?:arm64|arm64-simulator|x64-simulator))/[^/]+\\.bare$',
       '/Contents/Resources/bundled-officecli/[^/]+/officecli$',
       '/Contents/Resources/bundled-wayland-core/[^/]+/wayland-core$',
+      '/Contents/Resources/bundled-wayland-nano/[^/]+/wayland-nano$',
       '/Contents/Resources/bundled-constitution-fs/[^/]+/wayland-constitution-fs$',
     ]);
+    // The bundled Nano runtime carries its own publisher signature and must be
+    // left alone, exactly like the engine and the authoring runtime beside it.
+    const nanoPath = '/tmp/Wayland.app/Contents/Resources/bundled-wayland-nano/darwin-arm64/wayland-nano';
+    expect(signIgnore?.some((pattern) => new RegExp(pattern).test(nanoPath))).toBe(true);
     const bunPath = '/tmp/Wayland.app/Contents/Resources/bundled-bun/darwin-arm64/bun';
     expect(signIgnore?.some((pattern) => new RegExp(pattern).test(bunPath))).toBe(true);
     const whatsappNativePath =

--- a/tests/unit/prepareWaylandNano.test.ts
+++ b/tests/unit/prepareWaylandNano.test.ts
@@ -98,9 +98,7 @@ describe('strict bundled wayland-nano provenance', () => {
       '',
       undefined,
     ]) {
-      expect(() => prepareWaylandNano.normalizeSha256(bad, 'test pin')).toThrow(
-        /Malformed or placeholder SHA-256/
-      );
+      expect(() => prepareWaylandNano.normalizeSha256(bad, 'test pin')).toThrow(/Malformed or placeholder SHA-256/);
     }
 
     // Known positive: without it the rejections above would prove nothing.

--- a/tests/unit/prepareWaylandNano.test.ts
+++ b/tests/unit/prepareWaylandNano.test.ts
@@ -1,0 +1,160 @@
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const prepareWaylandNano = require('../../scripts/prepareWaylandNano.js') as {
+  (options?: Record<string, unknown>): unknown;
+  BUNDLE_CONTRACT: string;
+  BUNDLE_GENERATOR: string;
+  DEFAULT_WNANO_VERSION: string;
+  getAssetName(platform: string, arch: string, tag: string): string | null;
+  loadExpectedProvenance(
+    tag: string,
+    asset: string,
+    options?: { requireBinary?: boolean }
+  ): { archiveSha256: string; binarySha256: string | null };
+  normalizeExactReleaseTag(version: string): string;
+  pruneRuntimeDirectory(dir: string, allowedNames: string[]): void;
+};
+
+const originalSkip = process.env.WNANO_SKIP;
+const originalLegacySkip = process.env.WAYLAND_NANO_SKIP;
+
+afterEach(() => {
+  if (originalSkip === undefined) delete process.env.WNANO_SKIP;
+  else process.env.WNANO_SKIP = originalSkip;
+  if (originalLegacySkip === undefined) delete process.env.WAYLAND_NANO_SKIP;
+  else process.env.WAYLAND_NANO_SKIP = originalLegacySkip;
+});
+
+const SUPPORTED_TARGETS: Array<[string, string]> = [
+  ['darwin', 'arm64'],
+  ['darwin', 'x64'],
+  ['linux', 'arm64'],
+  ['linux', 'x64'],
+  ['win32', 'x64'],
+];
+
+describe('strict bundled wayland-nano provenance', () => {
+  it('names the five supported release assets after the unprefixed version and runtime key', () => {
+    for (const [platform, arch] of SUPPORTED_TARGETS) {
+      expect(prepareWaylandNano.getAssetName(platform, arch, 'v0.1.0')).toBe(
+        `wayland-nano-0.1.0-${platform}-${arch}.zip`
+      );
+    }
+    // The release workflow publishes no Windows ARM64 target.
+    expect(prepareWaylandNano.getAssetName('win32', 'arm64', 'v0.1.0')).toBeNull();
+  });
+
+  it('fails closed on the unfilled shasums skeleton (fill-on-release state)', () => {
+    // The first FerroxLabs/wayland-nano release assets land after this
+    // integration; until the manifest carries real pins every provenance
+    // lookup must throw - never skip verification.
+    expect(() =>
+      prepareWaylandNano.loadExpectedProvenance('v0.1.0', 'wayland-nano-0.1.0-darwin-arm64.zip', {
+        requireBinary: true,
+      })
+    ).toThrow(/No SHA-256 entries/);
+  });
+
+  it('pins independent archive and extracted-binary hashes for any future tag entries', () => {
+    // Schema guard for the fill-on-release commit: once real tag entries are
+    // added they must cover exactly the five supported assets, keyed by the
+    // getAssetName contract, with both independent pins.
+    const manifest = JSON.parse(fs.readFileSync(path.resolve('scripts/bundled-wnano-shasums.json'), 'utf8'));
+    for (const tag of Object.keys(manifest).filter((key) => !key.startsWith('_'))) {
+      const expectedAssets = SUPPORTED_TARGETS.map(([platform, arch]) =>
+        prepareWaylandNano.getAssetName(platform, arch, tag)
+      ).toSorted();
+      expect(Object.keys(manifest[tag]).toSorted()).toEqual(expectedAssets);
+      for (const proof of Object.values(manifest[tag]) as Array<Record<string, string>>) {
+        expect(proof.archiveSha256).toMatch(/^sha256:[0-9a-f]{64}$/);
+        expect(proof.binarySha256).toMatch(/^sha256:[0-9a-f]{64}$/);
+        expect(proof.binarySha256).not.toBe(proof.archiveSha256);
+      }
+    }
+  });
+
+  it('rejects placeholder or malformed pin values', () => {
+    // The skeleton's _fillOnReleaseExample deliberately nests PENDING values
+    // under a non-tag key; if such a placeholder ever reaches a real tag
+    // entry, normalizeSha256 rejects it (fail closed, never a loose match).
+    expect(() => prepareWaylandNano.loadExpectedProvenance('_fillOnReleaseExample', 'v0.1.0')).toThrow(
+      /Malformed or placeholder SHA-256/
+    );
+  });
+
+  it('rejects skip flags when strict preparation is requested', () => {
+    process.env.WNANO_SKIP = '1';
+    expect(() =>
+      prepareWaylandNano({
+        platform: 'darwin',
+        arch: 'arm64',
+        version: 'v0.1.0',
+        requireVerified: true,
+      })
+    ).toThrow(/cannot honor WNANO_SKIP/);
+  });
+
+  it('rejects a moving latest tag when strict preparation is requested', () => {
+    delete process.env.WNANO_SKIP;
+    delete process.env.WAYLAND_NANO_SKIP;
+    expect(() =>
+      prepareWaylandNano({ platform: 'darwin', arch: 'arm64', version: 'latest', requireVerified: true })
+    ).toThrow(/exact pinned release tag/);
+  });
+
+  it('rejects release-tag command injection before constructing a download command', () => {
+    expect(() => prepareWaylandNano.normalizeExactReleaseTag("v0.1.0'; Start-Process calc; '")).toThrow(
+      /exact vMAJOR\.MINOR\.PATCH/
+    );
+  });
+
+  it('accepts exact release tags, including prerelease tags', () => {
+    expect(prepareWaylandNano.normalizeExactReleaseTag('0.1.0')).toBe('v0.1.0');
+    expect(prepareWaylandNano.normalizeExactReleaseTag('v0.1.0-alpha.0')).toBe('v0.1.0-alpha.0');
+  });
+
+  it('prunes stale files and fallback executables from a selected runtime directory', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wayland-wnano-prune-'));
+    try {
+      fs.writeFileSync(path.join(root, 'wayland-nano'), 'pinned');
+      fs.writeFileSync(path.join(root, 'wnano'), 'stale-fallback');
+      fs.writeFileSync(path.join(root, 'manifest.json'), 'stale-receipt');
+      fs.mkdirSync(path.join(root, 'helpers'));
+      fs.writeFileSync(path.join(root, 'helpers', 'runner'), 'stale-helper');
+
+      prepareWaylandNano.pruneRuntimeDirectory(root, ['wayland-nano']);
+
+      expect(fs.readdirSync(root)).toEqual(['wayland-nano']);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('makes the package command and post-package verifier declare strict wnano target authority directly', () => {
+    const build = fs.readFileSync(path.resolve('scripts/build-with-builder.js'), 'utf8');
+    const builder = fs.readFileSync(path.resolve('electron-builder.yml'), 'utf8');
+    const verifier = fs.readFileSync(path.resolve('scripts/verify-packaged-resources.js'), 'utf8');
+    expect(build).toContain('requireVerified: true');
+    expect(build).toContain('version: prepareWaylandNano.DEFAULT_WNANO_VERSION');
+    expect(build).toContain('--wnano-runtime');
+    expect(verifier).toContain("kind: 'wnano-bundle'");
+    expect(verifier).toContain("['download', 'verified-cache'].includes(metadata.sourceType)");
+    expect(verifier).toContain('actualBinarySha256 === expected.binarySha256');
+    expect(builder).toContain('resources/bundled-wayland-nano');
+    expect(builder).toContain("'/Contents/Resources/bundled-wayland-nano/[^/]+/wayland-nano$'");
+  });
+
+  it('keeps the bundle receipt contract bound to binary pins and publisher attestation', () => {
+    const prepare = fs.readFileSync(path.resolve('scripts/prepareWaylandNano.js'), 'utf8');
+    expect(prepareWaylandNano.BUNDLE_CONTRACT).toBe('wayland-nano-bundle/1.0');
+    expect(prepareWaylandNano.BUNDLE_GENERATOR).toBe('prepareWaylandNano/1');
+    expect(prepare).toContain('verifyPublisherAttestation({');
+    expect(prepare).toContain('publisherAttestation: publisherAttestation || null');
+    expect(prepare).toContain('lacks archive-bound publisher');
+  });
+});

--- a/tests/unit/prepareWaylandNano.test.ts
+++ b/tests/unit/prepareWaylandNano.test.ts
@@ -17,6 +17,7 @@ const prepareWaylandNano = require('../../scripts/prepareWaylandNano.js') as {
     options?: { requireBinary?: boolean }
   ): { archiveSha256: string; binarySha256: string | null };
   normalizeExactReleaseTag(version: string): string;
+  normalizeSha256(raw: unknown, label: string): string;
   pruneRuntimeDirectory(dir: string, allowedNames: string[]): void;
 };
 
@@ -79,12 +80,31 @@ describe('strict bundled wayland-nano provenance', () => {
   });
 
   it('rejects placeholder or malformed pin values', () => {
-    // The skeleton's _fillOnReleaseExample deliberately nests PENDING values
-    // under a non-tag key; if such a placeholder ever reaches a real tag
-    // entry, normalizeSha256 rejects it (fail closed, never a loose match).
-    expect(() => prepareWaylandNano.loadExpectedProvenance('_fillOnReleaseExample', 'v0.1.0')).toThrow(
-      /Malformed or placeholder SHA-256/
-    );
+    // normalizeSha256 is the choke point every provenance lookup passes
+    // through. It must fail closed on a placeholder or a near-miss digest,
+    // never a loose match.
+    //
+    // This used to be driven through the manifest's _fillOnReleaseExample
+    // skeleton, which was removed when the real v0.1.1 pins landed. The
+    // invariant is unchanged and is now asserted against the guard itself,
+    // which is stricter: it covers near-miss shapes the skeleton never had.
+    for (const bad of [
+      'sha256:PENDING-fill-from-release-shasums-asset',
+      'PENDING-hash-of-extracted-verified-binary',
+      'sha256:not-a-hex-digest',
+      `sha256:${'a'.repeat(63)}`,
+      `sha256:${'a'.repeat(65)}`,
+      `sha256:${'g'.repeat(64)}`,
+      '',
+      undefined,
+    ]) {
+      expect(() => prepareWaylandNano.normalizeSha256(bad, 'test pin')).toThrow(
+        /Malformed or placeholder SHA-256/
+      );
+    }
+
+    // Known positive: without it the rejections above would prove nothing.
+    expect(prepareWaylandNano.normalizeSha256(`sha256:${'a'.repeat(64)}`, 'test pin')).toBe('a'.repeat(64));
   });
 
   it('rejects skip flags when strict preparation is requested', () => {

--- a/tests/unit/process/agent/wnano/binaryResolver.test.ts
+++ b/tests/unit/process/agent/wnano/binaryResolver.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Control PATH lookups deterministically: without this mock the resolver
+// would shell out to `which`/`where` and depend on the dev machine's PATH.
+vi.mock('node:child_process', () => ({ execFileSync: vi.fn() }));
+
+import { execFileSync } from 'node:child_process';
+import {
+  BINARY_CANDIDATES,
+  WNANO_OVERRIDE_SUBDIR,
+  getBinaryName,
+  resolveWNanoBinary,
+} from '@/process/agent/wnano/binaryResolver';
+
+const execFileSyncMock = vi.mocked(execFileSync);
+
+const runtimeKey = `${process.platform}-${process.arch}`;
+const devBundleDir = path.join(process.cwd(), 'resources', 'bundled-wayland-nano');
+const devBinaryPath = path.join(devBundleDir, runtimeKey, getBinaryName());
+
+function stageDevBinary(): void {
+  fs.mkdirSync(path.dirname(devBinaryPath), { recursive: true });
+  fs.writeFileSync(devBinaryPath, 'test-wayland-nano');
+}
+
+beforeEach(() => {
+  // Default: nothing on PATH.
+  execFileSyncMock.mockImplementation(() => {
+    throw new Error('not found');
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  fs.rmSync(devBundleDir, { recursive: true, force: true });
+});
+
+describe('resolveWNanoBinary', () => {
+  it('looks for the primary binary first, then the convenience alias', () => {
+    expect(BINARY_CANDIDATES).toEqual(['wayland-nano', 'wnano']);
+    expect(getBinaryName()).toBe(process.platform === 'win32' ? 'wayland-nano.exe' : 'wayland-nano');
+    expect(WNANO_OVERRIDE_SUBDIR).toBe('wayland-nano-overrides');
+  });
+
+  it('resolves the dev-resources bundle prepared by prepareWaylandNano.js', () => {
+    stageDevBinary();
+    expect(resolveWNanoBinary()).toBe(devBinaryPath);
+  });
+
+  it('prefers the dev-resources bundle over a PATH hit', () => {
+    stageDevBinary();
+    execFileSyncMock.mockReturnValue('C:\\elsewhere\\wayland-nano.exe\n');
+    expect(resolveWNanoBinary()).toBe(devBinaryPath);
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to PATH when no override, bundled, or dev binary exists', () => {
+    execFileSyncMock.mockImplementation((_cmd, args) => {
+      // Return a path that really exists so the resolver's existsSync gate passes.
+      if ((args as string[])[0] === 'wayland-nano') return `${process.execPath}\n`;
+      throw new Error('not found');
+    });
+    expect(resolveWNanoBinary()).toBe(process.execPath);
+  });
+
+  it('returns null when the binary cannot be found anywhere', () => {
+    expect(resolveWNanoBinary()).toBeNull();
+  });
+});

--- a/tests/unit/verifyPackagedResources.test.ts
+++ b/tests/unit/verifyPackagedResources.test.ts
@@ -153,6 +153,38 @@ const testWCoreAuthority = {
   },
 };
 
+// wayland-nano mirrors the wayland-core fixture. Its publisher-attestation
+// policy does not exist in the real policy file yet (the first signed
+// FerroxLabs/wayland-nano release lands after this integration), so the gate
+// accepts an injected policy selector for the wnano bundle checks.
+const TEST_WNANO_RELEASE = 'v0.1.0';
+const TEST_WNANO_ARCHIVE_SHA = 'd'.repeat(64);
+const TEST_WNANO_BYTES = Buffer.from('deterministic-test-wayland-nano');
+const TEST_WNANO_BINARY_SHA = crypto.createHash('sha256').update(TEST_WNANO_BYTES).digest('hex');
+const TEST_WNANO_POLICY = {
+  id: 'wayland-nano-v0.1.0-release',
+  repository: 'FerroxLabs/wayland-nano',
+  signerWorkflow: 'FerroxLabs/wayland-nano/.github/workflows/release.yml',
+  sourceRef: 'refs/heads/main',
+  sourceDigest: 'e'.repeat(40),
+  predicateType: 'https://slsa.dev/provenance/v1',
+  runner: 'github-hosted',
+};
+
+const testWNanoAuthority = {
+  BUNDLE_CONTRACT: 'wayland-nano-bundle/1.0',
+  BUNDLE_GENERATOR: 'prepareWaylandNano/1',
+  DEFAULT_WNANO_VERSION: TEST_WNANO_RELEASE,
+  getAssetName(platform: string, arch: string, tag: string): string {
+    return `wayland-nano-${tag.replace(/^v/, '')}-${platform}-${arch}.zip`;
+  },
+  loadExpectedProvenance(_tag: string, _asset: string, _options: { requireBinary: boolean }) {
+    return { archiveSha256: TEST_WNANO_ARCHIVE_SHA, binarySha256: TEST_WNANO_BINARY_SHA };
+  },
+};
+
+const testWNanoPolicySelector = (_releaseTag: string) => TEST_WNANO_POLICY;
+
 function writeMachExecutable(target: string, arch: 'arm64' | 'x64'): void {
   fs.mkdirSync(path.dirname(target), { recursive: true });
   fs.writeFileSync(target, machExecutableBytes(arch), { mode: 0o755 });
@@ -296,6 +328,46 @@ function addPackagedApp(
       skipped: false,
     })
   );
+  const wnanoBinary = path.join(resources, 'bundled-wayland-nano', `darwin-${arch}`, 'wayland-nano');
+  fs.mkdirSync(path.dirname(wnanoBinary), { recursive: true });
+  fs.writeFileSync(wnanoBinary, TEST_WNANO_BYTES);
+  const wnanoAsset = testWNanoAuthority.getAssetName('darwin', arch, TEST_WNANO_RELEASE);
+  fs.writeFileSync(
+    path.join(resources, 'bundled-wayland-nano', `darwin-${arch}`, 'manifest.json'),
+    JSON.stringify({
+      contract: testWNanoAuthority.BUNDLE_CONTRACT,
+      generator: testWNanoAuthority.BUNDLE_GENERATOR,
+      platform: 'darwin',
+      arch,
+      releaseTag: TEST_WNANO_RELEASE,
+      version: TEST_WNANO_RELEASE,
+      sourceType: 'download',
+      verified: true,
+      source: {
+        owner: 'FerroxLabs',
+        repository: 'wayland-nano',
+        url: `https://github.com/FerroxLabs/wayland-nano/releases/download/${TEST_WNANO_RELEASE}/${wnanoAsset}`,
+        asset: wnanoAsset,
+        archiveSha256: `sha256:${TEST_WNANO_ARCHIVE_SHA}`,
+      },
+      publisherAttestation: {
+        contract: 'wayland-publisher-attestations/1.0',
+        policyId: TEST_WNANO_POLICY.id,
+        repository: TEST_WNANO_POLICY.repository,
+        signerWorkflow: TEST_WNANO_POLICY.signerWorkflow,
+        sourceRef: TEST_WNANO_POLICY.sourceRef,
+        sourceDigest: TEST_WNANO_POLICY.sourceDigest,
+        predicateType: TEST_WNANO_POLICY.predicateType,
+        runner: TEST_WNANO_POLICY.runner,
+        asset: wnanoAsset,
+        sha256: `sha256:${TEST_WNANO_ARCHIVE_SHA}`,
+        verified: true,
+      },
+      binary: { name: 'wayland-nano', sha256: `sha256:${TEST_WNANO_BINARY_SHA}` },
+      files: ['wayland-nano'],
+      skipped: false,
+    })
+  );
   for (const extractorArch of ['arm64', 'x64']) {
     const target = path.join(resources, 'classic-recovery-tools', 'win', extractorArch, '7za.exe');
     fs.mkdirSync(path.dirname(target), { recursive: true });
@@ -387,7 +459,25 @@ function wcoreBinaryPath(out: string, runtime = 'darwin-arm64'): string {
   );
 }
 
-function verifyArgs(out: string, officeCliRuntime = 'darwin-arm64', wcoreRuntime = 'darwin-arm64'): string[] {
+function wnanoManifestPath(out: string, runtime = 'darwin-arm64'): string {
+  return path.join(packagedResourcesPath(out), 'bundled-wayland-nano', runtime, 'manifest.json');
+}
+
+function wnanoBinaryPath(out: string, runtime = 'darwin-arm64'): string {
+  return path.join(
+    packagedResourcesPath(out),
+    'bundled-wayland-nano',
+    runtime,
+    runtime.startsWith('win32-') ? 'wayland-nano.exe' : 'wayland-nano'
+  );
+}
+
+function verifyArgs(
+  out: string,
+  officeCliRuntime = 'darwin-arm64',
+  wcoreRuntime = 'darwin-arm64',
+  wnanoRuntime = wcoreRuntime
+): string[] {
   return [
     'scripts/verify-packaged-resources.js',
     '--out',
@@ -398,6 +488,8 @@ function verifyArgs(out: string, officeCliRuntime = 'darwin-arm64', wcoreRuntime
     wcoreRuntime.split('-')[1],
     '--wcore-runtime',
     wcoreRuntime,
+    '--wnano-runtime',
+    wnanoRuntime,
     '--officecli-runtime',
     officeCliRuntime,
   ];
@@ -429,6 +521,8 @@ describe('packaged resource release gate', () => {
       cwd: process.cwd(),
       logger: silentLogger,
       wcoreAuthority: testWCoreAuthority,
+      wnanoAuthority: testWNanoAuthority,
+      wnanoPolicySelector: testWNanoPolicySelector,
       voiceAuthority: TEST_VOICE_AUTHORITY,
       bunAuthority: TEST_BUN_AUTHORITY,
       modelsAuthority: TEST_MODELS_AUTHORITY,
@@ -463,6 +557,56 @@ describe('packaged resource release gate', () => {
     alteredManifest.publisherAttestation.sourceDigest = 'f'.repeat(40);
     fs.writeFileSync(alteredPath, JSON.stringify(alteredManifest));
     expect(() => verify(altered)).toThrow(/CRITICAL resource/);
+  });
+
+  it('rejects a Nano bundle whose publisher attestation is absent or altered', () => {
+    const out = createPackagedResources(true);
+    const manifestPath = wnanoManifestPath(out);
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as {
+      publisherAttestation: { sourceDigest: string } | null;
+    };
+    manifest.publisherAttestation = null;
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+    expect(() => verify(out)).toThrow(/CRITICAL resource/);
+
+    const altered = createPackagedResources(true);
+    const alteredPath = wnanoManifestPath(altered);
+    const alteredManifest = JSON.parse(fs.readFileSync(alteredPath, 'utf8')) as {
+      publisherAttestation: { sourceDigest: string };
+    };
+    alteredManifest.publisherAttestation.sourceDigest = 'f'.repeat(40);
+    fs.writeFileSync(alteredPath, JSON.stringify(alteredManifest));
+    expect(() => verify(altered)).toThrow(/CRITICAL resource/);
+  });
+
+  it('blocks a package whose bundled wayland-nano runtime is absent', () => {
+    const out = createPackagedResources(true);
+    fs.rmSync(path.join(packagedResourcesPath(out), 'bundled-wayland-nano'), { recursive: true, force: true });
+    expect(() => verify(out)).toThrow(/CRITICAL resource/);
+  });
+
+  it('blocks a local-prebuilt or unverified wayland-nano manifest', () => {
+    const out = createPackagedResources(true);
+    const manifest = wnanoManifestPath(out);
+    const metadata = JSON.parse(fs.readFileSync(manifest, 'utf8'));
+    metadata.sourceType = 'local-prebuilt';
+    metadata.verified = false;
+    fs.writeFileSync(manifest, JSON.stringify(metadata));
+    expect(() => verify(out)).toThrow();
+  });
+
+  it('blocks wayland-nano binary byte drift even when the manifest is unchanged', () => {
+    const out = createPackagedResources(true);
+    fs.appendFileSync(wnanoBinaryPath(out), 'tampered');
+    expect(() => verify(out)).toThrow();
+  });
+
+  it('blocks undeclared extra wayland-nano runtime content', () => {
+    const out = createPackagedResources(true);
+    const extra = path.join(packagedResourcesPath(out), 'bundled-wayland-nano', 'linux-x64');
+    fs.mkdirSync(extra, { recursive: true });
+    fs.writeFileSync(path.join(extra, 'wayland-nano'), 'unverified-extra-runtime');
+    expect(() => verify(out)).toThrow();
   });
 
   it('rejects a missing or malformed packaged capability seal', () => {


### PR DESCRIPTION
The v0.12.0 release build failed on all six platforms. This is the cause, and it is not the Nano or Core work: both downloaded and digest-verified cleanly in every job.

## What happened

OfficeCLI ships a background self-updater that is on by default. It resolves the moving `latest` release and swaps its own binary in place on a subsequent run. That silently replaces the exact bytes prepareOfficeCli has just digest-verified.

prepareOfficeCli invokes the binary about ten times for its contract and smoke checks, so the swap landed mid-sequence:

- Windows reported `1.0.144` against the pinned `1.0.136` and failed the contract assertion.
- macOS and Linux crashed inside `OfficeCli.Core.UpdateChecker.ApplyPendingUpdate()` with a missing `System.Diagnostics.Process` assembly.

## Reproduced locally

With the updater left at its default, the binary rewrote itself between two invocations:

    run 1: 1.0.136
    run 2: 1.0.144
    sha256 b8582853... -> 04757163...

With `autoUpdate` disabled it stays on the pinned bytes across the full prepare, and the updater does not even record a check.

## The fix

Every invocation of the bundled binary now runs against an isolated config home with `autoUpdate` disabled, so the contract and smoke checks exercise the pinned artifact rather than whatever upstream published most recently.

No check is relaxed or skipped. The version assertion and the full smoke suite still run, against the artifact we actually intend to ship.

## Verification

Full prepare executed on darwin-arm64: downloaded, digest-verified, contract and smoke checks passed, binary still `b8582853...` and still reporting `1.0.136` afterwards. `tests/unit/prepareOfficeCli.test.ts` 11/11 pass.

## Worth noting separately

The same self-updater is present in the binary shipped to users, where it can replace an attested runtime after installation. That is a supply-chain question beyond this fix and is not addressed here.
