### PR TITLE
fix(build): portable ps environment form and ignore signal-cli build outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -230,6 +230,9 @@ graphify-out/
 .blackboard/
 design-mockups/
 src/process/channels/signal-cli-runtime/tmp-*/
+# Prepared at build time by the signal-cli runtime step, like the other bundled
+# runtimes. Leaving it untracked kept the release smoke's clean-worktree gate red.
+src/process/channels/signal-cli-runtime/bin/
 
 # Canonical GSD plans/contracts are versioned. Only volatile proof/runtime state
 # and private acceptance material remain local.

--- a/scripts/build-with-builder.js
+++ b/scripts/build-with-builder.js
@@ -798,6 +798,13 @@ try {
   // scripts/bundled-wnano-shasums.json carries the signed release checksums.
   for (const platform of packagePlatforms) {
     for (const arch of packageArchitectures) {
+      if (!prepareWaylandNano.isSupportedWNanoTarget(platform, arch)) {
+        console.log(
+          `wayland-nano publishes no ${platform}-${arch} runtime; skipping the bundle. ` +
+            'Nano still launches on this target through the npx fallback.'
+        );
+        continue;
+      }
       prepareWaylandNano({
         platform,
         arch,
@@ -1067,7 +1074,11 @@ try {
     .flatMap((platform) => packageArchitectures.map((arch) => `--wcore-runtime ${platform}-${arch}`))
     .join(' ');
   const wnanoRuntimeArgs = packagePlatforms
-    .flatMap((platform) => packageArchitectures.map((arch) => `--wnano-runtime ${platform}-${arch}`))
+    .flatMap((platform) =>
+      packageArchitectures
+        .filter((arch) => prepareWaylandNano.isSupportedWNanoTarget(platform, arch))
+        .map((arch) => `--wnano-runtime ${platform}-${arch}`)
+    )
     .join(' ');
   execFileSync(
     'node',

--- a/scripts/platform-package-smoke.mjs
+++ b/scripts/platform-package-smoke.mjs
@@ -898,11 +898,21 @@ function processSnapshot(targetPlatform, dependencies = {}, includeEnvironment =
       )
     );
   }
-  // Poll using the small process table. The final sweep opts into `eww` so an
-  // inherited launch token can recover a child that immediately reparented.
+  // Poll using the small process table. The final sweep asks for the environment
+  // too, so an inherited launch token can recover a child that immediately
+  // reparented.
+  //
+  // The environment form is not portable. BSD ps (macOS) takes `eww -axo`, while
+  // procps (Linux) rejects that exact combination with "must set personality to
+  // get -x option" and wants the all-BSD `axeww o` instead. Verified on both:
+  // `-axo` alone carries no environment on procps, so the split is required
+  // rather than cosmetic.
+  const format = 'pid=,ppid=,lstart=,command=';
   const args = includeEnvironment
-    ? ['eww', '-axo', 'pid=,ppid=,lstart=,command=']
-    : ['-axo', 'pid=,ppid=,lstart=,command='];
+    ? process.platform === 'linux'
+      ? ['axeww', 'o', format]
+      : ['eww', '-axo', format]
+    : ['-axo', format];
   return parsePosixProcesses(execute('ps', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }));
 }
 

--- a/scripts/platform-package-smoke.mjs
+++ b/scripts/platform-package-smoke.mjs
@@ -18,6 +18,7 @@ const {
   inspectExecutable,
   verifyPackagedResources,
 } = require('./verify-packaged-resources.js');
+const { isSupportedWNanoTarget } = require('./prepareWaylandNano.js');
 
 const TAG = '[platform-package-smoke]';
 const OPTIONAL_RESOURCES = ['hub', 'whatsapp-bridge', 'signal-cli-runtime'];
@@ -198,7 +199,16 @@ export function currentSourceIdentity(cwd = process.cwd(), dependencies = {}) {
   // modified tracked file.
   const dirty = git('status', '--porcelain=v1', '--untracked-files=all');
   if (dirty) {
-    throw new Error(`${TAG} source worktree is not clean; refusing immutable commit/tree attestation`);
+    // Name the offending paths. Without them this gate reports only that something
+    // changed, which is undiagnosable on a CI runner whose worktree is already gone
+    // by the time anyone reads the log.
+    const paths = dirty.split('\n').filter(Boolean);
+    const shown = paths.slice(0, 20).join(', ');
+    const rest = paths.length > 20 ? ` (+${paths.length - 20} more)` : '';
+    throw new Error(
+      `${TAG} source worktree is not clean; refusing immutable commit/tree attestation. ` +
+        `Dirty paths: ${shown}${rest}`
+    );
   }
   return { commit, tree };
 }
@@ -1190,6 +1200,12 @@ export async function runSmoke(options, dependencies = {}) {
         `${options.targetPlatform}-${options.targetArch}`,
         '--officecli-runtime',
         `${options.targetPlatform}-${options.targetArch}`,
+        // Nano is bundled as of 0.12.0 and the verifier refuses to infer its target
+        // identity, so the installed-payload smoke has to declare it like the others.
+        // Targets wayland-nano does not publish (win32-arm64) carry no bundle to check.
+        ...(isSupportedWNanoTarget(options.targetPlatform, options.targetArch)
+          ? ['--wnano-runtime', `${options.targetPlatform}-${options.targetArch}`]
+          : []),
       ],
       logger,
     });

--- a/scripts/platform-package-smoke.mjs
+++ b/scripts/platform-package-smoke.mjs
@@ -596,17 +596,39 @@ export function installArtifactSnapshot(snapshotPath, targetPlatform, targetArch
           { encoding: 'utf8' }
         )
       );
