### PR TITLE
fix: ship the Windows portable zip (#941) and stop broadcasting cost events to paired devices (#987)

### DIFF
--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -795,7 +795,7 @@ jobs:
             out/*.deb
             out/*.AppImage
             out/*.rpm
-            out/Wayland-*-win32-*.zip
+            out/Wayland-*-win-*.zip
             out/Wayland-*-mac-*.zip
             out/*.yml
             out/*.blockmap

--- a/src/common/adapter/bridgeAllowlist.budgets.bun.test.ts
+++ b/src/common/adapter/bridgeAllowlist.budgets.bun.test.ts
@@ -8,7 +8,7 @@
 // cost.* namespace is denied by prefix - this locks that in against drift.
 
 import { describe, it, expect } from 'bun:test';
-import { isAllowedForRemote } from './bridgeAllowlist';
+import { isAllowedForRemote, isAllowedOutboundToRemote } from './bridgeAllowlist';
 
 describe('bridgeAllowlist - cost budget keys are remote-denied', () => {
   const deniedKeys = [
@@ -30,5 +30,32 @@ describe('bridgeAllowlist - cost budget keys are remote-denied', () => {
 
   it('still allows a non-cost provider', () => {
     expect(isAllowedForRemote('subscribe-cron.list-jobs')).toBe(true);
+  });
+});
+
+// #987: the same keys must also never be BROADCAST outbound to a paired device.
+// cost.budgetAlert and cost.budgetGateBlocked are real emitters; budgetGateBlocked
+// carries the held user message body. The outbound rule is derived from the
+// inbound one, so this asserts the lockstep rather than a second list.
+describe('bridgeAllowlist - cost budget emitters are never broadcast to remote peers', () => {
+  const deniedOutbound = [
+    'cost.budgetAlert',
+    'cost.budgetGateBlocked',
+    'cost.upsertBudget',
+    'cost.deleteBudget',
+    'cost.listBudgets',
+    'cost.byConversation',
+    'cost.series',
+    'cost.summary',
+  ];
+
+  for (const key of deniedOutbound) {
+    it(`never broadcasts ${key}`, () => {
+      expect(isAllowedOutboundToRemote(key)).toBe(false);
+    });
+  }
+
+  it('still broadcasts a non-cost emitter', () => {
+    expect(isAllowedOutboundToRemote('conversation.list-changed')).toBe(true);
   });
 });

--- a/src/common/adapter/bridgeAllowlist.ts
+++ b/src/common/adapter/bridgeAllowlist.ts
@@ -231,8 +231,15 @@ const REMOTE_DENIED_KEYS: ReadonlySet<string> = new Set([
   'wcoreToolKeys.delete',
   // --- Wayland Core engine config.toml mutation (rewrite tool allow-list /
   //     sandbox policy / env passthrough). A remote caller reaching this could
-  //     disable the sandbox or force-allow secrets into bash (SEC-6). ---
-  'wcoreConfig.setSection',
+  //     disable the sandbox or force-allow secrets into bash (SEC-6).
+  //
+  //     #987: a `wcoreConfig.setSection` entry used to head this group. No such
+  //     provider is registered — `setSection()` is a MAIN-process helper in
+  //     src/process/agent/wcore/configBridge.ts that the typed providers below
+  //     call; it never crosses the wire. Matching here is exact, so the entry
+  //     could never fire: it was protection that protected nothing, the same
+  //     failure the agent-installer note further down warns about. The real
+  //     wire surface is the typed setters, all of which are denied. ---
   'wcoreConfig.patchField',
   'wcoreConfig.setBrowserPolicy',
   'wcoreConfig.setRawEngineMode',
@@ -262,7 +269,7 @@ const REMOTE_DENIED_KEYS: ReadonlySet<string> = new Set([
   //     would spawn a Force/AutoEdit-mode agent with NO local user action. There
   //     is no per-call remote/local signal inside a buildProvider handler (remote
   //     enforcement is name-based here), so mode cannot be clamped in-handler;
-  //     deny the write/exec surface outright, mirroring `wcoreConfig.setSection`.
+  //     deny the write/exec surface outright, mirroring `wcoreConfig.patchField`.
   //     add-job/update-job set the mode; run-now fires the agent (exec);
   //     save-skill writes the job's SKILL.md verbatim (validated only for YAML
   //     frontmatter shape, NOT instruction content), so a remote caller could
@@ -580,25 +587,35 @@ export function isRemoteDeniedConfigWrite(name: string, data: unknown): boolean 
 }
 
 /**
- * Emitter/broadcast (main -> client) names that must NOT be forwarded to a
- * remote WebSocket peer. Inbound denial (isAllowedForRemote) stops a peer
+ * True iff an emitter `name` (main -> client) may be broadcast to a remote
+ * WebSocket peer. Inbound denial ({@link isAllowedForRemote}) stops a peer
  * INVOKING a provider; this stops a peer passively RECEIVING an emitter stream.
  *
- * #645: terminal.output / terminal.exit carry the live PTY stream (command
- * output, file contents, whatever the agent CLI prints). The terminal is
- * local-only, so a paired peer must never receive it even though it can never
- * spawn/drive one. The local Electron renderer is unaffected — it receives
- * emitters over the in-process IPC adapter, not this WS broadcast path.
+ * #987: this used to be a SECOND hand-maintained prefix list (`['terminal.']`),
+ * and a second hand-maintained list is exactly how it drifted. The inbound rule
+ * grew a `cost.` deny — the whole namespace, because those methods disclose
+ * spend — and the outbound rule did not, so `cost.budgetAlert` and
+ * `cost.budgetGateBlocked` were still broadcast to every paired device.
+ * budgetGateBlocked carries the HELD USER MESSAGE BODY (`content`, plus the
+ * attached file paths), not just a number.
+ *
+ * The fix is structural rather than one more entry: the outbound rule is now
+ * DERIVED from the inbound one, which is the single source of truth. The
+ * invariant is that a namespace a paired peer may not INVOKE is a namespace it
+ * may not RECEIVE either, so any future addition to REMOTE_DENIED_PREFIXES /
+ * REMOTE_DENIED_KEYS is denied in both directions by construction and the two
+ * rules cannot drift apart again.
+ *
+ * #645 (terminal.output / terminal.exit, the live PTY stream) is preserved by
+ * the derived `terminal.` namespace. The local Electron renderer is unaffected
+ * — it receives emitters over the in-process IPC adapter, not this WS broadcast
+ * path.
  */
-const REMOTE_OUTBOUND_DENIED_PREFIXES: readonly string[] = ['terminal.'];
-
-/** True iff an emitter `name` may be broadcast to remote WS peers. */
 export function isAllowedOutboundToRemote(name: string): boolean {
   if (typeof name !== 'string' || name.length === 0) return false;
-  for (const prefix of REMOTE_OUTBOUND_DENIED_PREFIXES) {
-    if (name.startsWith(prefix)) return false;
-  }
-  return true;
+  // Emitter names carry no `subscribe-` transport prefix, so re-add it and
+  // reuse the inbound predicate verbatim instead of re-implementing the match.
+  return isAllowedForRemote(`subscribe-${name}`);
 }
 
 /**

--- a/tests/unit/bridgeAllowlistCost.redteam.test.ts
+++ b/tests/unit/bridgeAllowlistCost.redteam.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isAllowedForRemote } from '@/common/adapter/bridgeAllowlist';
+import { isAllowedForRemote, isAllowedOutboundToRemote } from '@/common/adapter/bridgeAllowlist';
 
 /**
  * WS-D / R4: cost observability has no remote (paired-device WebSocket) view
@@ -32,5 +32,52 @@ describe('isAllowedForRemote - cost.* denied to remote callers', () => {
   // paired WebUI legitimately needs stays allowed (denylist, not whitelist).
   it('still allows a read-only sibling namespace for remote callers', () => {
     expect(isAllowedForRemote('subscribe-usage.queryFrequentlyUsedModels')).toBe(true);
+  });
+});
+
+/**
+ * #987: the OUTBOUND broadcast gate used to carry its own hand-maintained prefix
+ * list (`['terminal.']`) and had drifted away from the inbound rule above, so
+ * every cost.* EMITTER was still pushed to paired devices even though every
+ * cost.* PROVIDER was denied. `cost.budgetGateBlocked` in particular carries the
+ * held user message body (`content`) and its attached file paths.
+ *
+ * Assert the outbound denial for every key the inbound suite covers, so the two
+ * directions can never diverge again.
+ */
+describe('isAllowedOutboundToRemote - cost.* never broadcast to remote peers (#987)', () => {
+  const inboundDeniedKeys: ReadonlyArray<string> = [
+    'cost.summary',
+    'cost.byModel',
+    'cost.byBackend',
+    'cost.byTeam',
+    'cost.byConversation',
+    'cost.series',
+    'cost.upsertBudget',
+    'cost.deleteBudget',
+    // Covered by the bun budgets suite (src/common/adapter/bridgeAllowlist.budgets.bun.test.ts).
+    'cost.listBudgets',
+    // The two REAL emitters that were leaking (ipcBridge.ts cost.budgetAlert /
+    // cost.budgetGateBlocked).
+    'cost.budgetAlert',
+    'cost.budgetGateBlocked',
+  ];
+
+  it.each(inboundDeniedKeys)('never broadcasts %s to a remote peer', (key) => {
+    expect(isAllowedOutboundToRemote(key)).toBe(false);
+  });
+
+  // The invariant, stated directly: inbound-denied implies outbound-denied.
+  it.each(inboundDeniedKeys)('keeps outbound denial in lockstep with inbound for %s', (key) => {
+    expect(isAllowedForRemote(`subscribe-${key}`)).toBe(false);
+    expect(isAllowedOutboundToRemote(key)).toBe(false);
+  });
+
+  // Still a denylist, not a whitelist: the emitters a paired device needs remain
+  // broadcastable (these are the ones the #645 terminal suite already pins).
+  it('still broadcasts emitters a paired device legitimately needs', () => {
+    expect(isAllowedOutboundToRemote('chat.response.stream')).toBe(true);
+    expect(isAllowedOutboundToRemote('conversation.list-changed')).toBe(true);
+    expect(isAllowedOutboundToRemote('project.changed')).toBe(true);
   });
 });


### PR DESCRIPTION
Two small, independently-committed fixes.

## 1. #941 - the Windows portable zip was built and then discarded

The artifact upload step in _build-reusable.yml globbed out/Wayland-*-win32-*.zip. electron-builder's ${os} macro expands to "win" for Windows (and "mac" for macOS), and electron-builder.yml sets

    artifactName: ${productName}-${version}-${os}-${arch}.${ext}

so the real file is Wayland-<version>-win-<arch>.zip. The glob never matched. The mac line beside it matched because "mac" is already the ${os} value - which is exactly why v0.12.0 shipped both mac zips and no win zip while the Windows runner log shows the 572 MB file existing before upload.

One line changed.

### Verified, not assumed - no other place has the same mismatch

- scripts/prepare-release-assets.sh collects distributables with a generic -name "*.zip" find, so it passes any win zip through.
- The release step in build-and-release.yml lists release-assets/**/*.zip, also generic.
- build-matrix.yml uses $PACKAGE_OUT_DIR/*.zip, also generic.
- The remaining win32 strings in .github/ are matrix target_platform values (the Node platform string, correct there) and a prebuild-install --platform=win32 flag (also correct). None are filename globs.

No test asserts on this glob, so no test expectations were changed. Worth noting separately: scripts/verify-release-assets.sh checks for the .exe / .dmg / .deb distributables but never for a zip, which is why nothing caught the missing asset. Left alone here rather than widened mid-fix.

## 2. #987 - the outbound broadcast gate denied too little

src/common/adapter/bridgeAllowlist.ts had two rules for the same paired-device peer:

- inbound (isAllowedForRemote) denies the ENTIRE cost.* namespace, because those methods disclose spend
- outbound (isAllowedOutboundToRemote) denied only terminal.*, via its own separate hand-maintained prefix list

So cost.budgetAlert and cost.budgetGateBlocked - both real emitters registered in ipcBridge.ts - were broadcast to every paired remote device. BudgetGateBlocked is not a number: its payload is { conversationId, content, files, budgetId, scope, limitUsd, spentUsd, period } where content is the held user message body and files are its attachment paths.

### Fix is structural, not another entry

Adding 'cost.' to the second list would repeat the mistake that caused the bug. Instead isAllowedOutboundToRemote now delegates to isAllowedForRemote, re-adding the subscribe- transport prefix that emitter names do not carry:

    return isAllowedForRemote(`subscribe-${name}`);

The invariant: a namespace a paired peer may not INVOKE is a namespace it may not RECEIVE either. There is now one source of truth, so a future addition to REMOTE_DENIED_PREFIXES or REMOTE_DENIED_KEYS is denied in both directions by construction and the two rules cannot drift apart again.

### What stops reaching paired devices (checked against the real emitter set)

Enumerated all 55 buildEmitter registrations in src/ and evaluated both the old and new rule:

Newly denied outbound:
- cost.budgetAlert
- cost.budgetGateBlocked
- hub.state-changed

Still denied (unchanged): terminal.output, terminal.exit.
Unchanged and still broadcast: the other 50, including chat.response.stream, conversation.list-changed, project.changed, confirmation.*, team.*, channel.*-changed.

hub.state-changed is the one widening beyond the reported bug. It is safe: all six hub.* providers (get-extension-list, install, uninstall, update, retry-install, check-updates) are already inbound-denied, so a paired WebUI can neither enumerate nor act on hub state - the event was unusable to it and only disclosed the local extension inventory plus install status. Consistent with the namespace already being local-only in the other direction.

### Also removed: a denylist entry that protected nothing

'wcoreConfig.setSection' sat at the head of the engine-config group in REMOTE_DENIED_KEYS. No such provider is registered. setSection() is a MAIN-process helper in src/process/agent/wcore/configBridge.ts that the typed wire providers call internally; it never crosses IPC. REMOTE_DENIED_KEYS matches exactly, so the entry could never fire - it is the same failure the agent-installer comment further down in the same file warns about in capitals. The real wire surface (wcoreConfig.patchField, setBrowserPolicy, setRawEngineMode, setOutputBudget, plus the getSection/getBrowserPolicy/getEffectiveRuntime reads) stays denied, and a stale comment elsewhere in the file that referenced setSection as the exemplar now points at patchField.

## Verification

New tests were added to both existing homes for this invariant and were confirmed RED before the fix and GREEN after.

Before (source reverted to the pre-fix outbound rule, new tests in place):

    bun test src/common/adapter/bridgeAllowlist.budgets.bun.test.ts
     9 pass
     8 fail
    Ran 17 tests across 1 file.

    bunx vitest run tests/unit/bridgeAllowlist
     Test Files  1 failed | 9 passed (10)
          Tests  22 failed | 127 passed (149)

    AssertionError: expected true to be false
     tests/unit/bridgeAllowlistCost.redteam.test.ts:73:44
     expect(isAllowedOutboundToRemote(key)).toBe(false);

After:

    bun test src/common/adapter/bridgeAllowlist.budgets.bun.test.ts
     17 pass
     0 fail

    bunx vitest run tests/unit/bridgeAllowlist
     Test Files  10 passed (10)
          Tests  149 passed (149)

Wider run over everything that touches the allowlist, the WS adapter, and the workflow-structure assertions (tests/unit/bridgeAllowlist*, tests/unit/webserver, tests/unit/documentBridge, tests/unit/standaloneAdapter, tests/unit/process/bridge, tests/unit/process/utils/initBridgeStandalone, tests/unit/releasePackaging, tests/unit/platformPackageSmoke, tests/unit/scripts):

    Test Files  103 passed (103)
         Tests  1112 passed (1112)

    bunx tsc --noEmit
    (clean, exit 0)

No existing test was relaxed, skipped or deleted.

Fixes #941
Fixes #987
