### PR TITLE
fix(release): assert complete artifact set; gate workflow token flatness

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -251,6 +251,17 @@ jobs:
         shell: bash
         run: bash scripts/prepare-release-assets.sh build-artifacts release-assets
 
+      # #989: assert the COMPLETE expected artifact set before anything is
+      # published. verify-release-assets.sh previously ran only against the CI
+      # mock fixture in pr-checks.yml, so it never saw a real release - which is
+      # why #941 (the Windows portable zip dropped by a bad upload glob) reached
+      # users unnoticed for several releases. Running it here, on the real
+      # normalized assets, is what makes it an actual gate: a missing artifact
+      # class now fails the job before the draft release is created.
+      - name: Verify release assets (complete expected set)
+        shell: bash
+        run: bash scripts/verify-release-assets.sh release-assets
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/scripts/create-mock-release-artifacts.sh
+++ b/scripts/create-mock-release-artifacts.sh
@@ -1,8 +1,21 @@
 #!/usr/bin/env bash
+#
+# create-mock-release-artifacts.sh
+#
+# Build a fake build-artifacts/ tree shaped exactly like the real one that
+# _build-reusable.yml uploads, so prepare-release-assets.sh and
+# verify-release-assets.sh can be exercised in CI without a real build.
+#
+# #989: the artifact names below MIRROR a real release (see any published tag,
+# e.g. v0.12.0). They are not illustrative placeholders - verify-release-assets.sh
+# asserts the complete declared set, so if this fixture drifts from what
+# electron-builder.yml actually emits, the CI release-script-test job goes red
+# and the drift is caught here rather than in a shipped release.
 
 set -euo pipefail
 
 ARTIFACTS_DIR="${1:-build-artifacts}"
+VERSION="${2:-1.0.0}"
 
 rm -rf "$ARTIFACTS_DIR"
 mkdir -p "$ARTIFACTS_DIR/windows-build-x64"
@@ -12,70 +25,82 @@ mkdir -p "$ARTIFACTS_DIR/macos-build-arm64"
 mkdir -p "$ARTIFACTS_DIR/linux-build-x64"
 mkdir -p "$ARTIFACTS_DIR/linux-build-arm64"
 
-# Windows x64
-touch "$ARTIFACTS_DIR/windows-build-x64/Wayland-1.0.0-win-x64.exe"
-cat > "$ARTIFACTS_DIR/windows-build-x64/latest.yml" <<'EOF'
-version: 1.0.0
+# Windows x64 - nsis installer + blockmap + portable zip
+touch "$ARTIFACTS_DIR/windows-build-x64/Wayland-$VERSION-win-x64.exe"
+touch "$ARTIFACTS_DIR/windows-build-x64/Wayland-$VERSION-win-x64.exe.blockmap"
+touch "$ARTIFACTS_DIR/windows-build-x64/Wayland-$VERSION-win-x64.zip"
+cat > "$ARTIFACTS_DIR/windows-build-x64/latest.yml" <<EOF
+version: $VERSION
 files:
-  - url: Wayland-1.0.0-win-x64.exe
+  - url: Wayland-$VERSION-win-x64.exe
     sha512: fake-sha512-x64
     size: 100000
-path: Wayland-1.0.0-win-x64.exe
+path: Wayland-$VERSION-win-x64.exe
 sha512: fake-sha512-x64
 releaseDate: '2025-01-01'
 EOF
 
 # Windows arm64
-touch "$ARTIFACTS_DIR/windows-build-arm64/Wayland-1.0.0-win-arm64.exe"
-cat > "$ARTIFACTS_DIR/windows-build-arm64/latest.yml" <<'EOF'
-version: 1.0.0
+touch "$ARTIFACTS_DIR/windows-build-arm64/Wayland-$VERSION-win-arm64.exe"
+touch "$ARTIFACTS_DIR/windows-build-arm64/Wayland-$VERSION-win-arm64.exe.blockmap"
+touch "$ARTIFACTS_DIR/windows-build-arm64/Wayland-$VERSION-win-arm64.zip"
+cat > "$ARTIFACTS_DIR/windows-build-arm64/latest.yml" <<EOF
+version: $VERSION
 files:
-  - url: Wayland-1.0.0-win-arm64.exe
+  - url: Wayland-$VERSION-win-arm64.exe
     sha512: fake-sha512-arm64
     size: 100000
-path: Wayland-1.0.0-win-arm64.exe
+path: Wayland-$VERSION-win-arm64.exe
 sha512: fake-sha512-arm64
 releaseDate: '2025-01-01'
 EOF
 