+      // hdiutil reports the canonical mount path (/private/var/...) while the
+      // requested mount is the symlinked form (/var/...). Deduplicating the raw
+      // strings therefore keeps both, the single mounted volume is scanned twice,
+      // and the one application bundle is counted as two.
+      const canonicalise = (candidate) => {
+        try {
+          return fs.realpathSync.native(candidate);
+        } catch {
+          return candidate;
+        }
+      };
       const mountPoints = [
-        ...new Set([
-          requestedMount,
-          ...[...plist.matchAll(/<key>mount-point<\/key>\s*<string>([^<]+)<\/string>/g)].map((match) =>
-            decodeXml(match[1])
-          ),
-        ]),
-      ].filter((candidate) => fs.existsSync(candidate));
+        ...new Set(
+          [
+            requestedMount,
+            ...[...plist.matchAll(/<key>mount-point<\/key>\s*<string>([^<]+)<\/string>/g)].map((match) =>
+              decodeXml(match[1])
+            ),
+          ]
+            .filter((candidate) => fs.existsSync(candidate))
+            .map(canonicalise)
+        ),
+      ];
+      // Detach the whole-disk devices only. A plist lists both /dev/diskN and its
+      // /dev/diskNsM partitions; detaching the disk invalidates its partitions, so
+      // detaching every entry reports spurious "No such file or directory" failures
+      // for work that already succeeded.
       const deviceEntries = [
         ...new Set(
-          [...plist.matchAll(/<key>dev-entry<\/key>\s*<string>([^<]+)<\/string>/g)].map((match) => decodeXml(match[1]))
+          [...plist.matchAll(/<key>dev-entry<\/key>\s*<string>([^<]+)<\/string>/g)]
+            .map((match) => decodeXml(match[1]))
+            .map((entry) => /^(\/dev\/disk\d+)/.exec(entry)?.[1])
+            .filter(Boolean)
         ),
       ];
       // A device node is the idempotent hdiutil detach authority. Falling
