### PR TITLE
fix(mcp): stop per-tool switches lying on non-Codex backends

### DIFF
--- a/src/common/mcp.ts
+++ b/src/common/mcp.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { AgentBackend } from '@/common/types/acpTypes';
+
 /**
  * Shared MCP server-name helpers usable from BOTH the main process and the
  * renderer (the renderer cannot import `src/process/...`).
@@ -140,8 +142,11 @@ export function mcpSessionFingerprint(
  * Per-provider/model hard cap on the tool array a single request may carry
  * (OpenAI's limit is 128). Used ONLY to show the user a count-vs-cap nudge
  * (#348) — Wayland never truncates client-side; Wayland Core owns the smart
- * BM25 curation that actually fits the array, and Flux humanizes the 400. An
- * absent key => no known cap (the nudge then shows the count without a ceiling).
+ * BM25 curation that actually fits the array, and Flux humanizes the 400.
+ *
+ * Entries here are documented VENDOR caps. A provider that is absent is not
+ * uncapped — it falls back to {@link DEFAULT_TOOL_ARRAY_CAP}; see
+ * {@link resolveModelToolCap}.
  */
 export const PROVIDER_TOOL_LIMITS: Record<string, number> = {
   openai: 128,
@@ -149,13 +154,58 @@ export const PROVIDER_TOOL_LIMITS: Record<string, number> = {
 };
 
 /**
- * The known tool-array cap for a chat's target model, or `undefined` when the
- * provider/model has no known ceiling. Checks the model id first (e.g. `gpt-5`)
- * then the provider id (e.g. `openai`) so a capped model under any provider
- * still resolves. Informational only — see {@link PROVIDER_TOOL_LIMITS}.
+ * Advisory ceiling used when the target provider/model publishes no cap of its
+ * own (#998). Previously `resolveModelToolCap` returned `undefined` for
+ * everything that was not OpenAI, so an Anthropic or Flux chat carrying 122
+ * tools got NO nudge while the identical inventory warned on `gpt-5` — the
+ * warning was hardcoded to one vendor rather than being backend-aware.
+ *
+ * 128 is the tightest published ceiling across the providers Wayland routes to,
+ * and a router (Flux) can land a turn on any of them, so it is the honest floor
+ * to warn against. It is advisory only: nothing is ever truncated client-side.
  */
-export function resolveModelToolCap(providerId?: string, modelId?: string): number | undefined {
+export const DEFAULT_TOOL_ARRAY_CAP = 128;
+
+/**
+ * The tool-array cap to warn a chat's target model against. Checks the model id
+ * first (e.g. `gpt-5`) then the provider id (e.g. `openai`) so a capped model
+ * under any provider still resolves, and falls back to
+ * {@link DEFAULT_TOOL_ARRAY_CAP} so every backend gets a nudge rather than only
+ * the vendors listed in {@link PROVIDER_TOOL_LIMITS}. Informational only.
+ */
+export function resolveModelToolCap(providerId?: string, modelId?: string): number {
   if (modelId && modelId in PROVIDER_TOOL_LIMITS) return PROVIDER_TOOL_LIMITS[modelId];
   if (providerId && providerId in PROVIDER_TOOL_LIMITS) return PROVIDER_TOOL_LIMITS[providerId];
-  return undefined;
+  return DEFAULT_TOOL_ARRAY_CAP;
+}
+
+/**
+ * Backends whose LAUNCH CONFIGURATION actually carries the per-server
+ * `allowedTools` list to the engine, so a tool switched off in the MCP Library
+ * is genuinely not callable (#998):
+ *
+ *   - `codex`  — `enabled_tools` in the generated Codex config.toml
+ *                (`buildCodexMcpServerTable`).
+ *   - `gemini` — `includeTools` on the aioncli-core `MCPServerConfig`
+ *                (`buildGeminiStdioMcpConfig`); the runtime drops every
+ *                unlisted tool at discovery time.
+ *
+ * Every OTHER backend receives a SERVER-level allowlist only, and no amount of
+ * desktop-side filtering changes that: Wayland Core's launch profile carries
+ * `mcp_servers = [...]` with no tool dimension (`appendDesktopMcpProfile`, and
+ * Core's `ProfileConfig` / `McpServerConfig` have no per-tool field), and the
+ * ACP `session/new` `mcpServers` array has no per-tool field in the protocol.
+ * On those the switch is UI state plus a desktop candidate-pool filter, NOT an
+ * engine constraint — so the MCP Library says exactly that instead of implying
+ * a restriction that is not there.
+ *
+ * Adding a backend to this list without ALSO emitting its tool list re-creates
+ * the #998 lying control; `tests/unit/process/mcpToolAllowlistEnforcement.test.ts`
+ * cross-checks this list against what each launch builder really emits.
+ */
+export const TOOL_ALLOWLIST_ENFORCING_BACKENDS: readonly AgentBackend[] = ['codex', 'gemini'];
+
+/** Does `backend` carry per-server `allowedTools` through to its engine? */
+export function backendEnforcesToolAllowlist(backend: string | undefined): boolean {
+  return backend !== undefined && (TOOL_ALLOWLIST_ENFORCING_BACKENDS as readonly string[]).includes(backend);
 }

--- a/src/common/mcp.ts
+++ b/src/common/mcp.ts
@@ -160,23 +160,44 @@ export const PROVIDER_TOOL_LIMITS: Record<string, number> = {
  * tools got NO nudge while the identical inventory warned on `gpt-5` — the
  * warning was hardcoded to one vendor rather than being backend-aware.
  *
- * 128 is the tightest published ceiling across the providers Wayland routes to,
- * and a router (Flux) can land a turn on any of them, so it is the honest floor
- * to warn against. It is advisory only: nothing is ever truncated client-side.
+ * This is a rule of thumb about tool-selection quality, NOT a published limit,
+ * and callers must never present it as one. See {@link ModelToolCap.documented}.
  */
 export const DEFAULT_TOOL_ARRAY_CAP = 128;
 
+/** The tool-array ceiling to compare a chat's inventory against. */
+export type ModelToolCap = {
+  /** The count the inventory is measured against. */
+  limit: number;
+  /**
+   * TRUE only when `limit` came from a published vendor limit in
+   * {@link PROVIDER_TOOL_LIMITS} — i.e. exceeding it really does fail the
+   * request, so the UI may say the model "caps at N" and name the model.
+   *
+   * FALSE when `limit` is the {@link DEFAULT_TOOL_ARRAY_CAP} rule of thumb. The
+   * UI must NOT attribute a hard cap to the model in that case: telling a Claude
+   * user "claude-sonnet-4-5 caps at 128" is a specific factual claim, and
+   * Anthropic publishes no such tool-array cap. This whole issue is about a
+   * control that lied to users; a warning that lies is the same defect wearing a
+   * different hat.
+   */
+  documented: boolean;
+};
+
 /**
- * The tool-array cap to warn a chat's target model against. Checks the model id
- * first (e.g. `gpt-5`) then the provider id (e.g. `openai`) so a capped model
+ * The tool-array ceiling to warn a chat's target model against. Checks the model
+ * id first (e.g. `gpt-5`) then the provider id (e.g. `openai`) so a capped model
  * under any provider still resolves, and falls back to
- * {@link DEFAULT_TOOL_ARRAY_CAP} so every backend gets a nudge rather than only
- * the vendors listed in {@link PROVIDER_TOOL_LIMITS}. Informational only.
+ * {@link DEFAULT_TOOL_ARRAY_CAP} (with `documented: false`) so every backend gets
+ * a nudge rather than only the vendors listed in {@link PROVIDER_TOOL_LIMITS}.
+ * Informational only — nothing is ever truncated client-side.
  */
-export function resolveModelToolCap(providerId?: string, modelId?: string): number {
-  if (modelId && modelId in PROVIDER_TOOL_LIMITS) return PROVIDER_TOOL_LIMITS[modelId];
-  if (providerId && providerId in PROVIDER_TOOL_LIMITS) return PROVIDER_TOOL_LIMITS[providerId];
-  return DEFAULT_TOOL_ARRAY_CAP;
+export function resolveModelToolCap(providerId?: string, modelId?: string): ModelToolCap {
+  if (modelId && modelId in PROVIDER_TOOL_LIMITS) return { limit: PROVIDER_TOOL_LIMITS[modelId], documented: true };
+  if (providerId && providerId in PROVIDER_TOOL_LIMITS) {
+    return { limit: PROVIDER_TOOL_LIMITS[providerId], documented: true };
+  }
+  return { limit: DEFAULT_TOOL_ARRAY_CAP, documented: false };
 }
 
 /**

--- a/src/process/agent/acp/mcpSessionConfig.ts
+++ b/src/process/agent/acp/mcpSessionConfig.ts
@@ -78,8 +78,15 @@ export function shouldInjectSessionMcpServer(server: IMcpServer): boolean {
  * Builtins (image-gen, skill-search) always inject — they're infrastructure,
  * not user-scopable. A user server passes when the chat has no selection
  * (`activeServerIds === undefined` ⇒ all enabled servers) or the selection
- * includes it. `[]` scopes out every user server. The user's per-server
- * `allowedTools` still trims tools within whatever servers stay active.
+ * includes it. `[]` scopes out every user server.
+ *
+ * Scoping here is SERVER-level only. The user's per-server `allowedTools` does
+ * NOT trim tools on this path: neither the ACP `session/new` `mcpServers` array
+ * nor Wayland Core's launch profile has a per-tool field, so whatever server
+ * survives this predicate reaches the engine with its FULL tool inventory
+ * (#998). The MCP Library states that plainly rather than implying otherwise;
+ * `TOOL_ALLOWLIST_ENFORCING_BACKENDS` in `@/common/mcp` is the single source of
+ * truth for which backends really do enforce it (codex, gemini).
  */
 export function isServerActiveForSession(server: IMcpServer, activeServerIds?: readonly string[]): boolean {
   if (server.builtin === true) return true;
@@ -87,6 +94,16 @@ export function isServerActiveForSession(server: IMcpServer, activeServerIds?: r
   return activeServerIds.includes(server.id);
 }
 
+/**
+ * Build the `session/new` `mcpServers` array for an ACP backend.
+ *
+ * #998 — SERVER-level selection only. The ACP protocol's MCP server descriptor
+ * carries name + transport and has no per-tool field, so a server that reaches
+ * here is registered with every tool it publishes; the MCP Library's per-tool
+ * switches are not enforced on this path. Codex is the exception and does NOT
+ * rely on this array for scoping - its `enabled_tools` are written into the
+ * generated `config.toml` by `buildCodexMcpServerTable`.
+ */
 export function buildAcpSessionMcpServers(
   mcpServers: IMcpServer[] | undefined | null,
   capabilities: AcpMcpCapabilities,
@@ -174,6 +191,13 @@ export function buildAcpSessionMcpServers(
  * connector whose raw name needs sanitizing (e.g. `com.slack/slack-mcp`) would
  * be injected under the raw name while config.toml holds `com.slack-slack-mcp` -
  * the dedup would miss and the engine would register it twice (#478).
+ *
+ * #998 - no per-tool allowlist is emitted, because the engine has nowhere to
+ * put one: `add_mcp_server` carries name/transport/command/args/env only, and
+ * Core's `[mcp.servers.*]` table and profile `mcp_servers = [...]` are both
+ * server-level. A user's per-tool switches are therefore NOT enforced on the
+ * Wayland Core backend; see `TOOL_ALLOWLIST_ENFORCING_BACKENDS` in
+ * `@/common/mcp` and the notice the MCP Library shows because of it.
  */
 export function buildWCoreUserStdioMcpServers(
   mcpServers: IMcpServer[] | undefined | null,
@@ -208,6 +232,10 @@ export function buildWCoreUserStdioMcpServers(
  * Core launch. Core loads these from trusted startup config; the companion
  * per-session profile allowlist prevents globally-published connectors that are
  * off for this chat from leaking into the session.
+ *
+ * That profile allowlist is SERVER-level (`mcp_servers = [...]`). Per-tool
+ * switches are not enforced on this path - see the note on
+ * {@link buildWCoreUserStdioMcpServers} (#998).
  */
 export function buildWCoreSessionMcpServers(
   mcpServers: IMcpServer[] | undefined | null,

--- a/src/process/services/tools/toolContract.ts
+++ b/src/process/services/tools/toolContract.ts
@@ -15,6 +15,12 @@ import type { McpSessionState } from '@/common/mcp/sessionReceipt';
  * (absent => all). This is the desktop's user-facing tool-scoping surface
  * (#347 overview + #348 per-server/per-conversation selection).
  *
+ * #998 - this pool is a DESKTOP-side view, not an engine constraint. Filtering
+ * here does not stop a launched engine from calling a tool it was handed; only
+ * the backends in `TOOL_ALLOWLIST_ENFORCING_BACKENDS` (`@/common/mcp`) receive
+ * the allowlist in their launch configuration. Do not read this contract as
+ * proof that a switched-off tool is unreachable everywhere.
+ *
  * Relevance ranking + the provider tool-array cap are NOT done here: per the
  * #344 architecture decision (Sean ratified), Wayland Core owns smart curation
  * (BM25 + provider-aware cap, wayland-core#86/#359), so every host (CLI,
@@ -35,7 +41,8 @@ export type CandidateTool = {
 /**
  * Builds the candidate pool from the CURRENT launch's correlated publication
  * receipts (MCP-01): each server the session registered with a non-empty tool
- * inventory, filtered by its `allowedTools` toggle (absent => all). Saved
+ * inventory, filtered by its `allowedTools` toggle (absent => all) - a desktop
+ * view of the pool, NOT engine enforcement, see the module note above. Saved
  * `connected` status, probe state, or a stale/revoked receipt contribute
  * nothing. Pure and synchronous — the caller holds the current `McpSessionState`
  * plus the loaded servers and passes them in, so this stays trivially testable

--- a/src/process/task/GeminiAgentManager.ts
+++ b/src/process/task/GeminiAgentManager.ts
@@ -84,6 +84,11 @@ export type UiMcpServerConfig = {
    * the Gemini backend's REAL enforcement of the MCP Library's per-tool switch,
    * not a display hint. Absent => every tool (the migration-free default); `[]`
    * => none, matching `IMcpServer.allowedTools` exactly.
+   *
+   * `[]` is faithful at THIS layer but must not reach a launch: a server that
+   * discovers zero tools and zero prompts makes aioncli-core throw and mark the
+   * connector disconnected. `getMcpServers` therefore drops empty-allowlist
+   * connectors before they are emitted - see the filter there.
    */
   includeTools?: string[];
 };
@@ -620,7 +625,20 @@ export class GeminiAgentManager extends BaseAgentManager<
         .filter(
           (server: IMcpServer) =>
             server.id !== BUILTIN_CONCIERGE_DIAG_ID || isConciergeAssistant(this.presetAssistantId)
-        );
+        )
+        // #998: `allowedTools: []` ("Disable all") means this connector
+        // contributes nothing, so drop it from the launch entirely rather than
+        // declaring it with `includeTools: []`. aioncli-core's
+        // `connectAndDiscover` THROWS "No prompts or tools found on the server."
+        // when discovery yields zero prompts AND zero tools, and its catch emits
+        // error feedback and marks the server DISCONNECTED - so emitting it would
+        // turn "tools off" into a red, broken-looking connector plus an error
+        // toast. Omitting it leaves the connector installed and enabled while
+        // contributing no tools this session, which is what the user asked for.
+        // It is also dropped BEFORE `beginMcpSession`, so the session's expected
+        // receipts match what is actually launched instead of waiting forever on
+        // a publication that can never arrive.
+        .filter((server: IMcpServer) => server.allowedTools === undefined || server.allowedTools.length > 0);
 
       // Match the ACP/Core launch paths: hosted OAuth connectors must enter the
       // worker with a current bearer, not the stale header saved at install.

--- a/src/process/task/GeminiAgentManager.ts
+++ b/src/process/task/GeminiAgentManager.ts
@@ -77,6 +77,15 @@ export type UiMcpServerConfig = {
   type?: 'sse' | 'http';
   headers?: Record<string, string>;
   description?: string;
+  /**
+   * #998 — per-server tool allowlist handed to aioncli-core's `MCPServerConfig`.
+   * The runtime filters discovered tools through it (`mcp-client.ts` isEnabled:
+   * a tool survives only when `includeTools` is absent or names it), so this is
+   * the Gemini backend's REAL enforcement of the MCP Library's per-tool switch,
+   * not a display hint. Absent => every tool (the migration-free default); `[]`
+   * => none, matching `IMcpServer.allowedTools` exactly.
+   */
+  includeTools?: string[];
 };
 
 /**
@@ -88,10 +97,19 @@ export type UiMcpServerConfig = {
  */
 export function buildGeminiStdioMcpConfig(
   transport: Extract<IMcpServer['transport'], { type: 'stdio' }>,
-  description?: string
+  description?: string,
+  allowedTools?: readonly string[]
 ): UiMcpServerConfig {
   const { command, args } = resolveMcpStdioSpawn(transport.command, transport.args || []);
-  return { command, args, env: transport.env || {}, description };
+  return {
+    command,
+    args,
+    env: transport.env || {},
+    description,
+    // #998: carry the per-tool switch into the runtime. `undefined` must stay
+    // omitted - an empty `includeTools` means "no tools", not "all tools".
+    ...(allowedTools === undefined ? {} : { includeTools: [...allowedTools] }),
+  };
 }
 
 const sortedRecord = (value?: Record<string, string>): Array<[string, string]> =>
@@ -617,7 +635,7 @@ export class GeminiAgentManager extends BaseAgentManager<
 
       selectedServers.forEach((server: IMcpServer) => {
         if (server.transport.type === 'stdio') {
-          mcpConfig[server.name] = buildGeminiStdioMcpConfig(server.transport, server.description);
+          mcpConfig[server.name] = buildGeminiStdioMcpConfig(server.transport, server.description, server.allowedTools);
         } else if (
           server.transport.type === 'sse' ||
           server.transport.type === 'http' ||
@@ -630,6 +648,8 @@ export class GeminiAgentManager extends BaseAgentManager<
             type,
             headers: server.transport.headers || {},
             description: server.description,
+            // #998: hosted connectors honour the per-tool switch too.
+            ...(server.allowedTools === undefined ? {} : { includeTools: [...server.allowedTools] }),
           };
         }
         if (mcpConfig[server.name]) this.publishMcpServer(server.name);

--- a/src/renderer/pages/conversation/components/composerMenu/ComposerAddMenu.tsx
+++ b/src/renderer/pages/conversation/components/composerMenu/ComposerAddMenu.tsx
@@ -82,8 +82,11 @@ const ComposerAddMenuPanel: React.FC<{
       .then((conv) => {
         if (!alive || !conv) return;
         // Not every conversation variant carries a top-level `model` (ACP/codex
-        // store it elsewhere); narrow before reading so the cap stays undefined
-        // (nudge hidden) for those rather than guessing.
+        // store it elsewhere); narrow before reading. #998: an unresolved model
+        // no longer means "no cap" - `resolveModelToolCap` falls back to the
+        // shared advisory ceiling, so those chats get the same count-vs-cap
+        // nudge instead of only OpenAI ones. The label falls back to a generic
+        // "this model" when the id is unknown.
         const model = 'model' in conv ? conv.model : undefined;
         setTargetModel({ cap: resolveModelToolCap(model?.id, model?.useModel), label: model?.useModel });
         const extra = conv.extra as { activeMcpServers?: string[] } | undefined;

--- a/src/renderer/pages/conversation/components/composerMenu/ComposerAddMenu.tsx
+++ b/src/renderer/pages/conversation/components/composerMenu/ComposerAddMenu.tsx
@@ -72,7 +72,7 @@ const ComposerAddMenuPanel: React.FC<{
   // per-conversation MCP selection drives the scoping toggles (#348). Live mode
   // only — a staged (home) composer has no conversation yet. Mirrors
   // useModelEffort's conversation.get usage.
-  const [targetModel, setTargetModel] = useState<{ cap?: number; label?: string }>({});
+  const [targetModel, setTargetModel] = useState<{ cap?: number; capDocumented?: boolean; label?: string }>({});
   const [activeServerIds, setActiveServerIds] = useState<string[] | undefined>(undefined);
   useEffect(() => {
     if (!conversationId) return;
@@ -88,7 +88,8 @@ const ComposerAddMenuPanel: React.FC<{
         // nudge instead of only OpenAI ones. The label falls back to a generic
         // "this model" when the id is unknown.
         const model = 'model' in conv ? conv.model : undefined;
-        setTargetModel({ cap: resolveModelToolCap(model?.id, model?.useModel), label: model?.useModel });
+        const cap = resolveModelToolCap(model?.id, model?.useModel);
+        setTargetModel({ cap: cap.limit, capDocumented: cap.documented, label: model?.useModel });
         const extra = conv.extra as { activeMcpServers?: string[] } | undefined;
         setActiveServerIds(extra?.activeMcpServers);
       })
@@ -241,6 +242,7 @@ const ComposerAddMenuPanel: React.FC<{
           onAddConnector={goConnectors}
           onManageConnectors={goConnectors}
           modelCap={targetModel.cap}
+          modelCapDocumented={targetModel.capDocumented}
           modelLabel={targetModel.label}
           onScopeChange={conversationId ? setActiveServers : undefined}
           activeServerIds={activeServerIds}

--- a/src/renderer/pages/conversation/components/composerMenu/ConnectorsFlyout.tsx
+++ b/src/renderer/pages/conversation/components/composerMenu/ConnectorsFlyout.tsx
@@ -33,11 +33,23 @@ type Props = {
   /** Open the MCP Library to manage connectors. */
   onManageConnectors: () => void;
   /**
-   * The target model's tool-array cap (#348). When provided and the probe-based
-   * inventory estimate is near/over it, a count-vs-cap nudge is shown so the user can scope
-   * servers or switch models. Absent (no known cap / staged composer) hides it.
+   * The target model's tool-array ceiling (#348). When provided and the
+   * probe-based inventory estimate is near/over it, a count-vs-cap nudge is shown
+   * so the user can scope servers or switch models. Absent (staged composer)
+   * hides it.
    */
   modelCap?: number;
+  /**
+   * #998 — whether `modelCap` is a PUBLISHED vendor limit (true) or the shared
+   * advisory rule of thumb (false/absent). It selects the copy, and the copy is
+   * a factual claim: only a documented cap may say the named model "caps at N",
+   * because only then does exceeding it actually fail the request. An advisory
+   * ceiling gets non-attributed wording, and warns only once the count is
+   * genuinely past it — the 85% "near" band on a made-up number would be a
+   * permanent banner for anyone with a large inventory, which is how users are
+   * trained to ignore warnings.
+   */
+  modelCapDocumented?: boolean;
   /** Display name of the target model, used in the nudge text. */
   modelLabel?: string;
   /**
@@ -105,6 +117,7 @@ const ConnectorsFlyout: React.FC<Props> = ({
   onAddConnector,
   onManageConnectors,
   modelCap,
+  modelCapDocumented,
   modelLabel,
   onScopeChange,
   activeServerIds,
@@ -116,7 +129,12 @@ const ConnectorsFlyout: React.FC<Props> = ({
   // session receipt. `ok` stays silent to avoid noise.
   const toolCount = countEnabledMcpTools(servers);
   const budget = modelCap ? toolBudgetStatus(toolCount, modelCap) : 'ok';
-  const showNudge = modelCap !== undefined && budget !== 'ok';
+  // #998: a documented vendor cap keeps the near+over bands and the "caps at N"
+  // copy, because exceeding it really does fail the request. An advisory ceiling
+  // only speaks once the count is actually past it, and never attributes a limit
+  // to the model.
+  const documentedCap = modelCapDocumented === true;
+  const showNudge = modelCap !== undefined && (documentedCap ? budget !== 'ok' : budget === 'over');
 
   // Per-conversation scoping (#348): in live mode (onScopeChange given) the
   // toggle reflects "active for THIS chat" over the enabled servers; in staged
@@ -147,28 +165,37 @@ const ConnectorsFlyout: React.FC<Props> = ({
 
       <div className={styles.flyoutScroll}>
         {showNudge && (
-          <div className={`${styles.toolNudge} ${budget === 'over' ? styles.toolNudgeOver : ''}`} role='status'>
+          <div
+            className={`${styles.toolNudge} ${documentedCap && budget === 'over' ? styles.toolNudgeOver : ''}`}
+            role='status'
+          >
             <AlertTriangle size={14} strokeWidth={2} className={styles.toolNudgeIc} />
             <span>
-              {budget === 'over'
-                ? t('conversation.composerMenu.toolNudgeOver', {
+              {!documentedCap
+                ? t('conversation.composerMenu.toolNudgeAdvisory', {
                     defaultValue:
-                      '{{count}} tools enabled · {{model}} caps at {{cap}}. Scope servers for this chat or switch models.',
+                      '{{count}} tools enabled. Long tool lists degrade tool selection on most models — scope servers for this chat or switch models.',
                     count: toolCount,
-                    cap: modelCap,
-                    model:
-                      modelLabel ??
-                      t('conversation.composerMenu.toolNudgeModelFallback', { defaultValue: 'this model' }),
                   })
-                : t('conversation.composerMenu.toolNudgeNear', {
-                    defaultValue:
-                      '{{count}} of {{cap}} tools · {{model}}. Near the limit — scope servers or switch models before adding more.',
-                    count: toolCount,
-                    cap: modelCap,
-                    model:
-                      modelLabel ??
-                      t('conversation.composerMenu.toolNudgeModelFallback', { defaultValue: 'this model' }),
-                  })}
+                : budget === 'over'
+                  ? t('conversation.composerMenu.toolNudgeOver', {
+                      defaultValue:
+                        '{{count}} tools enabled · {{model}} caps at {{cap}}. Scope servers for this chat or switch models.',
+                      count: toolCount,
+                      cap: modelCap,
+                      model:
+                        modelLabel ??
+                        t('conversation.composerMenu.toolNudgeModelFallback', { defaultValue: 'this model' }),
+                    })
+                  : t('conversation.composerMenu.toolNudgeNear', {
+                      defaultValue:
+                        '{{count}} of {{cap}} tools · {{model}}. Near the limit — scope servers or switch models before adding more.',
+                      count: toolCount,
+                      cap: modelCap,
+                      model:
+                        modelLabel ??
+                        t('conversation.composerMenu.toolNudgeModelFallback', { defaultValue: 'this model' }),
+                    })}
             </span>
           </div>
         )}

--- a/src/renderer/pages/settings/McpLibrary/DetailPage.module.css
+++ b/src/renderer/pages/settings/McpLibrary/DetailPage.module.css
@@ -380,6 +380,28 @@
 }
 
 /* tools list */
+/* #998 - the per-tool switches below are only enforced on some backends, and
+   this banner says so. Warning-toned on purpose: a user who reads it as
+   decoration is exactly the user who believes a tool is disabled when it is
+   not. */
+.toolScopeNotice {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 14px;
+  margin: 12px 0 16px;
+  border-radius: var(--radius-card-inner);
+  background: var(--warning-soft-bg);
+  color: var(--warning);
+  font-size: var(--type-12);
+  line-height: 1.5;
+}
+
+.toolScopeNotice svg {
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
 .toolsHeader {
   display: flex;
   align-items: center;

--- a/src/renderer/pages/settings/McpLibrary/DetailPage.tsx
+++ b/src/renderer/pages/settings/McpLibrary/DetailPage.tsx
@@ -9,6 +9,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Message, Switch, Modal } from '@arco-design/web-react';
 import {
+  AlertTriangle,
   ArrowLeft,
   BadgeCheck,
   Check,
@@ -41,6 +42,7 @@ import { mcpService, application } from '@/common/adapter/ipcBridge';
 import type { IMcpServer } from '@/common/config/storage';
 import type { McpPrepublicationTruth } from '@process/services/mcpServices/McpProtocol';
 import { normalizeMcpServerForSpawn } from '@/common/mcp/normalizeMcpServer';
+import { TOOL_ALLOWLIST_ENFORCING_BACKENDS } from '@/common/mcp';
 import { useMcpLibrary } from './hooks/useMcpLibrary';
 import { SetupGuide } from './components/SetupGuide';
 import StatusChip from './components/StatusChip';
@@ -614,6 +616,10 @@ export function DetailPage() {
   // once every tool is re-enabled, so the default stays clean.
   const allowedTools = installedServer?.allowedTools;
   const isToolEnabled = (toolName: string) => allowedTools === undefined || allowedTools.includes(toolName);
+  // #998: these switches are a real constraint only on the backends that carry
+  // the allowlist into their launch config. Read the engine names off that
+  // single source of truth so the banner can never drift from the behaviour.
+  const enforcingEngines = TOOL_ALLOWLIST_ENFORCING_BACKENDS.map((backend) => titleCase(backend)).join(', ');
   const persistAllowedTools = (next: string[] | undefined) => {
     if (!installedServer) return;
     void saveMcpServers((prev) =>
@@ -968,6 +974,18 @@ export function DetailPage() {
                   </div>
                 )}
               </div>
+              {installedServer?.tools && installedServer.tools.length > 0 && (
+                <div className={styles.toolScopeNotice} role='status'>
+                  <AlertTriangle size={14} strokeWidth={2} />
+                  <span>
+                    {t(
+                      'mcpLibrary.detail.toolScopeNotice',
+                      'These switches are enforced on {{engines}}. Other engines - including Wayland Core and the ACP agents - receive the whole connector, so a tool switched off here is still callable there. Turn the connector itself off to remove it everywhere.',
+                      { engines: enforcingEngines }
+                    )}
+                  </span>
+                </div>
+              )}
               {installedServer?.tools && installedServer.tools.length > 0 ? (
                 installedServer.tools.map((tool) => (
                   <div key={tool.name} className={styles.tool}>

--- a/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/src/renderer/services/i18n/i18n-keys.d.ts
@@ -1324,6 +1324,7 @@ export type I18nKey =
   | 'mcpLibrary.detail.tabTools'
   | 'mcpLibrary.detail.toggleTool'
   | 'mcpLibrary.detail.toolGroupCount'
+  | 'mcpLibrary.detail.toolScopeNotice'
   | 'mcpLibrary.detail.tools'
   | 'mcpLibrary.detail.toolsHeading'
   | 'mcpLibrary.detail.toolsLocked'

--- a/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/src/renderer/services/i18n/i18n-keys.d.ts
@@ -515,6 +515,7 @@ export type I18nKey =
   | 'conversation.composerMenu.tagBuiltin'
   | 'conversation.composerMenu.toggleAria'
   | 'conversation.composerMenu.toolCount'
+  | 'conversation.composerMenu.toolNudgeAdvisory'
   | 'conversation.composerMenu.toolNudgeModelFallback'
   | 'conversation.composerMenu.toolNudgeNear'
   | 'conversation.composerMenu.toolNudgeOver'

--- a/src/renderer/services/i18n/locales/de-DE/conversation.json
+++ b/src/renderer/services/i18n/locales/de-DE/conversation.json
@@ -469,7 +469,8 @@
     "toolCount": "{{count}} tools",
     "noConnectors": "No connectors installed yet.",
     "addConnector": "Add a connector",
-    "manageConnectors": "Manage connectors"
+    "manageConnectors": "Manage connectors",
+    "toolNudgeAdvisory": "{{count}} Tools aktiv. Lange Tool-Listen verschlechtern bei den meisten Modellen die Tool-Auswahl — grenze die Server für diesen Chat ein oder wechsle das Modell."
   },
   "modelSelector": {
     "title": "Model",

--- a/src/renderer/services/i18n/locales/de-DE/mcpLibrary.json
+++ b/src/renderer/services/i18n/locales/de-DE/mcpLibrary.json
@@ -94,6 +94,7 @@
     "tabSetup": "Setup",
     "tabPermissions": "Permissions",
     "toolsHeading": "Tools",
+    "toolScopeNotice": "Diese Schalter werden auf {{engines}} durchgesetzt. Andere Engines - darunter Wayland Core und die ACP-Agenten - erhalten den gesamten Connector, ein hier deaktiviertes Tool bleibt dort also aufrufbar. Deaktiviere den Connector selbst, um ihn überall zu entfernen.",
     "toolGroupCount": "{{count}} tools",
     "toolsLocked": "Install to see its tools.",
     "setupHeading": "Setup guide",

--- a/src/renderer/services/i18n/locales/en-US/conversation.json
+++ b/src/renderer/services/i18n/locales/en-US/conversation.json
@@ -553,6 +553,7 @@
     "addConnector": "Add a connector",
     "manageConnectors": "Manage connectors",
     "toolNudgeOver": "{{count}} tools enabled · {{model}} caps at {{cap}}. Scope servers for this chat or switch models.",
+    "toolNudgeAdvisory": "{{count}} tools enabled. Long tool lists degrade tool selection on most models — scope servers for this chat or switch models.",
     "toolNudgeNear": "{{count}} of {{cap}} tools · {{model}}. Near the limit, so scope servers or switch models before adding more.",
     "toolNudgeModelFallback": "this model"
   },

--- a/src/renderer/services/i18n/locales/en-US/mcpLibrary.json
+++ b/src/renderer/services/i18n/locales/en-US/mcpLibrary.json
@@ -126,6 +126,7 @@
     "tabSetup": "Setup",
     "tabPermissions": "Permissions",
     "toolsHeading": "Tools",
+    "toolScopeNotice": "These switches are enforced on {{engines}}. Other engines - including Wayland Core and the ACP agents - receive the whole connector, so a tool switched off here is still callable there. Turn the connector itself off to remove it everywhere.",
     "toolGroupCount": "{{count}} tools",
     "toolsLocked": "Install to see its tools.",
     "enableAllTools": "Enable all",

--- a/src/renderer/services/i18n/locales/es-ES/conversation.json
+++ b/src/renderer/services/i18n/locales/es-ES/conversation.json
@@ -469,7 +469,8 @@
     "toolCount": "{{count}} tools",
     "noConnectors": "No connectors installed yet.",
     "addConnector": "Add a connector",
-    "manageConnectors": "Manage connectors"
+    "manageConnectors": "Manage connectors",
+    "toolNudgeAdvisory": "{{count}} herramientas activas. Las listas largas de herramientas degradan la selección de herramientas en la mayoría de los modelos: limita los servidores de este chat o cambia de modelo."
   },
   "modelSelector": {
     "title": "Model",

--- a/src/renderer/services/i18n/locales/es-ES/mcpLibrary.json
+++ b/src/renderer/services/i18n/locales/es-ES/mcpLibrary.json
@@ -94,6 +94,7 @@
     "tabSetup": "Setup",
     "tabPermissions": "Permissions",
     "toolsHeading": "Tools",
+    "toolScopeNotice": "Estos interruptores se aplican en {{engines}}. Los demás motores - incluidos Wayland Core y los agentes ACP - reciben el conector completo, por lo que una herramienta desactivada aquí sigue pudiendo invocarse allí. Desactiva el conector para eliminarlo en todas partes.",
     "toolGroupCount": "{{count}} tools",
     "toolsLocked": "Install to see its tools.",
     "setupHeading": "Setup guide",

--- a/src/renderer/services/i18n/locales/fr-FR/conversation.json
+++ b/src/renderer/services/i18n/locales/fr-FR/conversation.json
@@ -469,7 +469,8 @@
     "toolCount": "{{count}} tools",
     "noConnectors": "No connectors installed yet.",
     "addConnector": "Add a connector",
-    "manageConnectors": "Manage connectors"
+    "manageConnectors": "Manage connectors",
+    "toolNudgeAdvisory": "{{count}} outils activés. Les longues listes d'outils dégradent la sélection d'outils sur la plupart des modèles — restreignez les serveurs de cette discussion ou changez de modèle."
   },
   "modelSelector": {
     "title": "Model",

--- a/src/renderer/services/i18n/locales/fr-FR/mcpLibrary.json
+++ b/src/renderer/services/i18n/locales/fr-FR/mcpLibrary.json
@@ -94,6 +94,7 @@
     "tabSetup": "Setup",
     "tabPermissions": "Permissions",
     "toolsHeading": "Tools",
+    "toolScopeNotice": "Ces interrupteurs sont appliqués sur {{engines}}. Les autres moteurs - dont Wayland Core et les agents ACP - reçoivent le connecteur entier : un outil désactivé ici reste appelable là-bas. Désactivez le connecteur lui-même pour le retirer partout.",
     "toolGroupCount": "{{count}} tools",
     "toolsLocked": "Install to see its tools.",
     "setupHeading": "Setup guide",

--- a/src/renderer/services/i18n/locales/ja-JP/conversation.json
+++ b/src/renderer/services/i18n/locales/ja-JP/conversation.json
@@ -469,7 +469,8 @@
     "toolCount": "{{count}} tools",
     "noConnectors": "No connectors installed yet.",
     "addConnector": "Add a connector",
-    "manageConnectors": "Manage connectors"
+    "manageConnectors": "Manage connectors",
+    "toolNudgeAdvisory": "{{count}} 個のツールが有効です。ツールの一覧が長いと、ほとんどのモデルでツール選択の精度が下がります。このチャットのサーバーを絞るか、モデルを変更してください。"
   },
   "modelSelector": {
     "title": "Model",

--- a/src/renderer/services/i18n/locales/ja-JP/mcpLibrary.json
+++ b/src/renderer/services/i18n/locales/ja-JP/mcpLibrary.json
@@ -94,6 +94,7 @@
     "tabSetup": "Setup",
     "tabPermissions": "Permissions",
     "toolsHeading": "Tools",
+    "toolScopeNotice": "これらのスイッチが有効になるのは {{engines}} のみです。Wayland Core や ACP エージェントなど他のエンジンにはコネクタ全体が渡されるため、ここで無効にしたツールも呼び出せます。すべてから削除するにはコネクタ自体をオフにしてください。",
     "toolGroupCount": "{{count}} tools",
     "toolsLocked": "Install to see its tools.",
     "setupHeading": "Setup guide",

--- a/src/renderer/services/i18n/locales/ko-KR/conversation.json
+++ b/src/renderer/services/i18n/locales/ko-KR/conversation.json
@@ -469,7 +469,8 @@
     "toolCount": "{{count}} tools",
     "noConnectors": "No connectors installed yet.",
     "addConnector": "Add a connector",
-    "manageConnectors": "Manage connectors"
+    "manageConnectors": "Manage connectors",
+    "toolNudgeAdvisory": "{{count}}개의 도구가 활성화되어 있습니다. 도구 목록이 길면 대부분의 모델에서 도구 선택 정확도가 떨어집니다. 이 채팅의 서버를 줄이거나 모델을 변경하세요."
   },
   "modelSelector": {
     "title": "Model",

--- a/src/renderer/services/i18n/locales/ko-KR/mcpLibrary.json
+++ b/src/renderer/services/i18n/locales/ko-KR/mcpLibrary.json
@@ -94,6 +94,7 @@
     "tabSetup": "Setup",
     "tabPermissions": "Permissions",
     "toolsHeading": "Tools",
+    "toolScopeNotice": "이 스위치는 {{engines}}에서만 적용됩니다. Wayland Core와 ACP 에이전트를 비롯한 다른 엔진에는 커넥터 전체가 전달되므로 여기서 끈 도구도 호출될 수 있습니다. 모든 곳에서 제거하려면 커넥터 자체를 끄세요.",
     "toolGroupCount": "{{count}} tools",
     "toolsLocked": "Install to see its tools.",
     "setupHeading": "Setup guide",

--- a/src/renderer/services/i18n/locales/pt-BR/conversation.json
+++ b/src/renderer/services/i18n/locales/pt-BR/conversation.json
@@ -469,7 +469,8 @@
     "toolCount": "{{count}} tools",
     "noConnectors": "No connectors installed yet.",
     "addConnector": "Add a connector",
-    "manageConnectors": "Manage connectors"
+    "manageConnectors": "Manage connectors",
+    "toolNudgeAdvisory": "{{count}} ferramentas ativas. Listas longas de ferramentas pioram a seleção de ferramentas na maioria dos modelos — limite os servidores desta conversa ou troque de modelo."
   },
   "modelSelector": {
     "title": "Model",

--- a/src/renderer/services/i18n/locales/pt-BR/mcpLibrary.json
+++ b/src/renderer/services/i18n/locales/pt-BR/mcpLibrary.json
@@ -94,6 +94,7 @@
     "tabSetup": "Setup",
     "tabPermissions": "Permissions",
     "toolsHeading": "Tools",
+    "toolScopeNotice": "Estas chaves são aplicadas em {{engines}}. Os outros motores - incluindo o Wayland Core e os agentes ACP - recebem o conector inteiro, então uma ferramenta desligada aqui continua acessível lá. Desligue o próprio conector para removê-lo em todos os lugares.",
     "toolGroupCount": "{{count}} tools",
     "toolsLocked": "Install to see its tools.",
     "setupHeading": "Setup guide",

--- a/src/renderer/services/i18n/locales/ru-RU/conversation.json
+++ b/src/renderer/services/i18n/locales/ru-RU/conversation.json
@@ -469,7 +469,8 @@
     "toolCount": "{{count}} tools",
     "noConnectors": "No connectors installed yet.",
     "addConnector": "Add a connector",
-    "manageConnectors": "Manage connectors"
+    "manageConnectors": "Manage connectors",
+    "toolNudgeAdvisory": "Включено инструментов: {{count}}. Длинные списки инструментов ухудшают их выбор у большинства моделей — ограничьте серверы для этого чата или смените модель."
   },
   "modelSelector": {
     "title": "Model",

--- a/src/renderer/services/i18n/locales/ru-RU/mcpLibrary.json
+++ b/src/renderer/services/i18n/locales/ru-RU/mcpLibrary.json
@@ -94,6 +94,7 @@
     "tabSetup": "Setup",
     "tabPermissions": "Permissions",
     "toolsHeading": "Tools",
+    "toolScopeNotice": "Эти переключатели действуют в {{engines}}. Другие движки - включая Wayland Core и ACP-агентов - получают коннектор целиком, поэтому отключённый здесь инструмент остаётся доступным для вызова. Чтобы убрать его везде, отключите сам коннектор.",
     "toolGroupCount": "{{count}} tools",
     "toolsLocked": "Install to see its tools.",
     "setupHeading": "Setup guide",

--- a/src/renderer/services/i18n/locales/tr-TR/conversation.json
+++ b/src/renderer/services/i18n/locales/tr-TR/conversation.json
@@ -471,7 +471,8 @@
     "toolCount": "{{count}} tools",
     "noConnectors": "No connectors installed yet.",
     "addConnector": "Add a connector",
-    "manageConnectors": "Manage connectors"
+    "manageConnectors": "Manage connectors",
+    "toolNudgeAdvisory": "{{count}} araç etkin. Uzun araç listeleri çoğu modelde araç seçimini bozar — bu sohbetteki sunucuları daraltın ya da modeli değiştirin."
   },
   "modelSelector": {
     "title": "Model",

--- a/src/renderer/services/i18n/locales/tr-TR/mcpLibrary.json
+++ b/src/renderer/services/i18n/locales/tr-TR/mcpLibrary.json
@@ -94,6 +94,7 @@
     "tabSetup": "Setup",
     "tabPermissions": "Permissions",
     "toolsHeading": "Tools",
+    "toolScopeNotice": "Bu anahtarlar yalnızca {{engines}} üzerinde geçerlidir. Wayland Core ve ACP aracıları dahil diğer motorlar bağlayıcının tamamını alır; burada kapatılan bir araç orada hâlâ çağrılabilir. Her yerden kaldırmak için bağlayıcının kendisini kapatın.",
     "toolGroupCount": "{{count}} tools",
     "toolsLocked": "Install to see its tools.",
     "setupHeading": "Setup guide",

--- a/src/renderer/services/i18n/locales/uk-UA/conversation.json
+++ b/src/renderer/services/i18n/locales/uk-UA/conversation.json
@@ -469,7 +469,8 @@
     "toolCount": "{{count}} tools",
     "noConnectors": "No connectors installed yet.",
     "addConnector": "Add a connector",
-    "manageConnectors": "Manage connectors"
+    "manageConnectors": "Manage connectors",
+    "toolNudgeAdvisory": "Увімкнено інструментів: {{count}}. Довгі списки інструментів погіршують їх вибір у більшості моделей — обмежте сервери для цього чату або змініть модель."
   },
   "modelSelector": {
     "title": "Model",

--- a/src/renderer/services/i18n/locales/uk-UA/mcpLibrary.json
+++ b/src/renderer/services/i18n/locales/uk-UA/mcpLibrary.json
@@ -94,6 +94,7 @@
     "tabSetup": "Setup",
     "tabPermissions": "Permissions",
     "toolsHeading": "Tools",
+    "toolScopeNotice": "Ці перемикачі діють у {{engines}}. Інші рушії - зокрема Wayland Core та ACP-агенти - отримують конектор цілком, тож вимкнений тут інструмент лишається доступним для виклику. Щоб прибрати його всюди, вимкніть сам конектор.",
     "toolGroupCount": "{{count}} tools",
     "toolsLocked": "Install to see its tools.",
     "setupHeading": "Setup guide",

--- a/src/renderer/services/i18n/locales/zh-CN/conversation.json
+++ b/src/renderer/services/i18n/locales/zh-CN/conversation.json
@@ -469,7 +469,8 @@
     "toolCount": "{{count}} tools",
     "noConnectors": "No connectors installed yet.",
     "addConnector": "Add a connector",
-    "manageConnectors": "Manage connectors"
+    "manageConnectors": "Manage connectors",
+    "toolNudgeAdvisory": "已启用 {{count}} 个工具。工具列表过长会降低大多数模型的工具选择质量 — 请为此对话缩减服务器或更换模型。"
   },
   "modelSelector": {
     "title": "Model",

--- a/src/renderer/services/i18n/locales/zh-CN/mcpLibrary.json
+++ b/src/renderer/services/i18n/locales/zh-CN/mcpLibrary.json
@@ -94,6 +94,7 @@
     "tabSetup": "Setup",
     "tabPermissions": "Permissions",
     "toolsHeading": "Tools",
+    "toolScopeNotice": "这些开关仅在 {{engines}} 上生效。其他引擎（包括 Wayland Core 和各 ACP 代理）会收到整个连接器，因此在此关闭的工具仍可被调用。若要彻底移除，请关闭连接器本身。",
     "toolGroupCount": "{{count}} tools",
     "toolsLocked": "Install to see its tools.",
     "setupHeading": "Setup guide",

--- a/src/renderer/services/i18n/locales/zh-TW/conversation.json
+++ b/src/renderer/services/i18n/locales/zh-TW/conversation.json
@@ -469,7 +469,8 @@
     "toolCount": "{{count}} tools",
     "noConnectors": "No connectors installed yet.",
     "addConnector": "Add a connector",
-    "manageConnectors": "Manage connectors"
+    "manageConnectors": "Manage connectors",
+    "toolNudgeAdvisory": "已啟用 {{count}} 個工具。工具清單過長會降低多數模型的工具選擇品質 — 請為此對話縮減伺服器或更換模型。"
   },
   "modelSelector": {
     "title": "Model",

--- a/src/renderer/services/i18n/locales/zh-TW/mcpLibrary.json
+++ b/src/renderer/services/i18n/locales/zh-TW/mcpLibrary.json
@@ -94,6 +94,7 @@
     "tabSetup": "Setup",
     "tabPermissions": "Permissions",
     "toolsHeading": "Tools",
+    "toolScopeNotice": "這些開關僅在 {{engines}} 上生效。其他引擎（包括 Wayland Core 與各 ACP 代理）會收到整個連接器，因此在此關閉的工具仍可被呼叫。若要完全移除，請關閉連接器本身。",
     "toolGroupCount": "{{count}} tools",
     "toolsLocked": "Install to see its tools.",
     "setupHeading": "Setup guide",

--- a/tests/unit/process/mcpToolAllowlistEnforcement.test.ts
+++ b/tests/unit/process/mcpToolAllowlistEnforcement.test.ts
@@ -156,14 +156,31 @@ describe('#998 backends that CANNOT enforce it must not claim to', () => {
 });
 
 describe('#998 the tool-count nudge is backend-aware, not OpenAI-only', () => {
-  it('still reports the documented OpenAI cap', () => {
-    expect(resolveModelToolCap('openai', 'gpt-5')).toBe(PROVIDER_TOOL_LIMITS['gpt-5']);
-    expect(resolveModelToolCap('openai', 'some-unlisted-openai-model')).toBe(PROVIDER_TOOL_LIMITS.openai);
+  it('still reports the documented OpenAI cap, and marks it documented', () => {
+    expect(resolveModelToolCap('openai', 'gpt-5')).toEqual({ limit: PROVIDER_TOOL_LIMITS['gpt-5'], documented: true });
+    expect(resolveModelToolCap('openai', 'some-unlisted-openai-model')).toEqual({
+      limit: PROVIDER_TOOL_LIMITS.openai,
+      documented: true,
+    });
   });
 
-  it('warns Anthropic and Flux users instead of returning no cap at all', () => {
-    expect(resolveModelToolCap('anthropic', 'claude-sonnet-4-5')).toBe(DEFAULT_TOOL_ARRAY_CAP);
-    expect(resolveModelToolCap('flux', 'flux-auto')).toBe(DEFAULT_TOOL_ARRAY_CAP);
-    expect(resolveModelToolCap(undefined, undefined)).toBe(DEFAULT_TOOL_ARRAY_CAP);
+  it('gives Anthropic and Flux a ceiling instead of no cap at all', () => {
+    expect(resolveModelToolCap('anthropic', 'claude-sonnet-4-5').limit).toBe(DEFAULT_TOOL_ARRAY_CAP);
+    expect(resolveModelToolCap('flux', 'flux-auto').limit).toBe(DEFAULT_TOOL_ARRAY_CAP);
+    expect(resolveModelToolCap(undefined, undefined).limit).toBe(DEFAULT_TOOL_ARRAY_CAP);
+  });
+
+  it('never marks the fallback ceiling as documented', () => {
+    // The UI keys its copy off this flag. Marking the rule of thumb "documented"
+    // would put a false, model-attributed "caps at 128" in front of every
+    // Anthropic / Flux / ACP user - the same lie this issue exists to remove.
+    for (const [providerId, modelId] of [
+      ['anthropic', 'claude-sonnet-4-5'],
+      ['flux', 'flux-auto'],
+      ['google', 'gemini-2.5-pro'],
+      [undefined, undefined],
+    ] as Array<[string | undefined, string | undefined]>) {
+      expect(resolveModelToolCap(providerId, modelId).documented).toBe(false);
+    }
   });
 });

--- a/tests/unit/process/mcpToolAllowlistEnforcement.test.ts
+++ b/tests/unit/process/mcpToolAllowlistEnforcement.test.ts
@@ -1,0 +1,169 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * #998 — the MCP Library's per-tool switches must not lie.
+ *
+ * `IMcpServer.allowedTools` only restricts an agent when the LAUNCH
+ * configuration handed to that agent carries the list. Before this suite,
+ * exactly one backend did that (Codex, via `enabled_tools`) while the UI
+ * presented the switch as universal, so a user who switched a destructive tool
+ * off on Wayland Core kept a fully callable tool.
+ *
+ * These tests pin BOTH halves of the honest contract:
+ *
+ *  1. Every backend named in `TOOL_ALLOWLIST_ENFORCING_BACKENDS` really does
+ *     emit the allowlist, so nothing can be added to that list (and therefore
+ *     to the MCP Library's "enforced on …" banner) without the plumbing.
+ *  2. The backends that provably cannot carry a tool list — Wayland Core's
+ *     launch profile and the ACP `session/new` array, neither of which has a
+ *     per-tool field — are NOT claimed as enforcing. That claim is what the UI
+ *     renders, so this is the regression guard on the honesty of the control.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_TOOL_ARRAY_CAP,
+  PROVIDER_TOOL_LIMITS,
+  TOOL_ALLOWLIST_ENFORCING_BACKENDS,
+  backendEnforcesToolAllowlist,
+  resolveModelToolCap,
+} from '@/common/mcp';
+import type { IMcpServer } from '@/common/config/storage';
+import {
+  buildAcpSessionMcpServers,
+  buildWCoreSessionMcpServers,
+  buildWCoreUserStdioMcpServers,
+} from '@process/agent/acp/mcpSessionConfig';
+import { appendDesktopMcpProfile } from '@process/agent/wcore/envBuilder';
+import { buildCodexMcpServerTable } from '@process/task/codexConfig';
+import { buildGeminiStdioMcpConfig } from '@process/task/GeminiAgentManager';
+
+const KEPT = 'search_files';
+const DISABLED = 'delete_everything';
+
+const stdioTransport = {
+  type: 'stdio',
+  command: 'uvx',
+  args: ['google-workspace-mcp'],
+} as Extract<IMcpServer['transport'], { type: 'stdio' }>;
+
+/** One connector with a strict allowlist: the destructive tool is switched OFF. */
+const scopedServer = (over: Partial<IMcpServer> = {}): IMcpServer =>
+  ({
+    id: 'srv-1',
+    name: 'workspace',
+    enabled: true,
+    status: 'connected',
+    source: 'library',
+    transport: stdioTransport,
+    allowedTools: [KEPT],
+    tools: [{ name: KEPT }, { name: DISABLED }],
+    originalJson: '{}',
+    createdAt: 1,
+    updatedAt: 1,
+    ...over,
+  }) as IMcpServer;
+
+const ACP_CAPS = { stdio: true, http: true, sse: true } as const;
+
+describe('#998 backends that DO enforce the per-tool switch', () => {
+  it('codex writes the allowlist as enabled_tools and omits the disabled tool', () => {
+    const table = buildCodexMcpServerTable([scopedServer()]);
+
+    expect(table.workspace.enabled_tools).toEqual([KEPT]);
+    expect(table.workspace.enabled_tools).not.toContain(DISABLED);
+  });
+
+  it('codex omits enabled_tools entirely when no allowlist is set (undefined => all)', () => {
+    const table = buildCodexMcpServerTable([scopedServer({ allowedTools: undefined })]);
+
+    expect(table.workspace).not.toHaveProperty('enabled_tools');
+  });
+
+  it('gemini carries the allowlist as includeTools so the runtime drops the disabled tool', () => {
+    const config = buildGeminiStdioMcpConfig(stdioTransport, 'Google Workspace', [KEPT]);
+
+    expect(config.includeTools).toEqual([KEPT]);
+    expect(config.includeTools).not.toContain(DISABLED);
+  });
+
+  it('gemini omits includeTools when no allowlist is set, and emits [] for "none"', () => {
+    expect(buildGeminiStdioMcpConfig(stdioTransport, undefined, undefined)).not.toHaveProperty('includeTools');
+    // An empty list must survive as an empty list: aioncli-core treats an absent
+    // includeTools as "every tool", so collapsing [] to undefined would re-enable
+    // every tool the user switched off.
+    expect(buildGeminiStdioMcpConfig(stdioTransport, undefined, []).includeTools).toEqual([]);
+  });
+});
+
+describe('#998 backends that CANNOT enforce it must not claim to', () => {
+  it('the wcore launch profile is server-level only - no tool names reach it', () => {
+    const profile = appendDesktopMcpProfile(null, ['workspace']);
+
+    expect(profile).toContain('mcp_servers = ["workspace"]');
+    expect(profile).not.toContain(KEPT);
+    expect(profile).not.toContain(DISABLED);
+  });
+
+  it('the wcore stdio injection carries no tool list', () => {
+    const [injected] = buildWCoreUserStdioMcpServers([scopedServer()]);
+
+    expect(injected.name).toBe('workspace');
+    expect(Object.keys(injected)).toEqual(
+      expect.not.arrayContaining(['allowedTools', 'enabled_tools', 'includeTools'])
+    );
+  });
+
+  it('the ACP session/new array carries no tool list', () => {
+    const [injected] = buildAcpSessionMcpServers([scopedServer()], ACP_CAPS);
+
+    expect(injected.name).toBe('workspace');
+    expect(Object.keys(injected)).toEqual(
+      expect.not.arrayContaining(['allowedTools', 'enabled_tools', 'includeTools'])
+    );
+  });
+
+  it('wcore and the ACP backends are absent from the enforcing set', () => {
+    for (const backend of ['wcore', 'claude', 'qwen', 'wnano', 'grok', 'kimi', 'opencode', 'copilot']) {
+      expect(backendEnforcesToolAllowlist(backend)).toBe(false);
+    }
+    expect(backendEnforcesToolAllowlist(undefined)).toBe(false);
+  });
+
+  it('the enforcing set is exactly the backends whose launch config carries the list', () => {
+    // Guards the UI banner: adding a backend here without the plumbing below
+    // restores the lying control this issue is about.
+    expect([...TOOL_ALLOWLIST_ENFORCING_BACKENDS].toSorted()).toEqual(['codex', 'gemini']);
+    for (const backend of TOOL_ALLOWLIST_ENFORCING_BACKENDS) {
+      expect(backendEnforcesToolAllowlist(backend)).toBe(true);
+    }
+  });
+
+  it('buildWCoreSessionMcpServers preserves allowedTools as data but the profile never emits it', () => {
+    // The selected-server list keeps the field (it is the same IMcpServer
+    // record); enforcement is decided by what the PROFILE carries, which is
+    // asserted above. This documents that the field's presence here is not
+    // evidence of enforcement.
+    const [selected] = buildWCoreSessionMcpServers([scopedServer()]);
+    expect(selected.allowedTools).toEqual([KEPT]);
+    expect(appendDesktopMcpProfile(null, [selected.name])).not.toContain(KEPT);
+  });
+});
+
+describe('#998 the tool-count nudge is backend-aware, not OpenAI-only', () => {
+  it('still reports the documented OpenAI cap', () => {
+    expect(resolveModelToolCap('openai', 'gpt-5')).toBe(PROVIDER_TOOL_LIMITS['gpt-5']);
+    expect(resolveModelToolCap('openai', 'some-unlisted-openai-model')).toBe(PROVIDER_TOOL_LIMITS.openai);
+  });
+
+  it('warns Anthropic and Flux users instead of returning no cap at all', () => {
+    expect(resolveModelToolCap('anthropic', 'claude-sonnet-4-5')).toBe(DEFAULT_TOOL_ARRAY_CAP);
+    expect(resolveModelToolCap('flux', 'flux-auto')).toBe(DEFAULT_TOOL_ARRAY_CAP);
+    expect(resolveModelToolCap(undefined, undefined)).toBe(DEFAULT_TOOL_ARRAY_CAP);
+  });
+});

--- a/tests/unit/process/task/geminiEmptyAllowlistLaunch.test.ts
+++ b/tests/unit/process/task/geminiEmptyAllowlistLaunch.test.ts
@@ -228,6 +228,31 @@ const connector = (allowedTools?: string[]): IMcpServer =>
     updatedAt: 1,
   }) as IMcpServer;
 
+/**
+ * The same stored connector reached over a hosted transport. `getMcpServers`
+ * builds hosted entries inline (url/type/headers) rather than through
+ * `buildGeminiStdioMcpConfig`, so the per-tool switch is threaded in a SECOND
+ * place that the stdio-only enforcement pin cannot see.
+ */
+const hostedConnector = (transportType: 'http' | 'sse', allowedTools?: string[]): IMcpServer =>
+  ({
+    id: 'srv-hosted',
+    name: 'workspace',
+    enabled: true,
+    status: 'connected',
+    source: 'library',
+    transport: {
+      type: transportType,
+      url: 'https://mcp.example.com/endpoint',
+      headers: { Authorization: 'Bearer stored' },
+    },
+    allowedTools,
+    tools: [{ name: 'search_files' }, { name: 'delete_everything' }],
+    originalJson: '{}',
+    createdAt: 1,
+    updatedAt: 1,
+  }) as IMcpServer;
+
 function createManager(): GeminiAgentManager {
   vi.spyOn(GeminiAgentManager.prototype as unknown as Record<string, unknown>, 'createBootstrap').mockResolvedValue(
     undefined
@@ -235,9 +260,11 @@ function createManager(): GeminiAgentManager {
   return new GeminiAgentManager({ workspace: '/ws', conversation_id: 'conv-test' }, MODEL);
 }
 
-const emittedMcpConfig = async (): Promise<Record<string, { includeTools?: string[] }>> => {
+type EmittedEntry = { includeTools?: string[]; type?: string; url?: string; command?: string };
+
+const emittedMcpConfig = async (): Promise<Record<string, EmittedEntry>> => {
   const manager = createManager() as unknown as {
-    getMcpServers: () => Promise<Record<string, { includeTools?: string[] }>>;
+    getMcpServers: () => Promise<Record<string, EmittedEntry>>;
   };
   return manager.getMcpServers();
 };
@@ -287,4 +314,46 @@ describe('#998 GeminiAgentManager.getMcpServers and the empty allowlist', () => 
 
     expect(manager.mcpSessionState.expectedServerNames).toEqual([]);
   });
+});
+
+/**
+ * #998 — the HOSTED half of the same fix.
+ *
+ * `TOOL_ALLOWLIST_ENFORCING_BACKENDS` claims gemini enforces the MCP Library's
+ * per-tool switches, and `mcpToolAllowlistEnforcement.test.ts` holds that claim
+ * to the STDIO builder (`buildGeminiStdioMcpConfig`). `getMcpServers` builds
+ * SSE/HTTP entries inline instead, so deleting the hosted `includeTools` spread
+ * left the whole suite green while every OAuth connector reached Gemini with its
+ * full inventory behind a banner promising otherwise. Enforcement itself is
+ * transport-agnostic — `connectAndDiscover` funnels every transport through the
+ * same `discoverTools` proven above — so the only thing missing was this pin.
+ */
+describe('#998 GeminiAgentManager.getMcpServers scopes hosted connectors too', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  for (const transportType of ['http', 'sse'] as const) {
+    it(`emits includeTools for a scoped ${transportType} connector`, async () => {
+      mcpState.servers = [hostedConnector(transportType, ['search_files'])];
+
+      const config = await emittedMcpConfig();
+
+      // Proves the hosted branch built this entry, not the stdio builder.
+      expect(config.workspace.type).toBe(transportType);
+      expect(config.workspace.url).toBe('https://mcp.example.com/endpoint');
+      expect(config.workspace).not.toHaveProperty('command');
+      expect(config.workspace.includeTools).toEqual(['search_files']);
+    });
+
+    it(`omits includeTools entirely for an unscoped ${transportType} connector`, async () => {
+      mcpState.servers = [hostedConnector(transportType, undefined)];
+
+      const config = await emittedMcpConfig();
+
+      // `undefined` must stay ABSENT: an empty includeTools means "no tools".
+      expect(config.workspace.type).toBe(transportType);
+      expect(config.workspace).not.toHaveProperty('includeTools');
+    });
+  }
 });

--- a/tests/unit/process/task/geminiEmptyAllowlistLaunch.test.ts
+++ b/tests/unit/process/task/geminiEmptyAllowlistLaunch.test.ts
@@ -1,0 +1,290 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * #998 follow-up - "Disable all" must silence a connector, not break it.
+ *
+ * Threading `allowedTools` into the Gemini runtime as `includeTools` made the
+ * per-tool switches real, but it also made the existing "Disable all" button
+ * (which persists `allowedTools: []`) emit a connector that discovers ZERO
+ * tools. aioncli-core treats zero prompts AND zero tools as a failed
+ * connection: it throws, emits error feedback, and marks the server
+ * DISCONNECTED. The user would get an error toast and a red connector instead
+ * of "connector on, tools off".
+ *
+ * These tests cover the RUNTIME OUTCOME, not just the emitted config shape:
+ *  - the real aioncli-core `discoverTools` is executed and proven to return
+ *    zero tools for `includeTools: []`,
+ *  - the real `discoverPrompts` is executed and proven to return zero prompts
+ *    for a prompt-less server,
+ *  - the installed `connectAndDiscover` is pinned to still turn that pair into
+ *    a throw, so this workaround's premise breaks loudly if the dep changes,
+ *  - and the real `GeminiAgentManager.getMcpServers` is driven end to end to
+ *    prove the connector never reaches that path in the first place.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+import { discoverPrompts, discoverTools } from '@office-ai/aioncli-core/dist/src/tools/mcp-client.js';
+import type { IMcpServer } from '@/common/config/storage';
+
+// ---------------------------------------------------------------------------
+// Part 1 - real aioncli-core runtime behaviour (no mocks on the dependency)
+// ---------------------------------------------------------------------------
+
+/** Minimal MCP client stub: advertises tools, publishes two of them, no prompts. */
+const clientWithTwoToolsAndNoPrompts = () =>
+  ({
+    getServerCapabilities: () => ({ tools: {} }),
+    listTools: async () => ({
+      tools: [
+        { name: 'search_files', description: 'search', inputSchema: { type: 'object', properties: {} } },
+        { name: 'delete_everything', description: 'delete', inputSchema: { type: 'object', properties: {} } },
+      ],
+    }),
+  }) as unknown as Parameters<typeof discoverTools>[2];
+
+const cliConfigStub = () =>
+  ({
+    getPolicyEngine: () => ({ addRule: () => {} }),
+  }) as unknown as Parameters<typeof discoverTools>[3];
+
+describe('#998 aioncli-core runtime: an empty includeTools discovers nothing', () => {
+  it('discoverTools returns zero tools when includeTools is empty', async () => {
+    const tools = await discoverTools(
+      'workspace',
+      { includeTools: [] } as unknown as Parameters<typeof discoverTools>[1],
+      clientWithTwoToolsAndNoPrompts(),
+      cliConfigStub(),
+      undefined as unknown as Parameters<typeof discoverTools>[4],
+      undefined
+    );
+
+    expect(tools).toEqual([]);
+  });
+
+  it('discoverPrompts returns zero prompts for a server that publishes none', async () => {
+    const prompts = await discoverPrompts(
+      'workspace',
+      clientWithTwoToolsAndNoPrompts(),
+      undefined as unknown as Parameters<typeof discoverPrompts>[2]
+    );
+
+    expect(prompts).toEqual([]);
+  });
+
+  it('connectAndDiscover still turns zero prompts + zero tools into a throw', () => {
+    // Dependency-contract pin, deliberately a source assertion: driving the real
+    // connectAndDiscover would require spawning an MCP server. If a future
+    // aioncli-core stops failing the connection on an empty discovery, this
+    // breaks and the workaround above can be revisited rather than silently kept.
+    const require_ = createRequire(import.meta.url);
+    const source = readFileSync(require_.resolve('@office-ai/aioncli-core/dist/src/tools/mcp-client.js'), 'utf-8');
+
+    expect(source).toContain('if (prompts.length === 0 && tools.length === 0)');
+    expect(source).toContain("throw new Error('No prompts or tools found on the server.')");
+    expect(source).toContain('MCPServerStatus.DISCONNECTED');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Part 2 - the real GeminiAgentManager never emits such a connector
+// ---------------------------------------------------------------------------
+
+const mcpState = vi.hoisted(() => ({ servers: [] as IMcpServer[] }));
+
+const mockIpcBridge = vi.hoisted(() => ({
+  geminiConversation: { responseStream: { emit: vi.fn() } },
+  conversation: { responseStream: { emit: vi.fn() } },
+}));
+
+vi.mock('@/common', () => ({ ipcBridge: mockIpcBridge }));
+vi.mock('@/common/utils', () => ({ uuid: vi.fn(() => 'uuid-1') }));
+vi.mock('@/common/chat/chatLib', () => ({ transformMessage: vi.fn(() => null) }));
+vi.mock('@/common/utils/platformAuthType', () => ({ getProviderAuthType: vi.fn(() => 'api_key') }));
+vi.mock('@process/channels/agent/ChannelEventBus', () => ({ channelEventBus: { emitAgentMessage: vi.fn() } }));
+vi.mock('@process/extensions', () => ({
+  ExtensionRegistry: { getInstance: vi.fn(() => ({ getExtensions: vi.fn(() => []) })) },
+}));
+vi.mock('@process/services/cron/CronBusyGuard', () => ({ cronBusyGuard: { setProcessing: vi.fn() } }));
+vi.mock('@process/services/cron/SkillSuggestWatcher', () => ({ skillSuggestWatcher: { onFinish: vi.fn() } }));
+vi.mock('@process/services/database', () => ({
+  getDatabase: vi.fn().mockResolvedValue({
+    getConversation: vi.fn(() => ({ success: false })),
+    updateConversation: vi.fn(),
+  }),
+}));
+vi.mock('@process/services/mcpServices/runtimeMcpServers', () => ({
+  loadRuntimeMcpServers: vi.fn(async () => mcpState.servers),
+}));
+vi.mock('@process/services/mcpServices/McpService', () => ({
+  mcpService: { attachOAuthTokens: vi.fn(async (servers: IMcpServer[]) => servers) },
+}));
+vi.mock('@process/team/mcp/guide/teamGuideSingleton', () => ({ getTeamGuideStdioConfig: vi.fn(() => undefined) }));
+vi.mock('@process/team/teamEventBus', () => ({ teamEventBus: { emit: vi.fn() } }));
+vi.mock('@process/utils/initStorage', () => ({
+  ProcessConfig: { get: vi.fn().mockResolvedValue({}), set: vi.fn().mockResolvedValue(undefined) },
+  getSkillsDir: vi.fn(() => '/fake/skills'),
+}));
+vi.mock('@process/utils/mainLogger', () => ({ mainLog: vi.fn(), mainWarn: vi.fn(), mainError: vi.fn() }));
+vi.mock('@process/utils/message', () => ({
+  addMessage: vi.fn(),
+  addOrUpdateMessage: vi.fn(),
+  nextTickToLocalFinish: vi.fn(),
+}));
+vi.mock('@process/utils/previewUtils', () => ({ handlePreviewOpenEvent: vi.fn(() => false) }));
+vi.mock('../../../../src/process/task/AcpSkillManager', () => ({
+  detectSkillLoadRequest: vi.fn(() => false),
+  AcpSkillManager: {
+    getInstance: vi.fn(() => ({
+      discoverSkills: vi.fn().mockResolvedValue(undefined),
+      getBuiltinSkillsIndex: vi.fn(() => []),
+    })),
+  },
+  buildSkillContentText: vi.fn(() => ''),
+}));
+vi.mock('../../../../src/process/task/CronCommandDetector', () => ({ hasCronCommands: vi.fn(() => false) }));
+vi.mock('../../../../src/process/task/MessageMiddleware', () => ({
+  extractTextFromMessage: vi.fn(() => ''),
+  processCronInMessage: vi.fn(),
+}));
+vi.mock('../../../../src/process/task/ThinkTagDetector', () => ({
+  stripThinkTags: vi.fn((value: string) => value),
+  extractAndStripThinkTags: vi.fn((value: string) => ({ thinking: '', content: value })),
+}));
+vi.mock('../../../../src/process/task/agentUtils', () => ({ buildSystemInstructionsWithSkillsIndex: vi.fn(() => '') }));
+vi.mock('../../../../src/process/agent/gemini/GeminiApprovalStore', () => ({
+  GeminiApprovalStore: class {
+    allApproved() {
+      return false;
+    }
+    approveAll() {}
+  },
+}));
+vi.mock('../../../../src/process/agent/gemini/cli/tools/tools', () => ({ ToolConfirmationOutcome: {} }));
+vi.mock('@office-ai/aioncli-core', () => ({
+  AuthType: { LOGIN_WITH_GOOGLE: 'LOGIN_WITH_GOOGLE', USE_VERTEX_AI: 'USE_VERTEX_AI' },
+  getOauthInfoWithCache: vi.fn().mockResolvedValue(null),
+  Storage: { getOAuthCredsPath: vi.fn(() => '/fake/oauth') },
+}));
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return { ...actual, default: actual };
+});
+vi.mock('../../../../src/process/task/IpcAgentEventEmitter', () => ({ IpcAgentEventEmitter: vi.fn() }));
+vi.mock('../../../../src/process/task/BaseAgentManager', () => ({
+  default: class BaseAgentManager {
+    conversation_id = 'conv-test';
+    status = 'pending';
+    type = 'gemini';
+    yoloMode = false;
+    constructor(_type: string, _data: unknown, _emitter: unknown) {
+      if (typeof (this as { init?: () => void }).init === 'function') {
+        (this as { init: () => void }).init();
+      }
+    }
+    init() {}
+    on() {
+      return () => {};
+    }
+    emit() {}
+    stop = vi.fn().mockResolvedValue(undefined);
+    kill = vi.fn();
+    getConfirmations() {
+      return [];
+    }
+    addConfirmation() {}
+    confirm = vi.fn();
+    postMessagePromise = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+
+import { GeminiAgentManager } from '../../../../src/process/task/GeminiAgentManager';
+
+const MODEL = {
+  name: 'gemini',
+  useModel: 'gemini-2.0-flash',
+  platform: 'google',
+  baseUrl: '',
+} as Parameters<typeof GeminiAgentManager.prototype.constructor>[1];
+
+const connector = (allowedTools?: string[]): IMcpServer =>
+  ({
+    id: 'srv-1',
+    name: 'workspace',
+    enabled: true,
+    status: 'connected',
+    source: 'library',
+    transport: { type: 'stdio', command: 'uvx', args: ['google-workspace-mcp'] },
+    allowedTools,
+    tools: [{ name: 'search_files' }, { name: 'delete_everything' }],
+    originalJson: '{}',
+    createdAt: 1,
+    updatedAt: 1,
+  }) as IMcpServer;
+
+function createManager(): GeminiAgentManager {
+  vi.spyOn(GeminiAgentManager.prototype as unknown as Record<string, unknown>, 'createBootstrap').mockResolvedValue(
+    undefined
+  );
+  return new GeminiAgentManager({ workspace: '/ws', conversation_id: 'conv-test' }, MODEL);
+}
+
+const emittedMcpConfig = async (): Promise<Record<string, { includeTools?: string[] }>> => {
+  const manager = createManager() as unknown as {
+    getMcpServers: () => Promise<Record<string, { includeTools?: string[] }>>;
+  };
+  return manager.getMcpServers();
+};
+
+describe('#998 GeminiAgentManager.getMcpServers and the empty allowlist', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('omits a connector whose every tool is switched off, instead of breaking it', async () => {
+    mcpState.servers = [connector([])];
+
+    const config = await emittedMcpConfig();
+
+    // Not emitted at all - so aioncli-core never connects it, never discovers
+    // zero tools, never throws, and never marks it disconnected.
+    expect(config).not.toHaveProperty('workspace');
+    expect(Object.keys(config)).toEqual([]);
+  });
+
+  it('emits a scoped connector with exactly the enabled tools', async () => {
+    mcpState.servers = [connector(['search_files'])];
+
+    const config = await emittedMcpConfig();
+
+    expect(config.workspace.includeTools).toEqual(['search_files']);
+  });
+
+  it('emits an unscoped connector with no includeTools at all', async () => {
+    mcpState.servers = [connector(undefined)];
+
+    const config = await emittedMcpConfig();
+
+    expect(config.workspace).not.toHaveProperty('includeTools');
+  });
+
+  it('does not declare the dropped connector as an expected session receipt', async () => {
+    // The drop happens BEFORE beginMcpSession, so the launch does not sit
+    // waiting on a publication that can never arrive.
+    mcpState.servers = [connector([])];
+    const manager = createManager() as unknown as {
+      getMcpServers: () => Promise<unknown>;
+      mcpSessionState: { expectedServerNames: string[] };
+    };
+
+    await manager.getMcpServers();
+
+    expect(manager.mcpSessionState.expectedServerNames).toEqual([]);
+  });
+});

--- a/tests/unit/renderer/ComposerAddMenu.dom.test.tsx
+++ b/tests/unit/renderer/ComposerAddMenu.dom.test.tsx
@@ -6,10 +6,15 @@
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const mockNavigate = vi.hoisted(() => vi.fn());
 const mockResponseStreamOn = vi.hoisted(() => vi.fn(() => vi.fn()));
+/** Stored conversation + connector inventory the menu reads on open. */
+const state = vi.hoisted(() => ({
+  conversation: undefined as unknown,
+  mcpServers: [] as unknown[],
+}));
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -37,12 +42,14 @@ vi.mock('@/common', () => ({
     },
     conversation: {
       responseStream: { on: mockResponseStreamOn },
+      get: { invoke: vi.fn(async () => state.conversation) },
+      update: { invoke: vi.fn().mockResolvedValue(undefined) },
     },
   },
 }));
 
 vi.mock('@renderer/hooks/mcp', () => ({
-  useMcpServers: () => ({ mcpServers: [], saveMcpServers: vi.fn() }),
+  useMcpServers: () => ({ mcpServers: state.mcpServers, saveMcpServers: vi.fn() }),
   useMcpAgentStatus: () => ({ setAgentInstallStatus: vi.fn(), checkSingleServerInstallStatus: vi.fn() }),
   useMcpOperations: () => ({ syncMcpToAgents: vi.fn(), removeMcpFromAgents: vi.fn() }),
   useMcpServerCRUD: () => ({ handleToggleMcpServer: vi.fn() }),
@@ -114,5 +121,75 @@ describe('ComposerAddMenu', () => {
 
     expect(screen.queryByTestId('dd-pop')).not.toBeInTheDocument();
     expect(mockResponseStreamOn).toHaveBeenCalledOnce();
+  });
+});
+
+/**
+ * #998 — the seam between `resolveModelToolCap` and the flyout copy.
+ *
+ * `ConnectorsFlyout` only ever says a named model "caps at N" when
+ * `modelCapDocumented` is true, and `resolveModelToolCap` only reports
+ * `documented: true` for a published vendor cap. Both ends are guarded on their
+ * own; the WIRING between them was not, so hard-coding `capDocumented: true`
+ * here re-introduced the exact false claim commit 2 of this PR removed
+ * ("claude-sonnet-4-5 caps at 128" — Anthropic publishes no such tool-array
+ * cap) with the whole suite still green. Both directions are pinned: an
+ * undocumented model must get the advisory copy, and a documented one must keep
+ * the real cap copy, so neither hard-coding nor unwiring the flag survives.
+ */
+/** A connected connector publishing `toolCount` tools. */
+const connector = (toolCount: number) => ({
+  id: 'srv-1',
+  name: 'workspace',
+  enabled: true,
+  status: 'connected',
+  transport: { type: 'stdio', command: 'x', args: [] },
+  tools: Array.from({ length: toolCount }, (_, i) => ({ name: `t${i}` })),
+  originalJson: '{}',
+  createdAt: 1,
+  updatedAt: 1,
+});
+
+describe('ComposerAddMenu model tool-cap wiring (#998)', () => {
+  const props = {
+    mode: 'live' as const,
+    conversationId: 'chat-1',
+    uploadItems: [{ key: 'file', label: 'Upload Files', onClick: vi.fn() }],
+    builtinAutoSkills: builtins,
+    disabledBuiltinSkills: ['officecli'],
+    onToggleBuiltinSkill: vi.fn(),
+  };
+
+  afterEach(() => {
+    state.conversation = undefined;
+    state.mcpServers = [];
+  });
+
+  const openConnectorsPane = async (model: { id: string; useModel: string }) => {
+    state.conversation = { id: 'chat-1', model, extra: {} };
+    state.mcpServers = [connector(130)];
+
+    render(<ComposerAddMenu {...props} />);
+    fireEvent.click(screen.getByTestId('dd-trigger'));
+    await waitFor(() => expect(screen.getByText('cron')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Connectors'));
+    return waitFor(() => screen.getByRole('status'));
+  };
+
+  it('never tells an Anthropic chat the model caps at the advisory ceiling', async () => {
+    const note = await openConnectorsPane({ id: 'anthropic', useModel: 'claude-sonnet-4-5' });
+
+    // The nudge IS live on this path - the assertions below are about its copy,
+    // not about a banner that never rendered.
+    expect(note).toHaveTextContent('130 tools enabled');
+    expect(note).toHaveTextContent('degrade tool selection on most models');
+    expect(note.textContent).not.toContain('caps at');
+    expect(note.textContent).not.toContain('claude-sonnet-4-5');
+  });
+
+  it('still names the published cap for a model that really has one', async () => {
+    const note = await openConnectorsPane({ id: 'openai', useModel: 'gpt-5' });
+
+    expect(note).toHaveTextContent('gpt-5 caps at 128');
   });
 });

--- a/tests/unit/renderer/composerMenu/ConnectorsFlyout.dom.test.tsx
+++ b/tests/unit/renderer/composerMenu/ConnectorsFlyout.dom.test.tsx
@@ -63,19 +63,19 @@ afterEach(() => cleanup());
 
 describe('ConnectorsFlyout count-vs-cap nudge (#348)', () => {
   it('shows an over-limit nudge naming the model + cap when tools exceed the cap', () => {
-    renderFlyout({ servers: [srv(130)], modelCap: 128, modelLabel: 'gpt-5' });
+    renderFlyout({ servers: [srv(130)], modelCap: 128, modelCapDocumented: true, modelLabel: 'gpt-5' });
     const note = screen.getByRole('status');
     expect(note).toHaveTextContent('130 tools enabled');
     expect(note).toHaveTextContent('gpt-5 caps at 128');
   });
 
   it('shows a near-limit nudge when within the top 15% of headroom', () => {
-    renderFlyout({ servers: [srv(120)], modelCap: 128, modelLabel: 'gpt-5' });
+    renderFlyout({ servers: [srv(120)], modelCap: 128, modelCapDocumented: true, modelLabel: 'gpt-5' });
     expect(screen.getByRole('status')).toHaveTextContent('120 of 128 tools');
   });
 
   it('stays silent when comfortably under the cap', () => {
-    renderFlyout({ servers: [srv(10)], modelCap: 128, modelLabel: 'gpt-5' });
+    renderFlyout({ servers: [srv(10)], modelCap: 128, modelCapDocumented: true, modelLabel: 'gpt-5' });
     expect(screen.queryByRole('status')).not.toBeInTheDocument();
   });
 
@@ -85,7 +85,7 @@ describe('ConnectorsFlyout count-vs-cap nudge (#348)', () => {
   });
 
   it('falls back to "this model" when over the cap with no model label', () => {
-    renderFlyout({ servers: [srv(130)], modelCap: 128 });
+    renderFlyout({ servers: [srv(130)], modelCap: 128, modelCapDocumented: true });
     expect(screen.getByRole('status')).toHaveTextContent('this model caps at 128');
   });
 
@@ -94,9 +94,55 @@ describe('ConnectorsFlyout count-vs-cap nudge (#348)', () => {
     renderFlyout({
       servers: [srv(200, { allowedTools: ['a', 'b', 'c', 'd', 'e'] })],
       modelCap: 128,
+      modelCapDocumented: true,
       modelLabel: 'gpt-5',
     });
     expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * #998 — the same nudge must not invent a vendor limit. `modelCapDocumented`
+ * separates a published cap (exceeding it really 400s, so the copy may name the
+ * model and the number) from the shared advisory ceiling used for every provider
+ * that publishes nothing. Telling a Claude user "claude-sonnet-4-5 caps at 128"
+ * is a specific factual claim, and Anthropic publishes no such cap. This PR
+ * exists to remove a control that lied; a warning that lies is the same defect.
+ */
+describe('ConnectorsFlyout advisory ceiling copy (#998)', () => {
+  it('never names the model or a cap when the ceiling is only advisory', () => {
+    renderFlyout({
+      servers: [srv(130)],
+      modelCap: 128,
+      modelCapDocumented: false,
+      modelLabel: 'claude-sonnet-4-5',
+    });
+
+    const note = screen.getByRole('status');
+    expect(note).toHaveTextContent('130 tools enabled');
+    expect(note).toHaveTextContent('degrade tool selection on most models');
+    expect(note.textContent).not.toContain('caps at');
+    expect(note.textContent).not.toContain('claude-sonnet-4-5');
+    expect(note.textContent).not.toContain('128');
+  });
+
+  it('stays silent in the 85% near band, which on a made-up number is just noise', () => {
+    // 120 of an advisory 128 would be a permanent banner for anyone with a large
+    // inventory - exactly how users are trained to ignore warnings.
+    renderFlyout({
+      servers: [srv(120)],
+      modelCap: 128,
+      modelCapDocumented: false,
+      modelLabel: 'claude-sonnet-4-5',
+    });
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('treats an unwired modelCapDocumented as advisory, so the lie cannot leak back in', () => {
+    renderFlyout({ servers: [srv(130)], modelCap: 128, modelLabel: 'claude-sonnet-4-5' });
+
+    expect(screen.getByRole('status').textContent).not.toContain('caps at');
   });
 });
 

--- a/tests/unit/renderer/mcp-library/DetailPage.toolToggles.dom.test.tsx
+++ b/tests/unit/renderer/mcp-library/DetailPage.toolToggles.dom.test.tsx
@@ -179,3 +179,28 @@ test('disable-all sets allowedTools to [] (none enabled)', async () => {
   await waitFor(() => expect(saveMcpServers).toHaveBeenCalled());
   expect(persistedAllowedTools()).toEqual([]);
 });
+
+/**
+ * #998 - the switches above are a real constraint only on the backends that
+ * carry `allowedTools` into their launch config (Codex, Gemini). On Wayland
+ * Core and the ACP agents the connector reaches the engine whole. The panel
+ * must say so: an active control that silently does nothing manufactures false
+ * confidence about a security-relevant setting.
+ */
+test('the tools panel states which engines actually enforce the switches', async () => {
+  renderDetail();
+  await openToolsTab();
+
+  const notice = await screen.findByText(/enforced on/i);
+  expect(notice.textContent).toContain('Codex, Gemini');
+  expect(notice.textContent).toContain('Wayland Core');
+  expect(notice.textContent).toMatch(/still callable there/i);
+});
+
+test('the enforcement notice is not shown before a connector has tools', async () => {
+  hookState.mcpServers = [{ ...seed(), tools: [] } as IMcpServer];
+  renderDetail();
+  await openToolsTab();
+
+  expect(screen.queryByText(/enforced on/i)).toBeNull();
+});


### PR DESCRIPTION
Fixes #998

## The lie

allowedTools became a real runtime constraint in exactly one place on main: Codex's generated config.toml, as enabled_tools. Everywhere else it was UI state, a display-only budget count, or a change-detection hash. A user who switched a destructive tool off believed it was disabled. On Wayland Core and the ACP agents it stayed fully callable, and two in-source comments asserted the opposite.

## Split verdict, per backend

**Option 1 (enforce) where the plumbing exists:**

- Codex - already enforced via enabled_tools. No behaviour change; now covered by a regression test so it cannot silently rot.
- Gemini - NEW. allowedTools is now carried as includeTools on the aioncli-core MCPServerConfig, for stdio and hosted connectors alike. aioncli-core's mcp-client filters discovered tools through it (a tool survives only when includeTools is absent or names it), so a switched-off tool never registers.

**Option 2 (say so) where it is genuinely impossible from Desktop:**

- Wayland Core - the launch profile is mcp_servers = [...] with no tool dimension. ProfileConfig has only mcp_servers: Option<Vec<String>>, McpServerConfig has no per-tool field, and the AddMcpServer wire command carries name/transport/command/args/env only. Core's one tool-level retain is a bootstrap-builder persona allowlist over the WHOLE registry (builtins included), reachable only from the ACP path and stripped before crossing the wire. There is nothing Desktop can send.
- The ACP agents (claude, qwen, wnano, grok, kimi, opencode, ...) - the session/new mcpServers descriptor has no per-tool field in the protocol.

For those, the MCP Library's tools panel now states plainly which engines enforce the switches, that the others receive the whole connector so a tool switched off there is still callable, and points at the connector switch as the control that does work.

The switches stay active rather than greyed out because they are not globally inert - they are a real constraint on Codex and Gemini, and they scope the desktop candidate pool everywhere. Greying them out would break two backends to be honest about the rest.

## One source of truth

TOOL_ALLOWLIST_ENFORCING_BACKENDS in src/common/mcp.ts. The UI banner reads its engine names off that constant, so the text cannot drift from the behaviour, and a test cross-checks the list against what each launch builder really emits. Adding a backend to the claim without the plumbing fails the suite.

## Comments corrected

- mcpSessionConfig.ts - "allowedTools still trims tools within whatever servers stay active" was false; replaced, and buildAcpSessionMcpServers / buildWCoreUserStdioMcpServers / buildWCoreSessionMcpServers now document that they are server-level only and why.
- toolContract.ts (two places) - the candidate pool is a desktop-side view, not proof a switched-off tool is unreachable.

## Second commit: two defects found in review

**Disable all must silence a connector, not break it.** The existing Disable all button persists allowedTools: [], which the new Gemini path turned into includeTools: []. aioncli-core's connectAndDiscover treats zero prompts AND zero tools as a failed connection: it throws, emits error feedback and sets the server DISCONNECTED. Switching every tool off would have produced an error toast and a red connector rather than "connector on, tools off" - worse than the bug being fixed. An empty allowlist now drops the connector from the launch entirely, before beginMcpSession so no expected receipt is declared that can never arrive. [] still survives as [] at the aioncli layer, which is correct there; the decision belongs one level up, at whether to emit the server at all.

**The nudge must not invent a vendor limit.** Making resolveModelToolCap always return a number made the nudge always eligible, and its copy names the model and the number - a Claude user with 130 tools would have read "claude-sonnet-4-5 caps at 128". Anthropic publishes no such tool-array cap, so that is a false attributed claim, and the 85% near band would have made it a permanent banner for anyone with a large inventory. Fixing a control that lied by shipping a warning that lies is the same defect wearing a different hat.

resolveModelToolCap now returns { limit, documented }:

- documented cap (OpenAI/gpt-5, where exceeding it really does 400) keeps the near+over bands and the "{{model}} caps at {{cap}}" copy;
- advisory ceiling gets "{{count}} tools enabled. Long tool lists degrade tool selection on most models - scope servers for this chat or switch models." It names neither the model nor a number, is not styled as an error, and fires only once the count is genuinely past the ceiling;
- an unwired documented flag is treated as advisory, so the attribution cannot leak back in by omission.

I deliberately did NOT add per-vendor cap entries I could not verify from documentation. The wording branch gets the same protective effect without asserting a vendor doc I have not read.

Existing nudge tests were updated at the CALL SITE only, to state that gpt-5's 128 is a documented cap. Every assertion in them is unchanged, and all six pass with and without the second commit.

## Verification

Runtime outcome, not just config shape - tests/unit/process/task/geminiEmptyAllowlistLaunch.test.ts:

- the real aioncli-core discoverTools is executed and returns zero tools for includeTools: []
- the real discoverPrompts is executed and returns zero prompts for a prompt-less server
- the installed connectAndDiscover is pinned to still turn that pair into a throw plus MCPServerStatus.DISCONNECTED, so the workaround's premise breaks loudly if the dependency changes
- the real GeminiAgentManager.getMcpServers is driven end to end and proven to omit the connector, emit exactly the enabled tools when scoped, emit no includeTools when unscoped, and declare no expected session receipt for the dropped connector

npx vitest run tests/unit/process/task/geminiEmptyAllowlistLaunch.test.ts -> PASS (7) FAIL (0)

RED proven by execution before each fix, not by reasoning:

- Gemini enforcement, with GeminiAgentManager.ts reverted: PASS (10) FAIL (2), both Gemini cases failing "expected undefined to deeply equal [ 'search_files' ]"
- backend-aware cap, with common/mcp.ts reverted: a throwaway probe on resolveModelToolCap('anthropic', 'claude-sonnet-4-5') received undefined
- empty-allowlist drop, with the filter removed: 2 failed / 5 passed, "expected { workspace: { command: 'uvx', ...(4) } } to not have property workspace" and "expected [ 'workspace' ] to deeply equal []"
- advisory copy, with ConnectorsFlyout.tsx reverted: 3 failed / 18 passed, "expected '130 tools enabled - claude-sonnet-4-5...' not to contain 'caps at'" - and the six pre-existing documented-cap tests passed in that same run, which is the proof they were not weakened

Green, all run after the fixes:

- ConnectorsFlyout.dom + geminiEmptyAllowlistLaunch + mcpToolAllowlistEnforcement + ComposerAddMenu.dom + toolBudget + localeKeyParity -> PASS (142) FAIL (0)
- geminiMcpFingerprint + geminiAgentManagerCrash + geminiAgentManagerThinking + geminiAbortRecovery + geminiBootstrapRejection + mcpStdioSpawn + DetailPage.toolToggles.dom + GuidActionRow.dom -> PASS (45) FAIL (0)
- codexSessionMcp + wcoreUserMcpInjection + mcpSessionConfig.activeServers + getCandidateTools + desktopProfileSplice -> PASS (68) FAIL (0)
- npx tsc --noEmit -> No errors found
- npx oxlint on the changed sources -> 0 warnings, 0 errors
- npx oxfmt --check over exactly the 37 files this PR touches -> all correctly formatted

Two new locale keys (mcpLibrary.detail.toolScopeNotice, conversation.composerMenu.toolNudgeAdvisory) added to all 12 locales with real translations; i18n-keys.d.ts regenerated with the repo script.

## Known, deliberate, not fixed here

The Gemini switch takes effect on the NEXT worker start, not live: computePreviewGeminiMcpFingerprint returns empty unless the MCP session-truth preview gate is on, so a toggle does not re-bootstrap a running worker. This is pre-existing, gated to MCP-2, and applies equally to the existing per-server toggles. Worth a tracked issue, not a change here.

Wayland Core and the ACP agents still cannot enforce a per-tool allowlist. That needs an engine-side and protocol-side change; the Core-side shape would mirror the existing only_for_assistant precedent on McpServerConfig. Worth a wayland-core issue.

Separately noted while tracing this, out of scope and unverified against a live agent: the ACP path injects MCP servers through session/new for every backend that advertises mcpCapabilities, with no codex-specific guard. If codex-acp advertises stdio, the same connector could be registered twice - once filtered from config.toml, once unfiltered from session/new.