-# macOS x64
-touch "$ARTIFACTS_DIR/macos-build-x64/Wayland-1.0.0-mac-x64.dmg"
-touch "$ARTIFACTS_DIR/macos-build-x64/Wayland-1.0.0-mac-x64.zip"
-cat > "$ARTIFACTS_DIR/macos-build-x64/latest-mac.yml" <<'EOF'
-version: 1.0.0
+# macOS x64 - dmg + zip, each with a blockmap
+touch "$ARTIFACTS_DIR/macos-build-x64/Wayland-$VERSION-mac-x64.dmg"
+touch "$ARTIFACTS_DIR/macos-build-x64/Wayland-$VERSION-mac-x64.dmg.blockmap"
+touch "$ARTIFACTS_DIR/macos-build-x64/Wayland-$VERSION-mac-x64.zip"
+touch "$ARTIFACTS_DIR/macos-build-x64/Wayland-$VERSION-mac-x64.zip.blockmap"
+cat > "$ARTIFACTS_DIR/macos-build-x64/latest-mac.yml" <<EOF
+version: $VERSION
 files:
-  - url: Wayland-1.0.0-mac-x64.dmg
+  - url: Wayland-$VERSION-mac-x64.dmg
     sha512: fake-sha512-mac-x64
     size: 200000
 EOF
 
 # macOS arm64
-touch "$ARTIFACTS_DIR/macos-build-arm64/Wayland-1.0.0-mac-arm64.dmg"
-touch "$ARTIFACTS_DIR/macos-build-arm64/Wayland-1.0.0-mac-arm64.zip"
-cat > "$ARTIFACTS_DIR/macos-build-arm64/latest-mac.yml" <<'EOF'
-version: 1.0.0
+touch "$ARTIFACTS_DIR/macos-build-arm64/Wayland-$VERSION-mac-arm64.dmg"
+touch "$ARTIFACTS_DIR/macos-build-arm64/Wayland-$VERSION-mac-arm64.dmg.blockmap"
+touch "$ARTIFACTS_DIR/macos-build-arm64/Wayland-$VERSION-mac-arm64.zip"
+touch "$ARTIFACTS_DIR/macos-build-arm64/Wayland-$VERSION-mac-arm64.zip.blockmap"
+cat > "$ARTIFACTS_DIR/macos-build-arm64/latest-mac.yml" <<EOF
+version: $VERSION
 files:
-  - url: Wayland-1.0.0-mac-arm64.dmg
+  - url: Wayland-$VERSION-mac-arm64.dmg
     sha512: fake-sha512-mac-arm64
     size: 200000
 EOF
 
-# Linux x64
-touch "$ARTIFACTS_DIR/linux-build-x64/Wayland-1.0.0.deb"
-cat > "$ARTIFACTS_DIR/linux-build-x64/latest-linux.yml" <<'EOF'
-version: 1.0.0
+# Linux x64 - AppImage + deb + rpm (electron-builder arch naming differs per format)
+touch "$ARTIFACTS_DIR/linux-build-x64/Wayland-$VERSION-linux-x86_64.AppImage"
+touch "$ARTIFACTS_DIR/linux-build-x64/Wayland-$VERSION-linux-amd64.deb"
+touch "$ARTIFACTS_DIR/linux-build-x64/Wayland-$VERSION-linux-x86_64.rpm"
+cat > "$ARTIFACTS_DIR/linux-build-x64/latest-linux.yml" <<EOF
+version: $VERSION
 files:
-  - url: Wayland-1.0.0.deb
+  - url: Wayland-$VERSION-linux-x86_64.AppImage
     sha512: fake-sha512-linux
     size: 300000
 EOF
 
 # Linux arm64
-touch "$ARTIFACTS_DIR/linux-build-arm64/Wayland-1.0.0-arm64.deb"
-cat > "$ARTIFACTS_DIR/linux-build-arm64/latest-linux-arm64.yml" <<'EOF'
-version: 1.0.0
+touch "$ARTIFACTS_DIR/linux-build-arm64/Wayland-$VERSION-linux-arm64.AppImage"
+touch "$ARTIFACTS_DIR/linux-build-arm64/Wayland-$VERSION-linux-arm64.deb"
+touch "$ARTIFACTS_DIR/linux-build-arm64/Wayland-$VERSION-linux-aarch64.rpm"
+cat > "$ARTIFACTS_DIR/linux-build-arm64/latest-linux-arm64.yml" <<EOF
+version: $VERSION
 files:
