### PR TITLE
ci: restore the pre-tag packaged-build gate

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -1,6 +1,7 @@
 # Security review (per security_reminder_hook.py):
 # This workflow uses ${{ ... }} only for trusted contexts:
 #   - matrix.* values (defined inline in this file, trusted)
+#   - needs.* outputs produced by jobs in this same file (trusted)
 #   - github.event_name, github.ref, github.workspace, runner.* (trusted)
 # No untrusted PR/issue/commit text (github.event.issue.*, head_ref, etc.)
 # is ever interpolated into a run: step.
@@ -14,6 +15,11 @@ name: Build Matrix
 # targets. It intentionally has no repository-variable skip gate.
 # Manual trigger:
 #   gh workflow run build-matrix.yml
+#
+# Deliberately NOT a branch-protection required check: every trigger here is
+# paths-filtered, and GitHub counts a SKIPPED required check as a PASS
+# (documented bypass, see pr-checks.yml lines 10-24). Making it required would
+# hand any docs-only PR a free green on the packaged-build gate.
 
 on:
   push:
@@ -43,10 +49,81 @@ env:
   NODE_OPTIONS: '--max-old-space-size=8192'
 
 jobs:
+  # scripts/build-with-builder.js writes a candidate capability seal on every
+  # packaged build, and createCapabilitySeal() refuses to run without
+  # WAYLAND_CAPABILITY_RECEIPTS_DIR ("required for an evidence-backed package
+  # build", scripts/capability-seal/verifyCandidateCapabilitySeal.js:567-570).
+  # Nothing here produced those receipts, so from the seal's introduction every
+  # leg died seconds into the packaged build and this gate was 100% red - which
+  # is why nine packaging defects were first seen at tag time. This job is the
+  # same producer the release path uses (_build-reusable.yml lines 100-161).
+  capability-acceptance:
+    name: Candidate capability acceptance
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    outputs:
+      artifact-name: ${{ steps.candidate.outputs.artifact-name }}
+
+    steps:
+      - name: Checkout exact candidate
+        uses: actions/checkout@v4
+
+      - name: Capture exact candidate
+        id: candidate
+        shell: bash
+        run: |
+          set -euo pipefail
+          commit="$(git rev-parse HEAD)"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+          if [ "${commit}" != "${GITHUB_SHA}" ]; then
+            echo "Refusing to attest a checkout that differs from the workflow's immutable source commit." >&2
+            exit 1
+          fi
+          # readReceiptAuthority() rejects a manifest whose candidate commit+tree
+          # differ from the building checkout, so the build job below must resolve
+          # to this same commit. It does: it uses a bare actions/checkout on the
+          # same push/schedule/dispatch event, which is GITHUB_SHA by definition.
+          echo "artifact-name=capability-acceptance-${commit}" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Generate structured exact capability acceptance receipts
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/capability-seal/generateCapabilityAcceptanceReceipts.js \
+            --out "${RUNNER_TEMP}/capability-acceptance"
+
+      - name: Upload capability acceptance receipts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.candidate.outputs.artifact-name }}
+          path: ${{ runner.temp }}/capability-acceptance
+          if-no-files-found: error
+          retention-days: 7
+
   build:
     name: Build (${{ matrix.release_track }} / ${{ matrix.platform }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
+    needs: capability-acceptance
+    permissions:
+      actions: read
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -149,6 +226,23 @@ jobs:
       - name: Postinstall (CI uses prebuilt binaries; see scripts/postinstall.js)
         run: bun run postinstall || true
 
+      - name: Download exact capability acceptance authority
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.capability-acceptance.outputs.artifact-name }}
+          path: ${{ runner.temp }}/capability-acceptance
+
+      # A job-level `env:` entry cannot see the `runner` context (only
+      # github/inputs/needs/matrix/strategy/secrets/vars exist there), so this is
+      # exported from a step for the same reason, and with the same expression,
+      # as _build-reusable.yml lines 249-260. Keeping the expression identical to
+      # the download path above means the two cannot drift apart.
+      - name: Export capability acceptance authority path
+        shell: bash
+        env:
+          RECEIPTS_DIR: ${{ runner.temp }}/capability-acceptance
+        run: echo "WAYLAND_CAPABILITY_RECEIPTS_DIR=${RECEIPTS_DIR}" >> "$GITHUB_ENV"
+
       - name: Cache Electron artifacts
         uses: actions/cache@v4
         with:
@@ -212,6 +306,47 @@ jobs:
             --release-track "$WAYLAND_RELEASE_TRACK" \
             --candidate-state-file "${{ runner.temp }}/wayland-package-candidate-state.json" \
             --candidate-state-digest "${{ steps.package-candidate-state.outputs.candidate_state_digest }}"
+
+      # Mirrors _build-reusable.yml lines 717-718, but pins the resources
+      # directory explicitly. The test's own fallback
+      # (tests/integration/bundled-bun-packaged.test.ts findLatestResourcesDirUnderOut)
+      # only scans ./out for a directory whose basename is exactly "resources",
+      # which misses the preview track (out-preview) and every macOS bundle
+      # (Contents/Resources, capital R). Both resolve to null and the whole file
+      # silently it.skip()s to green. Resolve the real payload here and fail loudly
+      # when there is none.
+      - name: Verify packaged bundled bun assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          resources_dir="$(node -e '
+            const fs = require("fs");
+            const path = require("path");
+            const root = path.resolve(process.env.PACKAGE_OUT_DIR);
+            const found = [];
+            (function walk(dir, depth) {
+              if (depth > 6) return;
+              let entries;
+              try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+              for (const entry of entries) {
+                if (!entry.isDirectory()) continue;
+                const child = path.join(dir, entry.name);
+                if (entry.name.toLowerCase() === "resources" && fs.existsSync(path.join(child, "app.asar"))) {
+                  found.push(child);
+                } else {
+                  walk(child, depth + 1);
+                }
+              }
+            })(root, 0);
+            if (found.length === 0) {
+              console.error("No packaged resources directory containing app.asar under " + root);
+              process.exit(1);
+            }
+            found.sort((a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs);
+            process.stdout.write(found[0]);
+          ')"
+          echo "APP_RESOURCES_DIR=$resources_dir"
+          APP_RESOURCES_DIR="$resources_dir" bun run test:packaged:bun
 
       - name: List build output
         if: always()

--- a/tests/unit/platformPackageSmoke.test.ts
+++ b/tests/unit/platformPackageSmoke.test.ts
@@ -1337,8 +1337,23 @@ describe('platform workflows cannot silently skip installed-package smoke', () =
   it('covers all build-matrix targets with exact target identity and a mandatory smoke step', () => {
     const config = workflow('build-matrix.yml');
     const job = config.jobs.build;
-    expect(job.needs).toBeUndefined();
+    // The ONLY permitted dependency is the receipts producer. Without it the
+    // packaged build aborts on "WAYLAND_CAPABILITY_RECEIPTS_DIR is required for
+    // an evidence-backed package build" and this whole gate is dead; with any
+    // other `needs` (or any `if`) a leg could silently skip instead of failing.
+    expect(job.needs).toBe('capability-acceptance');
     expect(job.if).toBeUndefined();
+    const receiptsJob = config.jobs['capability-acceptance'];
+    expect(receiptsJob.if).toBeUndefined();
+    expect(receiptsJob.needs).toBeUndefined();
+    expect(
+      receiptsJob.steps!.find((step) => step.name === 'Generate structured exact capability acceptance receipts')!.run
+    ).toContain('generateCapabilityAcceptanceReceipts.js');
+    expect(
+      receiptsJob.steps!.find((step) => step.name === 'Upload capability acceptance receipts')!.with![
+        'if-no-files-found'
+      ]
+    ).toBe('error');
     expect(job.strategy!.matrix!.release_track).toEqual(['stable', 'preview']);
     expect(job.strategy!.matrix!.platform_target).toHaveLength(6);
     expect(job.strategy!.matrix!.include!.map((entry) => `${entry.target_platform}-${entry.arch}@${entry.os}`)).toEqual(
@@ -1355,6 +1370,7 @@ describe('platform workflows cannot silently skip installed-package smoke', () =
     const capture = steps.find((step) => step.name === 'Capture pre-build packaged content state')!;
     const smoke = steps.find((step) => step.name === 'Install and smoke real package payload')!;
     const hostAssertion = steps.find((step) => step.name === 'Assert native runner identity')!;
+    const upload = steps.find((step) => step.name === 'Upload artifacts')!;
     expect(steps.indexOf(hostAssertion)).toBeLessThan(steps.indexOf(capture));
     expect(steps.indexOf(capture)).toBeLessThan(steps.findIndex((step) => step.name === 'Run packaged build'));
     expect(capture.id).toBe('package-candidate-state');
@@ -1372,10 +1388,29 @@ describe('platform workflows cannot silently skip installed-package smoke', () =
     expect(smoke.run).toContain(
       '--candidate-state-digest "${{ steps.package-candidate-state.outputs.candidate_state_digest }}"'
     );
+    const download = steps.find((step) => step.name === 'Download exact capability acceptance authority')!;
+    const exportReceipts = steps.find((step) => step.name === 'Export capability acceptance authority path')!;
+    expect(download.with!.name).toBe('${{ needs.capability-acceptance.outputs.artifact-name }}');
+    expect(download.with!.path).toBe('${{ runner.temp }}/capability-acceptance');
+    // The exported path must be the same expression the artifact landed at, or
+    // the seal reads an empty directory.
+    expect(exportReceipts.env!.RECEIPTS_DIR).toBe(download.with!.path);
+    expect(exportReceipts.run).toContain('WAYLAND_CAPABILITY_RECEIPTS_DIR=${RECEIPTS_DIR}');
+    expect(steps.indexOf(exportReceipts)).toBeGreaterThan(steps.indexOf(download));
+    expect(steps.indexOf(exportReceipts)).toBeLessThan(steps.findIndex((step) => step.name === 'Run packaged build'));
+    // Packaged bundled-bun verification must run against the real payload
+    // directory: the test's own fallback scans ./out for a lowercase
+    // "resources" basename, which silently it.skip()s on macOS bundles
+    // (Contents/Resources) and on the preview track (out-preview).
+    const bundledBun = steps.find((step) => step.name === 'Verify packaged bundled bun assets')!;
+    expect(bundledBun.if).toBeUndefined();
+    expect(bundledBun['continue-on-error']).toBeUndefined();
+    expect(bundledBun.run).toContain('APP_RESOURCES_DIR="$resources_dir" bun run test:packaged:bun');
+    expect(steps.indexOf(bundledBun)).toBeGreaterThan(steps.indexOf(smoke));
+    expect(steps.indexOf(bundledBun)).toBeLessThan(steps.indexOf(upload));
     expect(config.env!.WCORE_SKIP).toBe('0');
     expect(job.env!.WAYLAND_RELEASE_TRACK).toBe('${{ matrix.release_track }}');
     expect(job.env!.PACKAGE_OUT_DIR).toContain('out-preview');
-    const upload = steps.find((step) => step.name === 'Upload artifacts')!;
     expect(upload.with!['if-no-files-found']).toBe('error');
     expect(upload.with!.path).toContain('platform-package-smoke-*.json');
     expect(upload.with!.name).toContain('${{ matrix.release_track }}');


### PR DESCRIPTION
build-matrix.yml has been 100% red for 16 consecutive runs since 2026-08-01, and that is the root cause of v0.12.0 taking ten tag attempts.

It runs the same packaged build and platform smoke on all six native targets as the release path, on every push to main. Since commit b3cd0511a (the capability seal) every one of its twelve legs has died about two seconds in:

    Build failed: WAYLAND_CAPABILITY_RECEIPTS_DIR is required for an evidence-backed package build

The receipts are produced only by the capability-acceptance job in _build-reusable.yml, which build-matrix lacks. Confirmed live on run 31935343005; last green run was 2026-07-27. Because the gate was dead and its red ignored, the tag became the first real execution of the packaging path - so each attempt surfaced exactly one defect and hid the rest. Seven of the nine failures would have been caught here.

Changes: add the capability-acceptance job and wire it as a dependency; download the receipts and export WAYLAND_CAPABILITY_RECEIPTS_DIR before the packaged build; add the missing 'Verify packaged bundled bun assets' step to match the release path.

Deliberately NOT added to branch-protection required checks: a paths-filtered required check counts as a pass when skipped, which is the documented bypass in pr-checks.yml:10-24.

The updated tests were confirmed load-bearing by reverting the workflow and watching them fail.