### PR TITLE
fix(macos): Developer ID sign staged runtimes so the app can notarize

### DIFF
--- a/scripts/build-with-builder.js
+++ b/scripts/build-with-builder.js
@@ -18,7 +18,11 @@ const prepareBundledBun = require('./prepareBundledBun');
 const prepareWaylandCore = require('./prepareWaylandCore');
 const prepareWaylandNano = require('./prepareWaylandNano');
 const prepareOfficeCli = require('./prepareOfficeCli');
-const { signDarwinStagedBinary, resolveDarwinSigningIdentity } = require('./signDarwinStagedBinary');
+const {
+  signDarwinStagedBinary,
+  resolveDarwinSigningIdentity,
+  darwinSigningIdentifier,
+} = require('./signDarwinStagedBinary');
 const prepareConstitutionFs = require('./prepareConstitutionFs');
 const { verifyThirdPartyExecutableLedger } = require('./supply-chain/verifyThirdPartyExecutableLedger');
 const { writeCapabilitySeal } = require('./capability-seal/verifyCandidateCapabilitySeal');
@@ -155,8 +159,20 @@ function viteBuildExists() {
   return fs.existsSync(path.join(mainDir, 'index.js')) && fs.existsSync(path.join(rendererDir, 'index.html'));
 }
 