-  - url: Wayland-1.0.0-arm64.deb
+  - url: Wayland-$VERSION-linux-arm64.AppImage
     sha512: fake-sha512-linux-arm64
     size: 300000
 EOF

--- a/scripts/verify-release-assets.sh
+++ b/scripts/verify-release-assets.sh
@@ -1,4 +1,21 @@
 #!/usr/bin/env bash
+#
+# verify-release-assets.sh
+#
+# Assert that a prepared release-assets/ directory contains the COMPLETE set of
+# artifacts the build is supposed to produce - per platform and per target - and
+# fail on any absence.
+#
+# Usage:
+#   ./scripts/verify-release-assets.sh [OUTPUT_DIR]
+#
+# #989: this verifier previously checked a hand-picked SUBSET (the .exe, .dmg
+# and .deb distributables) and had no zip expectation at all. That blind spot is
+# exactly why #941 shipped: the Windows portable zip was built, discarded by a
+# bad artifact glob, and no gate noticed the absence for multiple releases. A
+# gate that only confirms a few known names cannot report an artifact class it
+# was never told to look for, so the expected set is now DECLARED explicitly
+# below and every entry is required.
 
 set -euo pipefail
 
@@ -11,6 +28,9 @@ if [[ ! "$CHANNEL" =~ ^[a-z0-9-]+$ ]]; then
   exit 1
 fi
 
+# ---------------------------------------------------------------------------
+# 1) Updater metadata - the six feeds electron-updater resolves by name.
+# ---------------------------------------------------------------------------
 for f in "$CHANNEL.yml" "$CHANNEL-mac.yml" "$CHANNEL-linux.yml" "$CHANNEL-linux-arm64.yml"; do
   if [ ! -f "$OUTPUT_DIR/$f" ]; then
     echo "FAIL: missing canonical metadata: $f"
@@ -71,9 +91,81 @@ for f in "$CHANNEL-win-arm64.yml" "$CHANNEL-arm64-mac.yml"; do
   fi
 done
 
-for f in Wayland-1.0.0-win-x64.exe Wayland-1.0.0-win-arm64.exe Wayland-1.0.0-mac-x64.dmg Wayland-1.0.0-mac-arm64.dmg Wayland-1.0.0.deb Wayland-1.0.0-arm64.deb; do
+# ---------------------------------------------------------------------------
+# 2) Resolve the release version the artifact names are built from.
+#
+# electron-builder.yml sets artifactName to
+# ${productName}-${version}-${os}-${arch}.${ext} on every platform, so the whole
+# expected set is derivable from one version string. It is read from the
+# canonical channel feed (which step 1 already required to exist) so the
+# verifier needs no argument on either the CI fixture path or the real release
+# path; WAYLAND_RELEASE_VERSION overrides it.
+# ---------------------------------------------------------------------------
+VERSION="${WAYLAND_RELEASE_VERSION:-}"
+if [ -z "$VERSION" ] && [ -f "$OUTPUT_DIR/$CHANNEL.yml" ]; then
+  VERSION=$(grep -E '^version:' "$OUTPUT_DIR/$CHANNEL.yml" | head -n 1 | sed -E "s/^version:[[:space:]]*//; s/['\"]//g" || true)
+fi
+
+if [ -z "$VERSION" ]; then
+  echo "FAIL: cannot resolve release version (no WAYLAND_RELEASE_VERSION and no version: in $CHANNEL.yml)"
+  echo ""
+  echo "FAILED: $((ERRORS + 1)) errors found"
+  exit 1
+fi
+
+echo "PASS: resolved release version $VERSION"
+
+# ---------------------------------------------------------------------------
+# 3) The DECLARED expected artifact set.
+#
+# One entry per (platform, target, arch) that electron-builder.yml is configured
+# to produce, plus the blockmaps the differential updater depends on. Keep this
+# table in lockstep with the `target:` lists in electron-builder.yml - adding a
+# target there without adding it here recreates the #989 blind spot.
+#
+#   win:   nsis (.exe) + zip           -> x64, arm64   (+ .exe.blockmap)
+#   mac:   dmg + zip                   -> x64, arm64   (+ .dmg/.zip.blockmap)
+#   linux: AppImage + deb + rpm        -> x64, arm64
+#
+# electron-builder rewrites ${arch} per linux packaging format: deb uses
+# amd64/arm64, rpm uses x86_64/aarch64, AppImage uses x86_64/arm64. These are the
+# names observed on every shipped release (v0.11.3 through v0.12.0).
+#
+# No blockmap is required for the Windows zip: it is a portable distribution,
+# not an update feed target, and electron-builder emits no blockmap for it.
+# No checksum sidecar files are expected - the pipeline publishes none; integrity
+# is carried by the sha512 fields inside the updater metadata.
+# ---------------------------------------------------------------------------
+EXPECTED_ARTIFACTS=(
+  # Windows - nsis installer + its differential-update blockmap
+  "Wayland-$VERSION-win-x64.exe"
+  "Wayland-$VERSION-win-x64.exe.blockmap"
+  "Wayland-$VERSION-win-arm64.exe"
+  "Wayland-$VERSION-win-arm64.exe.blockmap"
+  # Windows - portable zip (the class #941 silently dropped)
+  "Wayland-$VERSION-win-x64.zip"
+  "Wayland-$VERSION-win-arm64.zip"
+  # macOS - dmg + the zip the macOS updater actually downloads
+  "Wayland-$VERSION-mac-x64.dmg"
+  "Wayland-$VERSION-mac-x64.dmg.blockmap"
+  "Wayland-$VERSION-mac-arm64.dmg"
+  "Wayland-$VERSION-mac-arm64.dmg.blockmap"
+  "Wayland-$VERSION-mac-x64.zip"
+  "Wayland-$VERSION-mac-x64.zip.blockmap"
+  "Wayland-$VERSION-mac-arm64.zip"
+  "Wayland-$VERSION-mac-arm64.zip.blockmap"
+  # Linux - all three packaging formats, both arches
+  "Wayland-$VERSION-linux-x86_64.AppImage"
+  "Wayland-$VERSION-linux-arm64.AppImage"
+  "Wayland-$VERSION-linux-amd64.deb"
+  "Wayland-$VERSION-linux-arm64.deb"
+  "Wayland-$VERSION-linux-x86_64.rpm"
+  "Wayland-$VERSION-linux-aarch64.rpm"
+)
+
+for f in "${EXPECTED_ARTIFACTS[@]}"; do
   if [ ! -f "$OUTPUT_DIR/$f" ]; then
