### PR TITLE
fix(build): declare that Windows ARM64 bundles no bun runtime

### DIFF
--- a/scripts/build-with-builder.js
+++ b/scripts/build-with-builder.js
@@ -745,7 +745,19 @@ try {
   // target here instead of inheriting the build host architecture.
   process.env.npm_config_target_arch = targetArch;
   // This only affects packaging assets; runtime integration will be added in a future PR.
-  prepareBundledBun({ platform: packagePlatforms[0], arch: packageArchitectures[0] });
+  const bunPlatform = packagePlatforms[0];
+  const bunArch = packageArchitectures[0];
+  const bunRuntimeAvailable = prepareBundledBun.isSupportedBunTarget(bunPlatform, bunArch);
+  if (bunRuntimeAvailable) {
+    prepareBundledBun({ platform: bunPlatform, arch: bunArch });
+  } else {
+    // Bun publishes nothing for this target. Staging a binary-less directory here is
+    // what left win32-arm64 shipping a manifest with no runtime; declare it instead.
+    console.log(
+      `bun publishes no ${bunPlatform}-${bunArch} runtime; skipping the bundle. ` +
+        'This target has never carried one.'
+    );
+  }
 
   // 5b. The optional offline Hub is unavailable until a real immutable source
   // authority exists. Remove stale bytes and report the honest degraded state;
@@ -1081,6 +1093,7 @@ try {
   // A target with no published runtime says so explicitly. The verifier refuses to
   // infer nano's target identity from a missing flag, and then requires the bundle
   // to be genuinely absent.
+  const bunRuntimeArgs = bunRuntimeAvailable ? [] : ['--no-bun-runtime'];
   const wnanoRuntimeArgs = (
     wnanoRuntimeKeys.length ? wnanoRuntimeKeys.map((key) => `--wnano-runtime ${key}`) : ['--no-wnano-runtime']
   ).join(' ');
@@ -1100,6 +1113,7 @@ try {
       packagedTarget.executablePath,
       ...wcoreRuntimeArgs.split(' '),
       ...wnanoRuntimeArgs.split(' '),
+      ...bunRuntimeArgs,
       ...officeCliRuntimeArgs.split(' '),
       // On a local verification build the seal is intentionally absent; tell the
       // verifier to require its ABSENCE (not its presence) while still enforcing

--- a/scripts/build-with-builder.js
+++ b/scripts/build-with-builder.js
@@ -754,8 +754,7 @@ try {
     // Bun publishes nothing for this target. Staging a binary-less directory here is
     // what left win32-arm64 shipping a manifest with no runtime; declare it instead.
     console.log(
-      `bun publishes no ${bunPlatform}-${bunArch} runtime; skipping the bundle. ` +
-        'This target has never carried one.'
+      `bun publishes no ${bunPlatform}-${bunArch} runtime; skipping the bundle. ` + 'This target has never carried one.'
     );
   }
 

--- a/scripts/platform-package-smoke.mjs
+++ b/scripts/platform-package-smoke.mjs
@@ -19,6 +19,7 @@ const {
   verifyPackagedResources,
 } = require('./verify-packaged-resources.js');
 const { isSupportedWNanoTarget } = require('./prepareWaylandNano.js');
+const { isSupportedBunTarget } = require('./prepareBundledBun.js');
 
 const TAG = '[platform-package-smoke]';
 const OPTIONAL_RESOURCES = ['hub', 'whatsapp-bridge', 'signal-cli-runtime'];
@@ -1264,6 +1265,8 @@ export async function runSmoke(options, dependencies = {}) {
         ...(isSupportedWNanoTarget(options.targetPlatform, options.targetArch)
           ? ['--wnano-runtime', `${options.targetPlatform}-${options.targetArch}`]
           : ['--no-wnano-runtime']),
+        // bun publishes no win32-arm64 runtime, so that target bundles none.
+        ...(isSupportedBunTarget(options.targetPlatform, options.targetArch) ? [] : ['--no-bun-runtime']),
       ],
       logger,
     });

--- a/scripts/prepareBundledBun.js
+++ b/scripts/prepareBundledBun.js
@@ -533,10 +533,25 @@ function prepareBundledBun(options = {}) {
   }
 }
 
