### PR TITLE
fix(memory): scope project quick-add and disclose dropped memory

### DIFF
--- a/src/common/adapter/bridgeAllowlist.ts
+++ b/src/common/adapter/bridgeAllowlist.ts
@@ -545,6 +545,13 @@ const REMOTE_DENIED_KEYS: ReadonlySet<string> = new Set([
   'memory.update-entry',
   'memory.delete-entry',
   'memory.restore-archived-entry',
+  //     #924: set-quick-add is a WRITE that was sitting on the allowed side of
+  //     the read/write line stated above. It creates an on-disk memory entry,
+  //     and it now carries a projectPath selector that steers WHICH indexed
+  //     project receives it. Denying it puts the namespace back in line with
+  //     the READS-only policy this block documents and keeps the new selector
+  //     off the remote surface entirely. Local Electron IPC is unaffected.
+  'memory.set-quick-add',
   // --- Project knowledge draft (reads arbitrary filePaths to feed the model) ---
   'project.generate-knowledge-draft',
   // --- Storage destructive / disk operations ---

--- a/src/common/adapter/ipcBridge.ts
+++ b/src/common/adapter/ipcBridge.ts
@@ -3221,7 +3221,7 @@ export const memory = {
   /** Quick-add a new memory from the renderer input. */
   setQuickAdd: buildProvider<
     { ok: boolean; error?: string },
-    { content: string; scope: 'project' | 'global'; type?: string }
+    { content: string; scope: 'project' | 'global'; type?: string; projectPath?: string }
   >('memory.set-quick-add'),
   /** Entries whose promotionScore meets the threshold. */
   getPromotionCandidates: buildProvider<PromotionCandidates, void>('memory.get-promotion-candidates'),

--- a/src/process/bridge/memoryArchiveBridge.ts
+++ b/src/process/bridge/memoryArchiveBridge.ts
@@ -43,6 +43,10 @@ const quickAddSchema = z.object({
   content: z.string().min(1).max(10_000),
   scope: z.enum(['project', 'global']),
   type: z.string().optional(),
+  // #924: the project the caller is actually in. The service accepts it only
+  // when it matches an indexed project root, so this is a selector, not a
+  // free-form write path.
+  projectPath: z.string().max(4_096).optional(),
 });
 
 const thresholdSchema = z.object({ threshold: z.number().int().min(0).max(100) });
@@ -187,7 +191,7 @@ export function initMemoryArchiveBridge(): void {
     const parsed = quickAddSchema.safeParse(args);
     if (!parsed.success) return { ok: false, error: parsed.error.message };
     try {
-      await svc.quickAdd(parsed.data.content, parsed.data.scope, parsed.data.type);
+      await svc.quickAdd(parsed.data.content, parsed.data.scope, parsed.data.type, parsed.data.projectPath);
       return { ok: true };
     } catch (err) {
       log.error('[memory-archive] setQuickAdd failed', { err });

--- a/src/process/services/memory/ijfwArchiveService.ts
+++ b/src/process/services/memory/ijfwArchiveService.ts
@@ -789,11 +789,49 @@ class IjfwArchiveService {
     };
   }
 
-  async quickAdd(content: string, scope: 'project' | 'global', type = 'observation'): Promise<void> {
+  /**
+   * Resolve the `.ijfw/memory` dir a project-scoped quick-add must be written
+   * to (#924).
+   *
+   * `projectPath` is the project the CALLER is in. It is accepted only when it
+   * matches an indexed project root, so an IPC caller can never steer a write
+   * at an arbitrary directory. When it cannot be resolved we fall back to the
+   * global store: writing the user's note somewhere predictable is correct,
+   * writing it into whichever unrelated project happens to be most recently
+   * active is not - that was the cross-project bleed in #924.
+   *
+   * The no-argument case keeps the historical `projects[0]` behaviour ONLY when
+   * there is a single indexed project, where it is unambiguous. With two or
+   * more, "most recently active" is a guess and we refuse to make it.
+   */
+  private resolveProjectMemoryDir(projectPath?: string): string {
+    const globalDir = path.join(os.homedir(), '.ijfw', 'memory');
+    const roots = this.index.projects;
+
+    if (projectPath && projectPath.trim()) {
+      const resolved = path.resolve(projectPath);
+      if (roots.some((p) => p.path === resolved)) return path.join(resolved, '.ijfw', 'memory');
+      log.warn('[memory-archive] quickAdd: unknown project path, writing to the global store', { projectPath });
+      return globalDir;
+    }
+
+    if (roots.length === 1) return path.join(roots[0].path, '.ijfw', 'memory');
+    if (roots.length > 1) {
+      log.warn('[memory-archive] quickAdd: no project path supplied, writing to the global store', {
+        candidates: roots.length,
+      });
+    }
+    return globalDir;
+  }
+
+  async quickAdd(
+    content: string,
+    scope: 'project' | 'global',
+    type = 'observation',
+    projectPath?: string
+  ): Promise<void> {
     const memDir =
-      scope === 'global'
-        ? path.join(os.homedir(), '.ijfw', 'memory')
-        : path.join(this.index.projects[0]?.path ?? os.homedir(), '.ijfw', 'memory');
+      scope === 'global' ? path.join(os.homedir(), '.ijfw', 'memory') : this.resolveProjectMemoryDir(projectPath);
     await fs.promises.mkdir(memDir, { recursive: true });
     const journalPath = path.join(memDir, 'journal.md');
     const now = new Date().toISOString();

--- a/src/process/services/memory/ijfwArchiveService.ts
+++ b/src/process/services/memory/ijfwArchiveService.ts
@@ -791,37 +791,37 @@ class IjfwArchiveService {
 
   /**
    * Resolve the `.ijfw/memory` dir a project-scoped quick-add must be written
-   * to (#924).
+   * to (#924), or null when no project can be named with confidence.
    *
    * `projectPath` is the project the CALLER is in. It is accepted only when it
    * matches an indexed project root, so an IPC caller can never steer a write
-   * at an arbitrary directory. When it cannot be resolved we fall back to the
-   * global store: writing the user's note somewhere predictable is correct,
-   * writing it into whichever unrelated project happens to be most recently
-   * active is not - that was the cross-project bleed in #924.
+   * at an arbitrary directory.
    *
-   * The no-argument case keeps the historical `projects[0]` behaviour ONLY when
-   * there is a single indexed project, where it is unambiguous. With two or
-   * more, "most recently active" is a guess and we refuse to make it.
+   * There is deliberately NO fallback to the global store. Redirecting a
+   * `project`-scoped save to the machine-wide brain would be worse than the bug
+   * it replaced: the old code misplaced the note into ONE unrelated project,
+   * whereas the global store is injected into every chat in every project by
+   * `loadGlobalMemoryBlock`. Refusing is the only honest answer, and the caller
+   * surfaces the refusal rather than silently widening the note's reach.
+   *
+   * The no-argument case keeps the historical behaviour ONLY when there is a
+   * single indexed project, where it is unambiguous.
    */
-  private resolveProjectMemoryDir(projectPath?: string): string {
-    const globalDir = path.join(os.homedir(), '.ijfw', 'memory');
+  private resolveProjectMemoryDir(projectPath?: string): string | null {
     const roots = this.index.projects;
 
     if (projectPath && projectPath.trim()) {
       const resolved = path.resolve(projectPath);
       if (roots.some((p) => p.path === resolved)) return path.join(resolved, '.ijfw', 'memory');
-      log.warn('[memory-archive] quickAdd: unknown project path, writing to the global store', { projectPath });
-      return globalDir;
+      log.warn('[memory-archive] quickAdd: project path is not an indexed project root', { projectPath });
+      return null;
     }
 
     if (roots.length === 1) return path.join(roots[0].path, '.ijfw', 'memory');
-    if (roots.length > 1) {
-      log.warn('[memory-archive] quickAdd: no project path supplied, writing to the global store', {
-        candidates: roots.length,
-      });
-    }
-    return globalDir;
+    log.warn('[memory-archive] quickAdd: no project named and the project is ambiguous', {
+      candidates: roots.length,
+    });
+    return null;
   }
 
   async quickAdd(
@@ -832,6 +832,9 @@ class IjfwArchiveService {
   ): Promise<void> {
     const memDir =
       scope === 'global' ? path.join(os.homedir(), '.ijfw', 'memory') : this.resolveProjectMemoryDir(projectPath);
+    if (memDir === null) {
+      throw new Error('unresolved_project_scope');
+    }
     await fs.promises.mkdir(memDir, { recursive: true });
     const journalPath = path.join(memDir, 'journal.md');
     const now = new Date().toISOString();

--- a/src/process/services/projectKnowledge/knowledge.ts
+++ b/src/process/services/projectKnowledge/knowledge.ts
@@ -189,13 +189,18 @@ export async function loadGlobalMemoryBlock(): Promise<string> {
     return '';
   }
 
-  const globalEntries = listed.entries
-    .filter((e) => e.sourcePath.startsWith(globalDir + path.sep))
-    .slice(0, MEMORY_BLOCK_MAX_ENTRIES);
+  const allGlobal = listed.entries.filter((e) => e.sourcePath.startsWith(globalDir + path.sep));
+  const globalEntries = allGlobal.slice(0, MEMORY_BLOCK_MAX_ENTRIES);
   if (globalEntries.length === 0) return '';
 
   const sections: string[] = [];
   let used = 0;
+  // #924: the block is the agent's whole record of the user's memory, so every
+  // way it shrinks must be visible in the text. `emitted` + `skippedEmpty`
+  // account for the entries the loop consumed; anything left over was dropped
+  // by a size cap and is disclosed in the trailing notice below.
+  let emitted = 0;
+  let skippedEmpty = 0;
   for (const entry of globalEntries) {
     // Stop before reading the next body once the remaining char budget is
     // nearly exhausted: the heading + label overhead means a section needs room
@@ -204,23 +209,39 @@ export async function loadGlobalMemoryBlock(): Promise<string> {
     if (used + MEMORY_ENTRY_CHAR_CAP > MEMORY_BLOCK_CHAR_CAP && used > 0) break;
 
     let body = entry.bodyPreview;
+    let previewOnly = true;
     try {
       const full = await svc.getEntry(entry.id);
-      if (full?.body) body = full.body;
+      if (full?.body) {
+        body = full.body;
+        previewOnly = false;
+      }
     } catch {
       // fall back to the preview already in hand
     }
     body = body.trim();
-    if (!body) continue;
+    if (!body) {
+      skippedEmpty++;
+      continue;
+    }
     if (body.length > MEMORY_ENTRY_CHAR_CAP) body = `${body.slice(0, MEMORY_ENTRY_CHAR_CAP)}\n\n…(truncated)`;
+    // #924: the list index carries only a 200-char preview. Substituting it for
+    // the body when the full read fails used to be silent, so the agent read a
+    // fragment as the complete entry and acted on the missing remainder.
+    else if (previewOnly) body = `${body}\n\n…(preview only - full entry unavailable)`;
     const heading = entry.summary.trim() || 'Untitled';
     const section = `## ${heading}\n\n${body}`;
     if (used + section.length > MEMORY_BLOCK_CHAR_CAP) break;
     sections.push(section);
     used += section.length;
+    emitted++;
   }
 
   if (sections.length === 0) return '';
+  const omitted = allGlobal.length - emitted - skippedEmpty;
+  if (omitted > 0) {
+    sections.push(`…(${omitted} more memory ${omitted === 1 ? 'entry' : 'entries'} omitted to fit the context budget)`);
+  }
   const label = i18n.t('memory.injectedLabel', {
     defaultValue:
       'User memory (from Wayland Memory) - the user dropped or saved this; use it to answer questions about it',

--- a/src/process/services/projectKnowledge/knowledge.ts
+++ b/src/process/services/projectKnowledge/knowledge.ts
@@ -196,11 +196,10 @@ export async function loadGlobalMemoryBlock(): Promise<string> {
   const sections: string[] = [];
   let used = 0;
   // #924: the block is the agent's whole record of the user's memory, so every
-  // way it shrinks must be visible in the text. `emitted` + `skippedEmpty`
-  // account for the entries the loop consumed; anything left over was dropped
-  // by a size cap and is disclosed in the trailing notice below.
+  // way it shrinks must be visible in the text. Every entry the loop reaches is
+  // emitted, so `emitted` alone accounts for them; anything left over was
+  // dropped by a size cap and is disclosed in the trailing notice below.
   let emitted = 0;
-  let skippedEmpty = 0;
   for (const entry of globalEntries) {
     // Stop before reading the next body once the remaining char budget is
     // nearly exhausted: the heading + label overhead means a section needs room
@@ -220,11 +219,15 @@ export async function loadGlobalMemoryBlock(): Promise<string> {
       // fall back to the preview already in hand
     }
     body = body.trim();
-    if (!body) {
-      skippedEmpty++;
-      continue;
-    }
-    if (body.length > MEMORY_ENTRY_CHAR_CAP) body = `${body.slice(0, MEMORY_ENTRY_CHAR_CAP)}\n\n…(truncated)`;
+    // #924: an entry can carry no body at all - a preference note whose SUMMARY
+    // is the whole note (its 200-char index preview is then empty too), or a
+    // source file `getEntry` could not read or could no longer match. Skipping
+    // it left NO marker: the count was subtracted back out of the omission
+    // notice below, so the entry vanished from a block that still looked
+    // complete. Emit the heading - which carries the note in the common case -
+    // and say the body was empty.
+    if (!body) body = '…(entry body empty)';
+    else if (body.length > MEMORY_ENTRY_CHAR_CAP) body = `${body.slice(0, MEMORY_ENTRY_CHAR_CAP)}\n\n…(truncated)`;
     // #924: the list index carries only a 200-char preview. Substituting it for
     // the body when the full read fails used to be silent, so the agent read a
     // fragment as the complete entry and acted on the missing remainder.
@@ -238,7 +241,7 @@ export async function loadGlobalMemoryBlock(): Promise<string> {
   }
 
   if (sections.length === 0) return '';
-  const omitted = allGlobal.length - emitted - skippedEmpty;
+  const omitted = allGlobal.length - emitted;
   if (omitted > 0) {
     sections.push(`…(${omitted} more memory ${omitted === 1 ? 'entry' : 'entries'} omitted to fit the context budget)`);
   }

--- a/src/renderer/pages/memory/components/ComposerModal.tsx
+++ b/src/renderer/pages/memory/components/ComposerModal.tsx
@@ -31,6 +31,13 @@ import styles from './ComposerModal.module.css';
 export type ComposerModalProps = {
   open: boolean;
   onClose: () => void;
+  /**
+   * Absolute path of the project the user is currently in, when there is one.
+   * Forwarded with a `project`-scoped save so the entry lands in THIS project
+   * (#924); without it the main process refuses to guess and writes to the
+   * global store rather than to an unrelated project.
+   */
+  projectPath?: string;
   onSubmit?: (entry: {
     content: string;
     scope: 'project' | 'global';
@@ -44,7 +51,7 @@ const MAX_CHARS = 8000;
 // Component
 // ---------------------------------------------------------------------------
 
-export function ComposerModal({ open, onClose, onSubmit }: ComposerModalProps): React.ReactElement | null {
+export function ComposerModal({ open, onClose, projectPath, onSubmit }: ComposerModalProps): React.ReactElement | null {
   const { t } = useTranslation();
 
   const [content, setContent] = useState('');
@@ -102,7 +109,11 @@ export function ComposerModal({ open, onClose, onSubmit }: ComposerModalProps): 
         await onSubmit({ content: trimmed, scope, tags });
       } else {
         // DEVIATION: tags not in IPC payload - scope IS forwarded
-        const result = await memoryBridge.setQuickAdd.invoke({ content: trimmed, scope });
+        const result = await memoryBridge.setQuickAdd.invoke({
+          content: trimmed,
+          scope,
+          ...(scope === 'project' && projectPath ? { projectPath } : {}),
+        });
         if (result.ok === false && result.error) {
           throw new Error(result.error);
         }
@@ -116,7 +127,7 @@ export function ComposerModal({ open, onClose, onSubmit }: ComposerModalProps): 
     } finally {
       setSubmitting(false);
     }
-  }, [content, scope, tags, onSubmit, onClose, t]);
+  }, [content, scope, tags, projectPath, onSubmit, onClose, t]);
 
   // ---- Cmd/Ctrl+Enter to submit ----
   const handleKeyDown = useCallback(

--- a/src/renderer/pages/memory/components/ComposerModal.tsx
+++ b/src/renderer/pages/memory/components/ComposerModal.tsx
@@ -36,7 +36,10 @@ export type ComposerModalProps = {
    * save must name exactly one of these (#924): the Memory page is a standalone
    * route with no conversation context, so there is nothing to infer the
    * project FROM and the destination has to be chosen explicitly. An empty list
-   * means project scope is unavailable and the toggle is disabled.
+   * does NOT disable project scope: the pill stays enabled and selected, the
+   * destination reads "no project selected", and main refuses the save - the
+   * handler below turns that refusal into copy telling the user to switch to
+   * global.
    */
   projects?: ReadonlyArray<{ path: string; basename: string }>;
   /** Project pre-selected on open - the Memory page's project filter, when set. */

--- a/src/renderer/pages/memory/components/ComposerModal.tsx
+++ b/src/renderer/pages/memory/components/ComposerModal.tsx
@@ -118,14 +118,31 @@ export function ComposerModal({
 
   // ESC already handled by Arco Modal's closable / onCancel - no extra listener needed.
 
+  // #924: the Memory page keys its project filter on BASENAME, and this modal
+  // turns that name into a WRITE destination. Two indexed projects can share a
+  // basename (`~/dev/one/app` and `~/dev/two/app` are both "app"), and a bare
+  // "app" then names an ambiguous place while the write always resolves to
+  // whichever came first. Qualify a colliding name with its parent directory so
+  // the label identifies exactly one project. Paths are compared as strings -
+  // the renderer has no `path` module - and both separators are handled because
+  // the same list is built from Windows paths too.
+  const basenameCounts = new Map<string, number>();
+  for (const p of projects) basenameCounts.set(p.basename, (basenameCounts.get(p.basename) ?? 0) + 1);
+  const labelFor = (p: { path: string; basename: string }): string => {
+    if ((basenameCounts.get(p.basename) ?? 0) < 2) return p.basename;
+    const parent = p.path.split(/[/\\]/).filter(Boolean).at(-2);
+    return parent ? `${p.basename} (${parent})` : p.path;
+  };
+
   // #924: name the destination the save will actually reach. Main is the
   // authority - it refuses a project-scoped save it cannot place rather than
   // redirecting it to the global brain - so the renderer's job is to pick the
   // project explicitly and show which one, never to re-decide the scope.
+  const selectedProject = projects.find((p) => p.path === projectPath);
   const destinationName =
     scope === 'global'
       ? t('archive.composer.destGlobal', 'Global memory (every chat)')
-      : (projects.find((p) => p.path === projectPath)?.basename ?? '');
+      : (selectedProject && labelFor(selectedProject)) || '';
 
   // ---- Submit ----
   const handleSubmit = useCallback(async () => {
@@ -356,7 +373,7 @@ export function ComposerModal({
             >
               {projects.map((p) => (
                 <option key={p.path} value={p.path}>
-                  {p.basename}
+                  {labelFor(p)}
                 </option>
               ))}
             </select>

--- a/src/renderer/pages/memory/components/ComposerModal.tsx
+++ b/src/renderer/pages/memory/components/ComposerModal.tsx
@@ -38,11 +38,7 @@ export type ComposerModalProps = {
    * global store rather than to an unrelated project.
    */
   projectPath?: string;
-  onSubmit?: (entry: {
-    content: string;
-    scope: 'project' | 'global';
-    tags: string[];
-  }) => void | Promise<void>;
+  onSubmit?: (entry: { content: string; scope: 'project' | 'global'; tags: string[] }) => void | Promise<void>;
 };
 
 const MAX_CHARS = 8000;
@@ -98,7 +94,7 @@ export function ComposerModal({ open, onClose, projectPath, onSubmit }: Composer
       setError(
         t('archive.composer.errorTooLong', `Content exceeds ${MAX_CHARS} character limit.`, {
           max: MAX_CHARS,
-        }),
+        })
       );
       return;
     }
@@ -137,7 +133,7 @@ export function ComposerModal({ open, onClose, projectPath, onSubmit }: Composer
         void handleSubmit();
       }
     },
-    [handleSubmit],
+    [handleSubmit]
   );
 
   // ---- Tag management ----
@@ -161,7 +157,7 @@ export function ComposerModal({ open, onClose, projectPath, onSubmit }: Composer
         setAddingTag(false);
       }
     },
-    [commitTag],
+    [commitTag]
   );
 
   const removeTag = useCallback((tag: string) => {
@@ -183,15 +179,13 @@ export function ComposerModal({ open, onClose, projectPath, onSubmit }: Composer
       reader.onload = (ev) => {
         const text = ev.target?.result;
         if (typeof text === 'string') {
-          const block = content.trim()
-            ? `${content}\n\n\`\`\`\n${text}\n\`\`\``
-            : text;
+          const block = content.trim() ? `${content}\n\n\`\`\`\n${text}\n\`\`\`` : text;
           setContent(block);
         }
       };
       reader.readAsText(file);
     },
-    [content],
+    [content]
   );
 
   if (!open) return null;
@@ -289,11 +283,7 @@ export function ComposerModal({ open, onClose, projectPath, onSubmit }: Composer
           {tags.map((tag) => (
             <span key={tag} className={styles.tagChip} data-testid={`composer-tag-${tag}`}>
               {tag}
-              <button
-                className={styles.tagRemoveBtn}
-                onClick={() => removeTag(tag)}
-                aria-label={`Remove tag ${tag}`}
-              >
+              <button className={styles.tagRemoveBtn} onClick={() => removeTag(tag)} aria-label={`Remove tag ${tag}`}>
                 <X size={10} aria-hidden />
               </button>
             </span>
@@ -311,11 +301,7 @@ export function ComposerModal({ open, onClose, projectPath, onSubmit }: Composer
               autoFocus
             />
           ) : (
-            <button
-              className={styles.addTagBtn}
-              onClick={() => setAddingTag(true)}
-              data-testid='composer-add-tag-btn'
-            >
+            <button className={styles.addTagBtn} onClick={() => setAddingTag(true)} data-testid='composer-add-tag-btn'>
               + {t('archive.composer.addTag', 'Add tag')}
             </button>
           )}
@@ -338,11 +324,7 @@ export function ComposerModal({ open, onClose, projectPath, onSubmit }: Composer
         <div className={styles.footer}>
           <span className={styles.footerHint}>⌘↵ {t('archive.composer.hint', 'to Remember')}</span>
           <div className={styles.footerActions}>
-            <Button
-              onClick={onClose}
-              disabled={submitting}
-              data-testid='composer-cancel-btn'
-            >
+            <Button onClick={onClose} disabled={submitting} data-testid='composer-cancel-btn'>
               {t('common.cancel', 'Cancel')}
             </Button>
             <Button

--- a/src/renderer/pages/memory/components/ComposerModal.tsx
+++ b/src/renderer/pages/memory/components/ComposerModal.tsx
@@ -72,13 +72,22 @@ export function ComposerModal({
   const tagInputRef = useRef<HTMLInputElement | null>(null);
   const dropZoneRef = useRef<HTMLDivElement | null>(null);
 
+  // The seed below reads exactly one thing out of `projects`: the first path.
+  // Depend on THAT, never on the array identity - `projects` is a fresh array on
+  // every parent render (the `= []` default included, and FullPanelShell builds
+  // its list with `.map`). With the array in the effect's dependency list the
+  // effect re-ran after every render, its close-branch `setTags([])` committed a
+  // new array each time, and the two fed each other in an unbounded loop that
+  // exhausted the heap.
+  const firstProjectPath = projects[0]?.path ?? '';
+
   // Auto-focus textarea when modal opens; reset state on close.
   useEffect(() => {
     if (open) {
       // Seed the destination from the page's project filter, else the first
       // indexed project. Never left blank while a project exists, so the
       // destination line below always names a real place (#924).
-      setProjectPath(defaultProjectPath ?? projects[0]?.path ?? '');
+      setProjectPath(defaultProjectPath ?? firstProjectPath);
       // Defer focus so Arco has time to mount
       const id = window.setTimeout(() => {
         textareaRef.current?.focus();
@@ -94,7 +103,7 @@ export function ComposerModal({
       setAddingTag(false);
       setError(null);
     }
-  }, [open, defaultProjectPath, projects]);
+  }, [open, defaultProjectPath, firstProjectPath]);
 
   // ESC already handled by Arco Modal's closable / onCancel - no extra listener needed.
 

--- a/src/renderer/pages/memory/components/ComposerModal.tsx
+++ b/src/renderer/pages/memory/components/ComposerModal.tsx
@@ -155,7 +155,20 @@ export function ComposerModal({
           ...(scope === 'project' && projectPath ? { projectPath } : {}),
         });
         if (result.ok === false && result.error) {
-          throw new Error(result.error);
+          // #924: main answers a project-scoped save it cannot place with the
+          // internal code `unresolved_project_scope`, and that code was printed
+          // straight at the user. It is reachable on the FIRST-RUN path - before
+          // anything is indexed there is no project to name, so `projects` is
+          // empty, no picker renders, and the save cannot resolve. Say what
+          // happened and what to do instead of leaking the identifier.
+          throw new Error(
+            result.error === 'unresolved_project_scope'
+              ? t(
+                  'archive.composer.errorNoProject',
+                  'No project is indexed yet, so this cannot be saved to a project. Switch to global to save it.'
+                )
+              : result.error
+          );
         }
         // Fire archive refresh via the event emitter so MemoryList picks it up
         // (same pattern as FullPanelShell's handleQuickAdd → reload)

--- a/src/renderer/pages/memory/components/ComposerModal.tsx
+++ b/src/renderer/pages/memory/components/ComposerModal.tsx
@@ -32,12 +32,15 @@ export type ComposerModalProps = {
   open: boolean;
   onClose: () => void;
   /**
-   * Absolute path of the project the user is currently in, when there is one.
-   * Forwarded with a `project`-scoped save so the entry lands in THIS project
-   * (#924); without it the main process refuses to guess and writes to the
-   * global store rather than to an unrelated project.
+   * Projects the archive has indexed, as {path, basename}. A `project`-scoped
+   * save must name exactly one of these (#924): the Memory page is a standalone
+   * route with no conversation context, so there is nothing to infer the
+   * project FROM and the destination has to be chosen explicitly. An empty list
+   * means project scope is unavailable and the toggle is disabled.
    */
-  projectPath?: string;
+  projects?: ReadonlyArray<{ path: string; basename: string }>;
+  /** Project pre-selected on open - the Memory page's project filter, when set. */
+  defaultProjectPath?: string;
   onSubmit?: (entry: { content: string; scope: 'project' | 'global'; tags: string[] }) => void | Promise<void>;
 };
 
@@ -47,11 +50,18 @@ const MAX_CHARS = 8000;
 // Component
 // ---------------------------------------------------------------------------
 
-export function ComposerModal({ open, onClose, projectPath, onSubmit }: ComposerModalProps): React.ReactElement | null {
+export function ComposerModal({
+  open,
+  onClose,
+  projects = [],
+  defaultProjectPath,
+  onSubmit,
+}: ComposerModalProps): React.ReactElement | null {
   const { t } = useTranslation();
 
   const [content, setContent] = useState('');
   const [scope, setScope] = useState<'project' | 'global'>('project');
+  const [projectPath, setProjectPath] = useState<string>('');
   const [tags, setTags] = useState<string[]>([]);
   const [tagInput, setTagInput] = useState('');
   const [addingTag, setAddingTag] = useState(false);
@@ -65,6 +75,10 @@ export function ComposerModal({ open, onClose, projectPath, onSubmit }: Composer
   // Auto-focus textarea when modal opens; reset state on close.
   useEffect(() => {
     if (open) {
+      // Seed the destination from the page's project filter, else the first
+      // indexed project. Never left blank while a project exists, so the
+      // destination line below always names a real place (#924).
+      setProjectPath(defaultProjectPath ?? projects[0]?.path ?? '');
       // Defer focus so Arco has time to mount
       const id = window.setTimeout(() => {
         textareaRef.current?.focus();
@@ -74,14 +88,24 @@ export function ComposerModal({ open, onClose, projectPath, onSubmit }: Composer
       // Clear on close
       setContent('');
       setScope('project');
+      setProjectPath('');
       setTags([]);
       setTagInput('');
       setAddingTag(false);
       setError(null);
     }
-  }, [open]);
+  }, [open, defaultProjectPath, projects]);
 
   // ESC already handled by Arco Modal's closable / onCancel - no extra listener needed.
+
+  // #924: name the destination the save will actually reach. Main is the
+  // authority - it refuses a project-scoped save it cannot place rather than
+  // redirecting it to the global brain - so the renderer's job is to pick the
+  // project explicitly and show which one, never to re-decide the scope.
+  const destinationName =
+    scope === 'global'
+      ? t('archive.composer.destGlobal', 'Global memory (every chat)')
+      : (projects.find((p) => p.path === projectPath)?.basename ?? '');
 
   // ---- Submit ----
   const handleSubmit = useCallback(async () => {
@@ -276,6 +300,30 @@ export function ComposerModal({ open, onClose, projectPath, onSubmit }: Composer
           >
             🌐 {t('archive.composer.scopeGlobal', 'global')}
           </button>
+        </div>
+
+        {/* ---- Destination (#924) ---- */}
+        {/* The scope pill alone told the user "project" while the actual
+            destination was resolved elsewhere and could differ. Name the real
+            place, and let them change it, before they save. */}
+        <div className={styles.scopeRow} data-testid='composer-destination-row'>
+          <span data-testid='composer-destination'>
+            {t('archive.composer.savingTo', 'Saving to')}: {destinationName || t('archive.composer.destNone', 'no project selected')}
+          </span>
+          {scope === 'project' && projects.length > 1 && (
+            <select
+              value={projectPath}
+              onChange={(e) => setProjectPath(e.target.value)}
+              aria-label={t('archive.composer.projectPicker', 'Project to save to')}
+              data-testid='composer-project-picker'
+            >
+              {projects.map((p) => (
+                <option key={p.path} value={p.path}>
+                  {p.basename}
+                </option>
+              ))}
+            </select>
+          )}
         </div>
 
         {/* ---- Tag chip input ---- */}

--- a/src/renderer/pages/memory/components/ComposerModal.tsx
+++ b/src/renderer/pages/memory/components/ComposerModal.tsx
@@ -308,7 +308,8 @@ export function ComposerModal({
             place, and let them change it, before they save. */}
         <div className={styles.scopeRow} data-testid='composer-destination-row'>
           <span data-testid='composer-destination'>
-            {t('archive.composer.savingTo', 'Saving to')}: {destinationName || t('archive.composer.destNone', 'no project selected')}
+            {t('archive.composer.savingTo', 'Saving to')}:{' '}
+            {destinationName || t('archive.composer.destNone', 'no project selected')}
           </span>
           {scope === 'project' && projects.length > 1 && (
             <select

--- a/src/renderer/pages/memory/components/ComposerModal.tsx
+++ b/src/renderer/pages/memory/components/ComposerModal.tsx
@@ -81,13 +81,23 @@ export function ComposerModal({
   // exhausted the heap.
   const firstProjectPath = projects[0]?.path ?? '';
 
+  // #924: once the user has picked a destination it is authoritative for the
+  // rest of this open cycle. `firstProjectPath` (and `defaultProjectPath`) move
+  // whenever a BACKGROUND index refresh reorders the project list - the Memory
+  // page re-fetches on `onIndexChanged`, which IJFW fires whenever an agent
+  // writes memory - and re-seeding then rewrote the chosen destination out from
+  // under the open picker, sending the note to a project the user never named.
+  // Seeding stays live only while the user has not chosen, so a project list
+  // that arrives after the modal opens still fills the destination in.
+  const userPickedRef = useRef(false);
+
   // Auto-focus textarea when modal opens; reset state on close.
   useEffect(() => {
     if (open) {
       // Seed the destination from the page's project filter, else the first
       // indexed project. Never left blank while a project exists, so the
       // destination line below always names a real place (#924).
-      setProjectPath(defaultProjectPath ?? firstProjectPath);
+      if (!userPickedRef.current) setProjectPath(defaultProjectPath ?? firstProjectPath);
       // Defer focus so Arco has time to mount
       const id = window.setTimeout(() => {
         textareaRef.current?.focus();
@@ -95,6 +105,7 @@ export function ComposerModal({
       return () => window.clearTimeout(id);
     } else {
       // Clear on close
+      userPickedRef.current = false;
       setContent('');
       setScope('project');
       setProjectPath('');
@@ -323,7 +334,10 @@ export function ComposerModal({
           {scope === 'project' && projects.length > 1 && (
             <select
               value={projectPath}
-              onChange={(e) => setProjectPath(e.target.value)}
+              onChange={(e) => {
+                userPickedRef.current = true;
+                setProjectPath(e.target.value);
+              }}
               aria-label={t('archive.composer.projectPicker', 'Project to save to')}
               data-testid='composer-project-picker'
             >

--- a/src/renderer/pages/memory/state-branches/FullPanelShell.tsx
+++ b/src/renderer/pages/memory/state-branches/FullPanelShell.tsx
@@ -59,7 +59,6 @@ import EmptyStateHero from '../components/EmptyStateHero';
 import MemoryStatusBar from '../components/MemoryStatusBar';
 import ImportDrawer from '../components/ImportDrawer';
 import ComposerModal from '../components/ComposerModal';
-import { useActiveBrainScope } from '../getActiveBrainScope';
 import EntryEditorModal from '../components/EntryEditorModal';
 import ArchivedMemoryModal from '../components/ArchivedMemoryModal';
 import { useMemoryIndex } from '../hooks/useMemoryIndex';
@@ -130,12 +129,6 @@ const FullPanelShell: React.FC = () => {
   // Root-namespace t for the one string reused from #591 (memory.settings.*),
   // so the strip adds no new i18n keys.
   const { t: tRoot } = useTranslation();
-
-  // #924: the project the active chat is working in. A `project`-scoped
-  // quick-add is written HERE, not into whichever project the archive index
-  // happens to rank first.
-  const brainScope = useActiveBrainScope();
-  const activeProjectPath = brainScope.scope === 'project' ? brainScope.path : undefined;
 
   const [filter, setFilter] = useState<ListFilter>(DEFAULT_FILTER);
   const [timeWindow, setTimeWindow] = useState<TimeWindow>('all');
@@ -404,6 +397,13 @@ const FullPanelShell: React.FC = () => {
   // Result count for filter bar
   const resultCountLabel = isLoading ? '' : `${total.toLocaleString()} ${t('archive.filter.results', 'results')}`;
 
+  // #924: the Memory page is a standalone route with no conversation context,
+  // so a project-scoped save cannot be inferred - it is chosen. Feed the
+  // composer the indexed projects and pre-select the page's project filter.
+  const composerProjects = projects.map((p) => ({ path: p.path, basename: p.basename }));
+  const composerDefaultProjectPath =
+    filter.project !== 'all' ? projects.find((p) => p.basename === filter.project)?.path : undefined;
+
   const projectSelected = filter.project !== 'all' ? filter.project : null;
   const typeCounts = stats?.typeCounts ?? {
     decision: 0,
@@ -663,7 +663,12 @@ const FullPanelShell: React.FC = () => {
       <ImportDrawer open={importOpen} onClose={() => setImportOpen(false)} />
 
       {/* ---- Composer modal ---- */}
-      <ComposerModal open={composerOpen} onClose={() => setComposerOpen(false)} projectPath={activeProjectPath} />
+      <ComposerModal
+        open={composerOpen}
+        onClose={() => setComposerOpen(false)}
+        projects={composerProjects}
+        defaultProjectPath={composerDefaultProjectPath}
+      />
 
       {/* ---- Entry editor modal (#414) ---- */}
       <EntryEditorModal

--- a/src/renderer/pages/memory/state-branches/FullPanelShell.tsx
+++ b/src/renderer/pages/memory/state-branches/FullPanelShell.tsx
@@ -59,6 +59,7 @@ import EmptyStateHero from '../components/EmptyStateHero';
 import MemoryStatusBar from '../components/MemoryStatusBar';
 import ImportDrawer from '../components/ImportDrawer';
 import ComposerModal from '../components/ComposerModal';
+import { useActiveBrainScope } from '../getActiveBrainScope';
 import EntryEditorModal from '../components/EntryEditorModal';
 import ArchivedMemoryModal from '../components/ArchivedMemoryModal';
 import { useMemoryIndex } from '../hooks/useMemoryIndex';
@@ -129,6 +130,12 @@ const FullPanelShell: React.FC = () => {
   // Root-namespace t for the one string reused from #591 (memory.settings.*),
   // so the strip adds no new i18n keys.
   const { t: tRoot } = useTranslation();
+
+  // #924: the project the active chat is working in. A `project`-scoped
+  // quick-add is written HERE, not into whichever project the archive index
+  // happens to rank first.
+  const brainScope = useActiveBrainScope();
+  const activeProjectPath = brainScope.scope === 'project' ? brainScope.path : undefined;
 
   const [filter, setFilter] = useState<ListFilter>(DEFAULT_FILTER);
   const [timeWindow, setTimeWindow] = useState<TimeWindow>('all');
@@ -656,7 +663,7 @@ const FullPanelShell: React.FC = () => {
       <ImportDrawer open={importOpen} onClose={() => setImportOpen(false)} />
 
       {/* ---- Composer modal ---- */}
-      <ComposerModal open={composerOpen} onClose={() => setComposerOpen(false)} />
+      <ComposerModal open={composerOpen} onClose={() => setComposerOpen(false)} projectPath={activeProjectPath} />
 
       {/* ---- Entry editor modal (#414) ---- */}
       <EntryEditorModal

--- a/tests/unit/bridgeAllowlist.redteam.test.ts
+++ b/tests/unit/bridgeAllowlist.redteam.test.ts
@@ -200,9 +200,15 @@ describe('isAllowedForRemote - doctor surface denied (#458)', () => {
  * local memory files. A remote (paired-device WebSocket) caller must never
  * reach them. Read-only views stay allowed so the remote Archive panel still
  * functions without granting host-filesystem mutation authority.
+ *
+ * #924 adds `memory.set-quick-add` to that deny set. It was on the allowed side
+ * of the read/write line despite CREATING an on-disk memory entry, and it now
+ * carries a `projectPath` selector that steers WHICH indexed project receives
+ * the write - so a remote peer could both write the user's memory and choose
+ * where it landed.
  */
 describe('isAllowedForRemote - memory mutation denied (#414)', () => {
-  it.each(['memory.update-entry', 'memory.delete-entry', 'memory.restore-archived-entry'])(
+  it.each(['memory.update-entry', 'memory.delete-entry', 'memory.restore-archived-entry', 'memory.set-quick-add'])(
     'denies subscribe-%s for remote callers (blocks remote memory mutation)',
     (key) => {
       expect(isAllowedForRemote(`subscribe-${key}`)).toBe(false);

--- a/tests/unit/process/services/globalMemoryBlockLossy.test.ts
+++ b/tests/unit/process/services/globalMemoryBlockLossy.test.ts
@@ -82,7 +82,7 @@ describe('loadGlobalMemoryBlock lossy disclosure (#924)', () => {
   });
 
   it('discloses how many entries the block budget dropped', async () => {
-    // Each body is 7_000 chars: two fit inside MEMORY_BLOCK_CHAR_CAP (24_000),
+    // Each body is 7_000 chars: three fit inside MEMORY_BLOCK_CHAR_CAP (24_000),
     // the loop then stops with entries still unread.
     const bodies: Record<string, string> = {};
     const entries: MemoryEntry[] = [];
@@ -107,8 +107,72 @@ describe('loadGlobalMemoryBlock lossy disclosure (#924)', () => {
 
     const block = await loadGlobalMemoryBlock();
     expect(block).toContain('entry 0');
-    // Some entries did not fit - the block must say so rather than end silently.
-    expect(block).toMatch(/\d+ more memory entr/);
+    // The COUNT is the whole disclosure: a notice that under-reports is worse
+    // than none, because it looks trustworthy. Three of six bodies fit, so the
+    // block must name exactly three - not "some", not an off-by-one.
+    expect(block.match(/^## entry \d+$/gm)).toHaveLength(3);
+    expect(block).toContain('…(3 more memory entries omitted to fit the context budget)');
+  });
+
+  it('counts entries dropped by the 50-entry cap exactly', async () => {
+    // MEMORY_BLOCK_MAX_ENTRIES (50) is a different drop path from the char cap
+    // above: the bodies are tiny, so all 50 survivors fit and the remaining 10
+    // are lost to the entry cap alone.
+    const entries: MemoryEntry[] = Array.from({ length: 60 }, (_, i) =>
+      entry({
+        id: `c${i}`,
+        summary: `capped ${i}`,
+        sourcePath: path.join(GLOBAL_DIR, `cap-${i}.md`),
+        storedAt: Date.now() - i * 1000,
+      })
+    );
+    setIjfwArchiveService({
+      listEntries: async () => ({ entries, total: entries.length }),
+      getEntry: async (id: string) => ({ ...entries.find((e) => e.id === id)!, body: `body ${id}` }),
+      dispose: () => {},
+    } as unknown as IjfwArchiveService);
+
+    const block = await loadGlobalMemoryBlock();
+    expect(block.match(/^## capped \d+$/gm)).toHaveLength(50);
+    expect(block).toContain('…(10 more memory entries omitted to fit the context budget)');
+  });
+
+  it('emits a summary-only entry with an empty-body marker instead of dropping it silently', async () => {
+    // The reachable case: a preference note whose SUMMARY is the whole note.
+    // `bodyPreview` is stripMarkdown(body).slice(0, 200) so it is '' too, and
+    // `getEntry` returns body: '' whenever the source block no longer matches.
+    // The entry used to be skipped AND subtracted back out of the omission
+    // notice, so it vanished from a block that still read as complete.
+    const summaryOnly = entry({
+      id: 'so',
+      summary: 'NEVER deploy on a Friday - this is the whole note',
+      sourcePath: path.join(GLOBAL_DIR, 'prefs.md'),
+      storedAt: Date.now(),
+      bodyPreview: '',
+    });
+    const withBody = entry({
+      id: 'wb',
+      summary: 'has a body',
+      sourcePath: path.join(GLOBAL_DIR, 'journal.md'),
+      storedAt: Date.now() - 1000,
+      bodyPreview: 'this body is present',
+    });
+    setIjfwArchiveService({
+      listEntries: async () => ({ entries: [summaryOnly, withBody], total: 2 }),
+      getEntry: async (id: string) =>
+        id === 'so' ? { ...summaryOnly, body: '' } : { ...withBody, body: 'this body is present' },
+      dispose: () => {},
+    } as unknown as IjfwArchiveService);
+
+    const block = await loadGlobalMemoryBlock();
+    // The note itself must survive - the summary IS the content here.
+    expect(block).toContain('NEVER deploy on a Friday - this is the whole note');
+    expect(block).toContain('…(entry body empty)');
+    expect(block).toContain('this body is present');
+    // Nothing was dropped, so no omission notice - and, critically, the empty
+    // entry must not be quietly subtracted out to make the numbers balance.
+    expect(block.match(/^## /gm)).toHaveLength(2);
+    expect(block).not.toMatch(/more memory entr/);
   });
 
   it('adds no omission notice when every entry fits', async () => {

--- a/tests/unit/process/services/globalMemoryBlockLossy.test.ts
+++ b/tests/unit/process/services/globalMemoryBlockLossy.test.ts
@@ -1,0 +1,129 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * GitHub #924 - silent loss in the injected global-memory block.
+ *
+ * `loadGlobalMemoryBlock` composes the block the chat agent receives as its
+ * record of the user's memory. Two paths used to shrink it with no marker at
+ * all, so the agent read a partial block as if it were the whole store:
+ *
+ *   1. When the full body read failed, the 200-character list `bodyPreview`
+ *      was substituted and presented as the complete entry.
+ *   2. When an entry did not fit the remaining block budget, it and every
+ *      entry after it were dropped without a word.
+ *
+ * The oversized-body path already appended `…(truncated)`; these two did not.
+ * The block must always disclose what it left out.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import os from 'os';
+import path from 'path';
+import type { MemoryEntry } from '@/common/types/memory';
+import type { IjfwArchiveService } from '@process/services/memory/ijfwArchiveService';
+
+vi.mock('@process/services/i18n', () => ({
+  default: { t: (_key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? _key },
+}));
+
+import { loadGlobalMemoryBlock } from '@process/services/projectKnowledge/knowledge';
+import { resetIjfwArchiveService, setIjfwArchiveService } from '@process/services/memory/ijfwArchiveService';
+
+const GLOBAL_DIR = path.join(os.homedir(), '.ijfw', 'memory');
+
+function entry(over: Partial<MemoryEntry> & { id: string; summary: string; sourcePath: string }): MemoryEntry {
+  return {
+    type: 'observation',
+    project: 'global',
+    projectPath: os.homedir(),
+    bodyPreview: '',
+    tags: [],
+    storedAt: Date.now(),
+    sourceLine: 0,
+    referencedBy: 0,
+    promotionScore: 0,
+    ...over,
+  };
+}
+
+afterEach(() => {
+  resetIjfwArchiveService();
+  vi.restoreAllMocks();
+});
+
+describe('loadGlobalMemoryBlock lossy disclosure (#924)', () => {
+  it('marks an entry whose full body could not be read instead of passing the preview off as complete', async () => {
+    const droppedPath = path.join(GLOBAL_DIR, 'dropped-1-spec.md');
+    setIjfwArchiveService({
+      listEntries: async () => ({
+        entries: [
+          entry({
+            id: 'p1',
+            summary: 'Five-step release spec',
+            sourcePath: droppedPath,
+            bodyPreview: 'Step 1 of 5: cut the branch',
+          }),
+        ],
+        total: 1,
+      }),
+      getEntry: async () => {
+        throw new Error('source file unreadable');
+      },
+      dispose: () => {},
+    } as unknown as IjfwArchiveService);
+
+    const block = await loadGlobalMemoryBlock();
+    expect(block).toContain('Five-step release spec');
+    expect(block).toContain('Step 1 of 5: cut the branch');
+    // The agent must be told this is a preview, not the whole entry.
+    expect(block).toContain('(preview only');
+  });
+
+  it('discloses how many entries the block budget dropped', async () => {
+    // Each body is 7_000 chars: two fit inside MEMORY_BLOCK_CHAR_CAP (24_000),
+    // the loop then stops with entries still unread.
+    const bodies: Record<string, string> = {};
+    const entries: MemoryEntry[] = [];
+    for (let i = 0; i < 6; i++) {
+      const id = `e${i}`;
+      bodies[id] = `${i}`.repeat(7_000);
+      entries.push(
+        entry({
+          id,
+          summary: `entry ${i}`,
+          sourcePath: path.join(GLOBAL_DIR, `drop-${i}.md`),
+          storedAt: Date.now() - i * 1000,
+          bodyPreview: `preview ${i}`,
+        })
+      );
+    }
+    setIjfwArchiveService({
+      listEntries: async () => ({ entries, total: entries.length }),
+      getEntry: async (id: string) => ({ ...entries.find((e) => e.id === id)!, body: bodies[id] }),
+      dispose: () => {},
+    } as unknown as IjfwArchiveService);
+
+    const block = await loadGlobalMemoryBlock();
+    expect(block).toContain('entry 0');
+    // Some entries did not fit - the block must say so rather than end silently.
+    expect(block).toMatch(/\d+ more memory entr/);
+  });
+
+  it('adds no omission notice when every entry fits', async () => {
+    setIjfwArchiveService({
+      listEntries: async () => ({
+        entries: [entry({ id: 'a', summary: 'small note', sourcePath: path.join(GLOBAL_DIR, 'a.md') })],
+        total: 1,
+      }),
+      getEntry: async () => ({ id: 'a', body: 'short body' }),
+      dispose: () => {},
+    } as unknown as IjfwArchiveService);
+
+    const block = await loadGlobalMemoryBlock();
+    expect(block).toContain('short body');
+    expect(block).not.toMatch(/more memory entr/);
+    expect(block).not.toContain('(preview only');
+  });
+});

--- a/tests/unit/process/services/memory/ijfwArchiveService.projectScope.test.ts
+++ b/tests/unit/process/services/memory/ijfwArchiveService.projectScope.test.ts
@@ -125,31 +125,50 @@ describe('IjfwArchiveService.quickAdd project scoping (#924)', () => {
     expect(alphaContent).not.toContain('beta-only secret note');
   });
 
-  it('falls back to the global store rather than guessing a project when the path is unknown', async () => {
+  it('refuses an unknown project path instead of redirecting the note anywhere', async () => {
     service = new IjfwArchiveService(noopWatcherFactory);
     await service.init();
 
-    await service.quickAdd('unscoped note', 'project', 'observation', path.join(tmpRoot, 'never-registered'));
+    await expect(
+      service.quickAdd('unscoped note', 'project', 'observation', path.join(tmpRoot, 'never-registered'))
+    ).rejects.toThrow('unresolved_project_scope');
 
+    // Not into another project, and NOT into the global store either - the
+    // global block is injected into every chat, so redirecting there would
+    // widen the note's reach far beyond the one project the user asked for.
     const globalJournal = path.join(fakeHome, '.ijfw', 'memory', 'journal.md');
-    expect(fs.existsSync(globalJournal)).toBe(true);
-    expect(fs.readFileSync(globalJournal, 'utf8')).toContain('unscoped note');
-
-    const alphaJournal = journalOf(recentProject);
-    const alphaContent = fs.existsSync(alphaJournal) ? fs.readFileSync(alphaJournal, 'utf8') : '';
-    expect(alphaContent).not.toContain('unscoped note');
+    expect(fs.existsSync(globalJournal)).toBe(false);
+    for (const root of [recentProject, callerProject]) {
+      const j = journalOf(root);
+      expect(fs.existsSync(j) ? fs.readFileSync(j, 'utf8') : '').not.toContain('unscoped note');
+    }
   });
   it('refuses to guess a project when the caller names none and several exist', async () => {
     service = new IjfwArchiveService(noopWatcherFactory);
     await service.init();
 
-    await service.quickAdd('ambiguous note', 'project');
+    await expect(service.quickAdd('ambiguous note', 'project')).rejects.toThrow('unresolved_project_scope');
 
     const globalJournal = path.join(fakeHome, '.ijfw', 'memory', 'journal.md');
-    expect(fs.readFileSync(globalJournal, 'utf8')).toContain('ambiguous note');
+    expect(fs.existsSync(globalJournal)).toBe(false);
     for (const root of [recentProject, callerProject]) {
       const j = journalOf(root);
       expect(fs.existsSync(j) ? fs.readFileSync(j, 'utf8') : '').not.toContain('ambiguous note');
     }
+  });
+
+  it('a project-scoped save can never land in the global store (#924 F1)', async () => {
+    service = new IjfwArchiveService(noopWatcherFactory);
+    await service.init();
+
+    // Every project-scope call shape: named-and-valid, named-and-unknown, unnamed.
+    await service.quickAdd('valid', 'project', 'observation', callerProject);
+    await expect(service.quickAdd('unknown', 'project', 'observation', '/nope')).rejects.toThrow();
+    await expect(service.quickAdd('unnamed', 'project')).rejects.toThrow();
+
+    // The global journal - the one loadGlobalMemoryBlock injects into EVERY
+    // chat - must be untouched by all three.
+    const globalJournal = path.join(fakeHome, '.ijfw', 'memory', 'journal.md');
+    expect(fs.existsSync(globalJournal)).toBe(false);
   });
 });

--- a/tests/unit/process/services/memory/ijfwArchiveService.projectScope.test.ts
+++ b/tests/unit/process/services/memory/ijfwArchiveService.projectScope.test.ts
@@ -1,0 +1,155 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * GitHub #924 - cross-project memory writes.
+ *
+ * `quickAdd(content, 'project')` used to resolve its destination from
+ * `index.projects[0]`, i.e. the most recently active IJFW project ANYWHERE on
+ * the machine, with no relation to the project the user was actually working
+ * in. Saving a project-scoped memory while in project B therefore appended it
+ * to project A's `.ijfw/memory/journal.md`, where any later session opened in
+ * project A would read it back as that project's own context.
+ *
+ * These tests stage two projects with different activity timestamps and assert
+ * the entry lands in the project the CALLER named, never in the most-recent one.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { IjfwArchiveService } from '@process/services/memory/ijfwArchiveService';
+import type { WatcherFactory } from '@process/services/memory/ijfwArchiveService';
+
+const noopWatcherFactory: WatcherFactory = () => ({ close: () => undefined });
+
+/**
+ * The service skips any project path containing '/tmp/' or 'Temp/', so fixtures
+ * must not live under os.tmpdir(). Root under the real homedir (mirrors the
+ * sibling suite).
+ */
+function makeTmpDir(): string {
+  const scratchRoot = path.join(os.homedir(), '.ijfw-test-scratch');
+  fs.mkdirSync(scratchRoot, { recursive: true });
+  return fs.mkdtempSync(path.join(scratchRoot, 'scope-'));
+}
+
+function writeProject(root: string, stored: string): void {
+  const memDir = path.join(root, '.ijfw', 'memory');
+  fs.mkdirSync(memDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(memDir, 'knowledge.md'),
+    [
+      '<!-- ijfw-schema: v1 -->',
+      '# Knowledge Base',
+      '---',
+      'type: observation',
+      `summary: seed entry for ${path.basename(root)}`,
+      `stored: ${stored}`,
+      'tags: []',
+      '---',
+      'seed body',
+    ].join('\n'),
+    'utf8'
+  );
+}
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+describe('IjfwArchiveService.quickAdd project scoping (#924)', () => {
+  let tmpRoot: string;
+  let fakeHome: string;
+  let recentProject: string;
+  let callerProject: string;
+  let service: IjfwArchiveService;
+  let origHome: string | undefined;
+  let origUserProfile: string | undefined;
+
+  beforeEach(() => {
+    tmpRoot = makeTmpDir();
+    fakeHome = path.join(tmpRoot, 'fake-home');
+    recentProject = path.join(tmpRoot, 'project-alpha');
+    callerProject = path.join(tmpRoot, 'project-beta');
+
+    // Alpha is the most recently active project on the machine; beta is the one
+    // the user is actually working in.
+    writeProject(recentProject, '2026-06-01T10:00:00.000Z');
+    writeProject(callerProject, '2026-01-01T10:00:00.000Z');
+
+    const ijfwHomeDir = path.join(fakeHome, '.ijfw');
+    fs.mkdirSync(ijfwHomeDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(ijfwHomeDir, 'registry.md'),
+      `${recentProject} | aaa | 2026-06-01T10:00:00.000Z\n${callerProject} | bbb | 2026-01-01T10:00:00.000Z\n`,
+      'utf8'
+    );
+
+    origHome = process.env.HOME;
+    origUserProfile = process.env.USERPROFILE;
+    process.env.HOME = fakeHome;
+    process.env.USERPROFILE = fakeHome;
+  });
+
+  afterEach(() => {
+    if (service) service.dispose();
+    restoreEnv('HOME', origHome);
+    restoreEnv('USERPROFILE', origUserProfile);
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  const journalOf = (root: string): string => path.join(root, '.ijfw', 'memory', 'journal.md');
+
+  it('writes a project-scoped entry into the named project, not the most recent one', async () => {
+    service = new IjfwArchiveService(noopWatcherFactory);
+    await service.init();
+
+    await service.quickAdd('beta-only secret note', 'project', 'observation', callerProject);
+
+    expect(fs.existsSync(journalOf(callerProject))).toBe(true);
+    expect(fs.readFileSync(journalOf(callerProject), 'utf8')).toContain('beta-only secret note');
+  });
+
+  it('never leaks a project-scoped entry into a different project', async () => {
+    service = new IjfwArchiveService(noopWatcherFactory);
+    await service.init();
+
+    await service.quickAdd('beta-only secret note', 'project', 'observation', callerProject);
+
+    const alphaJournal = journalOf(recentProject);
+    const alphaContent = fs.existsSync(alphaJournal) ? fs.readFileSync(alphaJournal, 'utf8') : '';
+    expect(alphaContent).not.toContain('beta-only secret note');
+  });
+
+  it('falls back to the global store rather than guessing a project when the path is unknown', async () => {
+    service = new IjfwArchiveService(noopWatcherFactory);
+    await service.init();
+
+    await service.quickAdd('unscoped note', 'project', 'observation', path.join(tmpRoot, 'never-registered'));
+
+    const globalJournal = path.join(fakeHome, '.ijfw', 'memory', 'journal.md');
+    expect(fs.existsSync(globalJournal)).toBe(true);
+    expect(fs.readFileSync(globalJournal, 'utf8')).toContain('unscoped note');
+
+    const alphaJournal = journalOf(recentProject);
+    const alphaContent = fs.existsSync(alphaJournal) ? fs.readFileSync(alphaJournal, 'utf8') : '';
+    expect(alphaContent).not.toContain('unscoped note');
+  });
+  it('refuses to guess a project when the caller names none and several exist', async () => {
+    service = new IjfwArchiveService(noopWatcherFactory);
+    await service.init();
+
+    await service.quickAdd('ambiguous note', 'project');
+
+    const globalJournal = path.join(fakeHome, '.ijfw', 'memory', 'journal.md');
+    expect(fs.readFileSync(globalJournal, 'utf8')).toContain('ambiguous note');
+    for (const root of [recentProject, callerProject]) {
+      const j = journalOf(root);
+      expect(fs.existsSync(j) ? fs.readFileSync(j, 'utf8') : '').not.toContain('ambiguous note');
+    }
+  });
+});

--- a/tests/unit/renderer/pages/memory/composerProjectDestination.dom.test.tsx
+++ b/tests/unit/renderer/pages/memory/composerProjectDestination.dom.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// @vitest-environment jsdom
+
+/**
+ * GitHub #924 - a project-scoped save must name its project, through the REAL
+ * renderer path.
+ *
+ * This drives the actual `/memory` route component tree (FullPanelShell ->
+ * ComposerModal -> ipcBridge.memory.setQuickAdd), not a service-level harness.
+ * That distinction is the whole point of this file: an earlier attempt at #924
+ * resolved the project from `useActiveBrainScope()`, which reads
+ * `ConversationProvider`. `/memory` is a SIBLING route to `/conversation/:id`
+ * and mounts no such provider, so the hook always returned the app scope and
+ * the wiring was inert - every project-scoped save fell through to the global
+ * store, which `loadGlobalMemoryBlock` injects into every chat in every
+ * project. A service-level test could not see that; this one can.
+ */
+
+import React from 'react';
+import { cleanup, fireEvent, render, screen, act, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MemoryStats, MemoryEntry, ProjectSummary, PromotionCandidates } from '@/common/types/memory';
+
+const ALPHA = '/dev/project-alpha';
+const BETA = '/dev/project-beta';
+
+const MOCK_PROJECTS: ProjectSummary[] = [
+  { path: ALPHA, basename: 'project-alpha', count: 9, lastActive: Date.now() },
+  { path: BETA, basename: 'project-beta', count: 2, lastActive: Date.now() - 100_000 },
+];
+
+const MOCK_STATS = {
+  total: 11,
+  decisions: 1,
+  wiki: 0,
+  sessions: 0,
+  projects: 2,
+  banked: 0,
+  deltas: {
+    total24h: 0, total7d: 0, decisions24h: 0, decisions7d: 0,
+    wiki24h: 0, wiki7d: 0, sessions24h: 0, sessions7d: 0,
+  },
+  sparkline: [],
+  sparklines: {
+    total: [], banked: [], decisions: [], wiki: [], sessions: [], projects: [],
+  },
+  typeCounts: { decision: 1, pattern: 0, session: 0, observation: 0, wiki: 0, preference: 0 },
+  streak: { sessions: 0, longestDays: 0, lastActiveDayMs: Date.now() },
+} as unknown as MemoryStats;
+
+const MOCK_ENTRY: MemoryEntry = {
+  id: 'e1',
+  type: 'decision',
+  project: 'project-alpha',
+  projectPath: ALPHA,
+  summary: 'seed',
+  bodyPreview: 'seed',
+  tags: [],
+  storedAt: Date.now(),
+  sourcePath: `${ALPHA}/.ijfw/memory/knowledge.md`,
+  sourceLine: 1,
+  referencedBy: 0,
+  promotionScore: 0,
+};
+
+const MOCK_CANDIDATES: PromotionCandidates = {
+  candidates: [], threshold: 90, lastRun: Date.now(), nextRun: Date.now() + 1000,
+};
+
+const { mockMemory, mockShell, mockIjfw, mockModalConfirm } = vi.hoisted(() => {
+  const emitter = { on: () => () => {} };
+  return {
+    mockMemory: {
+      getStats: { invoke: vi.fn() },
+      listEntries: { invoke: vi.fn() },
+      getEntry: { invoke: vi.fn() },
+      getProjects: { invoke: vi.fn() },
+      getTags: { invoke: vi.fn() },
+      getPromotionCandidates: { invoke: vi.fn() },
+      promote: { invoke: vi.fn() },
+      setQuickAdd: { invoke: vi.fn() },
+      updateEntry: { invoke: vi.fn() },
+      deleteEntry: { invoke: vi.fn() },
+      listArchivedEntries: { invoke: vi.fn() },
+      restoreArchivedEntry: { invoke: vi.fn() },
+      setPromotionThreshold: { invoke: vi.fn() },
+      onIndexChanged: emitter,
+      import: {
+        claudeMem: { invoke: vi.fn() },
+        obsidianVault: { invoke: vi.fn() },
+        scanDevDir: { invoke: vi.fn() },
+        processDropFolder: { invoke: vi.fn() },
+        getDropFolderStatus: { invoke: vi.fn().mockResolvedValue({ path: '~/x', watching: false, ingestedToday: 0 }) },
+      },
+      readSourceContext: { invoke: vi.fn() },
+    },
+    mockShell: { openFile: { invoke: vi.fn() }, openPath: { invoke: vi.fn().mockResolvedValue({ ok: true }) } },
+    mockIjfw: { getStatus: { invoke: vi.fn() }, onStatusChanged: emitter, brainInvoke: { invoke: vi.fn() } },
+    mockModalConfirm: vi.fn(() => ({ close: vi.fn() })),
+  };
+});
+
+vi.mock('@/common/adapter/ipcBridge', () => ({
+  memory: mockMemory, shell: mockShell, ijfw: mockIjfw, IjfwStatusPayload: {},
+}));
+vi.mock('@/common', () => ({ ipcBridge: { shell: mockShell, memory: mockMemory, ijfw: mockIjfw } }));
+
+vi.mock('@arco-design/web-react', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@arco-design/web-react');
+  return {
+    ...actual,
+    Message: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+    Modal: Object.assign(
+      ({ visible, children }: { visible?: boolean; children?: React.ReactNode }) =>
+        visible ? <div data-testid='arco-modal'>{children}</div> : null,
+      { confirm: mockModalConfirm }
+    ),
+    Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    Dropdown: ({ children, droplist }: { children: React.ReactNode; droplist: React.ReactNode }) => (
+      <div>{children}{droplist}</div>
+    ),
+  };
+});
+
+vi.mock('@icon-park/react', () => new Proxy({}, {
+  get: () => (p: Record<string, unknown>) => <span {...p} />,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, arg?: unknown) => {
+      if (typeof arg === 'string') return arg;
+      if (arg && typeof arg === 'object' && 'defaultValue' in arg) {
+        return (arg as { defaultValue?: string }).defaultValue ?? _key;
+      }
+      return _key;
+    },
+  }),
+}));
+
+vi.mock('@renderer/pages/memory/components/PromotionThresholdModal', () => ({
+  default: () => <div />,
+}));
+
+import FullPanelShell from '@renderer/pages/memory/state-branches/FullPanelShell';
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  localStorage.clear();
+});
+
+beforeEach(() => {
+  mockMemory.getStats.invoke.mockResolvedValue({ ok: true, stats: MOCK_STATS });
+  mockMemory.listEntries.invoke.mockResolvedValue({ entries: [MOCK_ENTRY], total: 1 });
+  mockMemory.getEntry.invoke.mockResolvedValue({ ...MOCK_ENTRY, body: 'b' });
+  mockMemory.getProjects.invoke.mockResolvedValue(MOCK_PROJECTS);
+  mockMemory.getTags.invoke.mockResolvedValue([]);
+  mockMemory.getPromotionCandidates.invoke.mockResolvedValue(MOCK_CANDIDATES);
+  mockMemory.setQuickAdd.invoke.mockResolvedValue({ ok: true });
+  mockMemory.listArchivedEntries.invoke.mockResolvedValue([]);
+  mockMemory.import.scanDevDir.invoke.mockResolvedValue({ count: 0, projectsFound: 0, errors: [] });
+  mockIjfw.getStatus.invoke.mockResolvedValue({ status: 'installed_current', cliCount: 0 });
+  mockIjfw.brainInvoke.invoke.mockResolvedValue({ ok: true });
+});
+
+async function openComposer(): Promise<void> {
+  await act(async () => {
+    render(
+      <MemoryRouter initialEntries={['/memory']}>
+        <FullPanelShell />
+      </MemoryRouter>
+    );
+  });
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('memory-btn-quickadd'));
+  });
+}
+
+describe('#924 F1: project-scoped save through the real /memory renderer path', () => {
+  it('sends a concrete projectPath, so the write can never fall through to the global store', async () => {
+    await openComposer();
+
+    fireEvent.change(screen.getByTestId('composer-textarea'), {
+      target: { value: 'note that must stay in one project' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('composer-submit-btn'));
+    });
+
+    await waitFor(() => expect(mockMemory.setQuickAdd.invoke).toHaveBeenCalled());
+    const payload = mockMemory.setQuickAdd.invoke.mock.calls[0][0];
+
+    expect(payload.scope).toBe('project');
+    // The regression: projectPath absent -> main cannot place the write.
+    expect(payload.projectPath).toBeTruthy();
+    expect(MOCK_PROJECTS.map((p) => p.path)).toContain(payload.projectPath);
+  });
+
+  it('names the destination in the UI before the user saves', async () => {
+    await openComposer();
+    const dest = screen.getByTestId('composer-destination');
+    expect(dest.textContent).toContain('Saving to');
+    expect(dest.textContent).toContain('project-alpha');
+  });
+
+  it('switching to global scope names the global destination and drops projectPath', async () => {
+    await openComposer();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('composer-scope-global'));
+    });
+    expect(screen.getByTestId('composer-destination').textContent).toContain('Global memory');
+
+    fireEvent.change(screen.getByTestId('composer-textarea'), { target: { value: 'global note' } });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('composer-submit-btn'));
+    });
+
+    await waitFor(() => expect(mockMemory.setQuickAdd.invoke).toHaveBeenCalled());
+    const payload = mockMemory.setQuickAdd.invoke.mock.calls[0][0];
+    expect(payload.scope).toBe('global');
+    expect(payload.projectPath).toBeUndefined();
+  });
+});

--- a/tests/unit/renderer/pages/memory/composerProjectDestination.dom.test.tsx
+++ b/tests/unit/renderer/pages/memory/composerProjectDestination.dom.test.tsx
@@ -317,4 +317,56 @@ describe('#924 F1: project-scoped save through the real /memory renderer path', 
     await waitFor(() => expect(mockMemory.setQuickAdd.invoke).toHaveBeenCalled());
     expect(mockMemory.setQuickAdd.invoke.mock.calls[0][0].projectPath).toBe(BETA);
   });
+
+  /**
+   * First run: nothing indexed yet, so there is no project to name and main
+   * refuses the save with the internal code `unresolved_project_scope`. That
+   * code was printed straight at the user, which tells them nothing and hides
+   * the one action that works (switch to global).
+   */
+  it('explains a refused project-scoped save instead of printing the internal code', async () => {
+    mockMemory.getProjects.invoke.mockResolvedValue([]);
+    // Mirror main: it refuses ONLY a project-scoped save it cannot place.
+    mockMemory.setQuickAdd.invoke.mockImplementation(async (payload: { scope: string; projectPath?: string }) =>
+      payload.scope === 'project' && !payload.projectPath
+        ? { ok: false, error: 'unresolved_project_scope' }
+        : { ok: true }
+    );
+    await openComposer();
+    expect(screen.queryByTestId('composer-project-picker')).toBeNull();
+
+    fireEvent.change(screen.getByTestId('composer-textarea'), { target: { value: 'my first ever note' } });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('composer-submit-btn'));
+    });
+
+    const err = await screen.findByTestId('composer-error');
+    expect(err.textContent).not.toContain('unresolved_project_scope');
+    expect(err.textContent).toContain('No project is indexed yet');
+    expect(err.textContent).toContain('global');
+    // The note is still in the box, so switching to global saves it.
+    expect((screen.getByTestId('composer-textarea') as HTMLTextAreaElement).value).toBe('my first ever note');
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('composer-scope-global'));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('composer-submit-btn'));
+    });
+    await waitFor(() => {
+      const last = mockMemory.setQuickAdd.invoke.mock.calls.at(-1)![0];
+      expect(last.scope).toBe('global');
+    });
+  });
+
+  it('still surfaces an unrecognised save error verbatim', async () => {
+    // Control for the mapping above: only the one known code is translated, so
+    // a genuine failure is not swallowed behind generic copy.
+    mockMemory.setQuickAdd.invoke.mockResolvedValue({ ok: false, error: 'disk full' });
+    await openComposer();
+    fireEvent.change(screen.getByTestId('composer-textarea'), { target: { value: 'note' } });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('composer-submit-btn'));
+    });
+    expect((await screen.findByTestId('composer-error')).textContent).toContain('disk full');
+  });
 });

--- a/tests/unit/renderer/pages/memory/composerProjectDestination.dom.test.tsx
+++ b/tests/unit/renderer/pages/memory/composerProjectDestination.dom.test.tsx
@@ -29,6 +29,7 @@ import type { MemoryStats, MemoryEntry, ProjectSummary, PromotionCandidates } fr
 
 const ALPHA = '/dev/project-alpha';
 const BETA = '/dev/project-beta';
+const GAMMA = '/dev/project-gamma';
 
 const MOCK_PROJECTS: ProjectSummary[] = [
   { path: ALPHA, basename: 'project-alpha', count: 9, lastActive: Date.now() },
@@ -87,9 +88,14 @@ const MOCK_CANDIDATES: PromotionCandidates = {
   nextRun: Date.now() + 1000,
 };
 
-const { mockMemory, mockShell, mockIjfw, mockModalConfirm } = vi.hoisted(() => {
+const { mockMemory, mockShell, mockIjfw, mockModalConfirm, indexListeners } = vi.hoisted(() => {
   const emitter = { on: () => () => {} };
+  // A REAL listener registry for memory.onIndexChanged: the F1 regression below
+  // only happens when the index-changed handlers actually run, so a no-op
+  // emitter cannot see it.
+  const indexListeners: Array<() => void> = [];
   return {
+    indexListeners,
     mockMemory: {
       getStats: { invoke: vi.fn() },
       listEntries: { invoke: vi.fn() },
@@ -104,7 +110,15 @@ const { mockMemory, mockShell, mockIjfw, mockModalConfirm } = vi.hoisted(() => {
       listArchivedEntries: { invoke: vi.fn() },
       restoreArchivedEntry: { invoke: vi.fn() },
       setPromotionThreshold: { invoke: vi.fn() },
-      onIndexChanged: emitter,
+      onIndexChanged: {
+        on: (cb: () => void) => {
+          indexListeners.push(cb);
+          return () => {
+            const i = indexListeners.indexOf(cb);
+            if (i >= 0) indexListeners.splice(i, 1);
+          };
+        },
+      },
       import: {
         claudeMem: { invoke: vi.fn() },
         obsidianVault: { invoke: vi.fn() },
@@ -182,6 +196,7 @@ afterEach(() => {
   cleanup();
   vi.clearAllMocks();
   localStorage.clear();
+  indexListeners.length = 0;
 });
 
 beforeEach(() => {
@@ -255,5 +270,51 @@ describe('#924 F1: project-scoped save through the real /memory renderer path', 
     const payload = mockMemory.setQuickAdd.invoke.mock.calls[0][0];
     expect(payload.scope).toBe('global');
     expect(payload.projectPath).toBeUndefined();
+  });
+
+  /**
+   * #924 recurrence: the reset effect re-seeded the destination from
+   * `projects[0]` whenever its deps changed. The Memory page re-fetches its
+   * project list on every `onIndexChanged`, which IJFW fires whenever an agent
+   * writes memory in the background, so a refresh that reordered the list
+   * rewrote the user's explicit pick WHILE THE MODAL WAS OPEN and the note went
+   * to a project they never named.
+   */
+  it('keeps the destination the user picked when a background index refresh reorders the projects', async () => {
+    await openComposer();
+
+    // Explicit pick: project-beta, not the default first entry.
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('composer-project-picker'), { target: { value: BETA } });
+    });
+    expect(screen.getByTestId('composer-destination').textContent).toContain('project-beta');
+
+    // A background write lands and GAMMA becomes the most recent project.
+    mockMemory.getProjects.invoke.mockResolvedValue([
+      { path: GAMMA, basename: 'project-gamma', count: 1, lastActive: Date.now() + 100_000 },
+      ...MOCK_PROJECTS,
+    ]);
+    expect(indexListeners.length).toBeGreaterThan(0);
+    await act(async () => {
+      indexListeners.forEach((fire) => fire());
+    });
+
+    // Control: the refresh really did reach the open composer - GAMMA is now an
+    // option - so a picker that still reads BETA is holding the user's choice,
+    // not merely failing to notice the change.
+    await waitFor(() => {
+      const picker = screen.getByTestId('composer-project-picker') as HTMLSelectElement;
+      expect(Array.from(picker.options).map((o) => o.value)).toContain(GAMMA);
+    });
+    expect((screen.getByTestId('composer-project-picker') as HTMLSelectElement).value).toBe(BETA);
+    expect(screen.getByTestId('composer-destination').textContent).toContain('project-beta');
+
+    fireEvent.change(screen.getByTestId('composer-textarea'), { target: { value: 'beta-only note' } });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('composer-submit-btn'));
+    });
+
+    await waitFor(() => expect(mockMemory.setQuickAdd.invoke).toHaveBeenCalled());
+    expect(mockMemory.setQuickAdd.invoke.mock.calls[0][0].projectPath).toBe(BETA);
   });
 });

--- a/tests/unit/renderer/pages/memory/composerProjectDestination.dom.test.tsx
+++ b/tests/unit/renderer/pages/memory/composerProjectDestination.dom.test.tsx
@@ -369,4 +369,32 @@ describe('#924 F1: project-scoped save through the real /memory renderer path', 
     });
     expect((await screen.findByTestId('composer-error')).textContent).toContain('disk full');
   });
+
+  /**
+   * The Memory page's project filter is keyed on BASENAME, and this modal turns
+   * that name into a write destination. Two indexed projects can share one, and
+   * the write silently resolves to whichever came first - so the label has to
+   * identify exactly one project.
+   */
+  it('disambiguates the destination when two indexed projects share a basename', async () => {
+    mockMemory.getProjects.invoke.mockResolvedValue([
+      { path: '/dev/one/app', basename: 'app', count: 3, lastActive: Date.now() },
+      { path: '/dev/two/app', basename: 'app', count: 1, lastActive: Date.now() - 1000 },
+    ]);
+    await openComposer();
+
+    const picker = screen.getByTestId('composer-project-picker') as HTMLSelectElement;
+    const labels = Array.from(picker.options).map((o) => o.textContent);
+    expect(new Set(labels).size).toBe(2);
+    expect(labels).toEqual(['app (one)', 'app (two)']);
+    expect(screen.getByTestId('composer-destination').textContent).toContain('app (one)');
+
+    // Control: a basename that does NOT collide keeps its plain name.
+    cleanup();
+    mockMemory.getProjects.invoke.mockResolvedValue(MOCK_PROJECTS);
+    await openComposer();
+    expect(
+      Array.from((screen.getByTestId('composer-project-picker') as HTMLSelectElement).options).map((o) => o.textContent)
+    ).toEqual(['project-alpha', 'project-beta']);
+  });
 });

--- a/tests/unit/renderer/pages/memory/composerProjectDestination.dom.test.tsx
+++ b/tests/unit/renderer/pages/memory/composerProjectDestination.dom.test.tsx
@@ -43,12 +43,23 @@ const MOCK_STATS = {
   projects: 2,
   banked: 0,
   deltas: {
-    total24h: 0, total7d: 0, decisions24h: 0, decisions7d: 0,
-    wiki24h: 0, wiki7d: 0, sessions24h: 0, sessions7d: 0,
+    total24h: 0,
+    total7d: 0,
+    decisions24h: 0,
+    decisions7d: 0,
+    wiki24h: 0,
+    wiki7d: 0,
+    sessions24h: 0,
+    sessions7d: 0,
   },
   sparkline: [],
   sparklines: {
-    total: [], banked: [], decisions: [], wiki: [], sessions: [], projects: [],
+    total: [],
+    banked: [],
+    decisions: [],
+    wiki: [],
+    sessions: [],
+    projects: [],
   },
   typeCounts: { decision: 1, pattern: 0, session: 0, observation: 0, wiki: 0, preference: 0 },
   streak: { sessions: 0, longestDays: 0, lastActiveDayMs: Date.now() },
@@ -70,7 +81,10 @@ const MOCK_ENTRY: MemoryEntry = {
 };
 
 const MOCK_CANDIDATES: PromotionCandidates = {
-  candidates: [], threshold: 90, lastRun: Date.now(), nextRun: Date.now() + 1000,
+  candidates: [],
+  threshold: 90,
+  lastRun: Date.now(),
+  nextRun: Date.now() + 1000,
 };
 
 const { mockMemory, mockShell, mockIjfw, mockModalConfirm } = vi.hoisted(() => {
@@ -107,7 +121,10 @@ const { mockMemory, mockShell, mockIjfw, mockModalConfirm } = vi.hoisted(() => {
 });
 
 vi.mock('@/common/adapter/ipcBridge', () => ({
-  memory: mockMemory, shell: mockShell, ijfw: mockIjfw, IjfwStatusPayload: {},
+  memory: mockMemory,
+  shell: mockShell,
+  ijfw: mockIjfw,
+  IjfwStatusPayload: {},
 }));
 vi.mock('@/common', () => ({ ipcBridge: { shell: mockShell, memory: mockMemory, ijfw: mockIjfw } }));
 
@@ -124,14 +141,24 @@ vi.mock('@arco-design/web-react', async () => {
     Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
     Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
     Dropdown: ({ children, droplist }: { children: React.ReactNode; droplist: React.ReactNode }) => (
-      <div>{children}{droplist}</div>
+      <div>
+        {children}
+        {droplist}
+      </div>
     ),
   };
 });
 
-vi.mock('@icon-park/react', () => new Proxy({}, {
-  get: () => (p: Record<string, unknown>) => <span {...p} />,
-}));
+vi.mock(
+  '@icon-park/react',
+  () =>
+    new Proxy(
+      {},
+      {
+        get: () => (p: Record<string, unknown>) => <span {...p} />,
+      }
+    )
+);
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({

--- a/tests/unit/renderer/pages/memory/composerProjectDestination.dom.test.tsx
+++ b/tests/unit/renderer/pages/memory/composerProjectDestination.dom.test.tsx
@@ -397,4 +397,49 @@ describe('#924 F1: project-scoped save through the real /memory renderer path', 
       Array.from((screen.getByTestId('composer-project-picker') as HTMLSelectElement).options).map((o) => o.textContent)
     ).toEqual(['project-alpha', 'project-beta']);
   });
+
+  /**
+   * The ref that makes a pick authoritative is cleared on close, and nothing
+   * pinned that. Leave it set and the next open skips the seeding branch:
+   * `projectPath` stays '' from the close reset, the destination reads "no
+   * project selected", and the save goes out with no `projectPath` at all -
+   * which main refuses. That is #924 coming back through the fix for #924.
+   *
+   * It is invisible in the picker, which still DISPLAYS project-alpha: a
+   * `<select>` whose value matches no option falls back to showing the first
+   * one. Assert the destination line and the payload, never the picker's value.
+   */
+  it('re-seeds the destination on reopen, so a pick from a previous open cycle cannot leave it blank', async () => {
+    await openComposer();
+
+    // Control: the pick really registers, so the reopen assertions below are
+    // exercising a ref that was actually set - not a cycle that never picked.
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('composer-project-picker'), { target: { value: BETA } });
+    });
+    expect(screen.getByTestId('composer-destination').textContent).toContain('project-beta');
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('composer-cancel-btn'));
+    });
+    expect(screen.queryByTestId('composer-destination')).toBeNull();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('memory-btn-quickadd'));
+    });
+
+    const dest = screen.getByTestId('composer-destination').textContent ?? '';
+    expect(dest).not.toContain('no project selected');
+    expect(dest).toContain('project-alpha');
+
+    fireEvent.change(screen.getByTestId('composer-textarea'), { target: { value: 'note after reopen' } });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('composer-submit-btn'));
+    });
+
+    await waitFor(() => expect(mockMemory.setQuickAdd.invoke).toHaveBeenCalled());
+    const payload = mockMemory.setQuickAdd.invoke.mock.calls[0][0];
+    expect(payload.scope).toBe('project');
+    expect(payload.projectPath).toBe(ALPHA);
+  });
 });


### PR DESCRIPTION
Fixes #924

Two independent defects sat under one title. Both are fixed here, each with a regression test that fails on main.

## 1. A project-scoped memory could be written into a different project

The Memory composer defaults to "project" scope. On save, the main process resolved the destination from the archive index's first project, which is the most recently active IJFW project anywhere on the machine, ranked by memory-file timestamps. It has no relationship to the project the user is working in. Saving a note while in project B therefore appended it to project A's memory journal, and a later session opened in project A read it back as that project's own context.

The fix has two halves, because the first version of it was wrong in an instructive way.

Main is now strict. A project-scoped save resolves to an indexed project root or it is refused. There is deliberately no fallback to the global store: the global block is injected into every chat in every project, so redirecting a misplaced note there would reach further than the original bug, which misplaced it into exactly one project. Refusing is the only honest answer.

The renderer now names the project. An earlier revision of this PR read the project from useActiveBrainScope, which depends on ConversationProvider. The Memory page is a sibling route to /conversation/:id and mounts no such provider, so that hook always returned the app scope and the wiring was inert. The composer now takes the project list from the archive index the page already holds, pre-selects the page's project filter, offers a picker when there is more than one, and displays the resolved destination before the user saves. Previously the pill said "project" while the real destination was decided elsewhere and could differ.

## 2. The injected memory block hid what it had dropped

The global-memory block is the agent's whole record of the user's memory. Two paths shrank it with no marker at all:

- when the full body read failed, the 200-character list preview was substituted and presented as the complete entry, so the agent acted on a fragment with nothing signalling the remainder was missing;
- when an entry did not fit the remaining budget, it and every entry after it were dropped silently.

The oversized-body path already appended a truncation marker. These two now do the same, and the block states how many entries it left out.

## Remote surface

memory.set-quick-add is now denied to remote peers. The memory namespace is documented as open to a paired WebUI for reads with its destructive mutations denied; set-quick-add is a write that was sitting on the allowed side of that line, and it now carries a projectPath selector. Denying it restores the stated policy and keeps the selector off the remote surface. Local IPC is unaffected and the denylist only grows.

## Verification

- New DOM test drives the real /memory route tree, not a service harness, because a service-level test cannot see inert renderer wiring. It asserts the IPC payload carries a concrete projectPath. Against the earlier revision it fails with "expected undefined to be truthy".
- New service test stages two projects with different activity and asserts the entry lands in the one the caller named, and that no project-scoped call shape can reach the global journal.
- New test for the injected-block disclosure.
- Existing suites for the memory service, the memory bridges, the project-knowledge block, the memory renderer pages, the remote denylist and locale parity all pass unchanged. No existing test was edited.
- tsc --noEmit clean, oxfmt clean.

## Not covered here

Global memory is injected into every chat regardless of project. That is the documented behaviour of #256 and has its own test suite asserting it, so it is deliberately left alone; whether it should stay global is a product question worth its own issue.

Closing this does not explain the foreign username in the original report. The mechanism fixed here is bounded by the user's own home directory, so another person's home has no path into it. The likelier origin is the import surface, which writes externally sourced content straight into the global brain that then reaches every chat. Worth a separate issue.

Two pre-existing items noticed and deliberately not touched: memory files are written 0644 while the IJFW atomic-write and lock helpers use 0600, and importBridge resolveMemoryDir contains a branch whose body is only comments, so it always returns the global dir regardless of its doc comment.