-    echo "FAIL: missing distributable: $f"
+    echo "FAIL: missing release artifact: $f"
     ERRORS=$((ERRORS + 1))
   else
     echo "PASS: $f exists"

--- a/tests/unit/process/services/workflow/workflowAdvanceTokenFlatness.test.ts
+++ b/tests/unit/process/services/workflow/workflowAdvanceTokenFlatness.test.ts
@@ -35,7 +35,10 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { sendWorkflowAdvanceDirective, type WorkflowAdvanceResetDeps } from '@process/services/workflow/workflowAdvanceReset';
+import {
+  sendWorkflowAdvanceDirective,
+  type WorkflowAdvanceResetDeps,
+} from '@process/services/workflow/workflowAdvanceReset';
 import { composeResetSeed } from '@process/task/resumeSeed';
 import type { TMessage } from '@/common/chat/chatLib';
 

--- a/tests/unit/process/services/workflow/workflowAdvanceTokenFlatness.test.ts
+++ b/tests/unit/process/services/workflow/workflowAdvanceTokenFlatness.test.ts
@@ -1,0 +1,201 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * #986 (follow-up to #723): per-step model input must stay FLAT as the step
+ * count grows.
+ *
+ * The original bug was invisible - a workflow produced correct output and
+ * simply cost a fortune, because each advance was sent into the SAME live
+ * backend session, which replayed turns 1..N-1 to the model on step N. Nothing
+ * failed and nothing errored; only the bill moved. Behavioural tests stay green
+ * through that regression by construction, so this file is a MEASUREMENT gate:
+ * it runs a multi-step workflow and asserts the per-step input does not grow
+ * with the step index.
+ *
+ * What "flat" means concretely here. On a wcore advance,
+ * `sendWorkflowAdvanceDirective` passes `skipCache: true` (which kills the
+ * engine process and drops its accumulated 1..N-1 context) plus
+ * `workflowResetSeed: WORKFLOW_RESET_SEED_BOUND`. On respawn,
+ * `WCoreManager.start()` reseeds the fresh session with
+ * `composeResetSeed(persistedMessages, workflowResetSeed)`, which under
+ * `priorTurnOnly` carries ONLY the immediately-prior turn, head-clipped to
+ * `priorTurnMaxChars`. So the persisted transcript grows linearly with N while
+ * the model's input per step is bounded by a constant. Both reseed branches are
+ * O(1) in N; that constant-ness is what is asserted.
+ *
+ * The engine is faked, but the two things that decide the answer are REAL: the
+ * production `sendWorkflowAdvanceDirective` chooses the options, and the
+ * production `composeResetSeed` computes the reseed. The fake only models the
+ * one engine property that matters - a respawn drops context, a reuse keeps it.
+ * Remove the reset from the production ternary and these assertions go red.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { sendWorkflowAdvanceDirective, type WorkflowAdvanceResetDeps } from '@process/services/workflow/workflowAdvanceReset';
+import { composeResetSeed } from '@process/task/resumeSeed';
+import type { TMessage } from '@/common/chat/chatLib';
+
+const STEP_COUNT = 6;
+/** Realistic per-step deliverable: well under priorTurnMaxChars (16000) so the
+ * whole prior turn is carried, and large enough that accumulation is obvious. */
+const DELIVERABLE_CHARS = 1500;
+
+/**
+ * Input size in tokens. Characters are converted with the standard ~4-chars-per
+ * token approximation; the conversion is monotone, so flat characters prove flat
+ * tokens and growth in one is growth in the other. A unit test has no real
+ * tokenizer, and the property under test is a ratio, not an absolute count.
+ */
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+let nextId = 0;
+const rightMsg = (content: string): TMessage =>
+  ({
+    id: `m${nextId++}`,
+    type: 'text',
+    position: 'right',
+    conversation_id: 'c1',
+    content: { content },
+    createdAt: 1,
+  }) as TMessage;
+
+const assistantMsg = (content: string): TMessage =>
+  ({
+    id: `m${nextId++}`,
+    type: 'text',
+    position: 'left',
+    conversation_id: 'c1',
+    content: { content },
+    createdAt: 1,
+  }) as TMessage;
+
+const deliverable = (step: number): string => `Step ${step} deliverable. `.padEnd(DELIVERABLE_CHARS, 'x');
+
+/**
+ * Run a `STEP_COUNT`-step in-conversation workflow and return the per-step model
+ * input size, in tokens, for steps 2..N (step 1 is the opening turn, not an
+ * advance).
+ *
+ * Two stores are modelled separately because that separation IS the fix: the
+ * persisted SQLite transcript (`store`) grows with every step and is never
+ * truncated, while the live engine's context (`engineContext`) is what the model
+ * is actually billed for.
+ */
+async function runWorkflow(): Promise<number[]> {
+  const store: TMessage[] = [];
+  let engineContext: string[] = [];
+  const perStepInputTokens: number[] = [];
+
+  // Step 1: the opening user turn and its deliverable, before any advance.
+  store.push(rightMsg('Run the 6-step workflow.'));
+  engineContext.push('Run the 6-step workflow.');
+  store.push(assistantMsg(deliverable(1)));
+  engineContext.push(deliverable(1));
+
+  const deps: WorkflowAdvanceResetDeps = {
+    getConversationType: async () => 'wcore',
+    getOrBuildTask: async (_conversationId, options) => {
+      // The one engine property that decides the answer: `skipCache` kills the
+      // process, so the fresh session starts from the reseed alone. Without it
+      // the live session is reused and keeps everything it has already seen.
+      if (options.skipCache) {
+        const seed = composeResetSeed(store, options.workflowResetSeed);
+        engineContext = seed ? [seed] : [];
+      }
+      return {
+        sendMessage: async (message: { content: string }) => {
+          engineContext.push(message.content);
+        },
+      };
+    },
+  };
+
+  for (let step = 2; step <= STEP_COUNT; step++) {
+    const directive = `Proceed to step ${step}.`;
+    // The live path persists the hidden directive BEFORE start() reads history.
+    store.push(rightMsg(directive));
+
+    // oxlint-disable-next-line no-await-in-loop -- steps are inherently sequential; step N's input depends on step N-1 having completed
+    await sendWorkflowAdvanceDirective('c1', directive, deps);
+
+    // Everything the engine now holds is the model's input for this step.
+    perStepInputTokens.push(estimateTokens(engineContext.join('\n')));
+
+    // The model answers; a live session retains its own output, and the
+    // transcript persists it.
+    engineContext.push(deliverable(step));
+    store.push(assistantMsg(deliverable(step)));
+  }
+
+  return perStepInputTokens;
+}
+
+describe('#986 workflow auto-advance keeps per-step input flat', () => {
+  it('does not grow per-step input tokens across the run', async () => {
+    const perStep = await runWorkflow();
+    expect(perStep).toHaveLength(STEP_COUNT - 1);
+
+    // Compare against step 2, not step 1: step 2 is the first reset step, so it
+    // carries no cold-start difference.
+    const [baseline] = perStep;
+    const last = perStep[perStep.length - 1];
+
+    expect(baseline).toBeGreaterThan(0);
+    // Flat, not a multiple of the baseline. A reintroduced 1..N-1 replay makes
+    // the last step a multiple of this, not a neighbour of it.
+    expect(last).toBeLessThanOrEqual(Math.ceil(baseline * 1.1));
+
+    // And no step in between drifts upward either - growth anywhere in the run
+    // is the regression, not just at the tail.
+    for (const tokens of perStep) {
+      expect(tokens).toBeLessThanOrEqual(Math.ceil(baseline * 1.1));
+    }
+  });
+
+  it('stays bounded by the carry-forward constant, not by the step count', async () => {
+    const perStep = await runWorkflow();
+
+    // The persisted transcript over 6 steps holds ~6 deliverables. If per-step
+    // input were proportional to the run, the last step would exceed a single
+    // deliverable's worth of tokens by roughly the step count. Bound it to a
+    // small multiple of ONE deliverable to catch that directly.
+    const oneDeliverable = estimateTokens(deliverable(1));
+    expect(perStep[perStep.length - 1]).toBeLessThan(oneDeliverable * 2);
+  });
+
+  /**
+   * Instrument check: the measurement above must be capable of reporting growth
+   * at all. Drive the same harness with an engine that is never respawned (the
+   * pre-#723 behaviour) and confirm the numbers climb. Without this, a harness
+   * that always reported a constant would pass the flatness assertions for the
+   * wrong reason.
+   */
+  it('the measurement detects accumulation when the session is never reset', async () => {
+    const store: TMessage[] = [];
+    const engineContext: string[] = [];
+    const perStep: number[] = [];
+
+    store.push(rightMsg('Run the 6-step workflow.'));
+    engineContext.push('Run the 6-step workflow.');
+    store.push(assistantMsg(deliverable(1)));
+    engineContext.push(deliverable(1));
+
+    for (let step = 2; step <= STEP_COUNT; step++) {
+      const directive = `Proceed to step ${step}.`;
+      store.push(rightMsg(directive));
+      engineContext.push(directive); // reused session: nothing is ever dropped
+      perStep.push(estimateTokens(engineContext.join('\n')));
+      engineContext.push(deliverable(step));
+      store.push(assistantMsg(deliverable(step)));
+    }
+
+    const last = perStep[perStep.length - 1];
+    expect(last).toBeGreaterThan(perStep[0] * 2);
+  });
+});