+// Bun publishes no Windows ARM64 build, so that target has no runtime to bundle
+// and never has had one: prepareBundledBun has always written a skipped manifest
+// and warned. Callers use this to state the absence explicitly instead of leaving
+// a binary-less directory for the packaged-resource gate to trip over.
+function isSupportedBunTarget(platform, arch, version = getRuntimeVersion()) {
+  const assetName = getPlatformAsset(platform, arch);
+  if (!assetName) return false;
+  try {
+    return Boolean(loadExpectedShaForAsset(version, assetName));
+  } catch {
+    return false;
+  }
+}
+
 module.exports = prepareBundledBun;
 // Named helpers exposed for unit tests (the default export stays the function).
 module.exports.needsBaselineVariant = needsBaselineVariant;
 module.exports.getPlatformAsset = getPlatformAsset;
+module.exports.isSupportedBunTarget = isSupportedBunTarget;
 module.exports.isCachedRuntimeValid = isCachedRuntimeValid;
 module.exports.resolveBundledBunTarget = resolveBundledBunTarget;
 module.exports.verifyRuntimeBinary = verifyRuntimeBinary;

--- a/scripts/verify-packaged-resources.js
+++ b/scripts/verify-packaged-resources.js
@@ -1223,8 +1223,7 @@ function verifyPackagedResources(options = {}) {
         continue;
       }
       const declaredAbsent =