@@ -619,7 +641,13 @@ export function installArtifactSnapshot(snapshotPath, targetPlatform, targetArch
           .filter((entry) => entry.isDirectory() && entry.name.endsWith('.app'))
           .map((entry) => ({ mountPoint, name: entry.name }));
       });
-      if (mountedApps.length !== 1) throw new Error(`${TAG} DMG must expose exactly one application bundle`);
+      if (mountedApps.length !== 1) {
+        throw new Error(
+          `${TAG} DMG must expose exactly one application bundle; found ${mountedApps.length} ` +
+            `(${mountedApps.map((app) => `${app.mountPoint}/${app.name}`).join(', ') || 'none'}) ` +
+            `across mount points ${mountPoints.join(', ') || 'none'}`
+        );
+      }
       const [{ mountPoint, name }] = mountedApps;
       execute('ditto', [path.join(mountPoint, name), path.join(installRoot, name)], { stdio: 'pipe' });
     } catch (error) {
@@ -628,6 +656,9 @@ export function installArtifactSnapshot(snapshotPath, targetPlatform, targetArch
       const cleanupErrors = [];
       if (attachAttempted) {
         for (const mounted of detachTargets) {
+          // Detaching one device of an attachment tears down its siblings, so a
+          // device that has already disappeared is a success, not a cleanup failure.
+          if (!fs.existsSync(mounted)) continue;
           try {
             execute('hdiutil', ['detach', mounted, '-force'], { stdio: 'pipe' });
           } catch (error) {

--- a/scripts/platform-package-smoke.mjs
+++ b/scripts/platform-package-smoke.mjs
@@ -607,18 +607,22 @@ export function installArtifactSnapshot(snapshotPath, targetPlatform, targetArch
           return candidate;
         }
       };
-      const mountPoints = [
-        ...new Set(
-          [
-            requestedMount,
-            ...[...plist.matchAll(/<key>mount-point<\/key>\s*<string>([^<]+)<\/string>/g)].map((match) =>
-              decodeXml(match[1])
-            ),
-          ]
-            .filter((candidate) => fs.existsSync(candidate))
-            .map(canonicalise)
+      const seenMountPoints = new Set();
+      const mountPoints = [];
+      for (const candidate of [
+        requestedMount,
+        ...[...plist.matchAll(/<key>mount-point<\/key>\s*<string>([^<]+)<\/string>/g)].map((match) =>
+          decodeXml(match[1])
         ),
-      ];
+      ]) {
+        if (!fs.existsSync(candidate)) continue;
+        const key = canonicalise(candidate);
+        if (seenMountPoints.has(key)) continue;
+        seenMountPoints.add(key);
+        // Keep the path as reported rather than its canonical form: only the
+        // duplicate detection needs canonicalising.
+        mountPoints.push(candidate);
+      }
       // Detach the whole-disk devices only. A plist lists both /dev/diskN and its
       // /dev/diskNsM partitions; detaching the disk invalidates its partitions, so
       // detaching every entry reports spurious "No such file or directory" failures
@@ -627,8 +631,7 @@ export function installArtifactSnapshot(snapshotPath, targetPlatform, targetArch
         ...new Set(
           [...plist.matchAll(/<key>dev-entry<\/key>\s*<string>([^<]+)<\/string>/g)]
             .map((match) => decodeXml(match[1]))
-            .map((entry) => /^(\/dev\/disk\d+)/.exec(entry)?.[1])
-            .filter(Boolean)
+            .map((entry) => /^(\/dev\/disk\d+)s\d+$/.exec(entry)?.[1] ?? entry)
         ),
       ];
       // A device node is the idempotent hdiutil detach authority. Falling
@@ -656,13 +659,15 @@ export function installArtifactSnapshot(snapshotPath, targetPlatform, targetArch
       const cleanupErrors = [];
       if (attachAttempted) {
         for (const mounted of detachTargets) {
-          // Detaching one device of an attachment tears down its siblings, so a
-          // device that has already disappeared is a success, not a cleanup failure.
-          if (!fs.existsSync(mounted)) continue;
           try {
             execute('hdiutil', ['detach', mounted, '-force'], { stdio: 'pipe' });
           } catch (error) {
-            cleanupErrors.push(`${mounted}: ${error instanceof Error ? error.message : String(error)}`);
+            // Detaching one device of an attachment tears down its siblings, so a
+            // device that is already gone reports a failure for work that has in
+            // fact succeeded. The desired end state is reached either way.
+            const message = error instanceof Error ? error.message : String(error);
+            if (/no such file or directory|not attached|no mountable file systems/i.test(message)) continue;
+            cleanupErrors.push(`${mounted}: ${message}`);
           }
         }
       }

--- a/scripts/platform-package-smoke.mjs
+++ b/scripts/platform-package-smoke.mjs
@@ -908,12 +908,23 @@ function processSnapshot(targetPlatform, dependencies = {}, includeEnvironment =
   // `-axo` alone carries no environment on procps, so the split is required
   // rather than cosmetic.
   const format = 'pid=,ppid=,lstart=,command=';
-  const args = includeEnvironment
-    ? process.platform === 'linux'
-      ? ['axeww', 'o', format]
-      : ['eww', '-axo', format]
-    : ['-axo', format];
-  return parsePosixProcesses(execute('ps', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }));
+  const options = { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 };
+  if (!includeEnvironment) {
+    return parsePosixProcesses(execute('ps', ['-axo', format], options));
+  }
+  try {
+    return parsePosixProcesses(execute('ps', ['eww', '-axo', format], options));
+  } catch (error) {
+    // procps (Linux) rejects that BSD/UNIX mix with "must set personality to get
+    // -x option" and wants the all-BSD spelling instead, while BSD ps (macOS)
+    // returns nothing for the all-BSD form. Retry only on that specific rejection
+    // so a real ps failure still propagates. Note `-axo` alone is not a substitute:
+    // it succeeds on procps but carries no environment, which would silently defeat
+    // the launch-token recovery this sweep exists for.
+    const message = error instanceof Error ? error.message : String(error);
+    if (!/must set personality|unsupported option|illegal option|invalid option/i.test(message)) throw error;
+    return parsePosixProcesses(execute('ps', ['axeww', 'o', format], options));
+  }
 }
 
 function descendantsFromSnapshot(rootPid, snapshot) {

--- a/scripts/platform-package-smoke.mjs
+++ b/scripts/platform-package-smoke.mjs
@@ -1342,7 +1342,12 @@ export async function runSmoke(options, dependencies = {}) {
       }
       const browser = await request(`http://127.0.0.1:${port}/json/version`);
       if (!browser.webSocketDebuggerUrl) throw new Error(`${TAG} browser CDP endpoint omitted its websocket URL`);
-      await command(browser.webSocketDebuggerUrl, 'Browser.close', {}, 5_000);
+      // Five seconds is the acknowledgement budget for the CDP call, not for the
+      // shutdown itself. Both macOS release builds timed out here while the packaged
+      // app was still working through init on a contended runner. What the smoke
+      // actually asserts (the process exits, and the shutdown evidence validates) is
+      // enforced below and unchanged; a genuine hang still fails.
+      await command(browser.webSocketDebuggerUrl, 'Browser.close', {}, 20_000);
       const shutdown = await waitForExitImpl(child, 10_000);
       await new Promise((resolve) => setTimeout(resolve, dependencies.shutdownSettleMs ?? 250));
       const descendantRecords = processMonitor.stop();

--- a/scripts/prepareOfficeCli.js
+++ b/scripts/prepareOfficeCli.js
@@ -363,26 +363,53 @@ function assertContractOutputs(versionOutput, topLevelHelp, formatHelp, watchHel
 // That silently replaces the exact bytes this script just digest-verified, and it
 // broke every platform of the 0.12.0 release build (Windows reported 1.0.144 against
 // a pinned 1.0.136; macOS and Linux crashed mid-swap inside ApplyPendingUpdate).
-// Every invocation of the bundled binary therefore runs against an isolated config
-// home with autoUpdate disabled, so the contract and smoke checks exercise the
-// pinned artifact rather than whatever upstream published most recently.
-function withUpdatesDisabled() {
-  // On Windows runners os.tmpdir() is an 8.3 short path (C:\\Users\\RUNNER~1\\...).
-  // Hand the child the expanded long form: a consumer that canonicalises the profile
-  // path differently would otherwise miss the config written here and fall back to its
-  // defaults, which is exactly the silent re-enable this function exists to prevent.
+//
+// The updater is disabled by writing `autoUpdate: false` into its config. Redirecting
+// HOME/USERPROFILE is not sufficient: on Windows the config directory resolves through
+// the shell API and the environment override is ignored, which is exactly why the first
+// attempt at this fix held on macOS and Linux but not on the Windows runners. So the
+// real per-user config is seeded for the duration of the probes and restored afterwards,
+// and the environment is isolated as well for hosts that do honour it.
+function officeCliConfigPath() {
+  return path.join(os.homedir(), '.officecli', 'config.json');
+}
+
+function beginUpdatesDisabled() {
+  const configPath = officeCliConfigPath();
+  const existed = fs.existsSync(configPath);
+  const previous = existed ? fs.readFileSync(configPath) : null;
+
   let configHome = fs.mkdtempSync(path.join(os.tmpdir(), 'wayland-officecli-home-'));
   try {
+    // os.tmpdir() is an 8.3 short path on Windows runners (C:\Users\RUNNER~1\...).
     configHome = fs.realpathSync.native(configHome);
   } catch {
     // A realpath failure is not fatal; the short path is still a usable directory.
   }
   fs.mkdirSync(path.join(configHome, '.officecli'), { recursive: true });
-  fs.writeFileSync(
-    path.join(configHome, '.officecli', 'config.json'),
-    `${JSON.stringify({ autoUpdate: false, log: false }, null, 2)}\n`
-  );
-  return { ...process.env, HOME: configHome, USERPROFILE: configHome };
+
+  const disabled = `${JSON.stringify({ autoUpdate: false, log: false }, null, 2)}\n`;
+  fs.writeFileSync(path.join(configHome, '.officecli', 'config.json'), disabled);
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  fs.writeFileSync(configPath, disabled);
+
+  return {
+    env: { ...process.env, HOME: configHome, USERPROFILE: configHome },
+    restore() {
+      if (previous === null) fs.rmSync(configPath, { force: true });
+      else fs.writeFileSync(configPath, previous);
+      fs.rmSync(configHome, { recursive: true, force: true });
+    },
+  };
+}
+
+function withUpdatesDisabled(probe) {
+  const session = beginUpdatesDisabled();
+  try {
+    return probe(session.env);
+  } finally {
+    session.restore();
+  }
 }
 
 // The probes above execute the binary. OfficeCLI's updater has replaced its own
@@ -401,18 +428,19 @@ function assertBinaryUnchangedByProbes(binaryPath, expectedSha, assetName, versi
 
 function verifyExecutableContract(binaryPath) {
   const contract = loadContract();
-  const env = withUpdatesDisabled();
-  const run = (args) =>
-    execFileSync(binaryPath, args, {
-      encoding: 'utf8',
-      timeout: 10_000,
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env,
-    });
-  const formatHelp = Object.fromEntries(
-    Object.keys(contract.requiredElements).map((format) => [format, run(['help', format])])
-  );
-  return assertContractOutputs(run(['--version']), run(['--help']), formatHelp, run(['watch', '--help']), contract);
+  return withUpdatesDisabled((env) => {
+    const run = (args) =>
+      execFileSync(binaryPath, args, {
+        encoding: 'utf8',
+        timeout: 10_000,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env,
+      });
+    const formatHelp = Object.fromEntries(
+      Object.keys(contract.requiredElements).map((format) => [format, run(['help', format])])
+    );
+    return assertContractOutputs(run(['--version']), run(['--help']), formatHelp, run(['watch', '--help']), contract);
+  });
 }
 
 function verifyExecutableSmoke(binaryPath) {
@@ -422,14 +450,14 @@ function verifyExecutableSmoke(binaryPath) {
     xlsx: path.join(tempDir, 'proof.xlsx'),
     pptx: path.join(tempDir, 'proof.pptx'),
   };
-  const env = withUpdatesDisabled();
+  const session = beginUpdatesDisabled();
   const run = (args) =>
     execFileSync(binaryPath, args, {
       encoding: 'utf8',
       timeout: 15_000,
       maxBuffer: 2 * 1024 * 1024,
       stdio: ['ignore', 'pipe', 'pipe'],
-      env,
+      env: session.env,
     });
 
   try {
@@ -732,6 +760,7 @@ function verifyExecutableSmoke(binaryPath) {
       }
     }
     fs.rmSync(tempDir, { recursive: true, force: true });
+    session.restore();
   }
 }
 

--- a/scripts/prepareWaylandNano.js
+++ b/scripts/prepareWaylandNano.js
@@ -272,10 +272,19 @@ function resolveLatestTag() {
  * publishes no Windows ARM64 target):
  *   wayland-nano-0.1.0-darwin-arm64.zip
  */
+// wayland-nano does not publish a runtime for every target Desktop packages
+// (there is no win32-arm64 build). Callers use this to bundle where a runtime
+// exists and fall back to the npx launcher where one does not, rather than
+// failing the whole platform build.
+const SUPPORTED_WNANO_TARGETS = new Set(['darwin-arm64', 'darwin-x64', 'linux-arm64', 'linux-x64', 'win32-x64']);
+
+function isSupportedWNanoTarget(platform, arch) {
+  return SUPPORTED_WNANO_TARGETS.has(`${platform}-${arch}`);
+}
+
 function getAssetName(platform, arch, tag) {
   const runtimeKey = `${platform}-${arch}`;
-  const supported = new Set(['darwin-arm64', 'darwin-x64', 'linux-arm64', 'linux-x64', 'win32-x64']);
-  if (!supported.has(runtimeKey)) return null;
+  if (!SUPPORTED_WNANO_TARGETS.has(runtimeKey)) return null;
   const version = tag.startsWith('v') ? tag.slice(1) : tag;
   return `wayland-nano-${version}-${runtimeKey}.zip`;
 }
@@ -712,6 +721,8 @@ prepareWaylandNano.SHASUMS_FILE = SHASUMS_FILE;
 prepareWaylandNano.getAssetName = getAssetName;
 prepareWaylandNano.loadExpectedProvenance = loadExpectedProvenance;
 prepareWaylandNano.normalizeSha256 = normalizeSha256;
+prepareWaylandNano.SUPPORTED_WNANO_TARGETS = SUPPORTED_WNANO_TARGETS;
+prepareWaylandNano.isSupportedWNanoTarget = isSupportedWNanoTarget;
 prepareWaylandNano.normalizeExactReleaseTag = normalizeExactReleaseTag;
 prepareWaylandNano.pruneRuntimeDirectory = pruneRuntimeDirectory;
 

--- a/scripts/verify-packaged-resources.js
+++ b/scripts/verify-packaged-resources.js
@@ -741,6 +741,37 @@ function verifyBridgeLock(sourceDir) {
   });
 }
 
+function describeTargetForDiagnostics(target, maxEntries = 24) {
+  if (!fs.existsSync(target)) return 'absent';
+  const stats = fs.lstatSync(target);
+  if (stats.isSymbolicLink()) return `symlink -> ${fs.readlinkSync(target)}`;
+  if (!stats.isDirectory()) return `file, ${stats.size} bytes`;
+  const walk = (dir, prefix = '', depth = 0) => {
+    if (depth > 1) return [];
+    const rows = [];
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const rel = `${prefix}${entry.name}`;
+      if (entry.isDirectory()) {
+        rows.push(`${rel}/`);
+        rows.push(...walk(path.join(dir, entry.name), `${rel}/`, depth + 1));
+      } else {
+        let size = '?';
+        try {
+          size = String(fs.statSync(path.join(dir, entry.name)).size);
+        } catch {
+          // A file that vanished between readdir and stat is itself worth showing.
+        }
+        rows.push(`${rel} (${size})`);
+      }
+    }
+    return rows;
+  };
+  const rows = walk(target);
+  if (!rows.length) return 'directory, empty';
+  const shown = rows.slice(0, maxEntries).join(', ');
+  return `directory, contains: ${shown}${rows.length > maxEntries ? ` (+${rows.length - maxEntries} more)` : ''}`;
+}
+
 function verifySourceMirror(
   bundleDir,
   sourceDir,
@@ -1203,6 +1234,12 @@ function verifyPackagedResources(options = {}) {
         logger.log(`${TAG}   OK   ${req.rel}`);
       } else if (req.critical || fs.existsSync(target)) {
         logger.error(`${TAG}   FAIL ${req.rel}  <-- CRITICAL, missing or invalid`);
+        // The per-resource checks return a bare boolean, so a failure otherwise says
+        // only that something is wrong with a path nobody can inspect afterwards.
+        // Show what is actually on disk; absent, empty and wrong-shape look identical
+        // in the verdict but not here.
+        logger.error(`${TAG}        path: ${target}`);
+        logger.error(`${TAG}        ${describeTargetForDiagnostics(target)}`);
         criticalFailures += 1;
         criticalFailureRels.push(req.rel);
       } else {


### PR DESCRIPTION
Two more release-build failures from attempt 4, both Linux-only. Attempt 4 cleared everything the previous rounds fixed and failed further along again.

## The process sweep's `ps` invocation is not portable

The final sweep asks `ps` for the environment so an inherited launch token can recover a child that immediately reparented. That form is BSD-specific:

- macOS BSD ps takes `ps eww -axo <fmt>`.
- Linux procps rejects that exact combination: `error: must set personality to get -x option`.

Verified in an `ubuntu:24.04` container against procps-ng 4.0.4, with the marker held only in the environment rather than the command line:

    ps eww -axo FMT   -> error: must set personality to get -x option
    ps -axo FMT       -> works, row is "8 1 ... sleep 30"                  (no environment)
    ps axeww o FMT    -> works, row is "8 1 ... sleep 30 ... WLMARKER=xyzzy ..."  (environment)

So `-axo` alone is not a substitute: it succeeds and silently carries no environment, which would have degraded the token recovery rather than failing loudly. The platform split is required. macOS keeps the form that works there; `axeww o` returns nothing on BSD ps.

## signal-cli build outputs were untracked and unignored

The signal-cli runtime step writes `bin/signal-cli` and `bin/manifest.json`. Neither was tracked nor ignored, so the smoke's clean-worktree gate refused the build:

    source worktree is not clean; refusing immutable commit/tree attestation.
    Dirty paths: ?? src/process/channels/signal-cli-runtime/bin/manifest.json, ?? src/process/channels/signal-cli-runtime/bin/signal-cli

They are prepared at build time exactly like the other bundled runtimes, and are now ignored alongside the existing `tmp-*/` rule. Confirmed neither path is tracked, so nothing leaves the index.

The gate itself is unchanged. The dirty-path listing added in #965 is what identified these two files; before it, the same failure said only that something had changed.

## Verification

`platformPackageSmoke.test.ts`: 47/47 pass, no test modified.
