### PR TITLE
ci: fetch Apple's notary log for a rejected submission

### DIFF
--- a/.github/workflows/notary-log.yml
+++ b/.github/workflows/notary-log.yml
@@ -1,0 +1,50 @@
+name: Notary Log
+
+# Fetch Apple's notarization log for a submission ID.
+#
+# `xcrun notarytool submit --wait` exits 0 even when Apple returns
+# `status: Invalid`, so a rejected submission surfaces downstream only as
+# "stapler staple failed" — which reads like a transient service problem and is
+# not. The actual reason lives in the notary log, which the build never fetched.
+# This workflow retrieves it for any submission ID printed by a build.
+#
+# Usage: gh workflow run notary-log.yml -f submission_id=<uuid>
+
+on:
+  workflow_dispatch:
+    inputs:
+      submission_id:
+        description: 'notarytool submission UUID (printed by the build as "id: <uuid>")'
+        type: string
+        required: true
+
+jobs:
+  notary-log:
+    name: Fetch notary log
+    runs-on: macos-14
+    steps:
+      - name: Fetch the notarization log
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          TEAM_ID: ${{ secrets.TEAM_ID }}
+          SUBMISSION_ID: ${{ inputs.submission_id }}
+        run: |
+          set -euo pipefail
+          # Password goes through the environment, never argv.
+          xcrun notarytool log "$SUBMISSION_ID" \
+            --apple-id "$APPLE_ID" \
+            --team-id "$TEAM_ID" \
+            --password "$APPLE_ID_PASSWORD" \
+            notary-log.json
+          echo "===================== NOTARY LOG ====================="
+          cat notary-log.json
+          echo "======================================================"
+
+      - name: Upload the log
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: notary-log-${{ inputs.submission_id }}
+          path: notary-log.json
+          if-no-files-found: warn


### PR DESCRIPTION
The 0.12.0 release is blocked because both macOS dmgs ship signed-but-unstapled, and the reason has been unavailable.

## What actually happened

In run 31923191220 the macos-arm64 build reported:

    Current status: Invalid.......................Processing complete
      status: Invalid
    The staple and validate action failed! Error 65.
    stapler staple failed or timed out

Apple did not time out. Apple **rejected** the binary, four times across the app zip and three dmg attempts. But xcrun notarytool submit --wait exits 0 even when the final status is Invalid, so notarizeDmg.js only ever sees the subsequent stapler failure and reports it as "failed or timed out", then advises re-running "once Apple's notary service recovers". For a deterministic rejection that advice is wrong and the retries cannot succeed.

The rejection reason lives in the notary log, which no build has ever fetched, so it is not recoverable from CI logs after the fact.

## What this adds

A workflow_dispatch job that fetches the notary log for any submission ID a build printed:

    gh workflow run notary-log.yml -f submission_id=<uuid>

The credential is passed through the environment, never argv. The log is echoed to the job output and uploaded as an artifact.

## Scope

Diagnostic only. No existing workflow, script, or signing step is modified, so this cannot affect a build or the release chain. The durable fix (surface the Invalid status at the point of submission instead of masking it as a staple failure) is deliberately left out of this PR so the release path stays untouched while 0.12.0 is in flight.