### PR TITLE
fix(smoke): budget the Windows silent install for ARM64 emulation

### DIFF
--- a/scripts/platform-package-smoke.mjs
+++ b/scripts/platform-package-smoke.mjs
@@ -25,6 +25,19 @@ const TAG = '[platform-package-smoke]';
 const OPTIONAL_RESOURCES = ['hub', 'whatsapp-bridge', 'signal-cli-runtime'];
 const VALID_PLATFORMS = new Set(['darwin', 'linux', 'win32']);
 const VALID_ARCHES = new Set(['x64', 'arm64']);
+
+// Budget for the NSIS silent install (`installer.exe /S`).
+//
+// NSIS emits only a 32-bit x86 installer stub - there is no ARM64 stub - so on
+// ARM64 Windows the installer runs under x86 emulation and its single-threaded
+// LZMA extraction of the packaged payload is far slower than the same work on
+// x64. A 120s budget was enough for win32-x64 and expired on win32-arm64 every
+// time, surfacing as a bare `spawnSync ... ETIMEDOUT` with no indication that a
+// timeout - rather than the installer - was the problem.
+//
+// This bounds a slow install, it does not weaken what is being verified: the
+// payload must still install and the app must still boot and shut down cleanly.
+const WINDOWS_SILENT_INSTALL_TIMEOUT_MS = 600_000;
 const VALID_RELEASE_TRACKS = new Set(['stable', 'preview']);
 const INSTALLER_EXTENSIONS = { darwin: '.dmg', linux: '.deb', win32: '.exe' };
 const SMOKE_EVENT_CONTRACT = 'wayland-package-smoke-event/1';
@@ -693,7 +706,27 @@ export function installArtifactSnapshot(snapshotPath, targetPlatform, targetArch
   } else if (targetPlatform === 'linux') {
     execute('dpkg-deb', ['-x', snapshotPath, installRoot], { stdio: 'pipe' });
   } else if (targetPlatform === 'win32') {
-    execute(snapshotPath, ['/S', `/D=${installRoot}`], { stdio: 'pipe', timeout: 120_000, windowsHide: true });
+    const startedAt = Date.now();
+    try {
+      execute(snapshotPath, ['/S', `/D=${installRoot}`], {
+        stdio: 'pipe',
+        timeout: WINDOWS_SILENT_INSTALL_TIMEOUT_MS,
+        windowsHide: true,
+      });
+    } catch (error) {
+      const elapsedMs = Date.now() - startedAt;
+      if (error?.code === 'ETIMEDOUT') {
+        throw new Error(
+          `${TAG} the Windows silent install did not finish within ` +
+            `${Math.round(WINDOWS_SILENT_INSTALL_TIMEOUT_MS / 1000)}s (ran ${Math.round(elapsedMs / 1000)}s). ` +
+            'The installer is still running, not wedged, if this keeps recurring - raise the budget rather than ' +
+            'weakening the check.',
+          { cause: error }
+        );
+      }
+      throw error;
+    }
+    console.log(`${TAG} silent install completed in ${Math.round((Date.now() - startedAt) / 1000)}s`);
   } else {
     throw new Error(`${TAG} unsupported installer platform: ${targetPlatform}`);
   }

--- a/tests/unit/platformPackageSmoke.test.ts
+++ b/tests/unit/platformPackageSmoke.test.ts
@@ -780,6 +780,43 @@ describe('real installer extraction and lifecycle evidence', () => {
     }
   );
 
+  it('gives the Windows silent install a budget that survives x86 emulation on ARM64', () => {
+    const root = temporaryRoot();
+    const installRoot = path.join(root, 'installed');
+    const candidate = {
+      appDir: installRoot,
+      resourceDir: path.join(installRoot, 'resources'),
+      executablePath: 'app',
+    };
+    const execute = vi.fn(() => '');
+    installArtifactSnapshot('/snapshot/installer.exe', 'win32', 'arm64', installRoot, {
+      execFileSync: execute,
+      resolveInstalledCandidate: vi.fn(() => candidate),
+      releaseTrack: 'stable',
+    });
+    // NSIS ships only an x86 stub, so win32-arm64 extracts the payload under
+    // emulation. 120s expired on every arm64 release attempt; the budget must
+    // stay well clear of it.
+    const options = execute.mock.calls[0][2] as { timeout: number };
+    expect(options.timeout).toBeGreaterThanOrEqual(600_000);
+  });
+
+  it('reports a timed-out Windows install as a budget overrun, not a bare ETIMEDOUT', () => {
+    const root = temporaryRoot();
+    const installRoot = path.join(root, 'installed');
+    const timedOut = Object.assign(new Error('spawnSync installer.exe ETIMEDOUT'), { code: 'ETIMEDOUT' });
+    const execute = vi.fn(() => {
+      throw timedOut;
+    });
+    expect(() =>
+      installArtifactSnapshot('/snapshot/installer.exe', 'win32', 'arm64', installRoot, {
+        execFileSync: execute,
+        resolveInstalledCandidate: vi.fn(),
+        releaseTrack: 'stable',
+      })
+    ).toThrow(/did not finish within/);
+  });
+
   it('mounts a DMG read-only, copies its application into private storage, and detaches it', () => {
     const root = temporaryRoot();
     const mount = path.join(root, 'mount');


### PR DESCRIPTION
windows-arm64 is the only platform that failed attempt 8, and it took the entire release tail down with it. It has now failed all eight 0.12.0 attempts and has never once cleared this step.

## Cause

The installed-package smoke gives the NSIS silent install a 120s budget:

    execute(snapshotPath, ['/S', `/D=${installRoot}`], { stdio: 'pipe', timeout: 120_000, ... })

NSIS emits only a 32-bit x86 installer stub; there is no ARM64 stub. On the windows-11-arm runner the installer therefore executes under x86 emulation, where its single-threaded LZMA extraction of the packaged payload is far slower than the same work on x64. The install was making progress, not wedging: it simply did not fit in 120s. win32-x64 completes the whole smoke (install, boot, CDP, clean shutdown) in about 200s, so its install has plenty of headroom and the bound was never exercised there.

The failure was also illegible. execFileSync surfaced only:

    spawnSync C:\Users\RUNNER~1\...\snapshot\installer.exe ETIMEDOUT

with nothing to indicate that the timeout, rather than the installer, was at fault.

## Change

- Raise the budget to 600s behind a named constant that documents why ARM64 needs the headroom.
- Report an overrun as an explicit budget overrun that states how long the install actually ran.
- Log the install duration on success, so a future slowdown is visible before it becomes a release failure.

## This does not weaken the check

The invariant is that the payload installs and the app boots, verifies its resources and shuts down cleanly. All of that still has to happen for the smoke to pass; only the arbitrary wall-clock bound moved.

## Verification

49 tests pass in tests/unit/platformPackageSmoke.test.ts, 2 of them new. The budget test was confirmed to fail against the old 120s value before being accepted, so it genuinely catches the regression rather than passing vacuously.