### PR TITLE
test(bun): accept a genuinely absent runtime on targets bun does not publish

### DIFF
--- a/tests/integration/bundled-bun-packaged.test.ts
+++ b/tests/integration/bundled-bun-packaged.test.ts
@@ -1,6 +1,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { describe, expect, it } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { isSupportedBunTarget } = require('../../scripts/prepareBundledBun.js') as {
+  isSupportedBunTarget: (platform: string, arch: string) => boolean;
+};
 
 function listDirsRecursive(dir: string): string[] {
   const results: string[] = [];
@@ -80,7 +86,17 @@ describe('Packaged bundled bun resources integrity', () => {
 
   runOrSkip('should include bundled-bun runtime files and valid manifest', () => {
     const bundledRoot = path.join(resourcesDir as string, 'bundled-bun');
-    expect(fs.existsSync(bundledRoot)).toBe(true);
+
+    // bun publishes no Windows-on-ARM64 binary, so that target stages NOTHING:
+    // the whole bundled-bun tree is absent, not a skipped manifest. The packaged
+    // verifier is told the same thing via --no-bun-runtime and requires genuine
+    // absence, so emitting a placeholder manifest here would contradict it.
+    // Ask the build's own predicate rather than hardcoding the target, so this
+    // stays correct the day bun starts publishing one.
+    if (!fs.existsSync(bundledRoot)) {
+      expect(isSupportedBunTarget(process.platform, process.arch)).toBe(false);
+      return;
+    }
 
     const platformDirs = fs
       .readdirSync(bundledRoot, { withFileTypes: true })


### PR DESCRIPTION
The only thing standing between attempt 9 and a published 0.12.0.

## Where attempt 9 got to

Five of six platforms green, and two firsts:

- Both macOS architectures notarized and stapled. Apple returned status: Accepted for the app and the dmg on arm64 and x64, after all 20 nested binaries were Developer ID signed at stage time. That was the blocker behind eight failed attempts.
- windows-arm64 installed and booted the packaged app for the first time ever: `silent install completed in 130s` (the old 120s budget is what had been killing it) followed by `PASS win32-arm64: identity, resources, readiness, capabilities, and clean shutdown verified`.

It then failed one step later, in `Verify packaged bundled bun assets`.

## Cause

bun publishes no Windows-on-ARM64 binary, so #969 made that target stage nothing at all: the whole bundled-bun tree is absent. The packaged verifier is told the same thing via --no-bun-runtime and requires genuine absence.

This test tolerated a SKIPPED MANIFEST, which is a state the build never produces. It asserted `fs.existsSync(bundledRoot)` before ever reaching that tolerance, so it failed on the missing directory:

    × should include bundled-bun runtime files and valid manifest
    AssertionError: expected false to be true

Emitting a placeholder manifest instead would contradict the verifier's absence requirement, so the test is what has to change.

## Change

Tolerate an absent bundled-bun tree, but only on a target bun genuinely does not publish, decided by the build's own isSupportedBunTarget predicate rather than a hardcoded platform string. It stays correct the day bun ships a Windows ARM64 build.

## This does not blanket-pass

Verified by pointing the test at an empty resources dir on darwin-arm64, where bun IS published: it fails, as it must.

    darwin-arm64 supported: true
    win32-arm64  supported: false
    win32-x64    supported: true

tsc clean.