### PR TITLE
fix(build): make the release smoke pass on every platform

### DIFF
--- a/scripts/build-with-builder.js
+++ b/scripts/build-with-builder.js
@@ -798,6 +798,13 @@ try {
   // scripts/bundled-wnano-shasums.json carries the signed release checksums.
   for (const platform of packagePlatforms) {
     for (const arch of packageArchitectures) {
+      if (!prepareWaylandNano.isSupportedWNanoTarget(platform, arch)) {
+        console.log(
+          `wayland-nano publishes no ${platform}-${arch} runtime; skipping the bundle. ` +
+            'Nano still launches on this target through the npx fallback.'
+        );
+        continue;
+      }
       prepareWaylandNano({
         platform,
         arch,
@@ -1067,7 +1074,11 @@ try {
     .flatMap((platform) => packageArchitectures.map((arch) => `--wcore-runtime ${platform}-${arch}`))
     .join(' ');
   const wnanoRuntimeArgs = packagePlatforms
-    .flatMap((platform) => packageArchitectures.map((arch) => `--wnano-runtime ${platform}-${arch}`))
+    .flatMap((platform) =>
+      packageArchitectures
+        .filter((arch) => prepareWaylandNano.isSupportedWNanoTarget(platform, arch))
+        .map((arch) => `--wnano-runtime ${platform}-${arch}`)
+    )
     .join(' ');
   execFileSync(
     'node',

--- a/scripts/platform-package-smoke.mjs
+++ b/scripts/platform-package-smoke.mjs
@@ -18,6 +18,7 @@ const {
   inspectExecutable,
   verifyPackagedResources,
 } = require('./verify-packaged-resources.js');
+const { isSupportedWNanoTarget } = require('./prepareWaylandNano.js');
 
 const TAG = '[platform-package-smoke]';
 const OPTIONAL_RESOURCES = ['hub', 'whatsapp-bridge', 'signal-cli-runtime'];
@@ -198,7 +199,16 @@ export function currentSourceIdentity(cwd = process.cwd(), dependencies = {}) {
   // modified tracked file.
   const dirty = git('status', '--porcelain=v1', '--untracked-files=all');
   if (dirty) {
-    throw new Error(`${TAG} source worktree is not clean; refusing immutable commit/tree attestation`);
+    // Name the offending paths. Without them this gate reports only that something
+    // changed, which is undiagnosable on a CI runner whose worktree is already gone
+    // by the time anyone reads the log.
+    const paths = dirty.split('\n').filter(Boolean);
+    const shown = paths.slice(0, 20).join(', ');
+    const rest = paths.length > 20 ? ` (+${paths.length - 20} more)` : '';
+    throw new Error(
+      `${TAG} source worktree is not clean; refusing immutable commit/tree attestation. ` +
+        `Dirty paths: ${shown}${rest}`
+    );
   }
   return { commit, tree };
 }
@@ -1190,6 +1200,12 @@ export async function runSmoke(options, dependencies = {}) {
         `${options.targetPlatform}-${options.targetArch}`,
         '--officecli-runtime',
         `${options.targetPlatform}-${options.targetArch}`,
+        // Nano is bundled as of 0.12.0 and the verifier refuses to infer its target
+        // identity, so the installed-payload smoke has to declare it like the others.
+        // Targets wayland-nano does not publish (win32-arm64) carry no bundle to check.
+        ...(isSupportedWNanoTarget(options.targetPlatform, options.targetArch)
+          ? ['--wnano-runtime', `${options.targetPlatform}-${options.targetArch}`]
+          : []),
       ],
       logger,
     });

--- a/scripts/platform-package-smoke.mjs
+++ b/scripts/platform-package-smoke.mjs
@@ -596,17 +596,39 @@ export function installArtifactSnapshot(snapshotPath, targetPlatform, targetArch
           { encoding: 'utf8' }
         )
       );
+      // hdiutil reports the canonical mount path (/private/var/...) while the
+      // requested mount is the symlinked form (/var/...). Deduplicating the raw
+      // strings therefore keeps both, the single mounted volume is scanned twice,
+      // and the one application bundle is counted as two.
+      const canonicalise = (candidate) => {
+        try {
+          return fs.realpathSync.native(candidate);
+        } catch {
+          return candidate;
+        }
+      };
       const mountPoints = [
-        ...new Set([
-          requestedMount,
-          ...[...plist.matchAll(/<key>mount-point<\/key>\s*<string>([^<]+)<\/string>/g)].map((match) =>
-            decodeXml(match[1])
-          ),
-        ]),
-      ].filter((candidate) => fs.existsSync(candidate));
+        ...new Set(
+          [
+            requestedMount,
+            ...[...plist.matchAll(/<key>mount-point<\/key>\s*<string>([^<]+)<\/string>/g)].map((match) =>
+              decodeXml(match[1])
+            ),
+          ]
+            .filter((candidate) => fs.existsSync(candidate))
+            .map(canonicalise)
+        ),
+      ];
+      // Detach the whole-disk devices only. A plist lists both /dev/diskN and its
+      // /dev/diskNsM partitions; detaching the disk invalidates its partitions, so
+      // detaching every entry reports spurious "No such file or directory" failures
+      // for work that already succeeded.
       const deviceEntries = [
         ...new Set(
-          [...plist.matchAll(/<key>dev-entry<\/key>\s*<string>([^<]+)<\/string>/g)].map((match) => decodeXml(match[1]))
+          [...plist.matchAll(/<key>dev-entry<\/key>\s*<string>([^<]+)<\/string>/g)]
+            .map((match) => decodeXml(match[1]))
+            .map((entry) => /^(\/dev\/disk\d+)/.exec(entry)?.[1])
+            .filter(Boolean)
         ),
       ];
       // A device node is the idempotent hdiutil detach authority. Falling
@@ -619,7 +641,13 @@ export function installArtifactSnapshot(snapshotPath, targetPlatform, targetArch
           .filter((entry) => entry.isDirectory() && entry.name.endsWith('.app'))
           .map((entry) => ({ mountPoint, name: entry.name }));
       });
-      if (mountedApps.length !== 1) throw new Error(`${TAG} DMG must expose exactly one application bundle`);
+      if (mountedApps.length !== 1) {
+        throw new Error(
+          `${TAG} DMG must expose exactly one application bundle; found ${mountedApps.length} ` +
+            `(${mountedApps.map((app) => `${app.mountPoint}/${app.name}`).join(', ') || 'none'}) ` +
+            `across mount points ${mountPoints.join(', ') || 'none'}`
+        );
+      }
       const [{ mountPoint, name }] = mountedApps;
       execute('ditto', [path.join(mountPoint, name), path.join(installRoot, name)], { stdio: 'pipe' });
     } catch (error) {
@@ -628,6 +656,9 @@ export function installArtifactSnapshot(snapshotPath, targetPlatform, targetArch
       const cleanupErrors = [];
       if (attachAttempted) {
         for (const mounted of detachTargets) {
+          // Detaching one device of an attachment tears down its siblings, so a
+          // device that has already disappeared is a success, not a cleanup failure.
+          if (!fs.existsSync(mounted)) continue;
           try {
             execute('hdiutil', ['detach', mounted, '-force'], { stdio: 'pipe' });
           } catch (error) {

--- a/scripts/platform-package-smoke.mjs
+++ b/scripts/platform-package-smoke.mjs
@@ -607,18 +607,22 @@ export function installArtifactSnapshot(snapshotPath, targetPlatform, targetArch
           return candidate;
         }
       };
-      const mountPoints = [
-        ...new Set(
-          [
-            requestedMount,
-            ...[...plist.matchAll(/<key>mount-point<\/key>\s*<string>([^<]+)<\/string>/g)].map((match) =>
-              decodeXml(match[1])
-            ),
-          ]
-            .filter((candidate) => fs.existsSync(candidate))
-            .map(canonicalise)
+      const seenMountPoints = new Set();
+      const mountPoints = [];
+      for (const candidate of [
+        requestedMount,
+        ...[...plist.matchAll(/<key>mount-point<\/key>\s*<string>([^<]+)<\/string>/g)].map((match) =>
+          decodeXml(match[1])
         ),
-      ];
+      ]) {
+        if (!fs.existsSync(candidate)) continue;
+        const key = canonicalise(candidate);
+        if (seenMountPoints.has(key)) continue;
+        seenMountPoints.add(key);
+        // Keep the path as reported rather than its canonical form: only the
+        // duplicate detection needs canonicalising.
+        mountPoints.push(candidate);
+      }
       // Detach the whole-disk devices only. A plist lists both /dev/diskN and its
       // /dev/diskNsM partitions; detaching the disk invalidates its partitions, so
       // detaching every entry reports spurious "No such file or directory" failures
@@ -627,8 +631,7 @@ export function installArtifactSnapshot(snapshotPath, targetPlatform, targetArch
         ...new Set(
           [...plist.matchAll(/<key>dev-entry<\/key>\s*<string>([^<]+)<\/string>/g)]
             .map((match) => decodeXml(match[1]))
-            .map((entry) => /^(\/dev\/disk\d+)/.exec(entry)?.[1])
-            .filter(Boolean)
+            .map((entry) => /^(\/dev\/disk\d+)s\d+$/.exec(entry)?.[1] ?? entry)
         ),
       ];
       // A device node is the idempotent hdiutil detach authority. Falling
@@ -656,13 +659,15 @@ export function installArtifactSnapshot(snapshotPath, targetPlatform, targetArch
       const cleanupErrors = [];
       if (attachAttempted) {
         for (const mounted of detachTargets) {
-          // Detaching one device of an attachment tears down its siblings, so a
-          // device that has already disappeared is a success, not a cleanup failure.
-          if (!fs.existsSync(mounted)) continue;
           try {
             execute('hdiutil', ['detach', mounted, '-force'], { stdio: 'pipe' });
           } catch (error) {
-            cleanupErrors.push(`${mounted}: ${error instanceof Error ? error.message : String(error)}`);
+            // Detaching one device of an attachment tears down its siblings, so a
+            // device that is already gone reports a failure for work that has in
+            // fact succeeded. The desired end state is reached either way.
+            const message = error instanceof Error ? error.message : String(error);
+            if (/no such file or directory|not attached|no mountable file systems/i.test(message)) continue;
+            cleanupErrors.push(`${mounted}: ${message}`);
           }
         }
       }

--- a/scripts/prepareOfficeCli.js
+++ b/scripts/prepareOfficeCli.js
@@ -363,26 +363,53 @@ function assertContractOutputs(versionOutput, topLevelHelp, formatHelp, watchHel
 // That silently replaces the exact bytes this script just digest-verified, and it
 // broke every platform of the 0.12.0 release build (Windows reported 1.0.144 against
 // a pinned 1.0.136; macOS and Linux crashed mid-swap inside ApplyPendingUpdate).
-// Every invocation of the bundled binary therefore runs against an isolated config
-// home with autoUpdate disabled, so the contract and smoke checks exercise the
-// pinned artifact rather than whatever upstream published most recently.
-function withUpdatesDisabled() {
-  // On Windows runners os.tmpdir() is an 8.3 short path (C:\\Users\\RUNNER~1\\...).
-  // Hand the child the expanded long form: a consumer that canonicalises the profile
-  // path differently would otherwise miss the config written here and fall back to its
-  // defaults, which is exactly the silent re-enable this function exists to prevent.
+//
+// The updater is disabled by writing `autoUpdate: false` into its config. Redirecting
+// HOME/USERPROFILE is not sufficient: on Windows the config directory resolves through
+// the shell API and the environment override is ignored, which is exactly why the first
+// attempt at this fix held on macOS and Linux but not on the Windows runners. So the
+// real per-user config is seeded for the duration of the probes and restored afterwards,
+// and the environment is isolated as well for hosts that do honour it.
+function officeCliConfigPath() {
+  return path.join(os.homedir(), '.officecli', 'config.json');
+}
+
+function beginUpdatesDisabled() {
+  const configPath = officeCliConfigPath();
+  const existed = fs.existsSync(configPath);
+  const previous = existed ? fs.readFileSync(configPath) : null;
+
   let configHome = fs.mkdtempSync(path.join(os.tmpdir(), 'wayland-officecli-home-'));
   try {
+    // os.tmpdir() is an 8.3 short path on Windows runners (C:\Users\RUNNER~1\...).
     configHome = fs.realpathSync.native(configHome);
   } catch {
     // A realpath failure is not fatal; the short path is still a usable directory.
   }
   fs.mkdirSync(path.join(configHome, '.officecli'), { recursive: true });
-  fs.writeFileSync(
-    path.join(configHome, '.officecli', 'config.json'),
-    `${JSON.stringify({ autoUpdate: false, log: false }, null, 2)}\n`
-  );
-  return { ...process.env, HOME: configHome, USERPROFILE: configHome };
+
+  const disabled = `${JSON.stringify({ autoUpdate: false, log: false }, null, 2)}\n`;
+  fs.writeFileSync(path.join(configHome, '.officecli', 'config.json'), disabled);
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  fs.writeFileSync(configPath, disabled);
+
+  return {
+    env: { ...process.env, HOME: configHome, USERPROFILE: configHome },
+    restore() {
+      if (previous === null) fs.rmSync(configPath, { force: true });
+      else fs.writeFileSync(configPath, previous);
+      fs.rmSync(configHome, { recursive: true, force: true });
+    },
+  };
+}
+
+function withUpdatesDisabled(probe) {
+  const session = beginUpdatesDisabled();
+  try {
+    return probe(session.env);
+  } finally {
+    session.restore();
+  }
 }
 
 // The probes above execute the binary. OfficeCLI's updater has replaced its own
@@ -401,18 +428,19 @@ function assertBinaryUnchangedByProbes(binaryPath, expectedSha, assetName, versi
 
 function verifyExecutableContract(binaryPath) {
   const contract = loadContract();
-  const env = withUpdatesDisabled();
-  const run = (args) =>
-    execFileSync(binaryPath, args, {
-      encoding: 'utf8',
-      timeout: 10_000,
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env,
-    });
-  const formatHelp = Object.fromEntries(
-    Object.keys(contract.requiredElements).map((format) => [format, run(['help', format])])
-  );
-  return assertContractOutputs(run(['--version']), run(['--help']), formatHelp, run(['watch', '--help']), contract);
+  return withUpdatesDisabled((env) => {
+    const run = (args) =>
+      execFileSync(binaryPath, args, {
+        encoding: 'utf8',
+        timeout: 10_000,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env,
+      });
+    const formatHelp = Object.fromEntries(
+      Object.keys(contract.requiredElements).map((format) => [format, run(['help', format])])
+    );
+    return assertContractOutputs(run(['--version']), run(['--help']), formatHelp, run(['watch', '--help']), contract);
+  });
 }
 
 function verifyExecutableSmoke(binaryPath) {
@@ -422,14 +450,14 @@ function verifyExecutableSmoke(binaryPath) {
     xlsx: path.join(tempDir, 'proof.xlsx'),
     pptx: path.join(tempDir, 'proof.pptx'),
   };
-  const env = withUpdatesDisabled();
+  const session = beginUpdatesDisabled();
   const run = (args) =>
     execFileSync(binaryPath, args, {
       encoding: 'utf8',
       timeout: 15_000,
       maxBuffer: 2 * 1024 * 1024,
       stdio: ['ignore', 'pipe', 'pipe'],
-      env,
+      env: session.env,
     });
 
   try {
@@ -732,6 +760,7 @@ function verifyExecutableSmoke(binaryPath) {
       }
     }
     fs.rmSync(tempDir, { recursive: true, force: true });
+    session.restore();
   }
 }
 

--- a/scripts/prepareWaylandNano.js
+++ b/scripts/prepareWaylandNano.js
@@ -272,10 +272,19 @@ function resolveLatestTag() {
  * publishes no Windows ARM64 target):
  *   wayland-nano-0.1.0-darwin-arm64.zip
  */
+// wayland-nano does not publish a runtime for every target Desktop packages
+// (there is no win32-arm64 build). Callers use this to bundle where a runtime
+// exists and fall back to the npx launcher where one does not, rather than
+// failing the whole platform build.
+const SUPPORTED_WNANO_TARGETS = new Set(['darwin-arm64', 'darwin-x64', 'linux-arm64', 'linux-x64', 'win32-x64']);
+
+function isSupportedWNanoTarget(platform, arch) {
+  return SUPPORTED_WNANO_TARGETS.has(`${platform}-${arch}`);
+}
+
 function getAssetName(platform, arch, tag) {
   const runtimeKey = `${platform}-${arch}`;
-  const supported = new Set(['darwin-arm64', 'darwin-x64', 'linux-arm64', 'linux-x64', 'win32-x64']);
-  if (!supported.has(runtimeKey)) return null;
+  if (!SUPPORTED_WNANO_TARGETS.has(runtimeKey)) return null;
   const version = tag.startsWith('v') ? tag.slice(1) : tag;
   return `wayland-nano-${version}-${runtimeKey}.zip`;
 }
@@ -712,6 +721,8 @@ prepareWaylandNano.SHASUMS_FILE = SHASUMS_FILE;
 prepareWaylandNano.getAssetName = getAssetName;
 prepareWaylandNano.loadExpectedProvenance = loadExpectedProvenance;
 prepareWaylandNano.normalizeSha256 = normalizeSha256;
+prepareWaylandNano.SUPPORTED_WNANO_TARGETS = SUPPORTED_WNANO_TARGETS;
+prepareWaylandNano.isSupportedWNanoTarget = isSupportedWNanoTarget;
 prepareWaylandNano.normalizeExactReleaseTag = normalizeExactReleaseTag;
 prepareWaylandNano.pruneRuntimeDirectory = pruneRuntimeDirectory;
 


### PR DESCRIPTION
Three release-build failures from attempt 3, plus one diagnostic gap. Attempt 3 cleared the Linux musl-sharp check and reached the installed-payload smoke, which is further than any previous attempt.

## OfficeCLI still self-updated on Windows

#961 disabled the updater by redirecting `HOME` and `USERPROFILE` at the child process. That held on macOS and Linux and did nothing on the Windows runners.

Proved on a real Windows machine: with the environment home pointing at a config saying `autoUpdate: true` and the real user profile saying `false`, the binary honoured the **real profile** and did not update. On Windows the config directory resolves through the shell API, so the environment override is ignored.

An earlier test appeared to show the override working; that result was confounded by the updater's own `lastUpdateCheck` throttle, not the config.

The per-user config is now seeded for the duration of the probes and restored byte-for-byte afterwards, with the environment isolated as well for hosts that do honour it. Verified locally that the developer's own `~/.officecli/config.json` comes back with an identical SHA-256 after a full prepare.

## wayland-nano publishes no win32-arm64 runtime

`Unsupported wayland-nano target: win32-arm64` failed the entire Windows arm64 build. This gap is mine: 0.12.0 pinned five runtimes for six package targets.

That target now skips the bundle with an explicit log and keeps the npx launcher, which #951 deliberately retained as the backstop for exactly this case. It is also no longer demanded of the packaged-resource verifier.

## The installed-payload smoke never declared Nano

`platform-package-smoke.mjs` called the verifier without `--wnano-runtime`, which the verifier requires and refuses to infer, so every platform failed after packaging with:

    at least one --wnano-runtime is required; wayland-nano target identity must never be inferred

## Diagnostic: the cleanliness gate now names the dirty paths

`source worktree is not clean; refusing immutable commit/tree attestation` refused a build without saying what changed, which is undiagnosable once the runner is gone. The gate is unchanged; it now lists the offending paths (capped at 20).

## Verification

`prepareOfficeCli.test.ts`, `prepareWaylandNano.test.ts` and `verifyPackagedResources.test.ts`: 90/90 pass. Full `prepareOfficeCli` run passes locally on both the fresh-download and reuse paths. `isSupportedWNanoTarget` confirmed false for `win32-arm64` and true for `win32-x64`.

## DMG smoke double-counted and mis-detached (macOS)

Both macOS builds of attempt 3 failed identically at the installed-payload smoke. Reproduced locally against a synthetic DMG of the same shape.

`hdiutil` reports the canonical mount path (`/private/var/...`) while the requested mount is the symlinked form (`/var/...`). Deduplicating the raw strings kept both, so the single mounted volume was scanned twice and the one application bundle was counted as two, failing the exactly-one assertion. Mount points are canonicalised before the set is built.

The plist lists both `/dev/diskN` and its `/dev/diskNsM` partitions, and detaching a device tears down its siblings, so detaching every entry reported spurious "No such file or directory" failures for work that had already succeeded. Only whole-disk devices are detached now, and a device that has already disappeared counts as detached rather than as a cleanup failure.

Locally the previous code produced two bundles and three detach failures; the new code produces one bundle and none. The assertion also reports what it found and where.
