### PR TITLE
fix(webui): reject remote-denied bridge calls instead of white-screening

### DIFF
--- a/src/common/adapter/bridgeAllowlist.ts
+++ b/src/common/adapter/bridgeAllowlist.ts
@@ -66,16 +66,106 @@ const CONTROL_ALLOWED: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Wrap `bridge.buildProvider` so every declared provider key is recorded.
+ * Thrown by a bridge `invoke()` when the call cannot reach its provider on the
+ * transport this renderer is using (#979).
  *
- * Returned object is identical in shape and behavior to the platform's
- * `buildProvider` - this is a pure side-effect wrapper.
+ * The platform's `invoke()` is RESOLVE-ONLY: it settles a call only when
+ * `subscribe.callback-<key><id>` arrives, and there is no reject path and no
+ * timeout in the wire protocol. The WS dispatcher therefore answers a
+ * remote-denied call with an error ENVELOPE (`settleRejectedInvoke`,
+ * src/process/webserver/adapter.ts) so the caller settles instead of hanging -
+ * which means the renderer receives a NON-NULL object where it expected data,
+ * every `?? []` / `?? default` is skipped, and the next `.find()` / `.slice()`
+ * throws in render phase and blanks the app via the root ErrorBoundary.
+ *
+ * This error restores the missing failure channel on the client side: a call
+ * that cannot succeed rejects, so `catch` / SWR `error` / `?? default` all work
+ * the way the call sites already assume.
+ */
+export class BridgeUnavailableError extends Error {
+  /** Provider key (the part after the `subscribe-` wire prefix). */
+  readonly key: string;
+  /** Why the call cannot reach a provider (`remote-forbidden` / `not-allowed`). */
+  readonly reason: string;
+
+  constructor(key: string, reason: string) {
+    super(`Bridge method "${key}" is not available on this transport (${reason})`);
+    this.name = 'BridgeUnavailableError';
+    this.key = key;
+    this.reason = reason;
+  }
+}
+
+/**
+ * True iff this JS context is a renderer talking to main over the REMOTE
+ * WebSocket transport (browser WebUI / paired device / standalone Docker).
+ *
+ * Reuses the signal the app already uses everywhere else for this question -
+ * the presence of the preload-injected `window.electronAPI` (see
+ * `isElectronDesktop()` in src/renderer/utils/platform.ts, and the transport
+ * branch in src/common/adapter/browser.ts which opens the WebSocket precisely
+ * when that object is absent). The main process has no `window`, so it is never
+ * classified as remote; this is deliberately evaluated per call rather than
+ * memoized at module load, because preload injection races module evaluation.
+ *
+ * This is a CLIENT-side convenience gate only. It is not a security control and
+ * removes none: the authority is still `isAllowedForRemote` on the server's WS
+ * dispatch path, which is what this function's key check consults.
+ */
+export function isRemoteBridgeTransport(): boolean {
+  return typeof window !== 'undefined' && !(window as { electronAPI?: unknown }).electronAPI;
+}
+
+/** `detail` values `settleRejectedInvoke` uses when it refuses a call. */
+const REJECTION_ENVELOPE_DETAILS: ReadonlySet<string> = new Set(['remote-forbidden', 'not-allowed']);
+
+/**
+ * True iff `value` is exactly the refusal envelope `settleRejectedInvoke`
+ * sends: `{ error: 'failed', detail: <refusal reason> }` and nothing else.
+ *
+ * The shape check is deliberately exact. Real providers do return payloads that
+ * carry `error: 'failed'` (e.g. `project.generate-knowledge-draft` answers
+ * `{ draft: '', error: 'failed', detail: <server message> }`), and those are
+ * legitimate resolved values that must NOT be turned into rejections.
+ */
+function isRefusalEnvelope(value: unknown): value is { error: 'failed'; detail: string } {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  if (record.error !== 'failed') return false;
+  if (typeof record.detail !== 'string' || !REJECTION_ENVELOPE_DETAILS.has(record.detail)) return false;
+  return Object.keys(record).length === 2;
+}
+
+/**
+ * Wrap `bridge.buildProvider` so every declared provider key is recorded, and
+ * so a call that the remote transport cannot serve REJECTS instead of resolving
+ * with the refusal envelope (#979).
+ *
+ * `provider` is passed through untouched; only `invoke` is wrapped, and only on
+ * the remote transport. On the local Electron renderer and in the main process
+ * this is the same pure side-effect wrapper it has always been.
  */
 export function buildProvider<Data, Params = undefined>(
   key: string
 ): ReturnType<typeof bridge.buildProvider<Data, Params>> {
   providerKeys.add(key);
-  return bridge.buildProvider<Data, Params>(key);
+  const base = bridge.buildProvider<Data, Params>(key);
+  const baseInvoke = base.invoke as (params?: Params) => Promise<Data>;
+
+  const invoke = async (params?: Params): Promise<Data> => {
+    if (!isRemoteBridgeTransport()) return baseInvoke(params);
+    // Fail fast on a key the server's WS dispatcher will refuse anyway. Reading
+    // the SAME predicate the dispatcher applies is what makes drift structurally
+    // impossible - there is no second copy of the denylist.
+    if (isRemoteDeniedProviderKey(key)) throw new BridgeUnavailableError(key, 'remote-forbidden');
+    const result = await baseInvoke(params);
+    // Defence in depth: a refusal can still arrive for a key this side did not
+    // classify as denied (e.g. the value-level config-write gate). Convert it.
+    if (isRefusalEnvelope(result)) throw new BridgeUnavailableError(key, result.detail);
+    return result;
+  };
+
+  return { provider: base.provider, invoke: invoke as typeof base.invoke };
 }
 
 /**
@@ -506,12 +596,25 @@ export function isAllowedForRemote(name: string): boolean {
   // heartbeat) is already constrained by isAllowedInboundName.
   if (!name.startsWith('subscribe-')) return true;
 
-  const key = name.slice('subscribe-'.length);
-  if (REMOTE_DENIED_KEYS.has(key)) return false;
+  return !isRemoteDeniedProviderKey(name.slice('subscribe-'.length));
+}
+
+/**
+ * Key-level half of {@link isAllowedForRemote}: true iff the provider key (the
+ * part after the `subscribe-` wire prefix) is denied to REMOTE callers.
+ *
+ * Exists so the bridge CLIENT (`buildProvider`, #979) can ask the same question
+ * the server's dispatcher asks, against the same two collections. Nothing about
+ * the denylist changes here - `isAllowedForRemote` is the identical function it
+ * was, expressed in terms of this predicate.
+ */
+export function isRemoteDeniedProviderKey(key: string): boolean {
+  if (typeof key !== 'string' || key.length === 0) return false;
+  if (REMOTE_DENIED_KEYS.has(key)) return true;
   for (const prefix of REMOTE_DENIED_PREFIXES) {
-    if (key.startsWith(prefix)) return false;
+    if (key.startsWith(prefix)) return true;
   }
-  return true;
+  return false;
 }
 
 /**

--- a/src/renderer/components/layout/Titlebar/SpendPill.tsx
+++ b/src/renderer/components/layout/Titlebar/SpendPill.tsx
@@ -21,6 +21,7 @@ import { ipcBridge } from '@/common';
 import type { BudgetSeverity } from '@renderer/pages/mission-control/cost/costChart';
 import { budgetSeverity } from '@renderer/pages/mission-control/cost/costChart';
 import { formatUsd } from '@renderer/utils/format/tokens';
+import { isElectronDesktop } from '@renderer/utils/platform';
 
 // Shares the exact tier colors used by the cost budget bars (Cost.module.css).
 const SEVERITY_COLOR: Record<BudgetSeverity, string> = {
@@ -40,8 +41,14 @@ export const SpendPill: React.FC = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
 
+  // The whole cost.* namespace is remote-denied (bridgeAllowlist.ts), so a
+  // browser WebUI can never read a budget: fetching would only ever fail, and
+  // the pill could only ever be blank. Skip the fetch and hide the control
+  // entirely rather than showing a dead affordance (#979).
+  const costAvailable = isElectronDesktop();
+
   const { data, mutate } = useSWR<BudgetLike[]>(
-    'titlebar-spend',
+    costAvailable ? 'titlebar-spend' : null,
     (): Promise<BudgetLike[]> => ipcBridge.cost.listBudgets.invoke() as Promise<BudgetLike[]>,
     { revalidateOnFocus: true }
   );
@@ -55,6 +62,8 @@ export const SpendPill: React.FC = () => {
     });
     return () => off();
   }, [mutate]);
+
+  if (!costAvailable) return null;
 
   const budgets = data ?? [];
   // Prefer the monthly global budget; fall back to any global budget.

--- a/src/renderer/hooks/system/useForegroundConversationReporter.ts
+++ b/src/renderer/hooks/system/useForegroundConversationReporter.ts
@@ -7,6 +7,7 @@
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { ipcBridge } from '@/common';
+import { isElectronDesktop } from '@renderer/utils/platform';
 
 /** The conversation id in `#/conversation/:id`, or null for any other route. */
 export function foregroundConversationIdFromPath(pathname: string): string | null {
@@ -35,6 +36,12 @@ export function useForegroundConversationReporter(): void {
   const { pathname } = useLocation();
 
   useEffect(() => {
+    // `app.set-foreground-conversation` is remote-denied on purpose: a paired
+    // browser's on-screen conversation is not the desktop's, so it must not
+    // steer the local completion-focus gate (#579). Reporting from a remote
+    // renderer can therefore only ever fail - don't make the call (#979).
+    if (!isElectronDesktop()) return;
+
     const conversationId = foregroundConversationIdFromPath(pathname);
     const report = () => {
       // Only the focused window owns the single main-process value.

--- a/src/renderer/pages/mission-control/index.tsx
+++ b/src/renderer/pages/mission-control/index.tsx
@@ -11,6 +11,7 @@ import { Button, Tabs } from '@arco-design/web-react';
 import { AlertTriangle, Bot, Clock, Gauge, GitBranch, PictureInPicture2, RefreshCw, Users } from 'lucide-react';
 import { ipcBridge } from '@/common';
 import { useIsPopoutMode } from '@/renderer/hooks/system/useIsPopoutMode';
+import { isElectronDesktop } from '@/renderer/utils/platform';
 import { useMissionControl } from './useMissionControl';
 import { CostTab } from './cost/CostTab';
 import PageShell from '@/renderer/components/layout/PageShell';
@@ -306,18 +307,26 @@ const MissionControlPage: React.FC = () => {
   const { t } = useTranslation();
   const isPopout = useIsPopoutMode();
 
+  // The whole cost.* namespace is remote-denied (bridgeAllowlist.ts), so on a
+  // browser WebUI the cost tab can only ever render empty panels. Drop the tab
+  // there instead, and never honor a `?tab=cost` deep-link into it (#979).
+  const costTabAvailable = isElectronDesktop();
+
   // Honor a `?tab=` deep-link (e.g. the Titlebar SpendPill opens ?tab=cost),
   // while keeping the tab user-switchable.
   const [searchParams] = useSearchParams();
-  const [activeTab, setActiveTab] = useState(searchParams.get('tab') === 'cost' ? 'cost' : 'operations');
+  const [activeTab, setActiveTab] = useState(
+    costTabAvailable && searchParams.get('tab') === 'cost' ? 'cost' : 'operations'
+  );
 
   // Re-sync when the deep-link changes while the page is ALREADY mounted (e.g.
   // clicking SpendPill from Mission Control): the one-shot initial state above
   // would otherwise leave the tab stale (xaudit finding 1).
   useEffect(() => {
     const tab = searchParams.get('tab');
-    if (tab === 'cost' || tab === 'operations') setActiveTab(tab);
-  }, [searchParams]);
+    if (tab === 'cost' && costTabAvailable) setActiveTab(tab);
+    else if (tab === 'operations') setActiveTab(tab);
+  }, [searchParams, costTabAvailable]);
 
   // Hide the pop-out trigger when this page is itself rendered inside a pop-out
   // window - there is nothing to pop out into from there (#157).
@@ -346,9 +355,11 @@ const MissionControlPage: React.FC = () => {
         <Tabs.TabPane key='operations' title={t('missionControl.tabs.operations')}>
           <OperationsView />
         </Tabs.TabPane>
-        <Tabs.TabPane key='cost' title={t('missionControl.tabs.cost')}>
-          <CostTab />
-        </Tabs.TabPane>
+        {costTabAvailable && (
+          <Tabs.TabPane key='cost' title={t('missionControl.tabs.cost')}>
+            <CostTab />
+          </Tabs.TabPane>
+        )}
       </Tabs>
     </PageShell>
   );

--- a/src/renderer/pages/settings/ChannelsIndex/PendingPairings.tsx
+++ b/src/renderer/pages/settings/ChannelsIndex/PendingPairings.tsx
@@ -68,9 +68,12 @@ const PendingPairings: React.FC = () => {
     return `${minutes} min`;
   };
 
+  // approve/reject are remote-denied (a paired WebUI must never self-approve), so
+  // on that transport the invoke REJECTS (#979). Catch it, or the operator gets
+  // silence where they used to get a failure toast.
   const handleApprove = useCallback(
     async (code: string) => {
-      const result = await channel.approvePairing.invoke({ code });
+      const result = await channel.approvePairing.invoke({ code }).catch((): undefined => undefined);
       if (result?.success) {
         Message.success(t('settings.channelsIndex.pendingPairing.approved'));
       } else {
@@ -82,7 +85,7 @@ const PendingPairings: React.FC = () => {
 
   const handleReject = useCallback(
     async (code: string) => {
-      const result = await channel.rejectPairing.invoke({ code });
+      const result = await channel.rejectPairing.invoke({ code }).catch((): undefined => undefined);
       if (result?.success) {
         Message.info(t('settings.channelsIndex.pendingPairing.rejected'));
       } else {

--- a/tests/unit/renderer/missionControlDeepLink.dom.test.tsx
+++ b/tests/unit/renderer/missionControlDeepLink.dom.test.tsx
@@ -89,4 +89,26 @@ describe('Mission Control ?tab deep-link (D-06 xaudit finding 1)', () => {
     );
     expect(tabByTitle('missionControl.tabs.cost')).toHaveAttribute('aria-selected', 'true');
   });
+
+  it('hides the cost tab on the remote WebUI transport and ignores ?tab=cost there (#979)', () => {
+    // The whole cost.* namespace is remote-denied, so on a browser WebUI the tab
+    // could only ever show empty panels - it must not be offered at all, and the
+    // SpendPill deep-link must not be able to land on it.
+    const electronApi = (window as { electronAPI?: unknown }).electronAPI;
+    delete (window as { electronAPI?: unknown }).electronAPI;
+    try {
+      render(
+        <MemoryRouter initialEntries={['/mission-control?tab=cost']}>
+          <Routes>
+            <Route path='/mission-control' element={<MissionControlPage />} />
+          </Routes>
+        </MemoryRouter>
+      );
+      expect(tabByTitle('missionControl.tabs.cost')).toBeUndefined();
+      expect(screen.queryByTestId('cost-tab-content')).not.toBeInTheDocument();
+      expect(tabByTitle('missionControl.tabs.operations')).toHaveAttribute('aria-selected', 'true');
+    } finally {
+      (window as { electronAPI?: unknown }).electronAPI = electronApi;
+    }
+  });
 });

--- a/tests/unit/renderer/remoteBridgeGating.dom.test.tsx
+++ b/tests/unit/renderer/remoteBridgeGating.dom.test.tsx
@@ -1,0 +1,272 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Regression test for #979 - the remote WebUI white-screens on load.
+ *
+ * On the remote (paired-device / standalone WebUI) transport the WS dispatcher
+ * refuses a remote-denied provider key, and `settleRejectedInvoke`
+ * (src/process/webserver/adapter.ts) replies with an ERROR ENVELOPE rather than
+ * a rejection, because @office-ai/platform's `invoke()` is resolve-only: it has
+ * no reject path and no timeout (verified against the platform bridge source -
+ * `invoke` resolves only when `subscribe.callback-<key><id>` arrives).
+ *
+ * That makes `await ipcBridge.cost.listBudgets.invoke() ?? []` resolve to a
+ * NON-NULL object, so the `?? []` default never fires and the next render-phase
+ * `.find(...)` / `.slice(...)` throws a TypeError that the root ErrorBoundary
+ * turns into a blank app.
+ *
+ * These tests drive the REAL ipcBridge over a loopback adapter that mirrors the
+ * server's behaviour exactly (allowlist decision via the real
+ * `isAllowedForRemote`, envelope byte-identical to `settleRejectedInvoke`), so
+ * the assertion is about the shipped client, not a hand-written shape.
+ */
+
+import { act, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { SWRConfig } from 'swr';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { bridge } from '@office-ai/platform';
+import { ipcBridge } from '@/common';
+import { BridgeUnavailableError, isAllowedForRemote } from '@/common/adapter/bridgeAllowlist';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? key,
+    i18n: { language: 'en' },
+  }),
+}));
+
+/** Payload `settleRejectedInvoke` sends for a remote-denied key (adapter.ts:40). */
+const REMOTE_FORBIDDEN_ENVELOPE = { error: 'failed', detail: 'remote-forbidden' } as const;
+
+type PlatformEmitter = { emit: (name: string, data: unknown) => void };
+
+let inboundEmitter: PlatformEmitter | null = null;
+/** Wire keys the loopback "server" saw, in order. */
+let seenKeys: string[] = [];
+
+/**
+ * Stand in for the WebSocket round trip: reply to every `subscribe-<key>` the
+ * way `src/process/webserver/adapter.ts` does for a remote caller.
+ */
+function installRemoteLoopbackAdapter(
+  allowedResponses: Record<string, unknown> = {},
+  /**
+   * The remote WS dispatcher applies the allowlist; the local Electron preload
+   * IPC path does not (the local renderer is the trusted user). Set false to
+   * model the local transport.
+   */
+  applyRemoteGate = true
+): void {
+  bridge.adapter({
+    emit(name: string, data: unknown) {
+      if (!name.startsWith('subscribe-')) return;
+      const key = name.slice('subscribe-'.length);
+      const id = (data as { id?: string } | undefined)?.id;
+      if (typeof id !== 'string') return;
+      seenKeys.push(key);
+      const reply =
+        !applyRemoteGate || isAllowedForRemote(name) ? (allowedResponses[key] ?? null) : REMOTE_FORBIDDEN_ENVELOPE;
+      // The platform listens on `subscribe.callback-${key}${id}` - identical to
+      // the name settleRejectedInvoke sends back.
+      queueMicrotask(() => inboundEmitter?.emit(`subscribe.callback-${key}${id}`, reply));
+    },
+    on(emitter: PlatformEmitter) {
+      inboundEmitter = emitter;
+    },
+  });
+}
+
+/** Make this renderer look like the browser WebUI (no preload-injected API). */
+function makeRendererRemote(): void {
+  delete (window as { electronAPI?: unknown }).electronAPI;
+  delete (globalThis as { electronAPI?: unknown }).electronAPI;
+}
+
+describe('#979 remote bridge gating', () => {
+  let electronApiBackup: unknown;
+
+  beforeEach(() => {
+    electronApiBackup = (window as { electronAPI?: unknown }).electronAPI;
+    seenKeys = [];
+    makeRendererRemote();
+    installRemoteLoopbackAdapter();
+  });
+
+  afterEach(() => {
+    (window as { electronAPI?: unknown }).electronAPI = electronApiBackup;
+    (globalThis as { electronAPI?: unknown }).electronAPI = electronApiBackup;
+  });
+
+  it('rejects instead of resolving with the error envelope for a remote-denied key', async () => {
+    await expect(ipcBridge.cost.listBudgets.invoke()).rejects.toBeInstanceOf(BridgeUnavailableError);
+  });
+
+  it('lets the renderer default (`?? []`) fire again for a remote-denied read', async () => {
+    const budgets = await ipcBridge.cost.listBudgets.invoke().catch(() => undefined);
+    // THIS is the #979 bug: before the fix `budgets` is the non-null envelope
+    // object, so `?? []` is skipped and the next `.find(...)` throws.
+    expect(budgets ?? []).toEqual([]);
+  });
+
+  it('rejects every remote-denied cost aggregate the Mission Control cost tab loads', async () => {
+    const window_ = { fromMs: 0, toMs: 1 };
+    const calls: Array<Promise<unknown>> = [
+      ipcBridge.cost.summary.invoke(window_),
+      ipcBridge.cost.byModel.invoke(window_),
+      ipcBridge.cost.byBackend.invoke(window_),
+      ipcBridge.cost.byConversation.invoke(window_),
+      ipcBridge.cost.byTeam.invoke(window_),
+      ipcBridge.cost.series.invoke({ window: window_, bucketMs: 1 }),
+    ];
+    const settled = await Promise.allSettled(calls);
+    for (const outcome of settled) {
+      expect(outcome.status).toBe('rejected');
+      expect((outcome as PromiseRejectedResult).reason).toBeInstanceOf(BridgeUnavailableError);
+    }
+  });
+
+  it('does not send a remote-denied invocation over the wire at all', async () => {
+    await ipcBridge.cost.listBudgets.invoke().catch(() => undefined);
+    expect(seenKeys).not.toContain('cost.listBudgets');
+  });
+
+  it('still resolves a remote-ALLOWED provider normally', async () => {
+    installRemoteLoopbackAdapter({ 'cron.list-jobs': [{ id: 'job-1' }] });
+    await expect(ipcBridge.cron.listJobs.invoke()).resolves.toEqual([{ id: 'job-1' }]);
+  });
+
+  it('leaves the local Electron transport untouched', async () => {
+    (window as { electronAPI?: unknown }).electronAPI = { emit: () => undefined, on: () => undefined };
+    installRemoteLoopbackAdapter({ 'cost.listBudgets': [{ id: 'b1' }] }, false);
+    // The local renderer is trusted; the wire gate never applies to it, so the
+    // call must go through and resolve with the provider's real answer.
+    await expect(ipcBridge.cost.listBudgets.invoke()).resolves.toEqual([{ id: 'b1' }]);
+    expect(seenKeys).toContain('cost.listBudgets');
+  });
+});
+
+describe('#979 remote renderer mount does not white-screen', () => {
+  let electronApiBackup: unknown;
+
+  beforeEach(() => {
+    electronApiBackup = (window as { electronAPI?: unknown }).electronAPI;
+    seenKeys = [];
+    makeRendererRemote();
+    installRemoteLoopbackAdapter();
+  });
+
+  afterEach(() => {
+    (window as { electronAPI?: unknown }).electronAPI = electronApiBackup;
+    (globalThis as { electronAPI?: unknown }).electronAPI = electronApiBackup;
+  });
+
+  /**
+   * Mount under the SAME root ErrorBoundary src/renderer/main.tsx uses, so the
+   * assertion is exactly the #979 symptom: a render-phase throw swaps the whole
+   * subtree for the boundary fallback (the white screen).
+   */
+  const mountUnderRootBoundary = async (node: React.ReactNode) => {
+    const { ErrorBoundary } = await import('@renderer/components/ErrorBoundary');
+    const result = render(
+      <ErrorBoundary>
+        <SWRConfig value={{ provider: () => new Map() }}>
+          <MemoryRouter>{node}</MemoryRouter>
+        </SWRConfig>
+      </ErrorBoundary>
+    );
+    // Let the loopback reply and SWR commit the resulting state.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    return result;
+  };
+
+  const expectNoBoundaryFallback = () => {
+    expect(screen.queryByText('Something went wrong')).not.toBeInTheDocument();
+  };
+
+  it('mounts SpendPill on the remote transport without blanking the tree', async () => {
+    // The pill is gated off on remote, so it must not even attempt the call.
+    const listBudgets = vi.spyOn(ipcBridge.cost.listBudgets, 'invoke');
+    const { SpendPill } = await import('@renderer/components/layout/Titlebar/SpendPill');
+    const { container } = await mountUnderRootBoundary(<SpendPill />);
+
+    // Before the fix the SWR fetcher resolved with the envelope and
+    // `budgets.find(...)` threw during render. After the fix the pill is simply
+    // absent on remote - there is no cost surface there at all.
+    expectNoBoundaryFallback();
+    expect(listBudgets).not.toHaveBeenCalled();
+    expect(seenKeys).not.toContain('cost.listBudgets');
+    expect(container).toBeEmptyDOMElement();
+    listBudgets.mockRestore();
+  });
+
+  it('mounts the Mission Control cost tab on the remote transport without blanking the tree', async () => {
+    const { CostTab } = await import('@renderer/pages/mission-control/cost/CostTab');
+    await mountUnderRootBoundary(<CostTab />);
+
+    // Before the fix `summary.events.toLocaleString()` ran against the envelope
+    // and threw. After the fix the aggregates reject, SWR keeps `data`
+    // undefined, and the `?? EMPTY_SUMMARY` / `?? []` defaults render the empty
+    // state.
+    expectNoBoundaryFallback();
+    await waitFor(() => expect(screen.getByText('missionControl.cost.emptyTitle')).toBeInTheDocument());
+  });
+});
+
+describe('#979 foreground-conversation reporter is skipped on the remote transport', () => {
+  let electronApiBackup: unknown;
+
+  beforeEach(() => {
+    electronApiBackup = (window as { electronAPI?: unknown }).electronAPI;
+    seenKeys = [];
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    installRemoteLoopbackAdapter();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    (window as { electronAPI?: unknown }).electronAPI = electronApiBackup;
+    (globalThis as { electronAPI?: unknown }).electronAPI = electronApiBackup;
+  });
+
+  const renderReporter = async () => {
+    const { useForegroundConversationReporter } =
+      await import('@renderer/hooks/system/useForegroundConversationReporter');
+    const Harness: React.FC = () => {
+      useForegroundConversationReporter();
+      return null;
+    };
+    render(
+      <MemoryRouter initialEntries={['/conversation/abc-123']}>
+        <Harness />
+      </MemoryRouter>
+    );
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  };
+
+  it('does not even attempt the report from a remote renderer', async () => {
+    const report = vi.spyOn(ipcBridge.application.setForegroundConversation, 'invoke');
+    makeRendererRemote();
+    await renderReporter();
+    expect(report).not.toHaveBeenCalled();
+    expect(seenKeys).not.toContain('app.set-foreground-conversation');
+  });
+
+  it('still reports from the local Electron renderer', async () => {
+    const report = vi.spyOn(ipcBridge.application.setForegroundConversation, 'invoke');
+    (window as { electronAPI?: unknown }).electronAPI = { emit: () => undefined, on: () => undefined };
+    await renderReporter();
+    expect(report).toHaveBeenCalledWith({ conversationId: 'abc-123' });
+    expect(seenKeys).toContain('app.set-foreground-conversation');
+  });
+});


### PR DESCRIPTION
Fixes #979.

## The defect

On the remote transport a call to a remote-denied bridge key did not fail - it succeeded with a poisoned value.

@office-ai/platform's invoke() is resolve-only. Verified against the platform bridge source: it emits subscribe-<key> with an id, then settles the promise only when subscribe.callback-<key><id> comes back. There is no reject path and no timeout in the wire protocol. So when the WS dispatcher refuses a remote-denied key, settleRejectedInvoke (src/process/webserver/adapter.ts) has to answer with an error envelope just to stop the caller hanging forever - that is deliberate, from #684.

The renderer therefore receives a non-null object where it expected data:

    const data = await ipcBridge.cost.listBudgets.invoke() ?? []

The ?? never fires, and the next render-phase budgets.find(...) throws a TypeError that the root ErrorBoundary at src/renderer/main.tsx:175 turns into a blank app. /mission-control has no route-level boundary, so the cost tab blanks the whole app too.

129 remote-denied methods have live renderer call sites (251 call sites). In the standalone / Docker build (src/server.ts, same initWebAdapter) the browser is the only UI, so all 129 affect every user of that deployment.

## The fix

Gate in the bridge client, at buildProvider in src/common/adapter/bridgeAllowlist.ts.

Verified buildProvider is genuinely the single chokepoint before building on it: it is the only wrapper over bridge.buildProvider anywhere in src (nothing calls the platform factory directly), it is called 506 times from ipcBridge.ts, and it is imported for actual use only there - the other files that grep for the name only mention it in comments.

On the REMOTE transport only, invoke now rejects with a typed BridgeUnavailableError for a remote-denied key, before the call reaches the wire; and a refusal envelope that still arrives is converted into the same rejection.

Properties preserved:

- The signature stays Promise<Data>, so zero call sites change type.
- Every ?? [] and ?? default in the renderer starts working again, which is what fixes all 8 known crash sites at once.
- The denylist is not duplicated. isAllowedForRemote is re-expressed in terms of a new isRemoteDeniedProviderKey, and the client consults that same predicate against the same two collections. Client/server drift is structurally impossible.

No deny entry was removed, weakened, or reordered. `git diff` on the allowlist removes exactly four logic lines, all of which moved verbatim into the extracted predicate. This is a client convenience gate, not a security control - the authority is still the WS dispatcher.

Envelope detection is shape-exact - error === 'failed', a known refusal detail, and no third key - because real providers do legitimately resolve with an error field: project.generate-knowledge-draft answers { draft: '', error: 'failed', detail: <server message> }, and that must stay a resolved value.

## Reject, not resolve-with-default - and why that is safe

Judged from the actual call sites, not from principle. All 251 renderer call sites of remote-denied methods were audited for what a rejection does:

- 235 SAFE-HANDLED - already inside try/catch, a chained .catch, or an SWR fetcher. All 8 known crash sites are in this bucket: every one of them goes through useSWR, which catches a fetcher rejection, leaves data undefined, and lets ?? [] / ?? EMPTY_SUMMARY fire.
- 16 SAFE-UNHANDLED - a bare void x.invoke(...) or an uncaught await in an effect/handler. Those become an unhandled promise rejection, which is console noise, not a crash.
- 0 RISKY. There is no react-query, no SWR suspense: true, no SWR global onError, and every <Suspense> in the tree wraps React.lazy for code splitting rather than a data promise - so a rejection cannot reach an error boundary. The only unhandledrejection listener (src/renderer/utils/ui/runtimePatches.ts:140) de-escalates: it preventDefaults a whitelist of ResizeObserver/Arco noise and otherwise passes through. The audit also specifically hunted the stuck-spinner pattern - state set before the await and reset only on the success path - and found no instance; every candidate resets in a catch or finally.

Resolving with a typed default was rejected as the design: for 129 heterogeneous methods there is no single honest default, and a silent fake success would hide a real capability boundary from code that wants to branch on it. Rejecting restores the failure channel the protocol never had, which is exactly what the call sites already assume.

Two call sites did lose real feedback under rejection - the pairing approve/reject handlers branched on result.success and showed a failure toast - so they get an explicit catch in this PR.

## Cosmetic gates

The existing mechanism for knowing the renderer is remote is the presence of the preload-injected window.electronAPI. It is codified as isElectronDesktop() in src/renderer/utils/platform.ts, and it is the same branch src/common/adapter/browser.ts uses to pick WebSocket over IPC. That is what these gates use - nothing new was invented. bridgeAllowlist.ts cannot import a renderer util, so it carries a cross-referenced isRemoteBridgeTransport() reading the identical signal, evaluated per call rather than memoized because preload injection races module evaluation.

- SpendPill: skip the SWR fetch and render nothing.
- Mission Control: drop the cost tab and stop honoring a ?tab=cost deep-link into it, so the SpendPill link cannot land on a dead tab.
- useForegroundConversationReporter: skip the report.

## Verification

Regression test: tests/unit/renderer/remoteBridgeGating.dom.test.tsx. It drives the real ipcBridge over a loopback adapter that takes its decision from the real isAllowedForRemote and replies with the byte-identical envelope settleRejectedInvoke sends, and the two mount cases render under the same root ErrorBoundary main.tsx installs.

Before (gate disabled, everything else identical) - 6 failed / 2 passed:

    x rejects instead of resolving with the error envelope for a remote-denied key
    x lets the renderer default (?? []) fire again for a remote-denied read
    x rejects every remote-denied cost aggregate the Mission Control cost tab loads
    x does not send a remote-denied invocation over the wire at all
    x mounts SpendPill on the remote transport without blanking the tree
    x mounts the Mission Control cost tab on the remote transport without blanking the tree

with the underlying failures being the literal #979 symptom:

    TypeError: budgets.find is not a function
        at SpendPill (src/renderer/components/layout/Titlebar/SpendPill.tsx:62:13)
    TypeError: budgets.map is not a function
        at BudgetsPanel (src/renderer/pages/mission-control/cost/BudgetsPanel.tsx:162:20)
    Error: expect(element).not.toBeInTheDocument()
    expected document not to contain element, found <h2>Something went wrong</h2> instead

After:

    Test Files  1 passed (1)
         Tests  10 passed (10)

Everything else:

- Allowlist suites - 12 files, 134 passed (bridgeAllowlist.redteam, bridgeAllowlistCost.redteam, WaylandTransfer, WorkspaceRetention, WebuiConfig, Terminal, ModelRegistry x2, AgentInstaller, WorkspaceTrust, adapterPayloadGuard, adapterEmitGuard).
- bun test src/common/adapter/bridgeAllowlist.budgets.bun.test.ts - 8 pass, 0 fail.
- Tests over the touched call sites - spendPill.dom, missionControlDeepLink.dom, foregroundConversationPath, taskCompletionNotifier, channelBridge, weixinConfigForm.dom - 18 + 63 passed.
- bunx tsc --noEmit - clean. oxlint - 0 errors on the changed files. oxfmt --check - clean.
- Full unit suite - 17694 passed, 13 failed, 154 skipped across 1625 files. All 13 failures are unrelated to this change and were run down individually: 8 pass when re-run in isolation (the box was at load average 64-80 during the full run), and the other 5 - acpAgentManagerNpmFallback x3, conversationBridge.tray, missionControlActivity.dom - reproduce identically on a clean tree with this branch's changes stashed, so they are pre-existing.

## Contradicting the brief

- The adapter path in the brief is src/webserver/adapter.ts; the real path is src/process/webserver/adapter.ts. Everything else about the root cause held up under verification, including the resolve-only, no-reject, no-timeout claim about the platform's invoke.
- The brief flagged an unhandled rejection in a mount effect as a possible new crash. It is not one here: no rejection path in this renderer can reach an error boundary, and every one of the 8 known crash sites is an SWR fetcher that catches. Details in the audit above.
