### PR TITLE
fix(macos): sign the nested binaries Apple rejects, keep the pin at stage

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -306,20 +306,30 @@ mac:
   gatekeeperAssess: false
   entitlements: entitlements.plist
   entitlementsInherit: entitlements.plist
-  # Preserve the exact independently pinned nested executable bytes. OfficeCLI
-  # is already Developer ID signed by its publisher. The released wayland-core
-  # and wayland-nano binaries are linker-signed. Re-signing any of them with
-  # Electron helper entitlements changes its pinned digest and grants a much
-  # broader authority surface than the standalone tool was built with; the
-  # post-package gate rechecks the exact bytes from Contents/Resources.
+  # Exclude ONLY nested binaries that already arrive Developer ID signed by
+  # their own publisher, so packaging preserves that publisher signature instead
+  # of replacing it with ours. Verified on the shipped 0.12.0 dmg:
+  #   bundled-bun/*/bun            -> Developer ID Application: Jarred Sumner
+  #   bundled-officecli/*/officecli -> Developer ID Application: AionUi Inc.
+  # Apple accepted both during notarization precisely because they carry a valid
+  # Developer ID signature, a secure timestamp and the hardened runtime.
+  #
+  # Nothing else may be listed here. Apple refuses to notarize an app that
+  # contains an unsigned or merely ad-hoc/linker-signed Mach-O, and every binary
+  # we bundle that upstream does NOT sign (our own wayland-core, wayland-nano and
+  # wayland-constitution-fs, plus the whatsapp-bridge sharp and bare-* natives)
+  # is exactly that. Listing them here made all six macOS notarization
+  # submissions for 0.12.0 come back "Invalid" with 14 rejected files. v0.11.18
+  # carried no signIgnore at all, signed all of them, and notarized.
+  #
+  # Their pinned upstream bytes are still verified - at STAGE time, where
+  # prepareWaylandCore / prepareWaylandNano download, checksum and attest them
+  # before packaging. Signing is a deliberate act applied to already-verified
+  # bytes, and the packaged gate then requires a Ferrox Labs Developer ID
+  # signature on each one (see verify-packaged-resources.js).
   signIgnore:
     - '/Contents/Resources/bundled-bun/[^/]+/bun$'
-    - '/Contents/Resources/whatsapp-bridge/node_modules/@img/sharp-(?:libvips-)?darwin-(?:arm64|x64)/.*(?:\.node|\.dylib)$'
-    - '/Contents/Resources/whatsapp-bridge/node_modules/(?:bare-fs|bare-os|bare-url)/prebuilds/(?:darwin-(?:arm64|x64)|ios-(?:arm64|arm64-simulator|x64-simulator))/[^/]+\.bare$'
     - '/Contents/Resources/bundled-officecli/[^/]+/officecli$'
-    - '/Contents/Resources/bundled-wayland-core/[^/]+/wayland-core$'
-    - '/Contents/Resources/bundled-wayland-nano/[^/]+/wayland-nano$'
-    - '/Contents/Resources/bundled-constitution-fs/[^/]+/wayland-constitution-fs$'
   # #466: Computer-Use uses Screen Recording (screenshots) + Apple Events (to
   # control other apps). NSAppleEventsUsageDescription IS an Apple-honored TCC
   # purpose string - macOS shows it on the automation consent prompt.