-function shouldSkipViteBuild(skipViteFlag, forceFlag) {
+function shouldSkipViteBuild(skipViteFlag, forceFlag, signedDarwinPackaging = false) {
   if (forceFlag) return false;
+  // Reusing a stale app.asar while the Constitution helper is re-signed ships an
+  // app that packages cleanly and then refuses to launch: the helper is
+  // re-hashed at runtime against the authority compiled INTO app.asar, and
+  // signing (with a fresh secure timestamp) changes the helper's bytes every
+  // time. The adjacent manifest would agree with the new binary while the
+  // embedded authority still described the old one, so the packaged gate passes
+  // and every launch fails with CONSTITUTION_FS_BINARY_UNVERIFIED.
+  if (signedDarwinPackaging && skipViteFlag) {
+    throw new Error(
+      '[build] --skip-vite cannot be combined with signed macOS packaging: the Constitution authority compiled into app.asar must be rebuilt whenever the helper is re-signed, or the packaged app will not launch.'
+    );
+  }
   if (skipViteFlag) return true;
 
   // Auto-detect: skip if build exists and hash matches
@@ -366,7 +382,10 @@ function isMachOFile(filePath) {
       magic === 0xfeedfacf || // 64-bit
       magic === 0xcefaedfe || // 32-bit, byte-swapped
       magic === 0xcffaedfe || // 64-bit, byte-swapped
-      magic === 0xcafebabe || // universal ("fat")
+      // 0xcafebabe is also the Java .class magic. Signing one would abort the
+      // build with "unsupported format for signature"; it fails closed rather
+      // than shipping something unsigned, but there is no reason to try.
+      (magic === 0xcafebabe && !filePath.endsWith('.class')) || // universal ("fat")
       magic === 0xbebafeca || // universal, byte-swapped
       magic === 0xcafebabf || // universal 64-bit
       magic === 0xbfbafeca // universal 64-bit, byte-swapped
@@ -422,7 +441,14 @@ function signWhatsAppBridgeNatives(nodeModules, options = {}) {
   walk(root);
   natives.sort();
   for (const native of natives) {
-    sign(native, { identity, label: path.relative(root, native) });
+    // Bind each signature to the bytes as installed, so a signature cannot be
+    // lifted onto a different native later.
+    const preSignSha256 = crypto.createHash('sha256').update(fs.readFileSync(native)).digest('hex');
+    sign(native, {
+      identity,
+      identifier: darwinSigningIdentifier(path.basename(native).replace(/[^A-Za-z0-9._-]/g, '_'), preSignSha256),
+      label: path.relative(root, native),
+    });
   }
   return natives;
 }
@@ -774,7 +800,11 @@ try {
   writeConstitutionPackageAuthority(constitutionAuthority);
 
   // 3. Check if we can skip Vite build (incremental build)
-  const skipViteBuild = shouldSkipViteBuild(skipVite, forceBuild);
+  const skipViteBuild = shouldSkipViteBuild(
+    skipVite,
+    forceBuild,
+    packagePlatforms[0] === 'darwin' && Boolean(resolveDarwinSigningIdentity())
+  );
 
   if (!skipViteBuild) {
     // Run electron-vite to build all bundles (main + preload + renderer)

--- a/scripts/build-with-builder.js
+++ b/scripts/build-with-builder.js
@@ -367,7 +367,9 @@ function isMachOFile(filePath) {
       magic === 0xcefaedfe || // 32-bit, byte-swapped
       magic === 0xcffaedfe || // 64-bit, byte-swapped
       magic === 0xcafebabe || // universal ("fat")
-      magic === 0xbebafeca // universal, byte-swapped
+      magic === 0xbebafeca || // universal, byte-swapped
+      magic === 0xcafebabf || // universal 64-bit
+      magic === 0xbfbafeca // universal 64-bit, byte-swapped
     );
   } catch {
     return false;
@@ -382,19 +384,45 @@ function signWhatsAppBridgeNatives(nodeModules, options = {}) {
   if (!fs.existsSync(nodeModules)) return [];
   const sign = options.signDarwinStagedBinary || signDarwinStagedBinary;
   const identity = options.signIdentity === undefined ? resolveDarwinSigningIdentity() : options.signIdentity;
+  // Symlinks are followed rather than skipped, but only while they stay inside
+  // the bridge's node_modules. A package manager that links a native in from a
+  // shared store would otherwise leave it unsigned here while electron-builder
+  // happily resolves and packages it - reintroducing the exact rejection this
+  // is meant to prevent. Anything pointing outside the tree is left alone: it is
+  // not ours to mutate, and the source/bundle mirror rejects escaping links.
+  const root = fs.realpathSync(nodeModules);
+  const seen = new Set();
   const natives = [];
   const walk = (dir) => {
     for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
       const target = path.join(dir, entry.name);
-      if (entry.isSymbolicLink()) continue;
-      if (entry.isDirectory()) walk(target);
-      else if (entry.isFile() && isMachOFile(target)) natives.push(target);
+      let real;
+      try {
+        real = fs.realpathSync(target);
+      } catch {
+        continue; // broken link
+      }
+      if (real !== root && !real.startsWith(`${root}${path.sep}`)) continue;
+      if (seen.has(real)) continue;
+      let stat;
+      try {
+        stat = fs.statSync(real);
+      } catch {
+        continue;
+      }
+      if (stat.isDirectory()) {
+        seen.add(real);
+        walk(real);
+      } else if (stat.isFile() && isMachOFile(real)) {
+        seen.add(real);
+        natives.push(real);
+      }
     }
   };
-  walk(nodeModules);
+  walk(root);
   natives.sort();
   for (const native of natives) {
-    sign(native, { identity, label: path.relative(nodeModules, native) });
+    sign(native, { identity, label: path.relative(root, native) });
   }
   return natives;
 }
@@ -1180,6 +1208,14 @@ try {
       // verifier to require its ABSENCE (not its presence) while still enforcing
       // every other critical resource + signature check.
       ...(localVerificationBuild ? ['--allow-missing-seal'] : []),
+      // If this build had a Developer ID identity then every darwin nested
+      // binary was signed above, so the gate must REFUSE an unsigned one rather
+      // than fall back to accepting raw upstream bytes: unsigned means no
+      // hardened runtime and a guaranteed notarization rejection later. Builds
+      // with no identity (local, forks, PRs without secrets) stay buildable.
+      // The decision comes from the build environment, never from data inside
+      // the package, so it cannot be flipped by editing a manifest.
+      ...(packagePlatforms[0] === 'darwin' && resolveDarwinSigningIdentity() ? ['--require-darwin-signature'] : []),
     ],
     { stdio: 'inherit', env: process.env }
   );

--- a/scripts/build-with-builder.js
+++ b/scripts/build-with-builder.js
@@ -18,6 +18,7 @@ const prepareBundledBun = require('./prepareBundledBun');
 const prepareWaylandCore = require('./prepareWaylandCore');
 const prepareWaylandNano = require('./prepareWaylandNano');
 const prepareOfficeCli = require('./prepareOfficeCli');
+const { signDarwinStagedBinary, resolveDarwinSigningIdentity } = require('./signDarwinStagedBinary');
 const prepareConstitutionFs = require('./prepareConstitutionFs');
 const { verifyThirdPartyExecutableLedger } = require('./supply-chain/verifyThirdPartyExecutableLedger');
 const { writeCapabilitySeal } = require('./capability-seal/verifyCandidateCapabilitySeal');
@@ -338,6 +339,66 @@ function prepareOptionalHubResources(options = {}) {
   return { available: false, reason: 'trusted-hub-authority-unavailable' };
 }
 
+// The bridge ships prebuilt natives (sharp's .node/.dylib and the bare-* .bare
+// runtimes) that npm publishes UNSIGNED. Apple refuses to notarize an app that
+// contains them in that state - all 11 were named in the notary log that blocked
+// 0.12.0 - so they are Developer ID signed here, right after install and before
+// the bridge tree is validated and copied into the package.
+//
+// Signing before validation is what keeps the source/bundle mirror exact: both
+// sides then hold the same signed bytes, so verifySourceMirror still compares
+// them byte for byte with no exemption. `mac.signIgnore` stops electron-builder
+// re-signing them during packaging.
+//
+// Detection is by Mach-O magic rather than by file extension. The natives Apple
+// named use .node, .dylib and .bare today, but the set is dependency-controlled
+// and an extension list would silently skip an extensionless executable - which
+// is exactly the failure mode this whole change exists to remove.
+function isMachOFile(filePath) {
+  let handle;
+  try {
+    handle = fs.openSync(filePath, 'r');
+    const head = Buffer.alloc(4);
+    if (fs.readSync(handle, head, 0, 4, 0) < 4) return false;
+    const magic = head.readUInt32BE(0);
+    return (
+      magic === 0xfeedface || // 32-bit
+      magic === 0xfeedfacf || // 64-bit
+      magic === 0xcefaedfe || // 32-bit, byte-swapped
+      magic === 0xcffaedfe || // 64-bit, byte-swapped
+      magic === 0xcafebabe || // universal ("fat")
+      magic === 0xbebafeca // universal, byte-swapped
+    );
+  } catch {
+    return false;
+  } finally {
+    if (handle !== undefined) fs.closeSync(handle);
+  }
+}
+
+// Every native is signed rather than a fixed list, so a dependency that starts
+// shipping a new one cannot silently reintroduce an unsigned binary.
+function signWhatsAppBridgeNatives(nodeModules, options = {}) {
+  if (!fs.existsSync(nodeModules)) return [];
+  const sign = options.signDarwinStagedBinary || signDarwinStagedBinary;
+  const identity = options.signIdentity === undefined ? resolveDarwinSigningIdentity() : options.signIdentity;
+  const natives = [];
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const target = path.join(dir, entry.name);
+      if (entry.isSymbolicLink()) continue;
+      if (entry.isDirectory()) walk(target);
+      else if (entry.isFile() && isMachOFile(target)) natives.push(target);
+    }
+  };
+  walk(nodeModules);
+  natives.sort();
+  for (const native of natives) {
+    sign(native, { identity, label: path.relative(nodeModules, native) });
+  }
+  return natives;
+}
+
 function prepareWhatsAppBridgeResources(options = {}) {
   const bridgeDir = options.bridgeDir || path.resolve(__dirname, '..', 'src', 'process', 'channels', 'whatsapp-bridge');
   const nodeModules = path.join(bridgeDir, 'node_modules');
@@ -352,6 +413,7 @@ function prepareWhatsAppBridgeResources(options = {}) {
       stdio: 'inherit',
       env: process.env,
     });
+    if (platform === 'darwin') signWhatsAppBridgeNatives(nodeModules, options);
     if (!validate()) throw new Error('WhatsApp bridge clean frozen-lock input failed source/dependency validation');
   } catch (error) {
     fs.rmSync(nodeModules, { recursive: true, force: true });

--- a/scripts/prepareConstitutionFs.js
+++ b/scripts/prepareConstitutionFs.js
@@ -10,6 +10,12 @@ const path = require('node:path');
 const ROOT = path.resolve(__dirname, '..');
 const GENERATED = path.join(ROOT, 'src', 'process', 'services', 'constitution', 'constitutionFsAuthority.generated.ts');
 
+const {
+  signDarwinStagedBinary,
+  resolveDarwinSigningIdentity,
+  darwinSigningIdentifier,
+} = require('./signDarwinStagedBinary');
+
 function writeGenerated(authority, generatedPath = GENERATED) {
   fs.mkdirSync(path.dirname(generatedPath), { recursive: true });
   fs.writeFileSync(
@@ -31,6 +37,10 @@ function prepareConstitutionFs(options = {}) {
     path.join(root, 'src', 'process', 'services', 'constitution', 'constitutionFsAuthority.generated.ts');
   const execute = options.execFileSync || execFileSync;
   const prebuiltBinary = options.prebuiltBinary;
+  // Undefined (not null) means "resolve from the environment"; tests pass an
+  // explicit identity, and a build without one leaves the helper unsigned.
+  const signIdentity =
+    options.signIdentity === undefined ? resolveDarwinSigningIdentity(options.env) : options.signIdentity;
   const supportedPlatform = platform === 'darwin' || platform === 'linux';
 
   fs.rmSync(outputRoot, { recursive: true, force: true });
@@ -66,11 +76,21 @@ function prepareConstitutionFs(options = {}) {
   fs.chmodSync(destination, 0o755);
 
   if (platform === 'darwin') {
-    const identity = process.env.WAYLAND_CONSTITUTION_FS_SIGN_IDENTITY || '-';
-    execute('/usr/bin/codesign', ['--force', '--sign', identity, '--timestamp=none', destination], {
-      stdio: 'inherit',
+    // Sign BEFORE the digest below is taken. The manifest, the authority
+    // embedded in app.asar and the packaged gate all pin these exact bytes, and
+    // the helper is re-hashed against that authority at runtime - so a signature
+    // applied later would fail every launch with
+    // CONSTITUTION_FS_BINARY_UNVERIFIED. Ad-hoc signing (the previous default)
+    // also made Apple reject the whole app during notarization.
+    // Bind the signature to the bytes we just built, so the signature cannot be
+    // reused to bless a different helper.
+    const unsignedSha256 = crypto.createHash('sha256').update(fs.readFileSync(destination)).digest('hex');
+    signDarwinStagedBinary(destination, {
+      execFileSync: execute,
+      identity: signIdentity,
+      identifier: darwinSigningIdentifier(fileName, unsignedSha256),
+      label: `constitution-fs ${platform}-${arch}`,
     });
-    execute('/usr/bin/codesign', ['--verify', '--strict', destination], { stdio: 'inherit' });
   }
 
   const bytes = fs.readFileSync(destination);

--- a/scripts/prepareWaylandCore.js
+++ b/scripts/prepareWaylandCore.js
@@ -25,6 +25,11 @@ const { execSync, execFileSync } = require('child_process');
 const crypto = require('crypto');
 const fs = require('fs');
 const os = require('os');
+const {
+  signDarwinStagedBinary,
+  resolveDarwinSigningIdentity,
+  darwinSigningIdentifier,
+} = require('./signDarwinStagedBinary');
 const path = require('path');
 const { verifyPublisherAttestation } = require('./supply-chain/verifyPublisherAttestation');
 
@@ -467,6 +472,7 @@ function verifiedBundleManifest({
   archiveSha256,
   binaryName,
   binarySha256,
+  stagedBinarySha256,
   publisherAttestation,
 }) {
   return {
@@ -488,7 +494,14 @@ function verifiedBundleManifest({
     },
     binary: {
       name: binaryName,
+      // The verified UPSTREAM digest - the provenance pin, unchanged.
       sha256: `sha256:${binarySha256}`,
+      // The digest of the bytes actually staged into the package. Identical to
+      // the upstream digest everywhere except macOS, where the binary is
+      // Developer ID signed above so that the app can notarize. The packaged
+      // gate compares the shipped bytes against THIS, so byte identity is still
+      // proven exactly rather than downgraded to "signed by someone we trust".
+      stagedSha256: `sha256:${stagedBinarySha256 || binarySha256}`,
     },
     publisherAttestation: publisherAttestation || null,
     files: [binaryName],
@@ -498,6 +511,8 @@ function verifiedBundleManifest({
 
 function prepareWaylandCore(options = {}) {
   const projectRoot = path.resolve(__dirname, '..');
+  const signIdentity =
+    options.signIdentity === undefined ? resolveDarwinSigningIdentity(options.env) : options.signIdentity;
   const platform = options.platform || process.platform;
   // Support cross-compilation: WCORE_ARCH > npm_config_target_arch > process.arch
   const arch = options.arch || process.env.WCORE_ARCH || process.env.npm_config_target_arch || process.arch;
@@ -697,6 +712,23 @@ function prepareWaylandCore(options = {}) {
       );
     }
 
+    // Apple refuses to notarize an app containing an ad-hoc / linker-signed
+    // Mach-O, and released wayland-core binaries are linker-signed. Sign here,
+    // AFTER the upstream bytes have been checksum- and attestation-verified
+    // above and BEFORE the digest the packaged gate pins is taken, so the
+    // provenance chain stays intact and the shipped bytes stay byte-exact.
+    // `mac.signIgnore` then keeps electron-builder from re-signing this path.
+    if (platform === 'darwin') {
+      signDarwinStagedBinary(targetBinaryPath, {
+        identity: signIdentity,
+        // Binds the signature to the pinned upstream bytes, so a substituted or
+        // downgraded binary cannot pass by rewriting the manifest beside it.
+        identifier: darwinSigningIdentifier(binaryName, binarySha256),
+        label: `wayland-core ${runtimeKey}`,
+      });
+    }
+    const stagedBinarySha256 = computeFileSha256(targetBinaryPath);
+
     const manifest = verifiedBundleManifest({
       platform,
       arch,
@@ -706,6 +738,7 @@ function prepareWaylandCore(options = {}) {
       archiveSha256,
       binaryName,
       binarySha256,
+      stagedBinarySha256,
       publisherAttestation,
     });
     if (!strict && !expected.binarySha256) manifest.verified = false;

--- a/scripts/prepareWaylandNano.js
+++ b/scripts/prepareWaylandNano.js
@@ -25,6 +25,11 @@ const { execSync, execFileSync } = require('child_process');
 const crypto = require('crypto');
 const fs = require('fs');
 const os = require('os');
+const {
+  signDarwinStagedBinary,
+  resolveDarwinSigningIdentity,
+  darwinSigningIdentifier,
+} = require('./signDarwinStagedBinary');
 const path = require('path');
 const { verifyPublisherAttestation } = require('./supply-chain/verifyPublisherAttestation');
 
@@ -438,6 +443,7 @@ function verifiedBundleManifest({
   archiveSha256,
   binaryName,
   binarySha256,
+  stagedBinarySha256,
   publisherAttestation,
 }) {
   return {
@@ -459,7 +465,12 @@ function verifiedBundleManifest({
     },
     binary: {
       name: binaryName,
+      // Verified UPSTREAM digest - the provenance pin.
       sha256: `sha256:${binarySha256}`,
+      // Digest of the bytes actually staged. Differs from the upstream digest
+      // only on macOS, where the binary is Developer ID signed above; the
+      // packaged gate compares the shipped bytes against this.
+      stagedSha256: `sha256:${stagedBinarySha256 || binarySha256}`,
     },
     publisherAttestation: publisherAttestation || null,
     files: [binaryName],
@@ -468,6 +479,8 @@ function verifiedBundleManifest({
 }
 
 function prepareWaylandNano(options = {}) {
+  const signIdentity =
+    options.signIdentity === undefined ? resolveDarwinSigningIdentity(options.env) : options.signIdentity;
   const projectRoot = path.resolve(__dirname, '..');
   const platform = options.platform || process.platform;
   // Support cross-compilation: WNANO_ARCH > npm_config_target_arch > process.arch
@@ -598,7 +611,7 @@ function prepareWaylandNano(options = {}) {
         source: {
           note: 'Dev-only pre-placed binary. It is not eligible for packaged-resource acceptance.',
         },
-        binary: { name: binaryName, sha256: `sha256:${binarySha256}` },
+        binary: { name: binaryName, sha256: `sha256:${binarySha256}`, stagedSha256: `sha256:${binarySha256}` },
         files: [binaryName],
         skipped: false,
       });
@@ -669,6 +682,18 @@ function prepareWaylandNano(options = {}) {
       );
     }
 
+    // Released wayland-nano binaries are linker-signed, which Apple rejects.
+    // Sign AFTER the upstream checksum/attestation checks above and BEFORE the
+    // digest the packaged gate pins, so provenance and byte identity both hold.
+    if (platform === 'darwin') {
+      signDarwinStagedBinary(targetBinaryPath, {
+        identity: signIdentity,
+        identifier: darwinSigningIdentifier(binaryName, binarySha256),
+        label: `wayland-nano ${runtimeKey}`,
+      });
+    }
+    const stagedBinarySha256 = computeFileSha256(targetBinaryPath);
+
     const manifest = verifiedBundleManifest({
       platform,
       arch,
@@ -678,6 +703,7 @@ function prepareWaylandNano(options = {}) {
       archiveSha256,
       binaryName,
       binarySha256,
+      stagedBinarySha256,
       publisherAttestation,
     });
     if (!strict && !expected.binarySha256) manifest.verified = false;

--- a/scripts/signDarwinStagedBinary.js
+++ b/scripts/signDarwinStagedBinary.js
@@ -1,0 +1,157 @@
+'use strict';
+
+// Developer ID signing for binaries we stage into the packaged app.
+//
+// Apple refuses to notarize an app that contains an unsigned or merely ad-hoc /
+// linker-signed Mach-O. Several binaries we bundle are exactly that: our own
+// wayland-core, wayland-nano and wayland-constitution-fs ship linker-signed
+// from their own release pipelines, and the whatsapp-bridge sharp and bare-*
+// natives are unsigned npm artifacts. bundled-bun and bundled-officecli are the
+// exceptions - their publishers sign them properly, so they are left untouched.
+//
+// The signing happens at STAGE time, before each binary's digest is recorded,
+// rather than during packaging. That ordering is what keeps every existing
+// integrity check exact:
+//
+//   * the staged manifest, the embedded authority and the packaged gate all
+//     record and compare the SAME post-signature bytes, so byte identity is
+//     preserved end to end rather than downgraded to "signed by someone we
+//     trust";
+//   * `mac.signIgnore` then stops electron-builder re-signing these paths
+//     during packaging, so the bytes cannot change after they were pinned;
+//   * `wayland-constitution-fs` in particular is re-hashed at RUNTIME against a
+//     digest embedded in app.asar, so a binary signed after that digest was
+//     recorded would fail every launch with CONSTITUTION_FS_BINARY_UNVERIFIED.
+//
+// The upstream-provenance guarantee is unaffected: the download, checksum and
+// attestation checks all run against the upstream bytes BEFORE this signature is
+// applied.
+
+const { execFileSync } = require('child_process');
+
+// Apple's canonical Developer ID Application requirement. Checking only
+// `subject.OU` would also accept an Apple Development or Mac Distribution
+// certificate from the same team, neither of which notarizes; the two marker
+// OIDs below are what actually pin it to a Developer ID Application leaf issued
+// under the Developer ID CA.
+//
+// The leading '=' is REQUIRED: `codesign -R` reads a bare argument as a path to
+// a requirement FILE and only parses inline requirement text when it starts with
+// '='. Without it codesign exits 1 with "invalid requirement specification",
+// which fails closed on correctly signed binaries too.
+const DARWIN_TEAM_ID = 'PX6SP9GPWJ';
+const DARWIN_DEVELOPER_ID_REQUIREMENT =
+  '=anchor apple generic and ' +
+  'certificate 1[field.1.2.840.113635.100.6.2.6] exists and ' +
+  'certificate leaf[field.1.2.840.113635.100.6.1.13] exists and ' +
+  `certificate leaf[subject.OU] = "${DARWIN_TEAM_ID}"`;
+
+/**
+ * Bind a signature to the exact upstream bytes it was produced from.
+ *
+ * Signing necessarily changes the binary, so the shipped bytes can no longer be
+ * compared to the pinned upstream digest directly. Recording the post-signature
+ * digest in the bundle manifest is not sufficient on its own: the manifest ships
+ * inside the app and is not independently authenticated, so anything able to
+ * rewrite the binary can rewrite the digest beside it and swap in a different -
+ * or older, vulnerable - binary that we also legitimately signed.
+ *
+ * Putting the upstream digest in the code-signing IDENTIFIER closes that. The
+ * identifier lives inside the signature, so it cannot be altered without the
+ * signing key, and the requirement below checks it. A substituted binary either
+ * carries a different identifier or no valid Ferrox Labs signature at all.
+ */
+function darwinSigningIdentifier(binaryName, upstreamSha256) {
+  const digest = String(upstreamSha256 || '')
+    .replace(/^sha256:/i, '')
+    .toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(digest)) {
+    throw new Error(`[sign-darwin] refusing to sign ${binaryName} without a pinned upstream sha256`);
+  }
+  return `${binaryName}.${digest}`;
+}
+
+function darwinDeveloperIdRequirementFor(identifier) {
+  if (!identifier) return DARWIN_DEVELOPER_ID_REQUIREMENT;
+  return `=identifier "${identifier}" and ${DARWIN_DEVELOPER_ID_REQUIREMENT.slice(1)}`;
+}
+
+/**
+ * The Developer ID identity to sign staged binaries with, or null when this
+ * build has none (local development, forks, PR builds without secrets).
+ */
+function resolveDarwinSigningIdentity(env = process.env) {
+  const identity = env.WAYLAND_DARWIN_SIGN_IDENTITY || env.CSC_NAME || env.identity;
+  const trimmed = typeof identity === 'string' ? identity.trim() : '';
+  // '-' is codesign's ad-hoc identity. Ad-hoc is precisely the state Apple
+  // rejects, so treat it as "no identity" rather than signing uselessly.
+  return trimmed && trimmed !== '-' ? trimmed : null;
+}
+
+/**
+ * Sign one staged binary with Developer ID, the hardened runtime and a secure
+ * timestamp - the three things Apple's notary service checks - then prove the
+ * result satisfies the Developer ID requirement before any digest is taken.
+ *
+ * Returns true when the binary was signed, false when this build has no
+ * identity. Throws if signing was attempted and did not produce a valid
+ * Developer ID signature: a silently unsigned binary would fail notarization
+ * much later, with a far less obvious error.
+ */
+function signDarwinStagedBinary(binaryPath, options = {}) {
+  const execute = options.execFileSync || execFileSync;
+  const identity = options.identity === undefined ? resolveDarwinSigningIdentity(options.env) : options.identity;
+  const label = options.label || binaryPath;
+  if (!identity) {
+    console.log(`[sign-darwin] no Developer ID identity for this build; leaving ${label} unsigned`);
+    return false;
+  }
+  const identifier = options.identifier;
+  execute(
+    '/usr/bin/codesign',
+    [
+      '--force',
+      '--options',
+      'runtime',
+      '--timestamp',
+      ...(identifier ? ['--identifier', identifier] : []),
+      '--sign',
+      identity,
+      binaryPath,
+    ],
+    { stdio: 'inherit' }
+  );
+  assertDarwinDeveloperIdSigned(binaryPath, { execFileSync: execute, identifier });
+  console.log(`[sign-darwin] signed ${label}`);
+  return true;
+}
+
+/** Throws unless the binary carries a valid Ferrox Labs Developer ID signature. */
+function assertDarwinDeveloperIdSigned(binaryPath, options = {}) {
+  const execute = options.execFileSync || execFileSync;
+  const requirement = darwinDeveloperIdRequirementFor(options.identifier);
+  execute('/usr/bin/codesign', ['--verify', '--strict', '-R', requirement, binaryPath], { stdio: 'pipe' });
+}
+
+// `identifier` may be passed positionally so call sites in the packaged gate
+// stay readable; an options object is still accepted.
+function isDarwinDeveloperIdSigned(binaryPath, options = {}) {
+  const resolved = typeof options === 'string' ? { identifier: options } : options;
+  try {
+    assertDarwinDeveloperIdSigned(binaryPath, resolved);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+module.exports = {
+  DARWIN_TEAM_ID,
+  DARWIN_DEVELOPER_ID_REQUIREMENT,
+  darwinSigningIdentifier,
+  darwinDeveloperIdRequirementFor,
+  resolveDarwinSigningIdentity,
+  signDarwinStagedBinary,
+  assertDarwinDeveloperIdSigned,
+  isDarwinDeveloperIdSigned,
+};

--- a/scripts/verify-packaged-resources.js
+++ b/scripts/verify-packaged-resources.js
@@ -28,6 +28,7 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 const { execFileSync } = require('child_process');
+const { isDarwinDeveloperIdSigned, darwinSigningIdentifier } = require('./signDarwinStagedBinary');
 const prepareWaylandCore = require('./prepareWaylandCore');
 const prepareWaylandNano = require('./prepareWaylandNano');
 const prepareOfficeCli = require('./prepareOfficeCli');
@@ -357,7 +358,12 @@ function parseRequiredRuntimes(argv, flag, label) {
   return [...new Set(runtimes)].sort();
 }
 
-function verifyWCoreRuntime(bundleDir, runtimeKey, authority = prepareWaylandCore) {
+function verifyWCoreRuntime(
+  bundleDir,
+  runtimeKey,
+  authority = prepareWaylandCore,
+  signedCheck = isDarwinDeveloperIdSigned
+) {
   const [platform, arch] = runtimeKey.split('-');
   const binaryName = platform === 'win32' ? 'wayland-core.exe' : 'wayland-core';
   const runtimeDir = path.join(bundleDir, runtimeKey);
@@ -383,6 +389,9 @@ function verifyWCoreRuntime(bundleDir, runtimeKey, authority = prepareWaylandCor
     .replace(/^sha256:/i, '')
     .toLowerCase();
   const manifestBinarySha256 = String(metadata.binary?.sha256 || '')
+    .replace(/^sha256:/i, '')
+    .toLowerCase();
+  const manifestStagedSha256 = String(metadata.binary?.stagedSha256 || '')
     .replace(/^sha256:/i, '')
     .toLowerCase();
   const expectedUrl = `https://github.com/FerroxLabs/wayland-core/releases/download/${releaseTag}/${assetName}`;
@@ -419,12 +428,30 @@ function verifyWCoreRuntime(bundleDir, runtimeKey, authority = prepareWaylandCor
     manifestArchiveSha256 === expected.archiveSha256 &&
     metadata.binary?.name === binaryName &&
     manifestBinarySha256 === expected.binarySha256 &&
-    actualBinarySha256 === expected.binarySha256 &&
+    // Byte identity is never traded for signer identity: the shipped bytes must
+    // equal the staged digest exactly. The staged bytes are then either the
+    // pinned upstream bytes verbatim, or - on macOS only - a Developer ID
+    // signed derivative of them, because Apple rejects ad-hoc Mach-O.
+    //
+    // Neither branch is a way in. Claiming the first forces the attacker to
+    // ship the genuine upstream binary. Claiming the second forces them to
+    // produce a Ferrox Labs signature whose IDENTIFIER embeds the pinned
+    // upstream digest - so a different, or older-but-also-signed, binary fails.
+    // The manifest is therefore not load-bearing for authenticity: it cannot be
+    // edited into accepting bytes we did not sign for this exact release.
+    actualBinarySha256 === manifestStagedSha256 &&
+    (manifestStagedSha256 === expected.binarySha256 ||
+      (platform === 'darwin' && signedCheck(binaryPath, darwinSigningIdentifier(binaryName, expected.binarySha256)))) &&
     JSON.stringify(metadata.files) === JSON.stringify([binaryName])
   );
 }
 
-function verifyWCoreBundle(bundleDir, requiredRuntimes, authority = prepareWaylandCore) {
+function verifyWCoreBundle(
+  bundleDir,
+  requiredRuntimes,
+  authority = prepareWaylandCore,
+  signedCheck = isDarwinDeveloperIdSigned
+) {
   if (!fs.statSync(bundleDir).isDirectory()) return false;
   const entries = fs.readdirSync(bundleDir, { withFileTypes: true });
   if (entries.length === 0) return false;
@@ -433,14 +460,20 @@ function verifyWCoreBundle(bundleDir, requiredRuntimes, authority = prepareWayla
   }
   const packagedRuntimes = entries.map((entry) => entry.name).sort();
   if (JSON.stringify(packagedRuntimes) !== JSON.stringify([...requiredRuntimes].sort())) return false;
-  return packagedRuntimes.every((runtime) => verifyWCoreRuntime(bundleDir, runtime, authority));
+  return packagedRuntimes.every((runtime) => verifyWCoreRuntime(bundleDir, runtime, authority, signedCheck));
 }
 
 // Mirrors verifyWCoreRuntime for the bundled wayland-nano agent. The policy
 // selector is injectable because, unlike wayland-core, the first
 // FerroxLabs/wayland-nano publisher-attestation policy only exists once the
 // first signed release lands - tests substitute their own until then.
-function verifyWNanoRuntime(bundleDir, runtimeKey, authority = prepareWaylandNano, policySelector = selectPolicy) {
+function verifyWNanoRuntime(
+  bundleDir,
+  runtimeKey,
+  authority = prepareWaylandNano,
+  policySelector = selectPolicy,
+  signedCheck = isDarwinDeveloperIdSigned
+) {
   const [platform, arch] = runtimeKey.split('-');
   const binaryName = platform === 'win32' ? 'wayland-nano.exe' : 'wayland-nano';
   const runtimeDir = path.join(bundleDir, runtimeKey);
@@ -466,6 +499,9 @@ function verifyWNanoRuntime(bundleDir, runtimeKey, authority = prepareWaylandNan
     .replace(/^sha256:/i, '')
     .toLowerCase();
   const manifestBinarySha256 = String(metadata.binary?.sha256 || '')
+    .replace(/^sha256:/i, '')
+    .toLowerCase();
+  const manifestStagedSha256 = String(metadata.binary?.stagedSha256 || '')
     .replace(/^sha256:/i, '')
     .toLowerCase();
   const expectedUrl = `https://github.com/FerroxLabs/wayland-nano/releases/download/${releaseTag}/${assetName}`;
@@ -502,12 +538,23 @@ function verifyWNanoRuntime(bundleDir, runtimeKey, authority = prepareWaylandNan
     manifestArchiveSha256 === expected.archiveSha256 &&
     metadata.binary?.name === binaryName &&
     manifestBinarySha256 === expected.binarySha256 &&
-    actualBinarySha256 === expected.binarySha256 &&
+    // Same contract as wayland-core: exact bytes against the staged digest, and
+    // the staged bytes are either the pinned upstream bytes or a macOS-signed
+    // derivative of them.
+    actualBinarySha256 === manifestStagedSha256 &&
+    (manifestStagedSha256 === expected.binarySha256 ||
+      (platform === 'darwin' && signedCheck(binaryPath, darwinSigningIdentifier(binaryName, expected.binarySha256)))) &&
     JSON.stringify(metadata.files) === JSON.stringify([binaryName])
   );
 }
 
-function verifyWNanoBundle(bundleDir, requiredRuntimes, authority = prepareWaylandNano, policySelector = selectPolicy) {
+function verifyWNanoBundle(
+  bundleDir,
+  requiredRuntimes,
+  authority = prepareWaylandNano,
+  policySelector = selectPolicy,
+  signedCheck = isDarwinDeveloperIdSigned
+) {
   if (!fs.statSync(bundleDir).isDirectory()) return false;
   const entries = fs.readdirSync(bundleDir, { withFileTypes: true });
   if (entries.length === 0) return false;
@@ -516,7 +563,9 @@ function verifyWNanoBundle(bundleDir, requiredRuntimes, authority = prepareWayla
   }
   const packagedRuntimes = entries.map((entry) => entry.name).sort();
   if (JSON.stringify(packagedRuntimes) !== JSON.stringify([...requiredRuntimes].sort())) return false;
-  return packagedRuntimes.every((runtime) => verifyWNanoRuntime(bundleDir, runtime, authority, policySelector));
+  return packagedRuntimes.every((runtime) =>
+    verifyWNanoRuntime(bundleDir, runtime, authority, policySelector, signedCheck)
+  );
 }
 
 function hasNonHiddenRegularFile(dir) {
@@ -992,7 +1041,8 @@ function isNonEmpty(
   verifyCandidateCapabilitySeal = verifyCapabilitySeal,
   requiredWNanoRuntimes = [],
   wnanoAuthority = prepareWaylandNano,
-  wnanoPolicySelector = selectPolicy
+  wnanoPolicySelector = selectPolicy,
+  darwinSignedCheck = isDarwinDeveloperIdSigned
 ) {
   try {
     if (kind === 'constitution-fs-bundle' && targetPlatform === 'win32') {
@@ -1012,10 +1062,10 @@ function isNonEmpty(
     }
     if (!st.isDirectory()) return false;
     if (kind === 'wcore-bundle') {
-      return verifyWCoreBundle(p, requiredWCoreRuntimes, wcoreAuthority);
+      return verifyWCoreBundle(p, requiredWCoreRuntimes, wcoreAuthority, darwinSignedCheck);
     }
     if (kind === 'wnano-bundle') {
-      return verifyWNanoBundle(p, requiredWNanoRuntimes, wnanoAuthority, wnanoPolicySelector);
+      return verifyWNanoBundle(p, requiredWNanoRuntimes, wnanoAuthority, wnanoPolicySelector, darwinSignedCheck);
     }
     if (kind === 'officecli-bundle') {
       const entries = fs.readdirSync(p, { withFileTypes: true });
@@ -1124,6 +1174,7 @@ function verifyPackagedResources(options = {}) {
     ((binaryPath) => officeCliAuthority.verifyDarwinPublisherSignature(binaryPath));
   const constitutionFsAuthority = options.constitutionFsAuthority;
   const verifyConstitutionFsDarwinSignature = options.verifyConstitutionFsDarwinSignature;
+  const darwinSignedCheck = options.darwinSignedCheck || isDarwinDeveloperIdSigned;
   const verifyCandidateCapabilitySeal = options.verifyCapabilitySeal || verifyCapabilitySeal;
   const verifyDarwinPackageSignature =
     options.verifyDarwinPackageSignature ||
@@ -1260,7 +1311,8 @@ function verifyPackagedResources(options = {}) {
         verifyCandidateCapabilitySeal,
         requiredWNanoRuntimes,
         wnanoAuthority,
-        wnanoPolicySelector
+        wnanoPolicySelector,
+        darwinSignedCheck
       );
       if (ok) {
         logger.log(`${TAG}   OK   ${req.rel}`);

--- a/scripts/verify-packaged-resources.js
+++ b/scripts/verify-packaged-resources.js
@@ -362,7 +362,8 @@ function verifyWCoreRuntime(
   bundleDir,
   runtimeKey,
   authority = prepareWaylandCore,
-  signedCheck = isDarwinDeveloperIdSigned
+  signedCheck = isDarwinDeveloperIdSigned,
+  requireDarwinSignature = false
 ) {
   const [platform, arch] = runtimeKey.split('-');
   const binaryName = platform === 'win32' ? 'wayland-core.exe' : 'wayland-core';
@@ -440,8 +441,14 @@ function verifyWCoreRuntime(
     // The manifest is therefore not load-bearing for authenticity: it cannot be
     // edited into accepting bytes we did not sign for this exact release.
     actualBinarySha256 === manifestStagedSha256 &&
-    (manifestStagedSha256 === expected.binarySha256 ||
-      (platform === 'darwin' && signedCheck(binaryPath, darwinSigningIdentifier(binaryName, expected.binarySha256)))) &&
+    (platform === 'darwin' && requireDarwinSignature
+      ? // A release build must ship the SIGNED binary. Accepting the unsigned
+        // upstream bytes would mean shipping genuine code with no hardened
+        // runtime, and Apple would refuse to notarize it anyway.
+        signedCheck(binaryPath, darwinSigningIdentifier(binaryName, expected.binarySha256))
+      : manifestStagedSha256 === expected.binarySha256 ||
+        (platform === 'darwin' &&
+          signedCheck(binaryPath, darwinSigningIdentifier(binaryName, expected.binarySha256)))) &&
     JSON.stringify(metadata.files) === JSON.stringify([binaryName])
   );
 }
@@ -450,7 +457,8 @@ function verifyWCoreBundle(
   bundleDir,
   requiredRuntimes,
   authority = prepareWaylandCore,
-  signedCheck = isDarwinDeveloperIdSigned
+  signedCheck = isDarwinDeveloperIdSigned,
+  requireDarwinSignature = false
 ) {
   if (!fs.statSync(bundleDir).isDirectory()) return false;
   const entries = fs.readdirSync(bundleDir, { withFileTypes: true });
@@ -460,7 +468,9 @@ function verifyWCoreBundle(
   }
   const packagedRuntimes = entries.map((entry) => entry.name).sort();
   if (JSON.stringify(packagedRuntimes) !== JSON.stringify([...requiredRuntimes].sort())) return false;
-  return packagedRuntimes.every((runtime) => verifyWCoreRuntime(bundleDir, runtime, authority, signedCheck));
+  return packagedRuntimes.every((runtime) =>
+    verifyWCoreRuntime(bundleDir, runtime, authority, signedCheck, requireDarwinSignature)
+  );
 }
 
 // Mirrors verifyWCoreRuntime for the bundled wayland-nano agent. The policy
@@ -472,7 +482,8 @@ function verifyWNanoRuntime(
   runtimeKey,
   authority = prepareWaylandNano,
   policySelector = selectPolicy,
-  signedCheck = isDarwinDeveloperIdSigned
+  signedCheck = isDarwinDeveloperIdSigned,
+  requireDarwinSignature = false
 ) {
   const [platform, arch] = runtimeKey.split('-');
   const binaryName = platform === 'win32' ? 'wayland-nano.exe' : 'wayland-nano';
@@ -542,8 +553,14 @@ function verifyWNanoRuntime(
     // the staged bytes are either the pinned upstream bytes or a macOS-signed
     // derivative of them.
     actualBinarySha256 === manifestStagedSha256 &&
-    (manifestStagedSha256 === expected.binarySha256 ||
-      (platform === 'darwin' && signedCheck(binaryPath, darwinSigningIdentifier(binaryName, expected.binarySha256)))) &&
+    (platform === 'darwin' && requireDarwinSignature
+      ? // A release build must ship the SIGNED binary. Accepting the unsigned
+        // upstream bytes would mean shipping genuine code with no hardened
+        // runtime, and Apple would refuse to notarize it anyway.
+        signedCheck(binaryPath, darwinSigningIdentifier(binaryName, expected.binarySha256))
+      : manifestStagedSha256 === expected.binarySha256 ||
+        (platform === 'darwin' &&
+          signedCheck(binaryPath, darwinSigningIdentifier(binaryName, expected.binarySha256)))) &&
     JSON.stringify(metadata.files) === JSON.stringify([binaryName])
   );
 }
@@ -553,7 +570,8 @@ function verifyWNanoBundle(
   requiredRuntimes,
   authority = prepareWaylandNano,
   policySelector = selectPolicy,
-  signedCheck = isDarwinDeveloperIdSigned
+  signedCheck = isDarwinDeveloperIdSigned,
+  requireDarwinSignature = false
 ) {
   if (!fs.statSync(bundleDir).isDirectory()) return false;
   const entries = fs.readdirSync(bundleDir, { withFileTypes: true });
@@ -564,7 +582,7 @@ function verifyWNanoBundle(
   const packagedRuntimes = entries.map((entry) => entry.name).sort();
   if (JSON.stringify(packagedRuntimes) !== JSON.stringify([...requiredRuntimes].sort())) return false;
   return packagedRuntimes.every((runtime) =>
-    verifyWNanoRuntime(bundleDir, runtime, authority, policySelector, signedCheck)
+    verifyWNanoRuntime(bundleDir, runtime, authority, policySelector, signedCheck, requireDarwinSignature)
   );
 }
 
@@ -1042,7 +1060,8 @@ function isNonEmpty(
   requiredWNanoRuntimes = [],
   wnanoAuthority = prepareWaylandNano,
   wnanoPolicySelector = selectPolicy,
-  darwinSignedCheck = isDarwinDeveloperIdSigned
+  darwinSignedCheck = isDarwinDeveloperIdSigned,
+  requireDarwinSignature = false
 ) {
   try {
     if (kind === 'constitution-fs-bundle' && targetPlatform === 'win32') {
@@ -1062,10 +1081,17 @@ function isNonEmpty(
     }
     if (!st.isDirectory()) return false;
     if (kind === 'wcore-bundle') {
-      return verifyWCoreBundle(p, requiredWCoreRuntimes, wcoreAuthority, darwinSignedCheck);
+      return verifyWCoreBundle(p, requiredWCoreRuntimes, wcoreAuthority, darwinSignedCheck, requireDarwinSignature);
     }
     if (kind === 'wnano-bundle') {
-      return verifyWNanoBundle(p, requiredWNanoRuntimes, wnanoAuthority, wnanoPolicySelector, darwinSignedCheck);
+      return verifyWNanoBundle(
+        p,
+        requiredWNanoRuntimes,
+        wnanoAuthority,
+        wnanoPolicySelector,
+        darwinSignedCheck,
+        requireDarwinSignature
+      );
     }
     if (kind === 'officecli-bundle') {
       const entries = fs.readdirSync(p, { withFileTypes: true });
@@ -1143,7 +1169,8 @@ function isNonEmpty(
         targetPlatform,
         targetArch,
         constitutionFsAuthority,
-        verifyConstitutionFsDarwinSignature
+        verifyConstitutionFsDarwinSignature,
+        requireDarwinSignature
       );
     }
     if (kind === 'bun-bundle') return verifyBunBundle(p, targetPlatform, targetArch, bunAuthority);
@@ -1175,6 +1202,10 @@ function verifyPackagedResources(options = {}) {
   const constitutionFsAuthority = options.constitutionFsAuthority;
   const verifyConstitutionFsDarwinSignature = options.verifyConstitutionFsDarwinSignature;
   const darwinSignedCheck = options.darwinSignedCheck || isDarwinDeveloperIdSigned;
+  // Release builds must ship Developer ID signed nested binaries; an unsigned
+  // one cannot notarize, so accepting it here would only defer the failure.
+  // Local and PR builds have no signing identity and stay buildable.
+  const requireDarwinSignature = options.requireDarwinSignature ?? argv.includes('--require-darwin-signature');
   const verifyCandidateCapabilitySeal = options.verifyCapabilitySeal || verifyCapabilitySeal;
   const verifyDarwinPackageSignature =
     options.verifyDarwinPackageSignature ||
@@ -1312,7 +1343,8 @@ function verifyPackagedResources(options = {}) {
         requiredWNanoRuntimes,
         wnanoAuthority,
         wnanoPolicySelector,
-        darwinSignedCheck
+        darwinSignedCheck,
+        requireDarwinSignature
       );
       if (ok) {
         logger.log(`${TAG}   OK   ${req.rel}`);

--- a/tests/unit/prepareConstitutionFs.test.ts
+++ b/tests/unit/prepareConstitutionFs.test.ts
@@ -131,7 +131,10 @@ describe('prepareConstitutionFs', () => {
     );
   });
 
-  it('signs the helper BEFORE recording the digest the runtime re-checks', () => {
+  // Darwin-only by construction: prepareConstitutionFs refuses a target whose
+  // platform is not the host, and signing only happens on darwin. The macOS
+  // CI shard is what exercises this.
+  it.skipIf(process.platform !== 'darwin')('signs the helper BEFORE recording the digest the runtime re-checks', () => {
     // The packaged app re-hashes this helper at launch against the authority
     // embedded in app.asar (constitutionFsBinary.ts). A signature applied after
     // that digest was recorded changes the bytes and makes every launch fail

--- a/tests/unit/prepareConstitutionFs.test.ts
+++ b/tests/unit/prepareConstitutionFs.test.ts
@@ -130,4 +130,47 @@ describe('prepareConstitutionFs', () => {
       'COPY --from=builder /app/resources/bundled-constitution-fs ./resources/bundled-constitution-fs'
     );
   });
+
+  it('signs the helper BEFORE recording the digest the runtime re-checks', () => {
+    // The packaged app re-hashes this helper at launch against the authority
+    // embedded in app.asar (constitutionFsBinary.ts). A signature applied after
+    // that digest was recorded changes the bytes and makes every launch fail
+    // with CONSTITUTION_FS_BINARY_UNVERIFIED - a notarized but broken app.
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'constitution-sign-order-'));
+    const prebuilt = path.join(root, 'wayland-constitution-fs');
+    fs.writeFileSync(prebuilt, 'unsigned-bytes');
+    const outputRoot = path.join(root, 'out');
+    const generated = path.join(root, 'authority.generated.ts');
+
+    const order: string[] = [];
+    const execFileSync = vi.fn((command: string, args: string[]) => {
+      if (command === '/usr/bin/codesign' && args.includes('--sign')) {
+        order.push('sign');
+        // A real signature rewrites the binary; model that so the digest below
+        // can only match if it was taken afterwards.
+        fs.writeFileSync(args[args.length - 1], 'signed-bytes');
+      }
+      return '';
+    });
+
+    const authority = prepareConstitutionFs({
+      platform: 'darwin',
+      arch: process.arch,
+      root,
+      outputRoot,
+      generated,
+      prebuiltBinary: prebuilt,
+      execFileSync,
+      signIdentity: 'Developer ID Application: Ferrox Labs, LLC (PX6SP9GPWJ)',
+    });
+
+    expect(order).toEqual(['sign']);
+    const staged = path.join(outputRoot, `darwin-${process.arch}`, 'wayland-constitution-fs');
+    const onDisk = createHash('sha256').update(fs.readFileSync(staged)).digest('hex');
+    expect(authority.sha256).toBe(`sha256:${onDisk}`);
+    // And the adjacent manifest agrees, which is what the runtime cross-checks.
+    const manifest = JSON.parse(fs.readFileSync(path.join(path.dirname(staged), 'manifest.json'), 'utf8'));
+    expect(manifest.binary.sha256).toBe(`sha256:${onDisk}`);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
 });

--- a/tests/unit/prepareWaylandCore.test.ts
+++ b/tests/unit/prepareWaylandCore.test.ts
@@ -137,7 +137,15 @@ describe('strict bundled wayland-core provenance', () => {
     expect(build).toContain('--wcore-runtime');
     expect(verifier).toContain("kind: 'wcore-bundle'");
     expect(verifier).toContain("['download', 'verified-cache'].includes(metadata.sourceType)");
-    expect(verifier).toContain('actualBinarySha256 === expected.binarySha256');
+    // The shipped bytes are pinned to the digest recorded when the binary was
+    // staged, and the staged bytes are either the pinned upstream bytes or a
+    // macOS Developer ID signed derivative of them - never merely 'signed'.
+    expect(verifier).toContain('actualBinarySha256 === manifestStagedSha256');
+    expect(verifier).toContain('manifestStagedSha256 === expected.binarySha256 ||');
+    // On darwin the fallback is not merely "signed by us": the signature's
+    // identifier must embed the pinned upstream digest, so a different or
+    // older binary we also signed cannot be substituted.
+    expect(verifier).toContain('darwinSigningIdentifier(binaryName, expected.binarySha256)');
     expect(builder).toContain("'/Contents/Resources/bundled-wayland-core/[^/]+/wayland-core$'");
   });
 

--- a/tests/unit/prepareWaylandNano.test.ts
+++ b/tests/unit/prepareWaylandNano.test.ts
@@ -162,7 +162,15 @@ describe('strict bundled wayland-nano provenance', () => {
     expect(build).toContain('--wnano-runtime');
     expect(verifier).toContain("kind: 'wnano-bundle'");
     expect(verifier).toContain("['download', 'verified-cache'].includes(metadata.sourceType)");
-    expect(verifier).toContain('actualBinarySha256 === expected.binarySha256');
+    // The shipped bytes are pinned to the digest recorded when the binary was
+    // staged, and the staged bytes are either the pinned upstream bytes or a
+    // macOS Developer ID signed derivative of them - never merely 'signed'.
+    expect(verifier).toContain('actualBinarySha256 === manifestStagedSha256');
+    expect(verifier).toContain('manifestStagedSha256 === expected.binarySha256 ||');
+    // On darwin the fallback is not merely "signed by us": the signature's
+    // identifier must embed the pinned upstream digest, so a different or
+    // older binary we also signed cannot be substituted.
+    expect(verifier).toContain('darwinSigningIdentifier(binaryName, expected.binarySha256)');
     expect(builder).toContain('resources/bundled-wayland-nano');
     expect(builder).toContain("'/Contents/Resources/bundled-wayland-nano/[^/]+/wayland-nano$'");
   });

--- a/tests/unit/signDarwinStagedBinary.test.ts
+++ b/tests/unit/signDarwinStagedBinary.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const {
+  DARWIN_DEVELOPER_ID_REQUIREMENT,
+  darwinSigningIdentifier,
+  darwinDeveloperIdRequirementFor,
+  resolveDarwinSigningIdentity,
+  signDarwinStagedBinary,
+  isDarwinDeveloperIdSigned,
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+} = require('../../scripts/signDarwinStagedBinary');
+
+describe('darwin staged-binary signing', () => {
+  it('pins the requirement to a Developer ID Application leaf, not merely our team', () => {
+    // subject.OU alone also matches Apple Development and Mac Distribution
+    // certificates from the same team, neither of which notarizes. The two
+    // marker OIDs are what make this specifically Developer ID Application
+    // issued under the Developer ID CA.
+    expect(DARWIN_DEVELOPER_ID_REQUIREMENT).toContain('field.1.2.840.113635.100.6.2.6'); // Developer ID CA
+    expect(DARWIN_DEVELOPER_ID_REQUIREMENT).toContain('field.1.2.840.113635.100.6.1.13'); // Developer ID Application
+    expect(DARWIN_DEVELOPER_ID_REQUIREMENT).toContain('"PX6SP9GPWJ"');
+  });
+
+  it('starts the requirement with = so codesign parses it as text, not a file path', () => {
+    // Without the '=' codesign exits 1 with "invalid requirement specification"
+    // and fails closed on correctly signed binaries too.
+    expect(DARWIN_DEVELOPER_ID_REQUIREMENT.startsWith('=')).toBe(true);
+  });
+
+  it('signs with the hardened runtime and a secure timestamp', () => {
+    const execFileSync = vi.fn();
+    signDarwinStagedBinary('/tmp/staged/wayland-core', { execFileSync, identity: 'Developer ID Application: X' });
+    const [command, args] = execFileSync.mock.calls[0];
+    expect(command).toBe('/usr/bin/codesign');
+    // Apple checks all three during notarization.
+    expect(args).toContain('--options');
+    expect(args).toContain('runtime');
+    expect(args).toContain('--timestamp');
+    expect(args).toContain('--sign');
+  });
+
+  it('verifies the result satisfies the requirement before the caller digests it', () => {
+    const calls: string[][] = [];
+    const execFileSync = vi.fn((_cmd: string, args: string[]) => {
+      calls.push(args);
+      return '';
+    });
+    signDarwinStagedBinary('/tmp/staged/wayland-core', { execFileSync, identity: 'Developer ID Application: X' });
+    // A signature that silently did not take would surface only at
+    // notarization, long after the digest was pinned.
+    expect(calls.some((args) => args.includes('--verify') && args.includes('-R'))).toBe(true);
+  });
+
+  it('refuses to treat ad-hoc as an identity', () => {
+    // '-' is codesign's ad-hoc identity and is exactly the state Apple rejects.
+    expect(resolveDarwinSigningIdentity({ WAYLAND_DARWIN_SIGN_IDENTITY: '-' })).toBeNull();
+    expect(resolveDarwinSigningIdentity({ CSC_NAME: '   ' })).toBeNull();
+    expect(resolveDarwinSigningIdentity({ CSC_NAME: 'Developer ID Application: Ferrox Labs, LLC' })).toBe(
+      'Developer ID Application: Ferrox Labs, LLC'
+    );
+  });
+
+  it('leaves the binary unsigned, and says so, when the build has no identity', () => {
+    const execFileSync = vi.fn();
+    expect(signDarwinStagedBinary('/tmp/staged/x', { execFileSync, identity: null })).toBe(false);
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+
+  it('reports an unsatisfied requirement as not signed', () => {
+    const execFileSync = vi.fn(() => {
+      throw new Error('code failed to satisfy specified code requirement(s)');
+    });
+    expect(isDarwinDeveloperIdSigned('/tmp/staged/x', { execFileSync })).toBe(false);
+  });
+
+  it('binds the signature to the pinned upstream digest via the identifier', () => {
+    const id = darwinSigningIdentifier('wayland-core', `sha256:${'a'.repeat(64)}`);
+    expect(id).toBe(`wayland-core.${'a'.repeat(64)}`);
+    const requirement = darwinDeveloperIdRequirementFor(id);
+    // The identifier lives inside the signature, so it cannot be edited without
+    // the signing key. This is what stops a different - or older, still validly
+    // signed - binary being swapped in and the manifest rewritten to match.
+    expect(requirement).toContain(`identifier "${id}"`);
+    expect(requirement.startsWith('=')).toBe(true);
+    expect(requirement).toContain('field.1.2.840.113635.100.6.1.13');
+  });
+
+  it('refuses to sign without a pinned upstream digest', () => {
+    // Signing with no binding would produce a signature reusable on any binary.
+    expect(() => darwinSigningIdentifier('wayland-core', '')).toThrow(/pinned upstream sha256/);
+    expect(() => darwinSigningIdentifier('wayland-core', 'not-a-digest')).toThrow(/pinned upstream sha256/);
+  });
+
+  it('passes the identifier to codesign when signing', () => {
+    const execFileSync = vi.fn();
+    signDarwinStagedBinary('/tmp/staged/wayland-core', {
+      execFileSync,
+      identity: 'Developer ID Application: X',
+      identifier: 'wayland-core.deadbeef',
+    });
+    const args = execFileSync.mock.calls[0][1] as string[];
+    expect(args).toContain('--identifier');
+    expect(args[args.indexOf('--identifier') + 1]).toBe('wayland-core.deadbeef');
+  });
+});

--- a/tests/unit/verifyPackagedResources.test.ts
+++ b/tests/unit/verifyPackagedResources.test.ts
@@ -323,7 +323,13 @@ function addPackagedApp(
         sha256: `sha256:${TEST_WCORE_ARCHIVE_SHA}`,
         verified: true,
       },
-      binary: { name: 'wayland-core', sha256: `sha256:${TEST_WCORE_BINARY_SHA}` },
+      binary: {
+        name: 'wayland-core',
+        sha256: `sha256:${TEST_WCORE_BINARY_SHA}`,
+        // Unsigned fixture: the staged bytes are the upstream bytes verbatim,
+        // which is what a build with no Developer ID identity produces.
+        stagedSha256: `sha256:${TEST_WCORE_BINARY_SHA}`,
+      },
       files: ['wayland-core'],
       skipped: false,
     })
@@ -363,7 +369,11 @@ function addPackagedApp(
         sha256: `sha256:${TEST_WNANO_ARCHIVE_SHA}`,
         verified: true,
       },
-      binary: { name: 'wayland-nano', sha256: `sha256:${TEST_WNANO_BINARY_SHA}` },
+      binary: {
+        name: 'wayland-nano',
+        sha256: `sha256:${TEST_WNANO_BINARY_SHA}`,
+        stagedSha256: `sha256:${TEST_WNANO_BINARY_SHA}`,
+      },
       files: ['wayland-nano'],
       skipped: false,
     })
@@ -856,6 +866,39 @@ describe('packaged resource release gate', () => {
     const out = createPackagedResources(true);
     fs.appendFileSync(wcoreBinaryPath(out), 'tampered');
     expect(() => verify(out)).toThrow();
+  });
+
+  it('fails closed on a wayland-core manifest with no staged digest', () => {
+    const out = createPackagedResources(true);
+    const manifest = wcoreManifestPath(out);
+    const metadata = JSON.parse(fs.readFileSync(manifest, 'utf8'));
+    delete metadata.binary.stagedSha256;
+    fs.writeFileSync(manifest, JSON.stringify(metadata));
+    // Without it there is nothing pinning the shipped bytes, so the gate must
+    // refuse rather than fall back to a laxer comparison.
+    expect(() => verify(out)).toThrow(/CRITICAL resource/);
+  });
+
+  it('demands a Developer ID signature once a darwin manifest claims signed staging', () => {
+    const out = createPackagedResources(true);
+    const manifest = wcoreManifestPath(out);
+    const metadata = JSON.parse(fs.readFileSync(manifest, 'utf8'));
+    // Model a signed staging: the staged bytes differ from the pinned upstream
+    // bytes, which is only legitimate because we signed them.
+    fs.appendFileSync(wcoreBinaryPath(out), 'signature');
+    metadata.binary.stagedSha256 = `sha256:${crypto
+      .createHash('sha256')
+      .update(fs.readFileSync(wcoreBinaryPath(out)))
+      .digest('hex')}`;
+    fs.writeFileSync(manifest, JSON.stringify(metadata));
+
+    // Bytes match the staged digest, so only the signature stands between this
+    // and acceptance. Unsigned must fail...
+    expect(() => verify(out, 'darwin-arm64', 'darwin-arm64', { darwinSignedCheck: () => false })).toThrow(
+      /CRITICAL resource/
+    );
+    // ...and a valid Ferrox Labs signature must be accepted.
+    expect(() => verify(out, 'darwin-arm64', 'darwin-arm64', { darwinSignedCheck: () => true })).not.toThrow();
   });
 
   it('blocks a wayland-core manifest from the wrong release', () => {

--- a/tests/unit/verifyPackagedResources.test.ts
+++ b/tests/unit/verifyPackagedResources.test.ts
@@ -901,6 +901,26 @@ describe('packaged resource release gate', () => {
     expect(() => verify(out, 'darwin-arm64', 'darwin-arm64', { darwinSignedCheck: () => true })).not.toThrow();
   });
 
+  it('refuses unsigned darwin runtimes once the build had a signing identity', () => {
+    const out = createPackagedResources(true);
+    // Unsigned staging: staged bytes are the upstream bytes verbatim. That is
+    // fine for a local build, but a release that could sign and did not would
+    // ship without the hardened runtime and be rejected by Apple.
+    expect(() =>
+      verify(out, 'darwin-arm64', 'darwin-arm64', {
+        requireDarwinSignature: true,
+        darwinSignedCheck: () => false,
+      })
+    ).toThrow(/CRITICAL resource/);
+    // The same build passes once the binaries carry our signature.
+    expect(() =>
+      verify(out, 'darwin-arm64', 'darwin-arm64', {
+        requireDarwinSignature: true,
+        darwinSignedCheck: () => true,
+      })
+    ).not.toThrow();
+  });
+
   it('blocks a wayland-core manifest from the wrong release', () => {
     const out = createPackagedResources(true);
     const manifest = wcoreManifestPath(out);

--- a/tests/unit/verifyPackagedResources.test.ts
+++ b/tests/unit/verifyPackagedResources.test.ts
@@ -893,11 +893,24 @@ describe('packaged resource release gate', () => {
     fs.writeFileSync(manifest, JSON.stringify(metadata));
 
     // Bytes match the staged digest, so only the signature stands between this
-    // and acceptance. Unsigned must fail...
+    // and acceptance: unsigned must fail. The accepting half of this pair lives
+    // in the itAcceptedSweep spec below, because a full accepting sweep cannot
+    // run on a Windows host (the fixture cannot reproduce POSIX exec modes).
     expect(() => verify(out, 'darwin-arm64', 'darwin-arm64', { darwinSignedCheck: () => false })).toThrow(
       /CRITICAL resource/
     );
-    // ...and a valid Ferrox Labs signature must be accepted.
+  });
+
+  itAcceptedSweep('accepts a darwin manifest claiming signed staging when the signature is valid', () => {
+    const out = createPackagedResources(true);
+    const manifest = wcoreManifestPath(out);
+    const metadata = JSON.parse(fs.readFileSync(manifest, 'utf8'));
+    fs.appendFileSync(wcoreBinaryPath(out), 'signature');
+    metadata.binary.stagedSha256 = `sha256:${crypto
+      .createHash('sha256')
+      .update(fs.readFileSync(wcoreBinaryPath(out)))
+      .digest('hex')}`;
+    fs.writeFileSync(manifest, JSON.stringify(metadata));
     expect(() => verify(out, 'darwin-arm64', 'darwin-arm64', { darwinSignedCheck: () => true })).not.toThrow();
   });
 
@@ -912,7 +925,10 @@ describe('packaged resource release gate', () => {
         darwinSignedCheck: () => false,
       })
     ).toThrow(/CRITICAL resource/);
-    // The same build passes once the binaries carry our signature.
+  });
+
+  itAcceptedSweep('accepts a signed darwin runtime under release signature enforcement', () => {
+    const out = createPackagedResources(true);
     expect(() =>
       verify(out, 'darwin-arm64', 'darwin-arm64', {
         requireDarwinSignature: true,


### PR DESCRIPTION
Unblocks macOS for 0.12.0. Supersedes #973, which two independent cross-audits rejected.

## What Apple actually said

Fetched with the notary-log workflow from #971:

    "status": "Invalid",
    "statusSummary": "Archive contains critical validation errors"

14 nested Mach-O binaries, each flagged "not signed with a valid Developer ID certificate", "signature does not include a secure timestamp", "executable does not have the hardened runtime enabled": wayland-core, wayland-nano, wayland-constitution-fs, and 11 whatsapp-bridge natives (sharp .node/.dylib plus bare-fs/bare-os/bare-url prebuilds).

Apple never timed out. notarytool exits 0 even when the final status is Invalid, so the build saw only the later stapler failure and reported a transient outage, which is why three retries per attempt could never succeed.

bundled-bun and bundled-officecli are Developer ID signed by their publishers (Jarred Sumner, AionUi Inc.) and Apple accepted both. v0.11.18 carried no signIgnore, signed everything, and notarized; it also shipped zero whatsapp natives, which are new in 0.12.0.

## Approach: sign at STAGE time, not at packaging time

Each binary is signed before its digest is recorded, and mac.signIgnore is left unchanged so electron-builder never re-signs. prepareConstitutionFs already had exactly this shape; it just signed ad-hoc with --timestamp=none, which Apple rejects.

The ordering is what makes this safe. The rejected alternative, signing during packaging, breaks two things:

- wayland-constitution-fs is re-hashed at RUNTIME against an authority embedded in app.asar (constitutionFsBinary.ts). A signature applied after that digest was recorded fails every launch with CONSTITUTION_FS_BINARY_UNVERIFIED: a notarized but unlaunchable app. A regression test pins the ordering and was confirmed to fail when the signing step is moved after the digest.
- It forced the packaged gate to accept "signed by us" in place of byte equality, which permits substitution.

## Byte identity is preserved, and authenticity no longer depends on the manifest

Bundle manifests gain binary.stagedSha256, the digest of the bytes actually staged; binary.sha256 still carries the verified upstream digest, so provenance is unchanged. The gate requires the shipped bytes to equal stagedSha256 exactly, and requires the staged bytes to be either the pinned upstream bytes verbatim or a darwin-signed derivative.

The manifest ships inside the app and is not independently authenticated, so stagedSha256 alone would let an attacker swap in a different, or older but still validly signed, binary and rewrite the digest beside it. Both auditors raised exactly that. It is closed cryptographically: each binary is signed with a code-signing IDENTIFIER of the form `<binaryName>.<pinned-upstream-sha256>`, and the gate's codesign requirement asserts that identifier. The identifier lives inside the signature, so it cannot be altered without the signing key. darwinSigningIdentifier() refuses to produce one without a valid pinned digest.

The whatsapp natives are signed in the source tree before the bridge is validated and copied, so verifySourceMirror still compares source and bundle byte for byte with no exemption at all. They are detected by Mach-O magic rather than file extension, so an extensionless native cannot be skipped.

## Requirement correctness

The requirement pins the Developer ID CA and Developer ID Application marker OIDs, not just subject.OU, which alone would also accept an Apple Development or Mac Distribution certificate from the same team.

Note for reviewers: codesign -R reads a bare argument as a path to a requirement FILE, so inline requirement text must start with '='. Without it codesign exits 1 with "invalid requirement specification" and fails closed on correctly signed binaries too.

Verified by execution against real artifacts:

| check | expected | result |
|---|---|---|
| v0.11.18 wayland-core (Developer ID: Ferrox Labs) | accept | exit 0 |
| v0.12.0 wayland-core (ad-hoc) | reject | exit 3 |
| v0.12.0 bun / officecli (other publishers) | reject | exit 3 |
| matching identifier in requirement | accept | exit 0 |
| mismatched identifier | reject | exit 3 |
| Mach-O magic detection on the real bundle | .bare and .node true, package.json false | as expected |

## Tests

121 pass across the six affected suites, including a new signDarwinStagedBinary suite. The sign-before-digest ordering test was confirmed to fail when the ordering is reversed, so it genuinely catches the regression.

Unrelated and pre-existing: tests/unit/process/task/acpAgentManagerNpmFallback.test.ts fails on a machine that has wayland-nano installed at ~/.local/bin, because the test does not isolate PATH. It passes in CI.

## Follow-up, not in this PR

Our three runtimes should be Developer ID signed in their own release pipelines the way bun and OfficeCLI already are, which would remove the need to sign them here at all.