### PR TITLE
fix(macos): fail the build when Apple rejects notarization

### DIFF
--- a/scripts/afterSign.js
+++ b/scripts/afterSign.js
@@ -1,6 +1,7 @@
 const { execSync } = require('child_process');
 const path = require('path');
-const { runBounded, isNotaryStall, markNotaryStalled } = require('./signingExec');
+const { runBounded, isNotaryStall, markNotaryStalled, submitToNotary, notaryRejectionError } = require('./signingExec');
+const { resolveDarwinSigningIdentity } = require('./signDarwinStagedBinary');
 
 // notarytool --wait window for the .app ticket. Kept in step with notarizeDmg's
 // (15 min): a healthy submission returns in 1-5 min, and a near-full-window burn
@@ -53,53 +54,81 @@ exports.default = async function afterSign(context) {
   // a release job stuck for hours on Apple's queue). Letting notarytool own the
   // timeout means the child always exits.
   //
-  // Any failure/timeout is non-fatal on purpose: the app stays Developer-ID
-  // signed (just not stapled), which installs with a one-time Gatekeeper prompt
-  // and can be re-released to staple once Apple's notary service recovers.
+  // A TRANSIENT failure/timeout is non-fatal on purpose: the app stays
+  // Developer-ID signed (just not stapled), which installs with a one-time
+  // Gatekeeper prompt and can be re-released to staple once Apple's notary
+  // service recovers.
+  //
+  // A REJECTION (Apple returns `status: Invalid`) is the opposite and MUST fail
+  // the build when this build had a Developer ID identity: the verdict is a
+  // judgement on these exact bytes, so "re-release later" is advice that can
+  // never work. Eight consecutive v0.12.0 release builds reported success while
+  // Apple was rejecting unsigned nested binaries, because notarytool exits 0 on
+  // a rejection and only the later stapler failure was visible — which reads as
+  // a transient outage. Builds with NO identity (local/dev/PR) keep warning and
+  // continuing, since they cannot produce a notarizable artifact at all.
+  const hasIdentity = Boolean(resolveDarwinSigningIdentity(process.env));
+  const label = `afterSign: ${appName}`;
   const zipPath = path.join(appOutDir, `${appName}-notarize.zip`);
   try {
     // notarytool requires an archive (zip/pkg/dmg), not a raw .app bundle.
     execSync(`ditto -c -k --keepParent "${appPath}" "${zipPath}"`, { stdio: 'inherit' });
 
-    // Pass the password through the environment ($NOTARYTOOL_PWD) so it never
-    // appears in this script's command string or logs.
-    const submitCmd = [
-      'xcrun notarytool submit',
-      `"${zipPath}"`,
-      `--apple-id "${appleId}"`,
-      `--team-id "${teamId}"`,
-      '--password "$NOTARYTOOL_PWD"',
-      '--wait',
-      `--timeout ${NOTARY_WAIT_TIMEOUT_MIN}m`,
-    ].join(' ');
-    const startedAt = Date.now();
-    try {
-      execSync(submitCmd, {
-        stdio: 'inherit',
-        env: { ...process.env, NOTARYTOOL_PWD: appleIdPassword },
-      });
-    } catch (submitError) {
+    // submitToNotary passes the password through the environment
+    // ($NOTARYTOOL_PWD) so it never appears in a command string or a log, and
+    // CAPTURES notarytool's transcript (re-emitting it) because Apple's verdict
+    // exists only in that text — the exit code is 0 either way.
+    const { classification, elapsedMs, failure } = submitToNotary({
+      archivePath: zipPath,
+      appleId,
+      appleIdPassword,
+      teamId,
+      waitTimeoutMin: NOTARY_WAIT_TIMEOUT_MIN,
+    });
+
+    if (classification.kind === 'rejected') {
+      // Deterministic refusal. Print Apple's own reason and stop — no retry, no
+      // stapler attempt that would mislabel this as an Apple outage.
+      throw notaryRejectionError({ classification, label, appleId, appleIdPassword, teamId, hasIdentity });
+    }
+
+    if (failure) {
       // A near-full-window failure means Apple's notary queue is stalled (not a
       // fast connection blip). Flag it so the dmg notarize that follows on the
       // same queue degrades immediately instead of burning a second full window.
-      if (isNotaryStall(Date.now() - startedAt, NOTARY_WAIT_TIMEOUT_MIN * 60000)) {
+      if (isNotaryStall(elapsedMs, NOTARY_WAIT_TIMEOUT_MIN * 60000)) {
         markNotaryStalled();
         console.warn(
           `afterSign: ${appName} notarize ran the full window before failing — Apple's notary queue is stalled; flagging so the dmg notarize degrades fast.`
         );
       }
-      throw submitError;
+      throw failure;
     }
 
     // Staple the ticket to the .app so Gatekeeper validates offline. `stapler`
     // contacts Apple's ticket servers with no client timeout, so bound it (same
     // unbounded-Apple-call class as the dmg-codesign hang that wedged v0.9.7).
-    if (!runBounded('xcrun', ['stapler', 'staple', appPath], { timeoutMs: 300000, label: `afterSign: stapling ${appName}` })) {
+    if (
+      !runBounded('xcrun', ['stapler', 'staple', appPath], {
+        timeoutMs: 300000,
+        label: `afterSign: stapling ${appName}`,
+      })
+    ) {
       throw new Error('stapler staple failed or timed out');
     }
     console.log('Notarization + stapling completed successfully');
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    if (error && error.notarizationFatal) {
+      console.error(`::error title=Notarization rejected::${message}`);
+      throw error;
+    }
+    if (error && error.notarizationRejected) {
+      console.warn(
+        `::warning title=Notarization rejected::${message} (non-fatal: this build has no Developer ID identity)`
+      );
+      return;
+    }
     console.warn(`::warning title=Notarization not completed::${message}`);
     console.warn(
       `⚠️ Continuing with a signed-but-unstapled build for ${appName}. Re-release to staple once Apple's notary service recovers.`

--- a/scripts/notarizeDmg.js
+++ b/scripts/notarizeDmg.js
@@ -1,6 +1,13 @@
-const { execSync } = require('child_process');
 const path = require('path');
-const { runBounded, isNotaryStall, markNotaryStalled, notaryStallSeen } = require('./signingExec');
+const {
+  runBounded,
+  isNotaryStall,
+  markNotaryStalled,
+  notaryStallSeen,
+  submitToNotary,
+  notaryRejectionError,
+} = require('./signingExec');
+const { resolveDarwinSigningIdentity } = require('./signDarwinStagedBinary');
 
 /**
  * afterAllArtifactBuild — notarize + staple the .dmg artifacts.
@@ -12,10 +19,16 @@ const { runBounded, isNotaryStall, markNotaryStalled, notaryStallSeen } = requir
  * perfectly notarized. That shipped once (rc.2.1). This hook closes the gap so
  * the disk image the user actually double-clicks is itself notarized.
  *
- * Mirrors afterSign's contract: failure is non-fatal and loud. The release
- * smoke gate (`scripts/release-smoke-macos.sh`) is the hard stop that refuses
- * to publish an unstapled dmg, so a transient notary stall degrades to "gate
- * blocks publish" rather than "broken dmg silently ships".
+ * Mirrors afterSign's contract: a TRANSIENT failure is non-fatal and loud. The
+ * release smoke gate (`scripts/release-smoke-macos.sh`) is the hard stop that
+ * refuses to publish an unstapled dmg, so a transient notary stall degrades to
+ * "gate blocks publish" rather than "broken dmg silently ships".
+ *
+ * A REJECTION (`status: Invalid`) fails the build outright when a Developer ID
+ * identity is present. It is a verdict on these bytes, so no amount of retrying
+ * or waiting for Apple to "recover" changes it, and letting it ride pushes the
+ * discovery all the way out to the smoke gate — which is how a v0.12.0
+ * rejection survived eight green release builds.
  *
  * @param {{ artifactPaths: string[], outDir: string }} buildResult
  */
@@ -42,6 +55,11 @@ exports.default = async function notarizeDmg(buildResult) {
     console.log('notarizeDmg: skipping — no signing identity (CSC_NAME) available');
     return;
   }
+  // Whether a notarization REJECTION should fail the build. `identity` above is
+  // only what codesign will be handed; this is the stricter read shared with the
+  // staged-binary signer (it also honours WAYLAND_DARWIN_SIGN_IDENTITY and
+  // rejects codesign's ad-hoc '-', which is exactly the state Apple refuses).
+  const hasIdentity = Boolean(resolveDarwinSigningIdentity(process.env));
 
   for (const dmg of dmgs) {
     const name = path.basename(dmg);
@@ -55,7 +73,7 @@ exports.default = async function notarizeDmg(buildResult) {
       // Without a retry a single Apple hiccup ships the dmg signed-but-unstapled
       // and the smoke gate blocks the entire release (v0.9.8 arm64 hit exactly
       // this). Retry the network-bound steps with backoff before degrading.
-      await notarizeAndStapleWithRetry({ dmg, name, appleId, appleIdPassword, teamId });
+      await notarizeAndStapleWithRetry({ dmg, name, appleId, appleIdPassword, teamId, hasIdentity });
 
       // Stapling rewrites the dmg bytes, so the updater metadata that referenced
       // the pre-staple dmg is now stale. The manifest CANNOT be repaired here:
@@ -66,6 +84,16 @@ exports.default = async function notarizeDmg(buildResult) {
       // smoke gate (verify-update-metadata.mjs) then confirms it.
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      if (error && error.notarizationFatal) {
+        console.error(`::error title=DMG notarization rejected::${name}: ${message}`);
+        throw error;
+      }
+      if (error && error.notarizationRejected) {
+        console.warn(
+          `::warning title=DMG notarization rejected::${name}: ${message} (non-fatal: this build has no Developer ID identity)`
+        );
+        continue;
+      }
       console.warn(`::warning title=DMG notarization not completed::${name}: ${message}`);
       console.warn(
         `⚠️ ${name} ships signed-but-unstapled. The release smoke gate will block publishing it — re-run once Apple's notary recovers.`
@@ -125,7 +153,7 @@ function shouldRetryNotarization({ attempt, maxAttempts, elapsedMs, waitTimeoutM
  * giving up, so the caller still degrades to "signed-but-unstapled" and the
  * smoke gate makes the final call.
  */
-async function notarizeAndStapleWithRetry({ dmg, name, appleId, appleIdPassword, teamId }) {
+async function notarizeAndStapleWithRetry({ dmg, name, appleId, appleIdPassword, teamId, hasIdentity }) {
   // If the .app notarize (afterSign) just hit a stall, the .dmg submission lands
   // on the SAME slow queue seconds later — don't re-burn three windows
   // rediscovering it; take one shot in case it cleared, then degrade.
@@ -135,36 +163,51 @@ async function notarizeAndStapleWithRetry({ dmg, name, appleId, appleIdPassword,
   }
   const backoffMs = 60000;
   const waitTimeoutMs = NOTARY_WAIT_TIMEOUT_MIN * 60000;
-  const submitCmd = [
-    'xcrun notarytool submit',
-    `"${dmg}"`,
-    `--apple-id "${appleId}"`,
-    `--team-id "${teamId}"`,
-    '--password "$NOTARYTOOL_PWD"',
-    '--wait',
-    `--timeout ${NOTARY_WAIT_TIMEOUT_MIN}m`,
-  ].join(' ');
 
   let lastError;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    const startedAt = Date.now();
+    let elapsedMs = 0;
     try {
       console.log(`notarizeDmg: submitting ${name} to Apple notary service (attempt ${attempt}/${maxAttempts})…`);
-      execSync(submitCmd, {
-        stdio: 'inherit',
-        env: { ...process.env, NOTARYTOOL_PWD: appleIdPassword },
+      const submitted = submitToNotary({
+        archivePath: dmg,
+        appleId,
+        appleIdPassword,
+        teamId,
+        waitTimeoutMin: NOTARY_WAIT_TIMEOUT_MIN,
       });
+      elapsedMs = submitted.elapsedMs;
+
+      if (submitted.classification.kind === 'rejected') {
+        // Apple judged these bytes and refused them. Retrying spends windows on
+        // a verdict that cannot change, so surface Apple's reason and stop.
+        throw notaryRejectionError({
+          classification: submitted.classification,
+          label: `notarizeDmg: ${name}`,
+          appleId,
+          appleIdPassword,
+          teamId,
+          hasIdentity,
+        });
+      }
+      if (submitted.failure) {
+        throw submitted.failure;
+      }
 
       // Staple the ticket so Gatekeeper validates the dmg offline. `stapler`
       // contacts Apple's ticket servers with no client timeout, so bound it too.
-      if (!runBounded('xcrun', ['stapler', 'staple', dmg], { timeoutMs: 300000, label: `notarizeDmg: stapling ${name}` })) {
+      if (
+        !runBounded('xcrun', ['stapler', 'staple', dmg], { timeoutMs: 300000, label: `notarizeDmg: stapling ${name}` })
+      ) {
         throw new Error(`stapler staple failed or timed out for ${name}`);
       }
       console.log(`notarizeDmg: stapled ${name}`);
       return;
     } catch (error) {
+      if (error && error.notarizationRejected) {
+        throw error;
+      }
       lastError = error;
-      const elapsedMs = Date.now() - startedAt;
       const message = error instanceof Error ? error.message : String(error);
       // A near-full-window failure is a stalled queue — record it so any later
       // notarize call short-circuits, and stop retrying here.
@@ -234,4 +277,3 @@ function signDmgNoTimestamp(identity, dmg) {
 
 // Exported for unit testing the retry policy without spawning notarytool.
 exports.shouldRetryNotarization = shouldRetryNotarization;
-

--- a/scripts/signingExec.js
+++ b/scripts/signingExec.js
@@ -1,4 +1,4 @@
-const { execFileSync } = require('child_process');
+const { execFileSync, execSync } = require('child_process');
 
 /**
  * Run a signing / notarization CLI with a HARD timeout.
@@ -84,6 +84,183 @@ function resetNotaryStalled() {
   notaryStalled = false;
 }
 
+/**
+ * Apple's terminal `status:` values that mean the submission was JUDGED and
+ * REFUSED. These are deterministic: the same bytes resubmitted get the same
+ * verdict, so retrying or "re-running once Apple recovers" can never help.
+ *
+ * This distinction is the whole point of this module's notarize helpers.
+ * `xcrun notarytool submit --wait` EXITS 0 on a rejection — it reports "I
+ * successfully obtained a verdict", not "the verdict was good". So an
+ * exit-code-only reading sees success, proceeds to `stapler`, and surfaces the
+ * failure as a stapler error, which looks exactly like a transient Apple
+ * outage. Eight consecutive v0.12.0 release builds went green that way while
+ * Apple was returning `status: Invalid` for unsigned nested binaries.
+ */
+const NOTARY_REJECTED_STATUSES = new Set(['invalid', 'rejected']);
+
+/**
+ * Pull the submission id and the final status out of a notarytool transcript.
+ *
+ * notarytool prints the id under several sections ("Submission ID received",
+ * "Successfully uploaded file", "Processing complete") — all the same uuid, so
+ * the first match is taken. The final verdict is the LAST `status:` line: with
+ * `--wait` the tool also prints interim `Current status: In Progress` lines.
+ *
+ * @param {string} output combined stdout+stderr of the notarytool run
+ * @returns {{ submissionId: string | null, status: string | null }}
+ */
+function parseNotarytoolOutput(output) {
+  const text = typeof output === 'string' ? output : '';
+  const idMatch = text.match(/^[^\S\n]*id:[^\S\n]*([0-9a-fA-F-]{36})[^\S\n]*$/m);
+  const statusMatches = text.match(/^[^\S\n]*status:[^\S\n]*(.+?)[^\S\n]*$/gm);
+  let status = null;
+  if (statusMatches && statusMatches.length > 0) {
+    const last = statusMatches[statusMatches.length - 1];
+    status = last.replace(/^[^\S\n]*status:[^\S\n]*/, '').trim() || null;
+  }
+  return { submissionId: idMatch ? idMatch[1] : null, status };
+}
+
+/**
+ * Classify one notarize attempt as `accepted`, `rejected` or `transient`.
+ *
+ * `rejected` requires Apple to have actually returned a terminal refusal
+ * status. Anything else — a connection blip, a queue stall, notarytool giving
+ * up on its own `--timeout`, an output shape we don't recognise — stays
+ * `transient` so the existing retry/backoff and degrade-with-a-warning
+ * behaviour is preserved unchanged.
+ *
+ * @param {{ output?: string, elapsedMs?: number, waitTimeoutMs?: number }} p
+ * @returns {{ kind: 'accepted'|'rejected'|'transient', status: string|null, submissionId: string|null, stalled: boolean }}
+ */
+function classifyNotarizationOutcome({ output, elapsedMs = 0, waitTimeoutMs = Number.POSITIVE_INFINITY } = {}) {
+  const { submissionId, status } = parseNotarytoolOutput(output);
+  const normalized = status ? status.toLowerCase() : null;
+  const stalled = isNotaryStall(elapsedMs, waitTimeoutMs);
+  if (normalized === 'accepted') {
+    return { kind: 'accepted', status, submissionId, stalled: false };
+  }
+  if (normalized && NOTARY_REJECTED_STATUSES.has(normalized)) {
+    return { kind: 'rejected', status, submissionId, stalled: false };
+  }
+  return { kind: 'transient', status, submissionId, stalled };
+}
+
+/**
+ * A rejection is only a BUILD FAILURE when this build had a real Developer ID
+ * identity to sign with. Local, dev and fork-PR builds have no identity, cannot
+ * produce a notarizable artifact by construction, and must stay usable — they
+ * keep the historic warn-and-continue behaviour.
+ *
+ * @param {{ kind: string, hasIdentity: boolean }} p
+ * @returns {boolean}
+ */
+function isNotarizationFatal({ kind, hasIdentity }) {
+  return kind === 'rejected' && Boolean(hasIdentity);
+}
+
+/**
+ * Print Apple's own reason for a rejection (`xcrun notarytool log <id>`).
+ *
+ * Without this the cause is unrecoverable after the build: the notarize
+ * transcript says only "Invalid", and the submission ages out of
+ * `notarytool history`. Diagnosing the v0.12.0 rejection took eight release
+ * attempts for exactly this reason. Best-effort and never throws — the caller
+ * is already failing the build and must not lose the primary error.
+ */
+function printNotarizationLog({ submissionId, appleId, appleIdPassword, teamId }) {
+  if (!submissionId) {
+    console.error(
+      'notarize: Apple returned no submission id, so the rejection log cannot be fetched. Run `xcrun notarytool history` to locate the submission.'
+    );
+    return;
+  }
+  const cmd = [
+    'xcrun notarytool log',
+    `"${submissionId}"`,
+    `--apple-id "${appleId}"`,
+    `--team-id "${teamId}"`,
+    '--password "$NOTARYTOOL_PWD"',
+  ].join(' ');
+  try {
+    const log = execSync(`${cmd} 2>&1`, {
+      encoding: 'utf8',
+      env: { ...process.env, NOTARYTOOL_PWD: appleIdPassword },
+      timeout: 120000,
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    console.error(`notarize: Apple's rejection log for submission ${submissionId}:\n${log}`);
+  } catch (error) {
+    console.error(`notarize: could not fetch the rejection log for ${submissionId}: ${error && error.message}`);
+  }
+}
+
+/**
+ * Submit an archive to Apple's notary service and classify the outcome.
+ *
+ * The password is passed through the environment ($NOTARYTOOL_PWD) so it never
+ * appears in a command string or a log. Output is CAPTURED (and echoed) rather
+ * than inherited, because the verdict only exists in that text — see
+ * NOTARY_REJECTED_STATUSES.
+ *
+ * @returns {{ classification: object, elapsedMs: number, failure: Error|null, output: string }}
+ */
+function submitToNotary({ archivePath, appleId, appleIdPassword, teamId, waitTimeoutMin }) {
+  const submitCmd = [
+    'xcrun notarytool submit',
+    `"${archivePath}"`,
+    `--apple-id "${appleId}"`,
+    `--team-id "${teamId}"`,
+    '--password "$NOTARYTOOL_PWD"',
+    '--wait',
+    `--timeout ${waitTimeoutMin}m`,
+  ].join(' ');
+
+  const startedAt = Date.now();
+  let output = '';
+  let failure = null;
+  try {
+    output = execSync(`${submitCmd} 2>&1`, {
+      encoding: 'utf8',
+      env: { ...process.env, NOTARYTOOL_PWD: appleIdPassword },
+      maxBuffer: 16 * 1024 * 1024,
+    });
+  } catch (error) {
+    failure = error instanceof Error ? error : new Error(String(error));
+    output = `${(error && error.stdout) || ''}${(error && error.stderr) || ''}`;
+  }
+  const elapsedMs = Date.now() - startedAt;
+  // stdio was piped to read the verdict, so re-emit the transcript ourselves.
+  if (output) {
+    process.stdout.write(output.endsWith('\n') ? output : `${output}\n`);
+  }
+  return {
+    classification: classifyNotarizationOutcome({ output, elapsedMs, waitTimeoutMs: waitTimeoutMin * 60000 }),
+    elapsedMs,
+    failure,
+    output,
+  };
+}
+
+/**
+ * Build the Error for a deterministic rejection, after printing Apple's reason.
+ *
+ * `notarizationRejected` tells the retry loop not to spend more windows on a
+ * verdict that cannot change. `notarizationFatal` tells the outer handler to
+ * fail the build instead of degrading to a `::warning`.
+ */
+function notaryRejectionError({ classification, label, appleId, appleIdPassword, teamId, hasIdentity }) {
+  printNotarizationLog({ submissionId: classification.submissionId, appleId, appleIdPassword, teamId });
+  const error = new Error(
+    `${label}: Apple notarization returned status "${classification.status}" (submission ${classification.submissionId || 'unknown'}). ` +
+      'That is a deterministic rejection of these bytes, not a transient outage — re-running produces the same verdict until the cause in the log above is fixed.'
+  );
+  error.notarizationRejected = true;
+  error.notarizationFatal = isNotarizationFatal({ kind: classification.kind, hasIdentity });
+  return error;
+}
+
 module.exports = {
   runBounded,
   NOTARY_STALL_FRACTION,
@@ -91,4 +268,11 @@ module.exports = {
   markNotaryStalled,
   notaryStallSeen,
   resetNotaryStalled,
+  NOTARY_REJECTED_STATUSES,
+  parseNotarytoolOutput,
+  classifyNotarizationOutcome,
+  isNotarizationFatal,
+  printNotarizationLog,
+  submitToNotary,
+  notaryRejectionError,
 };

--- a/tests/unit/notarizationClassification.test.ts
+++ b/tests/unit/notarizationClassification.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import signingExec = require('../../scripts/signingExec.js');
+
+type Classification = {
+  kind: 'accepted' | 'rejected' | 'transient';
+  status: string | null;
+  submissionId: string | null;
+  stalled: boolean;
+};
+
+const { parseNotarytoolOutput, classifyNotarizationOutcome, isNotarizationFatal } = signingExec as {
+  parseNotarytoolOutput: (output: string) => { submissionId: string | null; status: string | null };
+  classifyNotarizationOutcome: (p: { output?: string; elapsedMs?: number; waitTimeoutMs?: number }) => Classification;
+  isNotarizationFatal: (p: { kind: string; hasIdentity: boolean }) => boolean;
+};
+
+const SUBMISSION_ID = '2efe2717-52ef-43a5-96dc-0797e4ca1041';
+
+/** A real `xcrun notarytool submit --wait` transcript, verdict parameterised. */
+function transcript(status: string): string {
+  return [
+    'Conducting pre-submission checks for Wayland-notarize.zip and initiating connection to the Apple notary service...',
+    'Submission ID received',
+    `  id: ${SUBMISSION_ID}`,
+    'Upload progress: 100.00% (182 MB of 182 MB)',
+    'Successfully uploaded file',
+    `  id: ${SUBMISSION_ID}`,
+    '  path: /tmp/Wayland-notarize.zip',
+    'Waiting for processing to complete.',
+    'Current status: In Progress....',
+    'Processing complete',
+    `  id: ${SUBMISSION_ID}`,
+    `  status: ${status}`,
+    '',
+  ].join('\n');
+}
+
+// notarytool runs with `--timeout 15m`.
+const WAIT_MS = 15 * 60_000;
+
+describe('parseNotarytoolOutput', () => {
+  it('extracts the submission id and the FINAL status, not the interim one', () => {
+    // Without the submission id, `xcrun notarytool log <id>` cannot be run and
+    // Apple's actual reason is unrecoverable after the build ends.
+    expect(parseNotarytoolOutput(transcript('Invalid'))).toEqual({
+      submissionId: SUBMISSION_ID,
+      status: 'Invalid',
+    });
+  });
+
+  it('returns nulls when notarytool never got far enough to print a verdict', () => {
+    expect(parseNotarytoolOutput('Error: HTTP status code: 503. Service Unavailable')).toEqual({
+      submissionId: null,
+      status: null,
+    });
+  });
+});
+
+describe('classifyNotarizationOutcome', () => {
+  it('classifies `status: Invalid` as a REJECTION even though notarytool exits 0', () => {
+    // This is the v0.12.0 failure: notarytool exits 0 on a rejection, so an
+    // exit-code reading saw success and only the later stapler error surfaced.
+    const outcome = classifyNotarizationOutcome({
+      output: transcript('Invalid'),
+      elapsedMs: 90_000,
+      waitTimeoutMs: WAIT_MS,
+    });
+    expect(outcome.kind).toBe('rejected');
+    expect(outcome.submissionId).toBe(SUBMISSION_ID);
+    expect(outcome.status).toBe('Invalid');
+  });
+
+  it('classifies `status: Rejected` as a REJECTION', () => {
+    expect(classifyNotarizationOutcome({ output: transcript('Rejected') }).kind).toBe('rejected');
+  });
+
+  it('classifies `status: Accepted` as accepted', () => {
+    expect(classifyNotarizationOutcome({ output: transcript('Accepted') }).kind).toBe('accepted');
+  });
+
+  it('classifies a fast connection blip as TRANSIENT, so the retry policy still applies', () => {
+    const outcome = classifyNotarizationOutcome({
+      output: 'Error: NSURLErrorDomain Code=-1001 "The request timed out."',
+      elapsedMs: 4_000,
+      waitTimeoutMs: WAIT_MS,
+    });
+    expect(outcome.kind).toBe('transient');
+    expect(outcome.stalled).toBe(false);
+  });
+
+  it('classifies a burned-window stall as TRANSIENT and flags it stalled', () => {
+    // Apple's queue stalling must keep degrading with a warning — that is the
+    // deliberate existing behaviour and must not become fatal.
+    const outcome = classifyNotarizationOutcome({
+      output: 'Waiting for processing to complete.\nCurrent status: In Progress....',
+      elapsedMs: 14 * 60_000,
+      waitTimeoutMs: WAIT_MS,
+    });
+    expect(outcome.kind).toBe('transient');
+    expect(outcome.stalled).toBe(true);
+  });
+});
+
+describe('isNotarizationFatal', () => {
+  it('FAILS the build on a rejection when a Developer ID identity is present', () => {
+    expect(isNotarizationFatal({ kind: 'rejected', hasIdentity: true })).toBe(true);
+  });
+
+  it('stays non-fatal on a rejection with NO identity (local / dev / PR builds)', () => {
+    expect(isNotarizationFatal({ kind: 'rejected', hasIdentity: false })).toBe(false);
+  });
+
+  it('stays non-fatal for a transient failure even with an identity', () => {
+    expect(isNotarizationFatal({ kind: 'transient', hasIdentity: true })).toBe(false);
+    expect(isNotarizationFatal({ kind: 'accepted', hasIdentity: true })).toBe(false);
+  });
+});


### PR DESCRIPTION
Apple returned 'status: Invalid' - a deterministic rejection of unsigned nested binaries - on eight consecutive release attempts, and every one of those builds reported success.

Two behaviours combined to hide it. notarytool exits 0 even when the final status is Invalid, so the code only ever saw the subsequent stapler failure; and afterSign.js degraded any notarization outcome to a warning, advising a re-run 'once Apple's notary service recovers'. For a deterministic rejection that advice is wrong and the built-in retries cannot succeed. The rejection surfaced only much later, at the release smoke gate.

Changes: distinguish a rejection (Apple returns Invalid) from a genuine transient failure (network error, queue stall, timeout). When a Developer ID identity is present, a rejection now fails the build. Transient failures keep the existing warn-and-degrade behaviour and the existing retry policy, both deliberate and documented. Builds with no identity - local, forks, PRs without secrets - are unaffected. On a rejection the build now fetches and prints Apple's own reason via notarytool log, which is what made this take eight attempts to diagnose.

29 tests across the four affected files pass. The classification tests were confirmed load-bearing: emptying the rejected-status set and forcing the fatal check to false produces 3 failures. Fail-open path traced - an unrecognised transcript still degrades to transient exactly as before, never worse.