--- a/scripts/verify-packaged-resources.js
+++ b/scripts/verify-packaged-resources.js
@@ -92,6 +92,46 @@ const REQUIRED = [
 
 const VOICE_MODEL_FILES = Object.keys(voiceModelPinnedRelease.files);
 
+// Apple refuses to notarize an app containing an unsigned or merely ad-hoc /
+// linker-signed Mach-O, so every nested binary that upstream does not sign is
+// signed by us at package time (see mac.signIgnore in electron-builder.yml).
+// Signing rewrites the binary, so its packaged bytes can no longer equal the
+// pinned upstream digest. The upstream-bytes guarantee therefore lives at STAGE
+// time - prepareWaylandCore / prepareWaylandNano download, checksum and attest
+// the binary before it is packaged, and the staged manifest still has to record
+// that verified digest - while the packaged gate proves the shipped bytes are
+// the ones WE signed.
+//
+// The requirement below is what makes that check real. A bare
+// `codesign --verify --strict` also succeeds on an ad-hoc signature, which is
+// exactly the state that made 0.12.0 unnotarizable, so it cannot distinguish a
+// properly signed binary from the broken one. Pinning the leaf certificate to
+// the Ferrox Labs team fails closed on ad-hoc, on unsigned, and on a signature
+// from any other publisher. Apple's own notarization enforces the hardened
+// runtime on top of this.
+const DARWIN_SIGNING_TEAM_ID = 'PX6SP9GPWJ';
+// The leading '=' is REQUIRED and is not cosmetic: `codesign -R` treats a bare
+// argument as a path to a requirement FILE and only parses inline requirement
+// text when it starts with '='. Without it codesign exits 1 with
+// "invalid requirement specification", which fails closed on every binary -
+// including correctly signed ones - and would block all macOS builds.
+const DARWIN_SIGNING_REQUIREMENT = `=anchor apple generic and certificate leaf[subject.OU] = "${DARWIN_SIGNING_TEAM_ID}"`;
+
+function assertDarwinDeveloperIdSigned(binaryPath, exec = execFileSync) {
+  exec('/usr/bin/codesign', ['--verify', '--strict', '-R', DARWIN_SIGNING_REQUIREMENT, binaryPath], {
+    stdio: 'pipe',
+  });
+}
+
+function isDarwinDeveloperIdSigned(binaryPath, exec = execFileSync) {
+  try {
+    assertDarwinDeveloperIdSigned(binaryPath, exec);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function parseSingleArg(argv, flag, required = true) {
   const values = [];
   for (let index = 0; index < argv.length; index += 1) {
@@ -167,8 +207,10 @@ function verifyConstitutionFsBundle(
   targetPlatform,
   targetArch,
   authority,
-  verifyDarwinSignature = (binaryPath) =>
-    execFileSync('/usr/bin/codesign', ['--verify', '--strict', binaryPath], { stdio: 'pipe' })
+  // A bare `codesign --verify --strict` also passes on an ad-hoc signature, so it
+  // could not tell a properly signed binary from the ad-hoc state that made
+  // 0.12.0 unnotarizable. Pin the leaf certificate to the Ferrox Labs team.
+  verifyDarwinSignature = assertDarwinDeveloperIdSigned
 ) {
   if (targetPlatform === 'win32') return !fs.existsSync(bundleRoot);
   const runtime = `${targetPlatform}-${targetArch}`;
@@ -193,15 +235,21 @@ function verifyConstitutionFsBundle(
     manifest.platform !== targetPlatform ||
     manifest.arch !== targetArch ||
     manifest.binary.fileName !== 'wayland-constitution-fs' ||
-    manifest.binary.sha256 !== digest ||
-    manifest.binary.size !== bytes.length ||
     authority.supported !== true ||
     authority.protocolVersion !== 2 ||
     authority.platform !== targetPlatform ||
     authority.arch !== targetArch ||
-    authority.sha256 !== digest ||
-    authority.size !== bytes.length ||
-    authority.fileName !== manifest.binary.fileName
+    // The manifest and the package authority must always agree with each other:
+    // that pairing is what proves the staged, verified binary is the one that
+    // was packaged, and it holds on every platform.
+    authority.sha256 !== manifest.binary.sha256 ||
+    authority.size !== manifest.binary.size ||
+    authority.fileName !== manifest.binary.fileName ||
+    // Off darwin the bytes are untouched, so they must still hash to the staged
+    // digest. On darwin we sign the binary after staging, which necessarily
+    // changes the bytes; the Developer ID check below is what proves the shipped
+    // bytes are ours.
+    (targetPlatform !== 'darwin' && (manifest.binary.sha256 !== digest || manifest.binary.size !== bytes.length))
   )
     return false;
   const identity = inspectExecutable(binaryPath);
@@ -357,7 +405,12 @@ function parseRequiredRuntimes(argv, flag, label) {
   return [...new Set(runtimes)].sort();
 }
 
-function verifyWCoreRuntime(bundleDir, runtimeKey, authority = prepareWaylandCore) {
+function verifyWCoreRuntime(
+  bundleDir,
+  runtimeKey,
+  authority = prepareWaylandCore,
+  signedCheck = isDarwinDeveloperIdSigned
+) {
   const [platform, arch] = runtimeKey.split('-');
   const binaryName = platform === 'win32' ? 'wayland-core.exe' : 'wayland-core';
   const runtimeDir = path.join(bundleDir, runtimeKey);
@@ -419,12 +472,20 @@ function verifyWCoreRuntime(bundleDir, runtimeKey, authority = prepareWaylandCor
     manifestArchiveSha256 === expected.archiveSha256 &&
     metadata.binary?.name === binaryName &&
     manifestBinarySha256 === expected.binarySha256 &&
-    actualBinarySha256 === expected.binarySha256 &&
+    // On macOS we sign this binary, so the packaged bytes intentionally differ
+    // from the pinned upstream digest recorded above. Prove instead that the
+    // shipped bytes carry our Developer ID signature.
+    (runtimeKey.startsWith('darwin-') ? signedCheck(binaryPath) : actualBinarySha256 === expected.binarySha256) &&
     JSON.stringify(metadata.files) === JSON.stringify([binaryName])
   );
 }
 
-function verifyWCoreBundle(bundleDir, requiredRuntimes, authority = prepareWaylandCore) {
+function verifyWCoreBundle(
+  bundleDir,
+  requiredRuntimes,
+  authority = prepareWaylandCore,
+  signedCheck = isDarwinDeveloperIdSigned
+) {
   if (!fs.statSync(bundleDir).isDirectory()) return false;
   const entries = fs.readdirSync(bundleDir, { withFileTypes: true });
   if (entries.length === 0) return false;
@@ -433,14 +494,20 @@ function verifyWCoreBundle(bundleDir, requiredRuntimes, authority = prepareWayla
   }
   const packagedRuntimes = entries.map((entry) => entry.name).sort();
   if (JSON.stringify(packagedRuntimes) !== JSON.stringify([...requiredRuntimes].sort())) return false;
-  return packagedRuntimes.every((runtime) => verifyWCoreRuntime(bundleDir, runtime, authority));
+  return packagedRuntimes.every((runtime) => verifyWCoreRuntime(bundleDir, runtime, authority, signedCheck));
 }
 
 // Mirrors verifyWCoreRuntime for the bundled wayland-nano agent. The policy
 // selector is injectable because, unlike wayland-core, the first
 // FerroxLabs/wayland-nano publisher-attestation policy only exists once the
 // first signed release lands - tests substitute their own until then.
-function verifyWNanoRuntime(bundleDir, runtimeKey, authority = prepareWaylandNano, policySelector = selectPolicy) {
+function verifyWNanoRuntime(
+  bundleDir,
+  runtimeKey,
+  authority = prepareWaylandNano,
+  policySelector = selectPolicy,
+  signedCheck = isDarwinDeveloperIdSigned
+) {
   const [platform, arch] = runtimeKey.split('-');
   const binaryName = platform === 'win32' ? 'wayland-nano.exe' : 'wayland-nano';
   const runtimeDir = path.join(bundleDir, runtimeKey);
@@ -502,12 +569,20 @@ function verifyWNanoRuntime(bundleDir, runtimeKey, authority = prepareWaylandNan
     manifestArchiveSha256 === expected.archiveSha256 &&
     metadata.binary?.name === binaryName &&
     manifestBinarySha256 === expected.binarySha256 &&
-    actualBinarySha256 === expected.binarySha256 &&
+    // Signed by us on macOS, so the packaged bytes deliberately differ from the
+    // pinned upstream digest asserted above; require our signature instead.
+    (runtimeKey.startsWith('darwin-') ? signedCheck(binaryPath) : actualBinarySha256 === expected.binarySha256) &&
     JSON.stringify(metadata.files) === JSON.stringify([binaryName])
   );
 }
 
-function verifyWNanoBundle(bundleDir, requiredRuntimes, authority = prepareWaylandNano, policySelector = selectPolicy) {
+function verifyWNanoBundle(
+  bundleDir,
+  requiredRuntimes,
+  authority = prepareWaylandNano,
+  policySelector = selectPolicy,
+  signedCheck = isDarwinDeveloperIdSigned
+) {
   if (!fs.statSync(bundleDir).isDirectory()) return false;
   const entries = fs.readdirSync(bundleDir, { withFileTypes: true });
   if (entries.length === 0) return false;
@@ -516,7 +591,9 @@ function verifyWNanoBundle(bundleDir, requiredRuntimes, authority = prepareWayla
   }
   const packagedRuntimes = entries.map((entry) => entry.name).sort();
   if (JSON.stringify(packagedRuntimes) !== JSON.stringify([...requiredRuntimes].sort())) return false;
-  return packagedRuntimes.every((runtime) => verifyWNanoRuntime(bundleDir, runtime, authority, policySelector));
+  return packagedRuntimes.every((runtime) =>
+    verifyWNanoRuntime(bundleDir, runtime, authority, policySelector, signedCheck)
+  );
 }
 
 function hasNonHiddenRegularFile(dir) {
@@ -625,6 +702,32 @@ const WHATSAPP_APPLE_BARE_RUNTIMES = [
   ['ios-arm64-simulator', 'arm64'],
   ['ios-x64-simulator', 'x64'],
 ];
+
+// The whatsapp-bridge natives that electron-builder signs on macOS. They are
+// enumerated exhaustively (rather than pattern-matched at compare time) so a new
+// unsigned native cannot slip into the bundle unnoticed: anything that appears
+// here and is not accounted for fails the inventory assertion below.
+function darwinSignedBridgeNatives(arch) {
+  const expected = [
+    {
+      relative: `node_modules/@img/sharp-darwin-${arch}/lib/sharp-darwin-${arch}.node`,
+      arch,
+    },
+    {
+      relative: `node_modules/@img/sharp-libvips-darwin-${arch}/lib/libvips-cpp.8.17.3.dylib`,
+      arch,
+    },
+  ];
+  for (const packageName of WHATSAPP_APPLE_BARE_PACKAGES) {
+    for (const [runtime, runtimeArch] of WHATSAPP_APPLE_BARE_RUNTIMES) {
+      expected.push({
+        relative: `node_modules/${packageName}/prebuilds/${runtime}/${packageName}.bare`,
+        arch: runtimeArch,
+      });
+    }
+  }
+  return expected;
+}
 
 function verifyWhatsAppDarwinSignIgnoreInventory(sourceDir, arch) {
   const expected = [
@@ -777,7 +880,8 @@ function verifySourceMirror(
   sourceDir,
   authority = whatsappBridgeSource,
   targetPlatform = process.platform,
-  targetArch = process.arch
+  targetArch = process.arch,
+  signedCheck = isDarwinDeveloperIdSigned
 ) {
   if (
     authority.contract !== 'wayland-whatsapp-bridge-source/1.0' ||
@@ -800,8 +904,31 @@ function verifySourceMirror(
   const ignoredPlaceholders = new Set(
     WHATSAPP_OMITTED_EMPTY_PLACEHOLDERS.filter((relative) => fs.existsSync(path.join(sourceDir, relative)))
   );
-  const source = sourceInventory(sourceDir, sourceDir, [], ignoredPlaceholders);
-  const bundled = sourceInventory(bundleDir, bundleDir, [], ignoredPlaceholders);
+  // On macOS electron-builder signs the bridge's native binaries during
+  // packaging, so the bundled copies deliberately no longer hash to the source
+  // copies. Every other file must still mirror the source byte for byte, and
+  // each signed native must be present, be the right Mach-O, and carry our
+  // Developer ID signature - so the exemption cannot hide a substituted binary.
+  // Derive the exemption from the natives that are actually staged, exactly as
+  // verifyWhatsAppNativeTarget tolerates a bridge built without them. Anything
+  // present in the bundle but NOT in the source still trips the mirror below, so
+  // this cannot become a hole through which an extra unsigned native arrives.
+  const signedNatives =
+    targetPlatform === 'darwin'
+      ? darwinSignedBridgeNatives(targetArch).filter(({ relative }) =>
+          fs.existsSync(path.join(sourceDir, ...relative.split('/')))
+        )
+      : [];
+  for (const { relative, arch: expectedArch } of signedNatives) {
+    const bundledNative = path.join(bundleDir, ...relative.split('/'));
+    if (!fs.existsSync(bundledNative) || !fs.lstatSync(bundledNative).isFile()) return false;
+    const identity = inspectExecutable(bundledNative);
+    if (identity?.platform !== 'darwin' || identity.arch !== expectedArch) return false;
+    if (!signedCheck(bundledNative)) return false;
+  }
+  const mirrorExempt = new Set([...ignoredPlaceholders, ...signedNatives.map(({ relative }) => relative)]);
+  const source = sourceInventory(sourceDir, sourceDir, [], mirrorExempt);
+  const bundled = sourceInventory(bundleDir, bundleDir, [], mirrorExempt);
   return source !== null && bundled !== null && JSON.stringify(bundled) === JSON.stringify(source);
 }
 
@@ -992,7 +1119,8 @@ function isNonEmpty(
   verifyCandidateCapabilitySeal = verifyCapabilitySeal,
   requiredWNanoRuntimes = [],
   wnanoAuthority = prepareWaylandNano,
-  wnanoPolicySelector = selectPolicy
+  wnanoPolicySelector = selectPolicy,
+  darwinSignedCheck = isDarwinDeveloperIdSigned
 ) {
   try {
     if (kind === 'constitution-fs-bundle' && targetPlatform === 'win32') {
@@ -1012,10 +1140,10 @@ function isNonEmpty(
     }
     if (!st.isDirectory()) return false;
     if (kind === 'wcore-bundle') {
-      return verifyWCoreBundle(p, requiredWCoreRuntimes, wcoreAuthority);
+      return verifyWCoreBundle(p, requiredWCoreRuntimes, wcoreAuthority, darwinSignedCheck);
     }
     if (kind === 'wnano-bundle') {
-      return verifyWNanoBundle(p, requiredWNanoRuntimes, wnanoAuthority, wnanoPolicySelector);
+      return verifyWNanoBundle(p, requiredWNanoRuntimes, wnanoAuthority, wnanoPolicySelector, darwinSignedCheck);
     }
     if (kind === 'officecli-bundle') {
       const entries = fs.readdirSync(p, { withFileTypes: true });
@@ -1101,7 +1229,7 @@ function isNonEmpty(
     if (kind === 'signal-bundle') return verifySignalBundle(p, targetPlatform, targetArch);
     if (kind === 'hub-bundle') return false;
     if (kind === 'whatsapp-bundle')
-      return verifySourceMirror(p, whatsappSourceDir, whatsappAuthority, targetPlatform, targetArch);
+      return verifySourceMirror(p, whatsappSourceDir, whatsappAuthority, targetPlatform, targetArch, darwinSignedCheck);
     return hasNonHiddenRegularFile(p);
   } catch {
     return false;
@@ -1124,6 +1252,7 @@ function verifyPackagedResources(options = {}) {
     ((binaryPath) => officeCliAuthority.verifyDarwinPublisherSignature(binaryPath));
   const constitutionFsAuthority = options.constitutionFsAuthority;
   const verifyConstitutionFsDarwinSignature = options.verifyConstitutionFsDarwinSignature;
+  const darwinSignedCheck = options.darwinSignedCheck || isDarwinDeveloperIdSigned;
   const verifyCandidateCapabilitySeal = options.verifyCapabilitySeal || verifyCapabilitySeal;
   const verifyDarwinPackageSignature =
     options.verifyDarwinPackageSignature ||
@@ -1260,7 +1389,8 @@ function verifyPackagedResources(options = {}) {
         verifyCandidateCapabilitySeal,
         requiredWNanoRuntimes,
         wnanoAuthority,
-        wnanoPolicySelector
+        wnanoPolicySelector,
+        darwinSignedCheck
       );
       if (ok) {
         logger.log(`${TAG}   OK   ${req.rel}`);

--- a/tests/unit/prepareConstitutionFs.test.ts
+++ b/tests/unit/prepareConstitutionFs.test.ts
@@ -34,7 +34,10 @@ describe('prepareConstitutionFs', () => {
     expect(platformBinding).toBeGreaterThan(prepareCall);
     expect(prepareCall).toBeLessThan(build.indexOf('electron-vite build'));
     expect(builder).toContain('from: resources/bundled-constitution-fs');
-    expect(builder).toContain("'/Contents/Resources/bundled-constitution-fs/[^/]+/wayland-constitution-fs$'");
+    // The helper is ad-hoc signed upstream, so it must NOT be excluded from
+    // signing: Apple rejects an app containing it unsigned. It is signed during
+    // packaging and the packaged gate then requires our Developer ID on it.
+    expect(builder).not.toContain("'/Contents/Resources/bundled-constitution-fs/[^/]+/wayland-constitution-fs$'");
   });
 
   it('fails closed for a foreign target and removes stale helper bytes', () => {

--- a/tests/unit/prepareOfficeCli.test.ts
+++ b/tests/unit/prepareOfficeCli.test.ts
@@ -281,45 +281,48 @@ describe('prepareOfficeCli supply-chain contract', () => {
     expect(packageVerifier).toContain("rel: 'managed-cli-shims/officecli.cmd'");
   });
 
-  it('preserves the pinned publisher signature instead of applying Electron helper entitlements', () => {
+  it('excludes only nested binaries that upstream already Developer ID signs', () => {
     const builderConfig = parseYaml(fs.readFileSync(path.resolve('electron-builder.yml'), 'utf8')) as {
       mac?: { signIgnore?: string[] };
     };
     const signIgnore = builderConfig.mac?.signIgnore;
 
+    // Only bun and OfficeCLI arrive already signed by their own publisher
+    // (Jarred Sumner and AionUi Inc. respectively, both with a secure timestamp
+    // and the hardened runtime). Packaging preserves those signatures instead of
+    // replacing them with ours.
     expect(signIgnore).toEqual([
       '/Contents/Resources/bundled-bun/[^/]+/bun$',
-      '/Contents/Resources/whatsapp-bridge/node_modules/@img/sharp-(?:libvips-)?darwin-(?:arm64|x64)/.*(?:\\.node|\\.dylib)$',
-      '/Contents/Resources/whatsapp-bridge/node_modules/(?:bare-fs|bare-os|bare-url)/prebuilds/(?:darwin-(?:arm64|x64)|ios-(?:arm64|arm64-simulator|x64-simulator))/[^/]+\\.bare$',
       '/Contents/Resources/bundled-officecli/[^/]+/officecli$',
-      '/Contents/Resources/bundled-wayland-core/[^/]+/wayland-core$',
-      '/Contents/Resources/bundled-wayland-nano/[^/]+/wayland-nano$',
-      '/Contents/Resources/bundled-constitution-fs/[^/]+/wayland-constitution-fs$',
     ]);
-    // The bundled Nano runtime carries its own publisher signature and must be
-    // left alone, exactly like the engine and the authoring runtime beside it.
-    const nanoPath = '/tmp/Wayland.app/Contents/Resources/bundled-wayland-nano/darwin-arm64/wayland-nano';
-    expect(signIgnore?.some((pattern) => new RegExp(pattern).test(nanoPath))).toBe(true);
-    const bunPath = '/tmp/Wayland.app/Contents/Resources/bundled-bun/darwin-arm64/bun';
-    expect(signIgnore?.some((pattern) => new RegExp(pattern).test(bunPath))).toBe(true);
-    const whatsappNativePath =
-      '/tmp/Wayland.app/Contents/Resources/whatsapp-bridge/node_modules/@img/sharp-darwin-arm64/lib/sharp.node';
-    expect(signIgnore?.some((pattern) => new RegExp(pattern).test(whatsappNativePath))).toBe(true);
-    const whatsappBarePath =
-      '/tmp/Wayland.app/Contents/Resources/whatsapp-bridge/node_modules/bare-fs/prebuilds/ios-arm64/bare-fs.bare';
-    expect(signIgnore?.some((pattern) => new RegExp(pattern).test(whatsappBarePath))).toBe(true);
-    const whatsappAndroidBarePath =
-      '/tmp/Wayland.app/Contents/Resources/whatsapp-bridge/node_modules/bare-fs/prebuilds/android-arm64/bare-fs.bare';
-    expect(signIgnore?.some((pattern) => new RegExp(pattern).test(whatsappAndroidBarePath))).toBe(false);
-    const whatsappJavascriptPath = '/tmp/Wayland.app/Contents/Resources/whatsapp-bridge/node_modules/axios/index.js';
-    expect(signIgnore?.some((pattern) => new RegExp(pattern).test(whatsappJavascriptPath))).toBe(false);
-    const officeCliPath = '/tmp/Wayland.app/Contents/Resources/bundled-officecli/darwin-arm64/officecli';
-    expect(signIgnore?.some((pattern) => new RegExp(pattern).test(officeCliPath))).toBe(true);
-    expect(signIgnore?.some((pattern) => new RegExp(pattern).test('/tmp/Wayland.app/Contents/MacOS/Wayland'))).toBe(
+
+    const matches = (candidate: string) => signIgnore?.some((pattern) => new RegExp(pattern).test(candidate)) ?? false;
+    const app = '/tmp/Wayland.app/Contents';
+
+    expect(matches(`${app}/Resources/bundled-bun/darwin-arm64/bun`)).toBe(true);
+    expect(matches(`${app}/Resources/bundled-officecli/darwin-arm64/officecli`)).toBe(true);
+
+    // Everything below is ad-hoc / linker-signed or unsigned upstream. Listing
+    // any of them here makes Apple reject the whole app as "Invalid" - that is
+    // exactly what blocked every 0.12.0 macOS notarization attempt, with these
+    // files named in the notary log. They must be signed by us instead.
+    expect(matches(`${app}/Resources/bundled-wayland-core/darwin-arm64/wayland-core`)).toBe(false);
+    expect(matches(`${app}/Resources/bundled-wayland-nano/darwin-arm64/wayland-nano`)).toBe(false);
+    expect(matches(`${app}/Resources/bundled-constitution-fs/darwin-arm64/wayland-constitution-fs`)).toBe(false);
+    expect(
+      matches(`${app}/Resources/whatsapp-bridge/node_modules/@img/sharp-darwin-arm64/lib/sharp-darwin-arm64.node`)
+    ).toBe(false);
+    expect(
+      matches(
+        `${app}/Resources/whatsapp-bridge/node_modules/@img/sharp-libvips-darwin-arm64/lib/libvips-cpp.8.17.3.dylib`
+      )
+    ).toBe(false);
+    expect(matches(`${app}/Resources/whatsapp-bridge/node_modules/bare-fs/prebuilds/darwin-arm64/bare-fs.bare`)).toBe(
       false
     );
-    expect(
-      signIgnore?.some((pattern) => new RegExp(pattern).test('/tmp/Wayland.app/Contents/Frameworks/Wayland Helper.app'))
-    ).toBe(false);
+
+    // The app itself and its helpers were never excluded and must stay signed.
+    expect(matches(`${app}/MacOS/Wayland`)).toBe(false);
+    expect(matches(`${app}/Frameworks/Wayland Helper.app`)).toBe(false);
   });
 });

--- a/tests/unit/prepareWaylandCore.test.ts
+++ b/tests/unit/prepareWaylandCore.test.ts
@@ -138,7 +138,10 @@ describe('strict bundled wayland-core provenance', () => {
     expect(verifier).toContain("kind: 'wcore-bundle'");
     expect(verifier).toContain("['download', 'verified-cache'].includes(metadata.sourceType)");
     expect(verifier).toContain('actualBinarySha256 === expected.binarySha256');
-    expect(builder).toContain("'/Contents/Resources/bundled-wayland-core/[^/]+/wayland-core$'");
+    // Released wayland-core binaries are only linker-signed, so excluding them
+    // from signing makes Apple reject the whole app. They are signed at package
+    // time; the upstream byte pin is enforced at stage time instead.
+    expect(builder).not.toContain("'/Contents/Resources/bundled-wayland-core/[^/]+/wayland-core$'");
   });
 
   it('keeps the bundle receipt contract and future bump tooling bound to binary pins', () => {

--- a/tests/unit/prepareWaylandNano.test.ts
+++ b/tests/unit/prepareWaylandNano.test.ts
@@ -164,7 +164,9 @@ describe('strict bundled wayland-nano provenance', () => {
     expect(verifier).toContain("['download', 'verified-cache'].includes(metadata.sourceType)");
     expect(verifier).toContain('actualBinarySha256 === expected.binarySha256');
     expect(builder).toContain('resources/bundled-wayland-nano');
-    expect(builder).toContain("'/Contents/Resources/bundled-wayland-nano/[^/]+/wayland-nano$'");
+    // Same as wayland-core: linker-signed upstream, so it must be signed by us
+    // or notarization fails with "not signed with a valid Developer ID".
+    expect(builder).not.toContain("'/Contents/Resources/bundled-wayland-nano/[^/]+/wayland-nano$'");
   });
 
   it('keeps the bundle receipt contract bound to binary pins and publisher attestation', () => {

--- a/tests/unit/verifyPackagedResources.test.ts
+++ b/tests/unit/verifyPackagedResources.test.ts
@@ -507,6 +507,24 @@ afterEach(() => {
 // Production never verifies a darwin package from a Windows host (the darwin path shells out
 // to /usr/bin/codesign), so only the assertions that require the whole sweep to PASS are
 // host-limited. Every failure-path assertion in this file stays active on all hosts.
+// Stand-in for `codesign --verify` against a fixture: a real signature is
+// computed over the bytes, so it stays valid only while the bytes are unchanged.
+// Fixture binaries are written to match their staged manifest digest, which
+// gives a byte-exact reference to compare against without a signing identity.
+// A stub that blindly returned true would make every darwin byte-drift
+// assertion in this file vacuous.
+function fixtureSignatureIsIntact(binaryPath: string): boolean {
+  const manifestPath = path.join(path.dirname(binaryPath), 'manifest.json');
+  // Only the pinned runtimes ship a manifest beside the binary. Fixtures stage
+  // no whatsapp-bridge natives, so nothing else reaches this double today.
+  if (!fs.existsSync(manifestPath)) return true;
+  const actual = crypto.createHash('sha256').update(fs.readFileSync(binaryPath)).digest('hex');
+  const recorded = String(JSON.parse(fs.readFileSync(manifestPath, 'utf8'))?.binary?.sha256 || '')
+    .replace(/^sha256:/i, '')
+    .toLowerCase();
+  return recorded === actual;
+}
+
 const itAcceptedSweep = it.skipIf(process.platform === 'win32');
 
 describe('packaged resource release gate', () => {
@@ -528,7 +546,22 @@ describe('packaged resource release gate', () => {
       modelsAuthority: TEST_MODELS_AUTHORITY,
       officeCliAuthority: TEST_OFFICE_AUTHORITY,
       verifyOfficeCliDarwinSignature: () => TEST_OFFICE_SIGNATURE,
-      verifyConstitutionFsDarwinSignature: () => undefined,
+      // Same reasoning as darwinSignedCheck below: this replaces a codesign call
+      // that fails on tampered bytes, so the double has to fail on them too.
+      verifyConstitutionFsDarwinSignature: (binaryPath: string) => {
+        if (!fixtureSignatureIsIntact(binaryPath)) {
+          throw new Error('fixture: codesign signature does not match the packaged bytes');
+        }
+      },
+      // Fixtures are synthetic Mach-O stand-ins, so the real
+      // `codesign --verify --strict -R <Ferrox team>` cannot run against them.
+      // The double must still model what codesign actually guarantees: the
+      // signature is computed over the bytes, so ANY mutation invalidates it.
+      // A stub that blindly returned true would silently make every darwin
+      // byte-drift assertion in this file vacuous. In a fixture the packaged
+      // bytes are unsigned, so they still hash to the staged manifest digest -
+      // use that as the stand-in for a valid signature over these exact bytes.
+      darwinSignedCheck: fixtureSignatureIsIntact,
       verifyDarwinPackageSignature: () => undefined,
       verifyCapabilitySeal: () => undefined,
       ...extra,
@@ -856,6 +889,38 @@ describe('packaged resource release gate', () => {
     const out = createPackagedResources(true);
     fs.appendFileSync(wcoreBinaryPath(out), 'tampered');
     expect(() => verify(out)).toThrow();
+  });
+
+  it('rejects a darwin wayland-core binary that is not Developer ID signed by us', () => {
+    const out = createPackagedResources(true);
+    // Byte-identical to the staged manifest digest, i.e. the exact state that
+    // used to pass, but ad-hoc signed. Apple refuses to notarize this, so the
+    // packaged gate has to refuse it too.
+    expect(() => verify(out, 'darwin-arm64', 'darwin-arm64', { darwinSignedCheck: () => false })).toThrow(
+      /CRITICAL resource/
+    );
+  });
+
+  it('rejects a darwin wayland-nano binary that is not Developer ID signed by us', () => {
+    const out = createPackagedResources(true);
+    expect(() => verify(out, 'darwin-arm64', 'darwin-arm64', { darwinSignedCheck: () => false })).toThrow(
+      /CRITICAL resource/
+    );
+  });
+
+  itAcceptedSweep('requires the Developer ID check on exactly the darwin runtimes it signs', () => {
+    const out = createPackagedResources(true);
+    const checked: string[] = [];
+    verify(out, 'darwin-arm64', 'darwin-arm64', {
+      darwinSignedCheck: (binaryPath: string) => {
+        checked.push(path.basename(binaryPath));
+        return true;
+      },
+    });
+    // Both runtimes we sign on macOS must go through the signature gate; if the
+    // branch were keyed wrongly the packaged bytes would simply go unchecked.
+    expect(checked).toContain('wayland-core');
+    expect(checked).toContain('wayland-nano');
   });
 
   it('blocks a wayland-core manifest from the wrong release', () => {


### PR DESCRIPTION
Unblocks macOS for 0.12.0. Every notarization submission so far has come back Invalid.

## What Apple actually said

Fetched with the notary-log workflow from #971 (submission 26749782-31d9-4fe1-b698-3bb888ccada0):

    "status": "Invalid",
    "statusSummary": "Archive contains critical validation errors"

14 nested Mach-O binaries, each flagged "The binary is not signed with a valid Developer ID certificate", "The signature does not include a secure timestamp", "The executable does not have the hardened runtime enabled":

- bundled-wayland-core/darwin-arm64/wayland-core
- bundled-wayland-nano/darwin-arm64/wayland-nano
- bundled-constitution-fs/darwin-arm64/wayland-constitution-fs
- 11 whatsapp-bridge natives (sharp .node/.dylib, plus bare-fs/bare-os/bare-url prebuilds for darwin-arm64, darwin-x64 and ios-x64-simulator)

Apple was never timing out. notarytool exits 0 even when the final status is Invalid, so notarizeDmg.js saw only the subsequent stapler failure and reported "stapler staple failed or timed out ... re-run once Apple's notary service recovers". For a deterministic rejection that advice is wrong, and the three built-in retries could never succeed.

## Cause

mac.signIgnore excluded exactly those 14 files. The rule behind it is sound but was applied too widely:

- bundled-bun/bun is Developer ID signed by Jarred Sumner, bundled-officecli/officecli by AionUi Inc., both hardened and timestamped. Apple accepted both. Preserving a real publisher signature is correct.
- Our three runtimes are only ad-hoc / linker-signed, and the whatsapp natives, all new in 0.12.0, are unsigned. Excluding those means shipping unsigned code, which Apple refuses outright.

v0.11.18 carried no signIgnore at all, signed all of them, and notarized. Verified on the shipped 0.11.18 dmg: wayland-core there is Developer ID Application: Ferrox Labs, LLC with flags=0x10000(runtime), so signing it is proven runtime-safe, and that release had zero whatsapp natives.

## Change

Narrow signIgnore to the two genuinely upstream-signed binaries. Everything else is signed by us.

Signing rewrites bytes, so on darwin the packaged gate can no longer compare them to the pinned upstream digest. That guarantee moves to where it is enforceable: prepareWaylandCore and prepareWaylandNano already download, checksum and attest each binary at stage time, and the staged manifest must still record that verified digest. The packaged gate additionally proves the shipped bytes are the ones we signed.

Off darwin nothing is re-signed, so exact byte equality stays enforced there, unchanged.

## This tightens one check rather than loosening it

The constitution-fs gate used a bare codesign --verify --strict. That also passes on an ad-hoc signature, so it could not have detected the exact state that caused this outage. It now uses a requirement pinned to the Ferrox Labs team, like the others.

Verified by execution against real artifacts:

| binary | expected | result |
|---|---|---|
| v0.11.18 wayland-core (Developer ID: Ferrox Labs) | accept | exit 0 |
| v0.12.0 wayland-core (ad-hoc) | reject | exit 3 |
| v0.12.0 bun (Developer ID: Jarred Sumner) | reject, not our identity | exit 3 |

Note for reviewers: codesign -R treats a bare argument as a path to a requirement FILE. Inline requirement text must start with '='. Without it codesign exits 1 with "invalid requirement specification" and fails closed on every binary, including correctly signed ones. That is why the constant carries a leading '='.

## Tests

87 pass across the two directly affected suites, plus 27 in the three contract suites. Full unit suite: 17,666 passing.

Three contract tests asserted that electron-builder.yml still contained the removed patterns; they now assert the opposite, with the reason. The test doubles for both signature checks were made faithful: they previously returned true unconditionally, which would have made every darwin byte-drift assertion in the file vacuous. They now model what codesign guarantees, that a signature is only valid while the bytes are unchanged.

New coverage: a darwin binary that is not Developer ID signed by us is rejected; the signature gate is exercised on exactly the runtimes we sign.

## Follow-up, not in this PR

Our three runtimes should be Developer ID signed in their own release pipelines, the way bun and OfficeCLI already are. That would restore end-to-end byte pinning and make signIgnore correct for them. It needs Apple credentials in three repos.