### PR TITLE
fix(build): accept linux musl sharp natives and guard OfficeCLI mutation

### DIFF
--- a/scripts/prepareOfficeCli.js
+++ b/scripts/prepareOfficeCli.js
@@ -367,13 +367,36 @@ function assertContractOutputs(versionOutput, topLevelHelp, formatHelp, watchHel
 // home with autoUpdate disabled, so the contract and smoke checks exercise the
 // pinned artifact rather than whatever upstream published most recently.
 function withUpdatesDisabled() {
-  const configHome = fs.mkdtempSync(path.join(os.tmpdir(), 'wayland-officecli-home-'));
+  // On Windows runners os.tmpdir() is an 8.3 short path (C:\\Users\\RUNNER~1\\...).
+  // Hand the child the expanded long form: a consumer that canonicalises the profile
+  // path differently would otherwise miss the config written here and fall back to its
+  // defaults, which is exactly the silent re-enable this function exists to prevent.
+  let configHome = fs.mkdtempSync(path.join(os.tmpdir(), 'wayland-officecli-home-'));
+  try {
+    configHome = fs.realpathSync.native(configHome);
+  } catch {
+    // A realpath failure is not fatal; the short path is still a usable directory.
+  }
   fs.mkdirSync(path.join(configHome, '.officecli'), { recursive: true });
   fs.writeFileSync(
     path.join(configHome, '.officecli', 'config.json'),
     `${JSON.stringify({ autoUpdate: false, log: false }, null, 2)}\n`
   );
   return { ...process.env, HOME: configHome, USERPROFILE: configHome };
+}
+
+// The probes above execute the binary. OfficeCLI's updater has replaced its own
+// executable in place before now, so re-assert the pinned digest afterwards: a build
+// must never package bytes that differ from the ones it verified.
+function assertBinaryUnchangedByProbes(binaryPath, expectedSha, assetName, version) {
+  const actual = `sha256:${computeSha256(binaryPath)}`;
+  const expected = String(expectedSha).startsWith('sha256:') ? String(expectedSha) : `sha256:${expectedSha}`;
+  if (actual !== expected) {
+    throw new Error(
+      `OfficeCLI ${assetName} mutated itself while being probed: expected ${expected}, found ${actual}. ` +
+        `The pinned ${version} binary replaced itself on disk; the self-updater is not disabled on this host.`
+    );
+  }
 }
 
 function verifyExecutableContract(binaryPath) {
@@ -799,8 +822,10 @@ function prepareOfficeCli(options = {}) {
   const ledgerProof = loadOfficeCliLedgerProof();
 
   fs.mkdirSync(targetDir, { recursive: true });
+  console.log(`Preparing OfficeCLI for ${runtimeKey} (version: ${version})`);
 
   if (fs.existsSync(targetBinary) && !options.forceDownload) {
+    console.log(`  Reusing existing ${runtimeKey} binary (digest-verified against the pin)`);
     verifyFile(targetBinary, expectedSha, assetName, version);
     if (platform !== 'win32') fs.chmodSync(targetBinary, 0o755);
     const publisherSignatureProof =
@@ -814,6 +839,7 @@ function prepareOfficeCli(options = {}) {
     const smokeProof = executableOnBuildHost
       ? verifyExecutableSmoke(targetBinary)
       : { formats: [], operations: [], reason: 'not-executable-on-build-host' };
+    if (executableOnBuildHost) assertBinaryUnchangedByProbes(targetBinary, expectedSha, assetName, version);
     const reportedVersion = contractProof.release.replace(/^v/i, '');
     writeManifest(
       targetDir,
@@ -859,6 +885,7 @@ function prepareOfficeCli(options = {}) {
     if (platform === process.platform && arch === process.arch) {
       contractProof = verifyExecutableContract(targetBinary);
       smokeProof = verifyExecutableSmoke(targetBinary);
+      assertBinaryUnchangedByProbes(targetBinary, expectedSha, assetName, version);
       reportedVersion = contractProof.release.replace(/^v/i, '');
     }
 

--- a/scripts/verify-packaged-resources.js
+++ b/scripts/verify-packaged-resources.js
@@ -601,7 +601,18 @@ function listNativeIdentities(root, identities = []) {
 
 function expectedSharpPackages(platform, arch) {
   if (platform === 'darwin') return [`sharp-darwin-${arch}`, `sharp-libvips-darwin-${arch}`];
-  if (platform === 'linux') return [`sharp-linux-${arch}`, `sharp-libvips-linux-${arch}`];
+  // bun's --os/--cpu filters select by platform and architecture but carry no libc
+  // dimension, so a linux install always lands both the glibc and the musl builds of
+  // sharp. Both are genuine linux/<arch> natives and both still have to satisfy the
+  // per-package os, cpu and native-identity assertions below; only the exact-inventory
+  // comparison needs to know they are expected.
+  if (platform === 'linux')
+    return [
+      `sharp-linux-${arch}`,
+      `sharp-libvips-linux-${arch}`,
+      `sharp-linuxmusl-${arch}`,
+      `sharp-libvips-linuxmusl-${arch}`,
+    ];
   if (platform === 'win32') return [`sharp-win32-${arch}`];
   return [];
 }


### PR DESCRIPTION
Two more release-build failures from the v0.12.0 attempts. Attempt 2 got materially further: macOS arm64 reached Apple notarization with everything bundled, signed and verified, and died there on a transient `NSURLErrorDomain -1009`. These are the two real code failures behind it.

## Linux: musl sharp natives rejected

`verifyWhatsAppNativeTarget` compared the installed `@img` inventory against an exact list that omitted the musl builds. bun's `--os`/`--cpu` filters carry no libc dimension, so a linux install always lands both the glibc and the musl sharp packages:

    sharp-linux-x64  sharp-libvips-linux-x64
    sharp-linuxmusl-x64  sharp-libvips-linuxmusl-x64

The exact-inventory comparison therefore rejected every linux build. Both musl packages declare `os: ["linux"]` and `cpu: ["x64"]` and still have to pass the per-package os, cpu and native-identity assertions, so only the expected list needed to know about them. Nothing is loosened: a foreign-platform or foreign-arch package is still rejected.

This check arrived in #925 and had never been through a real linux release build.

Verified across `linux/x64`, `linux/arm64`, `darwin/arm64` and `win32/x64`. darwin and win32 inventories are unchanged by this commit.

## OfficeCLI: mutation guard, long-path config home, and logging

Following #961, three hardening changes:

- **The pinned digest is re-asserted after the probes.** The probes execute the binary, and this updater has replaced its own executable in place. A build can no longer package bytes that differ from the ones it verified, and the failure now names the cause instead of surfacing as a confusing version mismatch.
- **The isolated config home is resolved to its long form.** `os.tmpdir()` on Windows runners is an 8.3 short path (`C:\Users\RUNNER~1\...`); a consumer that canonicalises it differently would miss the config written there and silently fall back to updates enabled. This is the leading suspect for why #961 held on macOS and Linux but not on the Windows runners.
- **It logs like the other runtimes.** `prepareOfficeCli` was the only bundled runtime that prepared silently, which is why the Windows failure could not be read from the build logs at all.

## Verification

`#961`'s fix confirmed working on a real Windows machine, running the exact CI probe sequence (`help docx/xlsx/pptx`, `--help`, `watch --help`, then `--version`): version stayed `1.0.136` and the executable's SHA-256 was unchanged across the run. Without it the same binary rewrote itself to `1.0.144`.

Full `prepareOfficeCli` run passes locally on both the fresh-download and reuse paths. `prepareOfficeCli.test.ts` and `verifyPackagedResources.test.ts`: 79/79 pass.