--- a/tests/unit/scripts/verifyReleaseAssets.test.ts
+++ b/tests/unit/scripts/verifyReleaseAssets.test.ts
@@ -1,0 +1,136 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * #989: verify-release-assets.sh must assert the COMPLETE expected artifact set.
+ *
+ * The verifier previously checked a hand-picked subset (.exe/.dmg/.deb) and had
+ * no zip expectation at all, so the Windows portable zip could vanish and the
+ * gate still exited 0 - which is why #941 shipped unnoticed for several
+ * releases. These tests drive the real fixture pipeline
+ * (create-mock -> prepare -> verify) and assert the gate FAILS on the absence of
+ * every declared artifact class, one at a time. A gate that cannot fail is the
+ * defect, so the negative cases are the point of this file.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const VERSION = '1.0.0';
+const roots: string[] = [];
+
+function run(script: string, args: string[]) {
+  return spawnSync('bash', [script, ...args], { cwd: process.cwd(), encoding: 'utf8' });
+}
+
+/** Build a complete release-assets directory through the real release scripts. */
+function preparedAssets(): string {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'wayland-verify-assets-'));
+  roots.push(root);
+  const input = path.join(root, 'build-artifacts');
+  const output = path.join(root, 'release-assets');
+
+  const mock = run('scripts/create-mock-release-artifacts.sh', [input, VERSION]);
+  expect(mock.status, `${mock.stdout}\n${mock.stderr}`).toBe(0);
+
+  const prepared = run('scripts/prepare-release-assets.sh', [input, output]);
+  expect(prepared.status, `${prepared.stdout}\n${prepared.stderr}`).toBe(0);
+
+  return output;
+}
+
+function verify(output: string) {
+  return run('scripts/verify-release-assets.sh', [output]);
+}
+
+/**
+ * Every artifact the release is supposed to produce. Deliberately spelled out
+ * rather than imported from the script: if someone deletes an expectation from
+ * verify-release-assets.sh, this list still demands the gate fail on it.
+ */
+const EXPECTED_ARTIFACTS = [
+  `Wayland-${VERSION}-win-x64.exe`,
+  `Wayland-${VERSION}-win-x64.exe.blockmap`,
+  `Wayland-${VERSION}-win-arm64.exe`,
+  `Wayland-${VERSION}-win-arm64.exe.blockmap`,
+  `Wayland-${VERSION}-win-x64.zip`,
+  `Wayland-${VERSION}-win-arm64.zip`,
+  `Wayland-${VERSION}-mac-x64.dmg`,
+  `Wayland-${VERSION}-mac-x64.dmg.blockmap`,
+  `Wayland-${VERSION}-mac-arm64.dmg`,
+  `Wayland-${VERSION}-mac-arm64.dmg.blockmap`,
+  `Wayland-${VERSION}-mac-x64.zip`,
+  `Wayland-${VERSION}-mac-x64.zip.blockmap`,
+  `Wayland-${VERSION}-mac-arm64.zip`,
+  `Wayland-${VERSION}-mac-arm64.zip.blockmap`,
+  `Wayland-${VERSION}-linux-x86_64.AppImage`,
+  `Wayland-${VERSION}-linux-arm64.AppImage`,
+  `Wayland-${VERSION}-linux-amd64.deb`,
+  `Wayland-${VERSION}-linux-arm64.deb`,
+  `Wayland-${VERSION}-linux-x86_64.rpm`,
+  `Wayland-${VERSION}-linux-aarch64.rpm`,
+];
+
+const EXPECTED_METADATA = [
+  ['latest.yml', 'missing canonical metadata'],
+  ['latest-mac.yml', 'missing canonical metadata'],
+  ['latest-linux.yml', 'missing canonical metadata'],
+  ['latest-linux-arm64.yml', 'missing canonical metadata'],
+  ['latest-win-arm64.yml', 'missing arch-specific updater metadata'],
+  ['latest-arm64-mac.yml', 'missing arch-specific updater metadata'],
+] as const;
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('verify-release-assets expected-set completeness', () => {
+  it('passes on the complete artifact set the mock pipeline produces', () => {
+    const result = verify(preparedAssets());
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.stdout).toContain('ALL CHECKS PASSED');
+  });
+
+  it.each(EXPECTED_ARTIFACTS)('fails closed when %s is absent', (artifact) => {
+    const output = preparedAssets();
+    unlinkSync(path.join(output, artifact));
+
+    const result = verify(output);
+    expect(result.status, `expected a non-zero exit, got:\n${result.stdout}`).toBe(1);
+    expect(result.stdout).toContain(`FAIL: missing release artifact: ${artifact}`);
+  });
+
+  it.each(EXPECTED_METADATA)('fails closed when %s is absent', (metadata, message) => {
+    const output = preparedAssets();
+    unlinkSync(path.join(output, metadata));
+
+    const result = verify(output);
+    expect(result.status, `expected a non-zero exit, got:\n${result.stdout}`).toBe(1);
+    expect(result.stdout).toContain(`FAIL: ${message}: ${metadata}`);
+  });
+
+  /**
+   * The version drives every expected filename, so an unresolvable version must
+   * fail loudly rather than silently expand to a set of names nothing matches.
+   */
+  it('fails closed when the release version cannot be resolved', () => {
+    const output = preparedAssets();
+    // Keep the feed present and pointing at a real file so the metadata checks
+    // still pass - only the version: line, which the expected set is derived
+    // from, is gone.
+    writeFileSync(
+      path.join(output, 'latest.yml'),
+      `path: Wayland-${VERSION}-win-x64.exe\nsha512: fake\nreleaseDate: '2025-01-01'\n`
+    );
+
+    const result = verify(output);
+    expect(result.status, `expected a non-zero exit, got:\n${result.stdout}`).toBe(1);
+    expect(result.stdout).toContain('FAIL: cannot resolve release version');
+  });
+});