-        (req.absentWhen === 'noWNanoRuntime' && noWNanoRuntime) ||
-        (req.absentWhen === 'noBunRuntime' && noBunRuntime);
+        (req.absentWhen === 'noWNanoRuntime' && noWNanoRuntime) || (req.absentWhen === 'noBunRuntime' && noBunRuntime);
       if (declaredAbsent) {
         // Opting out of a runtime is not the same as not checking for it. The bundle
         // has to be genuinely absent, so a stale or half-copied one cannot ride along

--- a/scripts/verify-packaged-resources.js
+++ b/scripts/verify-packaged-resources.js
@@ -81,7 +81,7 @@ const REQUIRED = [
     size: 1231360,
     sha256: 'b0cfdeaf429f5cc53f85123dd8f5a5feb92c19d31aa34df257edf9a26be05f95',
   },
-  { rel: 'bundled-bun', critical: true, kind: 'bun-bundle' },
+  { rel: 'bundled-bun', critical: true, kind: 'bun-bundle', absentWhen: 'noBunRuntime' },
   { rel: 'modelsdev-snapshot.json', critical: true, kind: 'models-snapshot' },
   { rel: 'voice-models', critical: true, kind: 'voice-bundle' },
   // Degradable features - warn loudly but do not block the release.
@@ -1144,6 +1144,9 @@ function verifyPackagedResources(options = {}) {
   if (noWNanoRuntime && hasWNanoRuntimeFlag) {
     throw new Error(`${TAG} --no-wnano-runtime cannot be combined with --wnano-runtime`);
   }
+  // Bun publishes no Windows ARM64 build, so that target bundles none. Same rule as
+  // nano: the absence is declared, never inferred, and the bundle must then be gone.
+  const noBunRuntime = argv.includes('--no-bun-runtime');
   const requiredWNanoRuntimes = noWNanoRuntime ? [] : parseRequiredRuntimes(argv, '--wnano-runtime', 'wayland-nano');
   // Local verification builds (`build-with-builder.js` with WAYLAND_LOCAL_VERIFICATION=1
   // + `--dir`) intentionally OMIT the release capability seal. When this flag is set we
@@ -1219,7 +1222,10 @@ function verifyPackagedResources(options = {}) {
         }
         continue;
       }
-      if (req.absentWhen === 'noWNanoRuntime' && noWNanoRuntime) {
+      const declaredAbsent =
+        (req.absentWhen === 'noWNanoRuntime' && noWNanoRuntime) ||
+        (req.absentWhen === 'noBunRuntime' && noBunRuntime);
+      if (declaredAbsent) {
         // Opting out of a runtime is not the same as not checking for it. The bundle
         // has to be genuinely absent, so a stale or half-copied one cannot ride along
         // unverified on the one target that declares it ships none.
@@ -1228,7 +1234,7 @@ function verifyPackagedResources(options = {}) {
           logger.error(`${TAG}        path: ${target}`);
           logger.error(`${TAG}        ${describeTargetForDiagnostics(target)}`);
           criticalFailures += 1;
-          criticalFailureRels.push(`${req.rel} (present despite --no-wnano-runtime)`);
+          criticalFailureRels.push(`${req.rel} (present despite its declared absence)`);
         } else {
           logger.log(`${TAG}   SKIP ${req.rel}  (no runtime published for this target)`);
         }

--- a/tests/unit/verifyPackagedResources.test.ts
+++ b/tests/unit/verifyPackagedResources.test.ts
@@ -1002,6 +1002,24 @@ describe('packaged resource release gate', () => {
     );
   });
 
+  itAcceptedSweep('accepts a target that declares it bundles no bun runtime', () => {
+    // bun publishes no Windows ARM64 build, so that target bundles none and never
+    // has. Declaring it keeps the gate honest instead of leaving a binary-less
+    // directory, which is what win32-arm64 was shipping.
+    const out = createPackagedResources(true, 'darwin-arm64');
+    fs.rmSync(path.join(packagedResourcesPath(out), 'bundled-bun'), { recursive: true, force: true });
+    expect(() =>
+      verify(out, 'darwin-arm64', 'darwin-arm64', { argv: [...verifyArgs(out), '--no-bun-runtime'] })
+    ).not.toThrow();
+  });
+
+  it('blocks a declared-absent bun bundle that is actually present', () => {
+    const out = createPackagedResources(true, 'darwin-arm64');
+    expect(() =>
+      verify(out, 'darwin-arm64', 'darwin-arm64', { argv: [...verifyArgs(out), '--no-bun-runtime'] })
+    ).toThrow(/bundled-bun/);
+  });
+
   it('rejects declaring both a wayland-nano runtime and no wayland-nano runtime', () => {
     const out = createPackagedResources(true, 'darwin-arm64');
     expect(() =>


### PR DESCRIPTION
Attempt 7 result: **four of six platforms fully green** — linux-x64, linux-arm64, macos-x64, macos-arm64. Both macOS targets passed for the first time, confirming the quit-signal fix. Windows x64 hit a corrupt Chrome download from puppeteer's postinstall (a flake; it passed on attempt 6). Windows arm64 is what this PR fixes.

## What failed

Windows arm64 cleared the nano opt-out and then failed on `bundled-bun`. The diagnostics added in #965 showed why immediately:

    FAIL bundled-bun  <-- CRITICAL, missing or invalid
         directory, contains: win32-arm64/, win32-arm64/manifest.json (497)

The manifest is there; `bun.exe` is not.

## Why

bun publishes no Windows ARM64 build. `prepareBundledBun` asked for `bun-windows-aarch64.zip`, found no pinned digest, wrote a `skipped: true` manifest and warned — non-fatally, which it has always done.

`verifyBunBundle` did not exist at v0.11.18. **This is not a regression.** Windows ARM64 has been shipping without a bundled bun and nothing ever checked. The new gate is the first thing to notice.

## What this changes

It keeps that behaviour and makes it explicit rather than silent:

- The target is skipped rather than staged binary-less, so no manifest-without-runtime is packaged.
- `--no-bun-runtime` declares the absence to the verifier, which then requires the bundle to be **genuinely gone**.

Same rule as the nano opt-out: never inferred from a missing flag, and opting out is not the same as not looking. `isSupportedBunTarget` derives the answer from the pinned digest manifest rather than a hardcoded list, so it stays true if bun ever ships an ARM64 build.

## What it does not change

On Windows ARM64, npx-based local MCP servers still have no bundled runtime — exactly as in 0.11.18. No user on that platform is worse off.

The better long-term answer is probably to bundle the x64 bun and let Windows ARM64 run it under emulation, which would give that platform a working runtime for the first time. That changes the shipped payload and needs the verifier to accept a deliberately cross-architecture binary, so it is follow-up work rather than a release-night change.

## Verification

`isSupportedBunTarget`: false for win32-arm64, true for win32-x64, darwin-arm64, linux-arm64.
Two new specs: declared-absent is accepted, declared-absent-but-present is rejected.
128 specs pass across the four affected suites.