### PR DESCRIPTION
Two independent gate/coverage defects. One commit each.

## Fixes #989 - verify-release-assets.sh never checked for zip artifacts

The verifier asserted a hand-picked subset and had no zip expectation at all, so a missing zip exited 0. That blind spot is why #941 shipped unnoticed across several releases.

Two separate defects were found, and both are fixed:

1. **No zip expectation.** The expected set is now DECLARED explicitly per platform and per target, derived from the version in the channel feed, and every entry is required.
2. **The verifier never ran on a real release.** It was wired only into pr-checks.yml against the CI mock fixture. Even with a zip expectation present it could not have caught #941. It now also runs in build-and-release.yml on the real normalized assets, before the draft release is created.

Coverage before and after, checked against the shipped assets of v0.11.3, v0.11.9, v0.11.18 and v0.12.0:

| Artifact class | Before | After |
| --- | --- | --- |
| latest.yml, latest-mac.yml, latest-linux.yml, latest-linux-arm64.yml | covered | covered |
| latest-win-arm64.yml, latest-arm64-mac.yml | covered | covered |
| win x64/arm64 .exe | covered | covered |
| mac x64/arm64 .dmg | covered | covered |
| linux .deb (both arches) | covered, but under names no release ever produced | covered, real names |
| **win x64/arm64 .zip** | **absent** | added |
| **mac x64/arm64 .zip** | **absent** | added |
| **.exe.blockmap, .dmg.blockmap, .zip.blockmap** | **absent** | added |
| **linux .AppImage (both arches)** | **absent** | added |
| **linux .rpm (both arches)** | **absent** | added |
| checksum sidecars | absent | still absent, deliberately - the pipeline publishes none, integrity rides the sha512 fields inside the updater metadata |

No blockmap is required for the Windows zip: it is a portable distribution, not an update-feed target.

The mock fixture was realigned to the names a real release actually emits (linux amd64/x86_64/aarch64 naming, blockmaps, win zips). The old fixture used Wayland-1.0.0.deb, which no release has ever produced, so the fixture could not have exercised a realistic expected set.

### Executed proof the gate can fail

Old verifier, original fixture, the exact #941 scenario:

- win zips present, exit 0
- win zips removed, exit 0 - the blind spot
- mac zips removed, exit 0

New verifier, same removal: exit 1, with FAIL: missing release artifact for each.

New test tests/unit/scripts/verifyReleaseAssets.test.ts drives the real pipeline (create-mock, then prepare, then verify) and removes each of the 20 declared artifacts and each of the 6 metadata files one at a time, asserting a non-zero exit and the specific message every time. 28 tests, all passing. It follows the existing tests/unit/scripts/prepareReleaseAssets.test.ts pattern, so no new harness was needed.

Mutation check: deleting the four zip expectations from the verifier turns exactly four of those tests red. Restored and sha-verified afterwards.

## Fixes #986 - no test asserted per-step token flatness for workflow auto-advance

Follow-up to #723. The reset is correct and shipped; nothing asserted it stays correct. This regression class is invisible to behavioural tests - output stays right and only the bill moves.

What flat means here concretely: on a wcore advance, sendWorkflowAdvanceDirective passes skipCache true, which kills the engine process and drops its accumulated 1..N-1 context, plus workflowResetSeed. On respawn WCoreManager.start reseeds via composeResetSeed, which under priorTurnOnly carries only the immediately-prior turn, head-clipped to priorTurnMaxChars. The persisted transcript grows linearly with N while the model's input per step stays bounded by a constant.

The new test runs a six-step wcore workflow through the real sendWorkflowAdvanceDirective and the real composeResetSeed, and asserts the last step's input is a neighbour of step 2's rather than a multiple of it. Step 2 is the baseline, per the issue, so the cold-start turn does not skew the band. A second assertion bounds the last step against one deliverable's worth of tokens so proportional-to-run growth is caught directly.

Only the engine is faked, and it models exactly one property: a skipCache respawn drops context, a reuse keeps it.

### Executed proof the test goes red on the broken behaviour

Reverting the production ternary in workflowAdvanceReset.ts to the pre-#723 send (yoloMode only, no skipCache, no seed):

- expected 1906 to be less than or equal to 425
- expected 1906 to be less than 750

Step 6 goes from 386 to 1906 tokens - a 4.9x accumulation over five steps. Both flatness assertions fail. The production file was restored from a backup copy and sha-verified identical.

A third case drives the same harness with a never-reset session and asserts the numbers do climb, so a harness incapable of reporting growth cannot pass the flatness assertions for the wrong reason.

## Verification

- npx vitest run over all five touched or neighbouring suites: 60 passed, 0 failed
- npm run typecheck: clean
- npx oxlint on both new test files: 0 warnings, 0 errors
- npx oxfmt over exactly the changed files, committed separately
- Both workflow YAML files parse

No existing test was relaxed, skipped or deleted. No signing-pipeline change. No tag or release triggered.
