### PR TITLE
ci: check out the @wayland MCP sources and arm the #940 gate

### DIFF
--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -45,13 +45,6 @@ env:
   # PINNED_BUN_VERSION in scripts/prepareBundledBun.js and the
   # corresponding entry in scripts/bundled-bun-shasums.json.
   WAYLAND_BUN_VERSION: '1.3.14'
-  # #940: four @wayland MCP connectors (apple, imap, news, cal.com) build from
-  # the sibling waylandmcp repo, which has no GitHub remote yet - CI cannot
-  # check it out. scripts/build-mcp-servers.js now FAILS the build when a
-  # connector cannot be bundled, so CI must opt out explicitly until that repo
-  # lands. DELETE this line the moment waylandmcp is checkout-able in CI; that
-  # is the whole point of the gate.
-  WAYLAND_ALLOW_MISSING_MCP: '1'
 
 jobs:
   code-quality:
@@ -243,6 +236,30 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 30
           command: bun install --frozen-lockfile
+
+      # #940: the four bundled @wayland MCP connectors (apple, imap, news,
+      # cal.com) build from FerroxLabs/waylandmcp. actions/checkout refuses any
+      # `path` outside github.workspace, so the sources land at ./waylandmcp
+      # (gitignored) - the first candidate scripts/build-mcp-servers.js resolves.
+      # Must run AFTER the repo checkout above: that checkout's `git clean -ffdx`
+      # would delete this tree. There is deliberately NO bypass here - if this
+      # fails, the release build goes red rather than shipping a Library that
+      # offers four connectors it does not contain.
+      - name: Checkout @wayland MCP connector sources
+        uses: actions/checkout@v6
+        with:
+          repository: FerroxLabs/waylandmcp
+          ssh-key: ${{ secrets.WAYLANDMCP_DEPLOY_KEY }}
+          path: waylandmcp
+          persist-credentials: false
+
+      # esbuild resolves connector deps from the PER-PACKAGE node_modules
+      # (nodePaths in scripts/build-mcp-servers.js). bun's isolated linker does
+      # create packages/*/node_modules symlinks into the root store, so a plain
+      # workspace install at the root is enough.
+      - name: Install @wayland MCP connector dependencies
+        working-directory: waylandmcp
+        run: bun install --frozen-lockfile
 
       - name: Run postinstall
         run: bun run postinstall || true

--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -303,7 +303,20 @@ jobs:
           [[ "$mcp_sha" == "$WAYLANDMCP_REF" ]] || {
             echo "::error::waylandmcp HEAD $mcp_sha != pinned $WAYLANDMCP_REF" >&2; exit 1;
           }
-          bun install --frozen-lockfile
+          # Retried because this is an unattended network op on the release and
+          # publish paths, four lines below an app-side `bun install
+          # --frozen-lockfile` that IS wrapped in nick-fields/retry@v3. The
+          # checkout above needs no wrapper: its only network call (git fetch)
+          # already runs inside actions/checkout's own 3-attempt retry helper.
+          # Loop shape matches pr-checks.yml - a genuine failure still exits
+          # non-zero after the third attempt, so a retry cannot mask one.
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then exit 0; fi
+            echo "waylandmcp bun install attempt $attempt failed; retrying" >&2
+            sleep 30
+          done
+          echo "waylandmcp: bun install --frozen-lockfile failed after 3 attempts" >&2
+          exit 1
 
       - name: Run postinstall
         run: bun run postinstall || true

--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -240,11 +240,11 @@ jobs:
       # #940: the four bundled @wayland MCP connectors (apple, imap, news,
       # cal.com) build from FerroxLabs/waylandmcp. actions/checkout refuses any
       # `path` outside github.workspace, so the sources land at ./waylandmcp
-      # (gitignored) - the first candidate scripts/build-mcp-servers.js resolves.
-      # Must run AFTER the repo checkout above: that checkout's `git clean -ffdx`
-      # would delete this tree. There is deliberately NO bypass here - if this
-      # fails, the release build goes red rather than shipping a Library that
-      # offers four connectors it does not contain.
+      # (gitignored), and the next step moves it to the sibling position that
+      # build-mcp-servers.js already resolves. Must run AFTER the repo checkout
+      # above: that checkout's `git clean -ffdx` would delete this tree. There is
+      # deliberately NO bypass here - if this fails, the release build goes red
+      # rather than shipping a Library that offers four connectors it lacks.
       - name: Checkout @wayland MCP connector sources
         uses: actions/checkout@v6
         with:
@@ -253,13 +253,24 @@ jobs:
           path: waylandmcp
           persist-credentials: false
 
-      # esbuild resolves connector deps from the PER-PACKAGE node_modules
-      # (nodePaths in scripts/build-mcp-servers.js). bun's isolated linker does
-      # create packages/*/node_modules symlinks into the root store, so a plain
-      # workspace install at the root is enough.
-      - name: Install @wayland MCP connector dependencies
-        working-directory: waylandmcp
-        run: bun install --frozen-lockfile
+      # Move the checkout OUT of the app repo to /home/runner/work/wayland/waylandmcp,
+      # which is the pre-existing sibling candidate. This is a containment fix, not
+      # cosmetics: esbuild resolves a bare import by walking node_modules UPWARD from
+      # the entry point. Left inside the workspace, that walk continues into the
+      # desktop app's ~2100-package node_modules, so a connector importing something
+      # it does not declare resolves SILENTLY against the app's copy instead of
+      # failing. Proven by A/B: identical source bundles clean in-workspace and dies
+      # with "Could not resolve" as a sibling. Green build, wrong artifact is exactly
+      # the quiet substitution #940 exists to stop. The rm -rf covers a self-hosted
+      # runner, where the sibling path escapes the workspace `git clean -ffdx`.
+      - name: Relocate and install @wayland MCP connector sources
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf ../waylandmcp
+          mv waylandmcp ../waylandmcp
+          cd ../waylandmcp
+          bun install --frozen-lockfile
 
       - name: Run postinstall
         run: bun run postinstall || true

--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -26,6 +26,11 @@ on:
 
 env:
   BUN_INSTALL_REGISTRY: 'https://registry.npmjs.org/'
+  # Exact FerroxLabs/waylandmcp commit whose four @wayland MCP connectors are
+  # bundled into this build. Pinned, not floating, so the installer's connector
+  # sources have a recorded identity (#940). Keep byte-identical across all four
+  # workflows that check this repo out - waylandmcp SourcePin test enforces it.
+  WAYLANDMCP_REF: '29a253804ccd3d7f1eb385cf610b0dc27a130478'
   WAYLAND_RELEASE_TRACK: 'stable'
   WAYLAND_HUB_TAG: 'dist-ebc6a2b'
   # The FerroxLabs/waylandHub repo/tag does not exist yet, so
@@ -245,10 +250,23 @@ jobs:
       # above: that checkout's `git clean -ffdx` would delete this tree. There is
       # deliberately NO bypass here - if this fails, the release build goes red
       # rather than shipping a Library that offers four connectors it lacks.
+      # #940 PROVENANCE: pin the sources to an exact commit. With no `ref` this
+      # took whatever FerroxLabs/waylandmcp's default branch happened to hold at
+      # build time and recorded that identity nowhere, so a shipped installer
+      # carried code no receipt could name. scripts/platform-package-smoke.mjs
+      # attests the app's own commit AND its untracked tree precisely because "a
+      # newly introduced build input is just as authoritative as a modified
+      # tracked file" - but this input lives OUTSIDE the repo and is gitignored,
+      # so neither that attestation nor the dirty-tree gate can see it. The pin
+      # plus the rev-parse echo in the next step are what put its identity on the
+      # record. WAYLANDMCP_REF follows the WAYLAND_HUB_TAG named-constant
+      # convention; tests/unit/scripts/waylandmcpSourcePin.test.ts holds the four
+      # copies byte-identical so they cannot drift apart.
       - name: Checkout @wayland MCP connector sources
         uses: actions/checkout@v6
         with:
           repository: FerroxLabs/waylandmcp
+          ref: ${{ env.WAYLANDMCP_REF }}
           ssh-key: ${{ secrets.WAYLANDMCP_DEPLOY_KEY }}
           path: waylandmcp
           persist-credentials: false
@@ -270,6 +288,21 @@ jobs:
           rm -rf ../waylandmcp
           mv waylandmcp ../waylandmcp
           cd ../waylandmcp
+          # #940 PROVENANCE: say WHICH commit was bundled, and PROVE it is the
+          # pinned one. build-mcp-servers.js already logs the PATH it resolved,
+          # and a path is not an identity. An empty or malformed WAYLANDMCP_REF
+          # would make actions/checkout silently take the default branch instead
+          # - the same quiet substitution #940 exists to stop - so assert rather
+          # than trust, the same way release-acceptance-trust-root.yml asserts
+          # TRUST_ROOT_SHA.
+          mcp_sha="$(git rev-parse HEAD)"
+          echo "waylandmcp source commit: $mcp_sha"
+          [[ "$WAYLANDMCP_REF" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "::error::WAYLANDMCP_REF is not a 40-hex commit: '$WAYLANDMCP_REF'" >&2; exit 1;
+          }
+          [[ "$mcp_sha" == "$WAYLANDMCP_REF" ]] || {
+            echo "::error::waylandmcp HEAD $mcp_sha != pinned $WAYLANDMCP_REF" >&2; exit 1;
+          }
           bun install --frozen-lockfile
 
       - name: Run postinstall

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -747,9 +747,10 @@ jobs:
       # #940: build-payload.mjs runs scripts/build-mcp-servers.js, which bundles
       # the four @wayland MCP connectors from FerroxLabs/waylandmcp.
       # actions/checkout refuses any `path` outside github.workspace, so the
-      # sources land at ./waylandmcp (gitignored) - the first candidate that
-      # script resolves. Must run AFTER the repo checkout above, whose
-      # `git clean -ffdx` would delete this tree. No bypass on a publish path.
+      # sources land at ./waylandmcp (gitignored), and the next step moves them
+      # to the sibling position that script already resolves. Must run AFTER the
+      # repo checkout above, whose `git clean -ffdx` would delete this tree. No
+      # bypass on a publish path.
       - name: Checkout @wayland MCP connector sources
         uses: actions/checkout@v6
         with:
@@ -758,9 +759,24 @@ jobs:
           path: waylandmcp
           persist-credentials: false
 
-      - name: Install @wayland MCP connector dependencies
-        working-directory: waylandmcp
-        run: bun install --frozen-lockfile
+      # Move the checkout OUT of the app repo to /home/runner/work/wayland/waylandmcp,
+      # which is the pre-existing sibling candidate. This is a containment fix, not
+      # cosmetics: esbuild resolves a bare import by walking node_modules UPWARD from
+      # the entry point. Left inside the workspace, that walk continues into the
+      # desktop app's ~2100-package node_modules, so a connector importing something
+      # it does not declare resolves SILENTLY against the app's copy instead of
+      # failing. Proven by A/B: identical source bundles clean in-workspace and dies
+      # with "Could not resolve" as a sibling. Green build, wrong artifact is exactly
+      # the quiet substitution #940 exists to stop. The rm -rf covers a self-hosted
+      # runner, where the sibling path escapes the workspace `git clean -ffdx`.
+      - name: Relocate and install @wayland MCP connector sources
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf ../waylandmcp
+          mv waylandmcp ../waylandmcp
+          cd ../waylandmcp
+          bun install --frozen-lockfile
 
       - name: Build the getwayland payload (syncs version to the release)
         working-directory: installer

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -809,7 +809,20 @@ jobs:
           [[ "$mcp_sha" == "$WAYLANDMCP_REF" ]] || {
             echo "::error::waylandmcp HEAD $mcp_sha != pinned $WAYLANDMCP_REF" >&2; exit 1;
           }
-          bun install --frozen-lockfile
+          # Retried because this is an unattended network op on the release and
+          # publish paths, four lines below an app-side `bun install
+          # --frozen-lockfile` that IS wrapped in nick-fields/retry@v3. The
+          # checkout above needs no wrapper: its only network call (git fetch)
+          # already runs inside actions/checkout's own 3-attempt retry helper.
+          # Loop shape matches pr-checks.yml - a genuine failure still exits
+          # non-zero after the third attempt, so a retry cannot mask one.
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then exit 0; fi
+            echo "waylandmcp bun install attempt $attempt failed; retrying" >&2
+            sleep 30
+          done
+          echo "waylandmcp: bun install --frozen-lockfile failed after 3 attempts" >&2
+          exit 1
 
       - name: Build the getwayland payload (syncs version to the release)
         working-directory: installer

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -11,13 +11,6 @@ on:
 
 env:
   BUN_INSTALL_REGISTRY: 'https://registry.npmjs.org/'
-  # #940: four @wayland MCP connectors (apple, imap, news, cal.com) build from
-  # the sibling waylandmcp repo, which has no GitHub remote yet - CI cannot
-  # check it out. scripts/build-mcp-servers.js now FAILS the build when a
-  # connector cannot be bundled, so CI must opt out explicitly until that repo
-  # lands. DELETE this line the moment waylandmcp is checkout-able in CI; that
-  # is the whole point of the gate.
-  WAYLAND_ALLOW_MISSING_MCP: '1'
 
 jobs:
   build-pipeline:
@@ -749,6 +742,24 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # #940: build-payload.mjs runs scripts/build-mcp-servers.js, which bundles
+      # the four @wayland MCP connectors from FerroxLabs/waylandmcp.
+      # actions/checkout refuses any `path` outside github.workspace, so the
+      # sources land at ./waylandmcp (gitignored) - the first candidate that
+      # script resolves. Must run AFTER the repo checkout above, whose
+      # `git clean -ffdx` would delete this tree. No bypass on a publish path.
+      - name: Checkout @wayland MCP connector sources
+        uses: actions/checkout@v6
+        with:
+          repository: FerroxLabs/waylandmcp
+          ssh-key: ${{ secrets.WAYLANDMCP_DEPLOY_KEY }}
+          path: waylandmcp
+          persist-credentials: false
+
+      - name: Install @wayland MCP connector dependencies
+        working-directory: waylandmcp
         run: bun install --frozen-lockfile
 
       - name: Build the getwayland payload (syncs version to the release)

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -11,6 +11,11 @@ on:
 
 env:
   BUN_INSTALL_REGISTRY: 'https://registry.npmjs.org/'
+  # Exact FerroxLabs/waylandmcp commit whose four @wayland MCP connectors are
+  # bundled into this build. Pinned, not floating, so the installer's connector
+  # sources have a recorded identity (#940). Keep byte-identical across all four
+  # workflows that check this repo out - waylandmcp SourcePin test enforces it.
+  WAYLANDMCP_REF: '29a253804ccd3d7f1eb385cf610b0dc27a130478'
 
 jobs:
   build-pipeline:
@@ -751,10 +756,23 @@ jobs:
       # to the sibling position that script already resolves. Must run AFTER the
       # repo checkout above, whose `git clean -ffdx` would delete this tree. No
       # bypass on a publish path.
+      # #940 PROVENANCE: pin the sources to an exact commit. With no `ref` this
+      # took whatever FerroxLabs/waylandmcp's default branch happened to hold at
+      # build time and recorded that identity nowhere, so a shipped installer
+      # carried code no receipt could name. scripts/platform-package-smoke.mjs
+      # attests the app's own commit AND its untracked tree precisely because "a
+      # newly introduced build input is just as authoritative as a modified
+      # tracked file" - but this input lives OUTSIDE the repo and is gitignored,
+      # so neither that attestation nor the dirty-tree gate can see it. The pin
+      # plus the rev-parse echo in the next step are what put its identity on the
+      # record. WAYLANDMCP_REF follows the WAYLAND_HUB_TAG named-constant
+      # convention; tests/unit/scripts/waylandmcpSourcePin.test.ts holds the four
+      # copies byte-identical so they cannot drift apart.
       - name: Checkout @wayland MCP connector sources
         uses: actions/checkout@v6
         with:
           repository: FerroxLabs/waylandmcp
+          ref: ${{ env.WAYLANDMCP_REF }}
           ssh-key: ${{ secrets.WAYLANDMCP_DEPLOY_KEY }}
           path: waylandmcp
           persist-credentials: false
@@ -776,6 +794,21 @@ jobs:
           rm -rf ../waylandmcp
           mv waylandmcp ../waylandmcp
           cd ../waylandmcp
+          # #940 PROVENANCE: say WHICH commit was bundled, and PROVE it is the
+          # pinned one. build-mcp-servers.js already logs the PATH it resolved,
+          # and a path is not an identity. An empty or malformed WAYLANDMCP_REF
+          # would make actions/checkout silently take the default branch instead
+          # - the same quiet substitution #940 exists to stop - so assert rather
+          # than trust, the same way release-acceptance-trust-root.yml asserts
+          # TRUST_ROOT_SHA.
+          mcp_sha="$(git rev-parse HEAD)"
+          echo "waylandmcp source commit: $mcp_sha"
+          [[ "$WAYLANDMCP_REF" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "::error::WAYLANDMCP_REF is not a 40-hex commit: '$WAYLANDMCP_REF'" >&2; exit 1;
+          }
+          [[ "$mcp_sha" == "$WAYLANDMCP_REF" ]] || {
+            echo "::error::waylandmcp HEAD $mcp_sha != pinned $WAYLANDMCP_REF" >&2; exit 1;
+          }
           bun install --frozen-lockfile
 
       - name: Build the getwayland payload (syncs version to the release)

--- a/.github/workflows/build-manual.yml
+++ b/.github/workflows/build-manual.yml
@@ -32,13 +32,6 @@ on:
 
 env:
   BUN_INSTALL_REGISTRY: 'https://registry.npmjs.org/'
-  # #940: four @wayland MCP connectors (apple, imap, news, cal.com) build from
-  # the sibling waylandmcp repo, which has no GitHub remote yet - CI cannot
-  # check it out. scripts/build-mcp-servers.js now FAILS the build when a
-  # connector cannot be bundled, so CI must opt out explicitly until that repo
-  # lands. DELETE this line the moment waylandmcp is checkout-able in CI; that
-  # is the whole point of the gate.
-  WAYLAND_ALLOW_MISSING_MCP: '1'
 
 jobs:
   prepare-matrix:

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -47,13 +47,6 @@ env:
   WCORE_SKIP: '0'
   CI: 'true'
   NODE_OPTIONS: '--max-old-space-size=8192'
-  # #940: four @wayland MCP connectors (apple, imap, news, cal.com) build from
-  # the sibling waylandmcp repo, which has no GitHub remote yet - CI cannot
-  # check it out. scripts/build-mcp-servers.js now FAILS the build when a
-  # connector cannot be bundled, so CI must opt out explicitly until that repo
-  # lands. DELETE this line the moment waylandmcp is checkout-able in CI; that
-  # is the whole point of the gate.
-  WAYLAND_ALLOW_MISSING_MCP: '1'
 
 jobs:
   # scripts/build-with-builder.js writes a candidate capability seal on every
@@ -228,6 +221,25 @@ jobs:
             libxss1 libatspi2.0-dev libgtk-3-dev libxrandr2 libasound2-dev xvfb
 
       - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # #940: the four bundled @wayland MCP connectors (apple, imap, news,
+      # cal.com) build from FerroxLabs/waylandmcp. actions/checkout refuses any
+      # `path` outside github.workspace, so the sources land at ./waylandmcp
+      # (gitignored) - the first candidate scripts/build-mcp-servers.js resolves.
+      # Must run AFTER the repo checkout above, whose `git clean -ffdx` would
+      # delete this tree. No bypass: this gate exists to keep a packaged build
+      # from passing while four connectors are missing from it.
+      - name: Checkout @wayland MCP connector sources
+        uses: actions/checkout@v4
+        with:
+          repository: FerroxLabs/waylandmcp
+          ssh-key: ${{ secrets.WAYLANDMCP_DEPLOY_KEY }}
+          path: waylandmcp
+          persist-credentials: false
+
+      - name: Install @wayland MCP connector dependencies
+        working-directory: waylandmcp
         run: bun install --frozen-lockfile
 
       - name: Postinstall (CI uses prebuilt binaries; see scripts/postinstall.js)

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -45,6 +45,11 @@ permissions:
 env:
   # Platform smoke verifies the bundled engine as a critical runtime.
   WCORE_SKIP: '0'
+  # Exact FerroxLabs/waylandmcp commit whose four @wayland MCP connectors are
+  # bundled into this build. Pinned, not floating, so the installer's connector
+  # sources have a recorded identity (#940). Keep byte-identical across all four
+  # workflows that check this repo out - waylandmcp SourcePin test enforces it.
+  WAYLANDMCP_REF: '29a253804ccd3d7f1eb385cf610b0dc27a130478'
   CI: 'true'
   NODE_OPTIONS: '--max-old-space-size=8192'
 
@@ -231,10 +236,23 @@ jobs:
       # above, whose `git clean -ffdx` would delete this tree. No bypass: this
       # gate exists to keep a packaged build from passing while four connectors
       # are missing from it.
+      # #940 PROVENANCE: pin the sources to an exact commit. With no `ref` this
+      # took whatever FerroxLabs/waylandmcp's default branch happened to hold at
+      # build time and recorded that identity nowhere, so a shipped installer
+      # carried code no receipt could name. scripts/platform-package-smoke.mjs
+      # attests the app's own commit AND its untracked tree precisely because "a
+      # newly introduced build input is just as authoritative as a modified
+      # tracked file" - but this input lives OUTSIDE the repo and is gitignored,
+      # so neither that attestation nor the dirty-tree gate can see it. The pin
+      # plus the rev-parse echo in the next step are what put its identity on the
+      # record. WAYLANDMCP_REF follows the WAYLAND_HUB_TAG named-constant
+      # convention; tests/unit/scripts/waylandmcpSourcePin.test.ts holds the four
+      # copies byte-identical so they cannot drift apart.
       - name: Checkout @wayland MCP connector sources
         uses: actions/checkout@v4
         with:
           repository: FerroxLabs/waylandmcp
+          ref: ${{ env.WAYLANDMCP_REF }}
           ssh-key: ${{ secrets.WAYLANDMCP_DEPLOY_KEY }}
           path: waylandmcp
           persist-credentials: false
@@ -256,6 +274,21 @@ jobs:
           rm -rf ../waylandmcp
           mv waylandmcp ../waylandmcp
           cd ../waylandmcp
+          # #940 PROVENANCE: say WHICH commit was bundled, and PROVE it is the
+          # pinned one. build-mcp-servers.js already logs the PATH it resolved,
+          # and a path is not an identity. An empty or malformed WAYLANDMCP_REF
+          # would make actions/checkout silently take the default branch instead
+          # - the same quiet substitution #940 exists to stop - so assert rather
+          # than trust, the same way release-acceptance-trust-root.yml asserts
+          # TRUST_ROOT_SHA.
+          mcp_sha="$(git rev-parse HEAD)"
+          echo "waylandmcp source commit: $mcp_sha"
+          [[ "$WAYLANDMCP_REF" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "::error::WAYLANDMCP_REF is not a 40-hex commit: '$WAYLANDMCP_REF'" >&2; exit 1;
+          }
+          [[ "$mcp_sha" == "$WAYLANDMCP_REF" ]] || {
+            echo "::error::waylandmcp HEAD $mcp_sha != pinned $WAYLANDMCP_REF" >&2; exit 1;
+          }
           bun install --frozen-lockfile
 
       - name: Postinstall (CI uses prebuilt binaries; see scripts/postinstall.js)

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -226,10 +226,11 @@ jobs:
       # #940: the four bundled @wayland MCP connectors (apple, imap, news,
       # cal.com) build from FerroxLabs/waylandmcp. actions/checkout refuses any
       # `path` outside github.workspace, so the sources land at ./waylandmcp
-      # (gitignored) - the first candidate scripts/build-mcp-servers.js resolves.
-      # Must run AFTER the repo checkout above, whose `git clean -ffdx` would
-      # delete this tree. No bypass: this gate exists to keep a packaged build
-      # from passing while four connectors are missing from it.
+      # (gitignored), and the next step moves it to the sibling position that
+      # build-mcp-servers.js already resolves. Must run AFTER the repo checkout
+      # above, whose `git clean -ffdx` would delete this tree. No bypass: this
+      # gate exists to keep a packaged build from passing while four connectors
+      # are missing from it.
       - name: Checkout @wayland MCP connector sources
         uses: actions/checkout@v4
         with:
@@ -238,9 +239,24 @@ jobs:
           path: waylandmcp
           persist-credentials: false
 
-      - name: Install @wayland MCP connector dependencies
-        working-directory: waylandmcp
-        run: bun install --frozen-lockfile
+      # Move the checkout OUT of the app repo to /home/runner/work/wayland/waylandmcp,
+      # which is the pre-existing sibling candidate. This is a containment fix, not
+      # cosmetics: esbuild resolves a bare import by walking node_modules UPWARD from
+      # the entry point. Left inside the workspace, that walk continues into the
+      # desktop app's ~2100-package node_modules, so a connector importing something
+      # it does not declare resolves SILENTLY against the app's copy instead of
+      # failing. Proven by A/B: identical source bundles clean in-workspace and dies
+      # with "Could not resolve" as a sibling. Green build, wrong artifact is exactly
+      # the quiet substitution #940 exists to stop. The rm -rf covers a self-hosted
+      # runner, where the sibling path escapes the workspace `git clean -ffdx`.
+      - name: Relocate and install @wayland MCP connector sources
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf ../waylandmcp
+          mv waylandmcp ../waylandmcp
+          cd ../waylandmcp
+          bun install --frozen-lockfile
 
       - name: Postinstall (CI uses prebuilt binaries; see scripts/postinstall.js)
         run: bun run postinstall || true

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -289,7 +289,20 @@ jobs:
           [[ "$mcp_sha" == "$WAYLANDMCP_REF" ]] || {
             echo "::error::waylandmcp HEAD $mcp_sha != pinned $WAYLANDMCP_REF" >&2; exit 1;
           }
-          bun install --frozen-lockfile
+          # Retried because this is an unattended network op on the release and
+          # publish paths, four lines below an app-side `bun install
+          # --frozen-lockfile` that IS wrapped in nick-fields/retry@v3. The
+          # checkout above needs no wrapper: its only network call (git fetch)
+          # already runs inside actions/checkout's own 3-attempt retry helper.
+          # Loop shape matches pr-checks.yml - a genuine failure still exits
+          # non-zero after the third attempt, so a retry cannot mask one.
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then exit 0; fi
+            echo "waylandmcp bun install attempt $attempt failed; retrying" >&2
+            sleep 30
+          done
+          echo "waylandmcp: bun install --frozen-lockfile failed after 3 attempts" >&2
+          exit 1
 
       - name: Postinstall (CI uses prebuilt binaries; see scripts/postinstall.js)
         run: bun run postinstall || true

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -774,44 +774,16 @@ jobs:
       - name: Postinstall (CI uses prebuilt binaries; see scripts/postinstall.js)
         run: bun run postinstall || true
 
-      # #940: the electron-vite build below bundles the four @wayland MCP
-      # connectors from the PRIVATE FerroxLabs/waylandmcp repo. A pull request
-      # from a FORK gets no repo secrets, so the deploy key is empty there and
-      # the sources are unreachable by construction - that PR keeps the bypass
-      # and says so loudly. This is the ONLY place the bypass survives; every
-      # release/publish path checks the sources out unconditionally and goes red
-      # if it cannot, so a shipped build can never be missing the connectors.
-      - name: Detect access to the @wayland MCP connector sources
-        id: mcp-src
-        env:
-          MCP_DEPLOY_KEY: ${{ secrets.WAYLANDMCP_DEPLOY_KEY }}
-        run: |
-          if [ -n "$MCP_DEPLOY_KEY" ]; then
-            echo 'available=true' >> "$GITHUB_OUTPUT"
-          else
-            echo 'available=false' >> "$GITHUB_OUTPUT"
-            echo 'WAYLAND_ALLOW_MISSING_MCP=1' >> "$GITHUB_ENV"
-            echo '::warning title=@wayland MCP connectors NOT built::Fork PRs get no repo secrets, so the private connector sources cannot be checked out and apple/imap/news/cal.com are excluded from this build only. Release builds have no such bypass (#940).'
-          fi
-
-      # actions/checkout refuses any `path` outside github.workspace, so the
-      # sources land at ./waylandmcp (gitignored) - the first candidate
-      # scripts/build-mcp-servers.js resolves. Must run AFTER the repo checkout
-      # above, whose `git clean -ffdx` would delete this tree.
-      - name: Checkout @wayland MCP connector sources
-        if: steps.mcp-src.outputs.available == 'true'
-        uses: actions/checkout@v4
-        with:
-          repository: FerroxLabs/waylandmcp
-          ssh-key: ${{ secrets.WAYLANDMCP_DEPLOY_KEY }}
-          path: waylandmcp
-          persist-credentials: false
-
-      - name: Install @wayland MCP connector dependencies
-        if: steps.mcp-src.outputs.available == 'true'
-        working-directory: waylandmcp
-        run: bun install --frozen-lockfile
-
+      # #940: no @wayland MCP connector checkout here on purpose. The build
+      # below runs electron-vite in PRODUCTION mode, and electron.vite.config.ts
+      # registers buildMcpServersPlugin only when mode === 'development', so
+      # nothing in this workflow ever invokes scripts/build-mcp-servers.js - the
+      # WAYLAND_ALLOW_MISSING_MCP=1 that used to sit in this file's env was never
+      # load-bearing. Checking the private sources out for a build that does not
+      # consume them would also break every FORK pull request, which gets no repo
+      # secrets. The connectors are proved by build-matrix.yml (every push to
+      # main, plus weekly) and by the release path, neither of which can be run
+      # from a fork and neither of which has a bypass any more.
       - name: Typecheck
         run: bunx tsc --noEmit
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -781,9 +781,16 @@ jobs:
       # WAYLAND_ALLOW_MISSING_MCP=1 that used to sit in this file's env was never
       # load-bearing. Checking the private sources out for a build that does not
       # consume them would also break every FORK pull request, which gets no repo
-      # secrets. The connectors are proved by build-matrix.yml (every push to
-      # main, plus weekly) and by the release path, neither of which can be run
-      # from a fork and neither of which has a bypass any more.
+      # secrets. The connectors are built by build-matrix.yml (every push to main,
+      # plus weekly) and by the release path, neither of which can run from a fork
+      # and neither of which has a bypass any more. Note "built", not "proved":
+      # build-matrix is currently RED on main - in run 31993152345 four legs went
+      # green, macos-x64 and both preview Linux legs failed at Run packaged build,
+      # and all four Windows legs were cancelled. So the only standing proof today
+      # is the four legs that do pass; the Windows connector checkout in particular
+      # has never executed. A single build-manual.yml dispatch across all six
+      # platforms goes through _build-reusable with secrets: inherit and neither
+      # tags nor publishes, which is the cheapest way to close that gap.
       - name: Typecheck
         run: bunx tsc --noEmit
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -69,13 +69,6 @@ env:
   WCORE_SKIP: '1'
   CI: 'true'
   NODE_OPTIONS: '--max-old-space-size=8192'
-  # #940: four @wayland MCP connectors (apple, imap, news, cal.com) build from
-  # the sibling waylandmcp repo, which has no GitHub remote yet - CI cannot
-  # check it out. scripts/build-mcp-servers.js now FAILS the build when a
-  # connector cannot be bundled, so CI must opt out explicitly until that repo
-  # lands. DELETE this line the moment waylandmcp is checkout-able in CI; that
-  # is the whole point of the gate.
-  WAYLAND_ALLOW_MISSING_MCP: '1'
 
 jobs:
   # Cancel in-progress runs when PR is closed (merged or manually closed)
@@ -780,6 +773,44 @@ jobs:
 
       - name: Postinstall (CI uses prebuilt binaries; see scripts/postinstall.js)
         run: bun run postinstall || true
+
+      # #940: the electron-vite build below bundles the four @wayland MCP
+      # connectors from the PRIVATE FerroxLabs/waylandmcp repo. A pull request
+      # from a FORK gets no repo secrets, so the deploy key is empty there and
+      # the sources are unreachable by construction - that PR keeps the bypass
+      # and says so loudly. This is the ONLY place the bypass survives; every
+      # release/publish path checks the sources out unconditionally and goes red
+      # if it cannot, so a shipped build can never be missing the connectors.
+      - name: Detect access to the @wayland MCP connector sources
+        id: mcp-src
+        env:
+          MCP_DEPLOY_KEY: ${{ secrets.WAYLANDMCP_DEPLOY_KEY }}
+        run: |
+          if [ -n "$MCP_DEPLOY_KEY" ]; then
+            echo 'available=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'available=false' >> "$GITHUB_OUTPUT"
+            echo 'WAYLAND_ALLOW_MISSING_MCP=1' >> "$GITHUB_ENV"
+            echo '::warning title=@wayland MCP connectors NOT built::Fork PRs get no repo secrets, so the private connector sources cannot be checked out and apple/imap/news/cal.com are excluded from this build only. Release builds have no such bypass (#940).'
+          fi
+
+      # actions/checkout refuses any `path` outside github.workspace, so the
+      # sources land at ./waylandmcp (gitignored) - the first candidate
+      # scripts/build-mcp-servers.js resolves. Must run AFTER the repo checkout
+      # above, whose `git clean -ffdx` would delete this tree.
+      - name: Checkout @wayland MCP connector sources
+        if: steps.mcp-src.outputs.available == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: FerroxLabs/waylandmcp
+          ssh-key: ${{ secrets.WAYLANDMCP_DEPLOY_KEY }}
+          path: waylandmcp
+          persist-credentials: false
+
+      - name: Install @wayland MCP connector dependencies
+        if: steps.mcp-src.outputs.available == 'true'
+        working-directory: waylandmcp
+        run: bun install --frozen-lockfile
 
       - name: Typecheck
         run: bunx tsc --noEmit

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -19,13 +19,6 @@ jobs:
   publish:
     name: Publish getwayland to npm
     runs-on: ubuntu-latest
-    env:
-      # #940: build-payload.mjs runs scripts/build-mcp-servers.js, which now
-      # FAILS when a @wayland MCP connector cannot be bundled. Those four
-      # connectors build from the sibling waylandmcp repo, which has no GitHub
-      # remote yet, so CI must opt out explicitly. DELETE this the moment
-      # waylandmcp is checkout-able in CI.
-      WAYLAND_ALLOW_MISSING_MCP: '1'
     steps:
       - name: Require an npm token
         env:
@@ -55,6 +48,24 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # #940: build-payload.mjs runs scripts/build-mcp-servers.js, which bundles
+      # the four @wayland MCP connectors from FerroxLabs/waylandmcp.
+      # actions/checkout refuses any `path` outside github.workspace, so the
+      # sources land at ./waylandmcp (gitignored) - the first candidate that
+      # script resolves. Must run AFTER the repo checkout above, whose
+      # `git clean -ffdx` would delete this tree. No bypass on a publish path.
+      - name: Checkout @wayland MCP connector sources
+        uses: actions/checkout@v6
+        with:
+          repository: FerroxLabs/waylandmcp
+          ssh-key: ${{ secrets.WAYLANDMCP_DEPLOY_KEY }}
+          path: waylandmcp
+          persist-credentials: false
+
+      - name: Install @wayland MCP connector dependencies
+        working-directory: waylandmcp
         run: bun install --frozen-lockfile
 
       - name: Build the getwayland payload (syncs version to app/package.json)

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -117,7 +117,20 @@ jobs:
           [[ "$mcp_sha" == "$WAYLANDMCP_REF" ]] || {
             echo "::error::waylandmcp HEAD $mcp_sha != pinned $WAYLANDMCP_REF" >&2; exit 1;
           }
-          bun install --frozen-lockfile
+          # Retried because this is an unattended network op on the release and
+          # publish paths, four lines below an app-side `bun install
+          # --frozen-lockfile` that IS wrapped in nick-fields/retry@v3. The
+          # checkout above needs no wrapper: its only network call (git fetch)
+          # already runs inside actions/checkout's own 3-attempt retry helper.
+          # Loop shape matches pr-checks.yml - a genuine failure still exits
+          # non-zero after the third attempt, so a retry cannot mask one.
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then exit 0; fi
+            echo "waylandmcp bun install attempt $attempt failed; retrying" >&2
+            sleep 30
+          done
+          echo "waylandmcp: bun install --frozen-lockfile failed after 3 attempts" >&2
+          exit 1
 
       - name: Build the getwayland payload (syncs version to app/package.json)
         working-directory: installer

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -53,9 +53,10 @@ jobs:
       # #940: build-payload.mjs runs scripts/build-mcp-servers.js, which bundles
       # the four @wayland MCP connectors from FerroxLabs/waylandmcp.
       # actions/checkout refuses any `path` outside github.workspace, so the
-      # sources land at ./waylandmcp (gitignored) - the first candidate that
-      # script resolves. Must run AFTER the repo checkout above, whose
-      # `git clean -ffdx` would delete this tree. No bypass on a publish path.
+      # sources land at ./waylandmcp (gitignored), and the next step moves them
+      # to the sibling position that script already resolves. Must run AFTER the
+      # repo checkout above, whose `git clean -ffdx` would delete this tree. No
+      # bypass on a publish path.
       - name: Checkout @wayland MCP connector sources
         uses: actions/checkout@v6
         with:
@@ -64,9 +65,24 @@ jobs:
           path: waylandmcp
           persist-credentials: false
 
-      - name: Install @wayland MCP connector dependencies
-        working-directory: waylandmcp
-        run: bun install --frozen-lockfile
+      # Move the checkout OUT of the app repo to /home/runner/work/wayland/waylandmcp,
+      # which is the pre-existing sibling candidate. This is a containment fix, not
+      # cosmetics: esbuild resolves a bare import by walking node_modules UPWARD from
+      # the entry point. Left inside the workspace, that walk continues into the
+      # desktop app's ~2100-package node_modules, so a connector importing something
+      # it does not declare resolves SILENTLY against the app's copy instead of
+      # failing. Proven by A/B: identical source bundles clean in-workspace and dies
+      # with "Could not resolve" as a sibling. Green build, wrong artifact is exactly
+      # the quiet substitution #940 exists to stop. The rm -rf covers a self-hosted
+      # runner, where the sibling path escapes the workspace `git clean -ffdx`.
+      - name: Relocate and install @wayland MCP connector sources
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf ../waylandmcp
+          mv waylandmcp ../waylandmcp
+          cd ../waylandmcp
+          bun install --frozen-lockfile
 
       - name: Build the getwayland payload (syncs version to app/package.json)
         working-directory: installer

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -15,6 +15,13 @@ on:
         required: true
         default: 'feat/workflows-collaborative-surface'
 
+env:
+  # Exact FerroxLabs/waylandmcp commit whose four @wayland MCP connectors are
+  # bundled into this build. Pinned, not floating, so the installer's connector
+  # sources have a recorded identity (#940). Keep byte-identical across all four
+  # workflows that check this repo out - waylandmcp SourcePin test enforces it.
+  WAYLANDMCP_REF: '29a253804ccd3d7f1eb385cf610b0dc27a130478'
+
 jobs:
   publish:
     name: Publish getwayland to npm
@@ -57,10 +64,23 @@ jobs:
       # to the sibling position that script already resolves. Must run AFTER the
       # repo checkout above, whose `git clean -ffdx` would delete this tree. No
       # bypass on a publish path.
+      # #940 PROVENANCE: pin the sources to an exact commit. With no `ref` this
+      # took whatever FerroxLabs/waylandmcp's default branch happened to hold at
+      # build time and recorded that identity nowhere, so a shipped installer
+      # carried code no receipt could name. scripts/platform-package-smoke.mjs
+      # attests the app's own commit AND its untracked tree precisely because "a
+      # newly introduced build input is just as authoritative as a modified
+      # tracked file" - but this input lives OUTSIDE the repo and is gitignored,
+      # so neither that attestation nor the dirty-tree gate can see it. The pin
+      # plus the rev-parse echo in the next step are what put its identity on the
+      # record. WAYLANDMCP_REF follows the WAYLAND_HUB_TAG named-constant
+      # convention; tests/unit/scripts/waylandmcpSourcePin.test.ts holds the four
+      # copies byte-identical so they cannot drift apart.
       - name: Checkout @wayland MCP connector sources
         uses: actions/checkout@v6
         with:
           repository: FerroxLabs/waylandmcp
+          ref: ${{ env.WAYLANDMCP_REF }}
           ssh-key: ${{ secrets.WAYLANDMCP_DEPLOY_KEY }}
           path: waylandmcp
           persist-credentials: false
@@ -82,6 +102,21 @@ jobs:
           rm -rf ../waylandmcp
           mv waylandmcp ../waylandmcp
           cd ../waylandmcp
+          # #940 PROVENANCE: say WHICH commit was bundled, and PROVE it is the
+          # pinned one. build-mcp-servers.js already logs the PATH it resolved,
+          # and a path is not an identity. An empty or malformed WAYLANDMCP_REF
+          # would make actions/checkout silently take the default branch instead
+          # - the same quiet substitution #940 exists to stop - so assert rather
+          # than trust, the same way release-acceptance-trust-root.yml asserts
+          # TRUST_ROOT_SHA.
+          mcp_sha="$(git rev-parse HEAD)"
+          echo "waylandmcp source commit: $mcp_sha"
+          [[ "$WAYLANDMCP_REF" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "::error::WAYLANDMCP_REF is not a 40-hex commit: '$WAYLANDMCP_REF'" >&2; exit 1;
+          }
+          [[ "$mcp_sha" == "$WAYLANDMCP_REF" ]] || {
+            echo "::error::waylandmcp HEAD $mcp_sha != pinned $WAYLANDMCP_REF" >&2; exit 1;
+          }
           bun install --frozen-lockfile
 
       - name: Build the getwayland payload (syncs version to app/package.json)

--- a/.gitignore
+++ b/.gitignore
@@ -264,3 +264,9 @@ installer/payload/
 # at build time from src/process/resources/**; shipped via electron-builder
 # extraResources so no loose SKILL.md reaches the package.
 .skill-pack/
+
+# #940: FerroxLabs/waylandmcp, checked out here by every workflow that builds so
+# scripts/build-mcp-servers.js can bundle the four @wayland MCP connectors.
+# actions/checkout refuses any path outside github.workspace, so it has to land
+# inside the repo - it must never be committable.
+/waylandmcp/

--- a/.gitignore
+++ b/.gitignore
@@ -265,8 +265,11 @@ installer/payload/
 # extraResources so no loose SKILL.md reaches the package.
 .skill-pack/
 
-# #940: FerroxLabs/waylandmcp, checked out here by every workflow that builds so
-# scripts/build-mcp-servers.js can bundle the four @wayland MCP connectors.
-# actions/checkout refuses any path outside github.workspace, so it has to land
-# inside the repo - it must never be committable.
+# #940: FerroxLabs/waylandmcp lands here transiently. actions/checkout cannot
+# write above github.workspace, so the connector sources are checked out here and
+# then MOVED to the sibling position build-mcp-servers.js resolves. Keep this
+# ignore: besides making the checkout uncommittable, it is what stops
+# scripts/platform-package-smoke.mjs (which throws on ANY non-ignored untracked
+# path, and runs after the checkout) from hard-failing every packaged build if
+# the tree is ever left behind.
 /waylandmcp/

--- a/scripts/build-mcp-servers.js
+++ b/scripts/build-mcp-servers.js
@@ -44,10 +44,10 @@ const SHARED_OPTIONS = {
  * installers because both skips below were unconditional warnings, and the
  * Library still advertised cards for them.
  *
- * CI no longer sets it on any trusted build: every workflow that builds now
- * checks FerroxLabs/waylandmcp out to ./waylandmcp first. The ONE remaining
- * setter is pr-checks.yml on a FORK pull request, which gets no repo secrets
- * and therefore cannot read the private connector sources at all - see #940.
+ * NOTHING in CI sets it any more: every workflow that actually runs this script
+ * checks FerroxLabs/waylandmcp out to ./waylandmcp first. The env var stays as
+ * the deliberate, loud escape hatch for a local build without the sources - see
+ * #940.
  */
 const ALLOW_MISSING_ENV = 'WAYLAND_ALLOW_MISSING_MCP';
 

--- a/scripts/build-mcp-servers.js
+++ b/scripts/build-mcp-servers.js
@@ -44,8 +44,10 @@ const SHARED_OPTIONS = {
  * installers because both skips below were unconditional warnings, and the
  * Library still advertised cards for them.
  *
- * It is set deliberately in CI while FerroxLabs/waylandmcp does not exist as a
- * checkout-able repo. Remove the CI setting the moment it does - see #940.
+ * CI no longer sets it on any trusted build: every workflow that builds now
+ * checks FerroxLabs/waylandmcp out to ./waylandmcp first. The ONE remaining
+ * setter is pr-checks.yml on a FORK pull request, which gets no repo secrets
+ * and therefore cannot read the private connector sources at all - see #940.
  */
 const ALLOW_MISSING_ENV = 'WAYLAND_ALLOW_MISSING_MCP';
 
@@ -74,8 +76,33 @@ function skipOptionalMcpOrFail(pkgName, detail, env = process.env) {
 }
 
 /**
- * Bundle a sibling @wayland/<name>-mcp package into a single self-contained
- * .mjs file in out/main/. These packages live in ~/dev/waylandmcp and ship
+ * Where a @wayland/<name>-mcp source tree may live, in priority order.
+ *
+ * WAYLAND_MCP_SRC is an explicit override and therefore AUTHORITATIVE: when it
+ * is set it is the ONLY candidate. Falling back to a different tree after an
+ * operator named one silently builds something other than what was asked for -
+ * the same class of quiet substitution #940 is about.
+ */
+function mcpSourceCandidates(pkgName, env = process.env) {
+  if (env.WAYLAND_MCP_SRC) return [env.WAYLAND_MCP_SRC];
+  return [
+    // #940: the CI checkout. actions/checkout refuses any `path` outside
+    // github.workspace, so the sibling layouts below are unreachable on a runner
+    // (ROOT/.. is /home/runner/work/wayland, above the workspace). Every
+    // workflow that builds therefore checks FerroxLabs/waylandmcp out to
+    // ./waylandmcp inside the repo (gitignored). First, so a deliberate in-repo
+    // checkout always wins over whatever happens to sit in ~/dev.
+    path.resolve(ROOT, 'waylandmcp', 'packages', pkgName),
+    path.resolve(ROOT, '..', '..', 'waylandmcp', 'packages', pkgName),
+    path.resolve(ROOT, '..', 'waylandmcp', 'packages', pkgName),
+    path.join(require('os').homedir(), 'dev', 'waylandmcp', 'packages', pkgName),
+  ];
+}
+
+/**
+ * Bundle a @wayland/<name>-mcp package into a single self-contained .mjs file
+ * in out/main/. These packages live in FerroxLabs/waylandmcp - checked out to
+ * ./waylandmcp in CI, or a sibling ~/dev/waylandmcp tree locally - and ship
  * with the Electron installer (no npm registry dep).
  *
  * Sources use top-level await so the bundle must be ESM, not CJS.
@@ -84,23 +111,18 @@ function skipOptionalMcpOrFail(pkgName, detail, env = process.env) {
  * `WAYLAND_ALLOW_MISSING_MCP=1` is set (#940).
  */
 async function bundleWaylandMcp(pkgName, outName, opts = {}) {
-  // WAYLAND_MCP_SRC is an explicit override and therefore AUTHORITATIVE: when
-  // it is set it is the ONLY candidate. Falling back to a different tree after
-  // an operator named one silently builds something other than what was asked
-  // for - the same class of quiet substitution #940 is about.
-  const candidates = process.env.WAYLAND_MCP_SRC
-    ? [process.env.WAYLAND_MCP_SRC]
-    : [
-        path.resolve(ROOT, '..', '..', 'waylandmcp', 'packages', pkgName),
-        path.resolve(ROOT, '..', 'waylandmcp', 'packages', pkgName),
-        path.join(require('os').homedir(), 'dev', 'waylandmcp', 'packages', pkgName),
-      ];
+  const candidates = mcpSourceCandidates(pkgName);
 
   const src = candidates.find((p) => fs.existsSync(path.join(p, 'src', 'index.ts')));
   if (!src) {
     skipOptionalMcpOrFail(pkgName, `source not found in any of: ${candidates.join(', ')}`);
     return;
   }
+
+  // Say WHICH tree was bundled. Four candidates resolve silently, and a build
+  // that picked up a stale ~/dev copy instead of the intended checkout is the
+  // same quiet-substitution failure #940 is about - only visible if it is logged.
+  console.log(`[build-mcp-servers] @wayland/${pkgName} <- ${src}`);
 
   // A bundle failure of one of these - e.g. a transitive dep whose nested
   // node_modules copy is incomplete on a given runner (an @opentelemetry/core
@@ -199,4 +221,10 @@ if (require.main === module) {
   });
 }
 
-module.exports = { ALLOW_MISSING_ENV, bundleWaylandMcp, optionalMcpBypassEnabled, skipOptionalMcpOrFail };
+module.exports = {
+  ALLOW_MISSING_ENV,
+  bundleWaylandMcp,
+  mcpSourceCandidates,
+  optionalMcpBypassEnabled,
+  skipOptionalMcpOrFail,
+};

--- a/scripts/build-mcp-servers.js
+++ b/scripts/build-mcp-servers.js
@@ -85,14 +85,15 @@ function skipOptionalMcpOrFail(pkgName, detail, env = process.env) {
  */
 function mcpSourceCandidates(pkgName, env = process.env) {
   if (env.WAYLAND_MCP_SRC) return [env.WAYLAND_MCP_SRC];
+  // #940: every candidate is a SIBLING of the app repo, never inside it, and that
+  // is load-bearing. esbuild resolves a bare import by walking node_modules
+  // upward from the entry point, so a tree placed inside the repo would have the
+  // app's ~2100-package node_modules on that walk: a connector importing
+  // something it does not declare would resolve silently against the app's copy
+  // instead of failing. actions/checkout cannot write above github.workspace, so
+  // CI checks out to ./waylandmcp and then MOVES the tree to ROOT/.. before
+  // building - see the "Relocate and install" step in the build workflows.
   return [
-    // #940: the CI checkout. actions/checkout refuses any `path` outside
-    // github.workspace, so the sibling layouts below are unreachable on a runner
-    // (ROOT/.. is /home/runner/work/wayland, above the workspace). Every
-    // workflow that builds therefore checks FerroxLabs/waylandmcp out to
-    // ./waylandmcp inside the repo (gitignored). First, so a deliberate in-repo
-    // checkout always wins over whatever happens to sit in ~/dev.
-    path.resolve(ROOT, 'waylandmcp', 'packages', pkgName),
     path.resolve(ROOT, '..', '..', 'waylandmcp', 'packages', pkgName),
     path.resolve(ROOT, '..', 'waylandmcp', 'packages', pkgName),
     path.join(require('os').homedir(), 'dev', 'waylandmcp', 'packages', pkgName),
@@ -207,7 +208,23 @@ async function main() {
         if (fs.existsSync(bridge)) {
           fs.copyFileSync(bridge, path.join(OUT_MAIN, 'eventkit-bridge'));
           fs.chmodSync(path.join(OUT_MAIN, 'eventkit-bridge'), 0o755);
+          return;
         }
+        // #940: this used to be a silent no-op, and silence is the bug. The
+        // binary is built by `bun run build:native` (swiftc) into dist/, which
+        // waylandmcp gitignores, so a plain CI checkout never has it. Without it
+        // the apple connector still ships and still advertises 9 tools that
+        // cannot work: Calendar listEvents/createEvent/updateEvent/deleteEvent/
+        // findFreeSlot and Reminders listReminders/createReminder/
+        // completeReminder/deleteReminder all route through it. Notes, Mail,
+        // Maps and Photos use AppleScript and are unaffected. A card that offers
+        // a control which cannot work is the failure #940 is about, so say it
+        // loudly enough to find in a CI log. Tracked for a real fix in #1013.
+        console.warn(
+          `::warning::[build-mcp-servers] @wayland/apple-mcp was bundled WITHOUT its Swift EventKit ` +
+            `bridge (no ${bridge}). On macOS its 5 Calendar and 4 Reminders tools will fail at runtime ` +
+            `while the Library still offers them; Notes/Mail/Maps/Photos are unaffected. See #1013.`
+        );
       },
     }),
   ]);

--- a/scripts/build-mcp-servers.js
+++ b/scripts/build-mcp-servers.js
@@ -101,6 +101,39 @@ function mcpSourceCandidates(pkgName, env = process.env) {
 }
 
 /**
+ * Copy the Swift EventKit bridge binary alongside the apple-mcp JS bundle.
+ *
+ * Extracted from an inline callback so it is reachable from a unit test: both
+ * branches are log-only behaviour that nothing could otherwise pin, and the
+ * `return` below is load-bearing in the direction that is easy to miss - drop it
+ * and EVERY macOS build that DOES have the bridge also emits the "will fail at
+ * runtime" warning, a control lying the opposite way.
+ */
+async function copyEventKitBridge(src, outMain = OUT_MAIN) {
+  const bridge = path.join(src, 'dist', 'eventkit-bridge');
+  if (fs.existsSync(bridge)) {
+    fs.copyFileSync(bridge, path.join(outMain, 'eventkit-bridge'));
+    fs.chmodSync(path.join(outMain, 'eventkit-bridge'), 0o755);
+    return;
+  }
+  // #940: this used to be a silent no-op, and silence is the bug. The
+  // binary is built by `bun run build:native` (swiftc) into dist/, which
+  // waylandmcp gitignores, so a plain CI checkout never has it. Without it
+  // the apple connector still ships and still advertises 9 tools that
+  // cannot work: Calendar listEvents/createEvent/updateEvent/deleteEvent/
+  // findFreeSlot and Reminders listReminders/createReminder/
+  // completeReminder/deleteReminder all route through it. Notes, Mail,
+  // Maps and Photos use AppleScript and are unaffected. A card that offers
+  // a control which cannot work is the failure #940 is about, so say it
+  // loudly enough to find in a CI log. Tracked for a real fix in #1013.
+  console.warn(
+    `::warning::[build-mcp-servers] @wayland/apple-mcp was bundled WITHOUT its Swift EventKit ` +
+      `bridge (no ${bridge}). On macOS its 5 Calendar and 4 Reminders tools will fail at runtime ` +
+      `while the Library still offers them; Notes/Mail/Maps/Photos are unaffected. See #1013.`
+  );
+}
+
+/**
  * Bundle a @wayland/<name>-mcp package into a single self-contained .mjs file
  * in out/main/. These packages live in FerroxLabs/waylandmcp - checked out to
  * ./waylandmcp in CI, or a sibling ~/dev/waylandmcp tree locally - and ship
@@ -201,32 +234,7 @@ async function main() {
     bundleWaylandMcp('imap-mcp', 'builtin-mcp-imap.mjs'),
     bundleWaylandMcp('news-mcp', 'builtin-mcp-news.mjs'),
     bundleWaylandMcp('cal-com-mcp', 'builtin-mcp-cal-com.mjs'),
-    bundleWaylandMcp('apple-mcp', 'builtin-mcp-apple.mjs', {
-      onSuccess: async (src) => {
-        // Copy the Swift EventKit bridge binary alongside the JS bundle.
-        const bridge = path.join(src, 'dist', 'eventkit-bridge');
-        if (fs.existsSync(bridge)) {
-          fs.copyFileSync(bridge, path.join(OUT_MAIN, 'eventkit-bridge'));
-          fs.chmodSync(path.join(OUT_MAIN, 'eventkit-bridge'), 0o755);
-          return;
-        }
-        // #940: this used to be a silent no-op, and silence is the bug. The
-        // binary is built by `bun run build:native` (swiftc) into dist/, which
-        // waylandmcp gitignores, so a plain CI checkout never has it. Without it
-        // the apple connector still ships and still advertises 9 tools that
-        // cannot work: Calendar listEvents/createEvent/updateEvent/deleteEvent/
-        // findFreeSlot and Reminders listReminders/createReminder/
-        // completeReminder/deleteReminder all route through it. Notes, Mail,
-        // Maps and Photos use AppleScript and are unaffected. A card that offers
-        // a control which cannot work is the failure #940 is about, so say it
-        // loudly enough to find in a CI log. Tracked for a real fix in #1013.
-        console.warn(
-          `::warning::[build-mcp-servers] @wayland/apple-mcp was bundled WITHOUT its Swift EventKit ` +
-            `bridge (no ${bridge}). On macOS its 5 Calendar and 4 Reminders tools will fail at runtime ` +
-            `while the Library still offers them; Notes/Mail/Maps/Photos are unaffected. See #1013.`
-        );
-      },
-    }),
+    bundleWaylandMcp('apple-mcp', 'builtin-mcp-apple.mjs', { onSuccess: copyEventKitBridge }),
   ]);
 }
 
@@ -241,6 +249,7 @@ if (require.main === module) {
 module.exports = {
   ALLOW_MISSING_ENV,
   bundleWaylandMcp,
+  copyEventKitBridge,
   mcpSourceCandidates,
   optionalMcpBypassEnabled,
   skipOptionalMcpOrFail,

--- a/tests/unit/scripts/buildMcpServersGate.test.ts
+++ b/tests/unit/scripts/buildMcpServersGate.test.ts
@@ -5,7 +5,9 @@
  */
 
 import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
 import { createRequire } from 'node:module';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -27,7 +29,12 @@ const REPO_ROOT = path.resolve(__dirname, '../../..');
 // unless it is the process entry point.
 const gate = require_(SCRIPT) as {
   ALLOW_MISSING_ENV: string;
-  bundleWaylandMcp: (pkgName: string, outName: string) => Promise<void>;
+  bundleWaylandMcp: (
+    pkgName: string,
+    outName: string,
+    opts?: { onSuccess?: (src: string) => Promise<void> }
+  ) => Promise<void>;
+  copyEventKitBridge: (src: string, outMain?: string) => Promise<void>;
   mcpSourceCandidates: (pkgName: string, env?: NodeJS.ProcessEnv) => string[];
   optionalMcpBypassEnabled: (env?: NodeJS.ProcessEnv) => boolean;
   skipOptionalMcpOrFail: (pkgName: string, detail: string, env?: NodeJS.ProcessEnv) => void;
@@ -145,6 +152,73 @@ describe('build-mcp-servers optional-MCP gate (#940)', () => {
     process.env.WAYLAND_ALLOW_MISSING_MCP = '1';
     await expect(gate.bundleWaylandMcp('imap-mcp', 'builtin-mcp-imap.mjs')).resolves.toBeUndefined();
     expect(String(warn.mock.calls[0]?.[0])).toContain('::warning::');
+  });
+
+  // #940 PROVENANCE (mutation M5): four candidate trees resolve silently, so the
+  // build log naming the one it picked IS the control - and nothing pinned it.
+  // Deleting the console.log left this suite 20/20 green.
+  it('logs WHICH source tree it bundled, by absolute path', async () => {
+    const src = fs.mkdtempSync(path.join(os.tmpdir(), 'wl-mcp-src-'));
+    fs.mkdirSync(path.join(src, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(src, 'src', 'index.ts'), 'export const probe = 1;\n');
+    // A throwaway outName so a real out/main/builtin-mcp-*.mjs is never clobbered.
+    const outName = 'buildMcpServersGate-provenance-probe.mjs';
+    const written = path.join(REPO_ROOT, 'out/main', outName);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    process.env.WAYLAND_MCP_SRC = src;
+    try {
+      await gate.bundleWaylandMcp('imap-mcp', outName);
+      const lines = log.mock.calls.map((call) => String(call[0]));
+      expect(lines).toContain(`[build-mcp-servers] @wayland/imap-mcp <- ${src}`);
+      // The bundle really ran, so the assertion above is about the success path.
+      expect(fs.existsSync(written)).toBe(true);
+    } finally {
+      fs.rmSync(src, { recursive: true, force: true });
+      fs.rmSync(written, { force: true });
+    }
+  }, 60_000);
+
+  // #940 (mutation M6): the `return` after a successful copy is load-bearing in
+  // the direction that is easy to miss. Without it EVERY macOS build that DOES
+  // have the Swift bridge also prints "5 Calendar and 4 Reminders tools will fail
+  // at runtime" - a control lying the opposite way, and deleting the `return`
+  // also left this suite 20/20 green.
+  it('copies the EventKit bridge and stays SILENT when it is present', async () => {
+    const src = fs.mkdtempSync(path.join(os.tmpdir(), 'wl-mcp-apple-'));
+    const outMain = fs.mkdtempSync(path.join(os.tmpdir(), 'wl-mcp-out-'));
+    fs.mkdirSync(path.join(src, 'dist'), { recursive: true });
+    fs.writeFileSync(path.join(src, 'dist', 'eventkit-bridge'), 'binary');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await gate.copyEventKitBridge(src, outMain);
+      const copied = path.join(outMain, 'eventkit-bridge');
+      expect(fs.readFileSync(copied, 'utf-8')).toBe('binary');
+      // 0o755 on the copy, so the packaged app can execute it.
+      expect(fs.statSync(copied).mode & 0o777).toBe(0o755);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      fs.rmSync(src, { recursive: true, force: true });
+      fs.rmSync(outMain, { recursive: true, force: true });
+    }
+  });
+
+  it('warns loudly and names the tools when the EventKit bridge is absent', async () => {
+    const src = fs.mkdtempSync(path.join(os.tmpdir(), 'wl-mcp-apple-'));
+    const outMain = fs.mkdtempSync(path.join(os.tmpdir(), 'wl-mcp-out-'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await gate.copyEventKitBridge(src, outMain);
+      expect(fs.existsSync(path.join(outMain, 'eventkit-bridge'))).toBe(false);
+      expect(warn).toHaveBeenCalledTimes(1);
+      const message = String(warn.mock.calls[0]?.[0]);
+      expect(message).toContain('::warning::');
+      expect(message).toContain('WITHOUT its Swift EventKit');
+      expect(message).toContain('5 Calendar and 4 Reminders tools will fail at runtime');
+      expect(message).toContain('#1013');
+    } finally {
+      fs.rmSync(src, { recursive: true, force: true });
+      fs.rmSync(outMain, { recursive: true, force: true });
+    }
   });
 
   it('exits NON-ZERO end to end when a connector source is missing and the opt-out is NOT set', () => {

--- a/tests/unit/scripts/buildMcpServersGate.test.ts
+++ b/tests/unit/scripts/buildMcpServersGate.test.ts
@@ -28,6 +28,7 @@ const REPO_ROOT = path.resolve(__dirname, '../../..');
 const gate = require_(SCRIPT) as {
   ALLOW_MISSING_ENV: string;
   bundleWaylandMcp: (pkgName: string, outName: string) => Promise<void>;
+  mcpSourceCandidates: (pkgName: string, env?: NodeJS.ProcessEnv) => string[];
   optionalMcpBypassEnabled: (env?: NodeJS.ProcessEnv) => boolean;
   skipOptionalMcpOrFail: (pkgName: string, detail: string, env?: NodeJS.ProcessEnv) => void;
 };
@@ -48,6 +49,22 @@ describe('build-mcp-servers optional-MCP gate (#940)', () => {
     expect(gate.optionalMcpBypassEnabled({ WAYLAND_ALLOW_MISSING_MCP: '0' })).toBe(false);
     expect(gate.optionalMcpBypassEnabled({ WAYLAND_ALLOW_MISSING_MCP: 'true' })).toBe(false);
     expect(gate.optionalMcpBypassEnabled({ WAYLAND_ALLOW_MISSING_MCP: '1' })).toBe(true);
+  });
+
+  // #940: the six workflows that build check FerroxLabs/waylandmcp out to
+  // ./waylandmcp INSIDE the workspace, because actions/checkout refuses any
+  // `path` above github.workspace. If that candidate ever stops being first,
+  // CI silently reverts to bundling nothing (or, worse, a stale ~/dev tree).
+  it('resolves the in-workspace CI checkout first', () => {
+    const candidates = gate.mcpSourceCandidates('imap-mcp', {});
+    expect(candidates[0]).toBe(path.join(REPO_ROOT, 'waylandmcp', 'packages', 'imap-mcp'));
+    // The sibling layouts local dev relies on must survive alongside it.
+    expect(candidates).toContain(path.resolve(REPO_ROOT, '..', '..', 'waylandmcp', 'packages', 'imap-mcp'));
+    expect(candidates).toContain(path.resolve(REPO_ROOT, '..', 'waylandmcp', 'packages', 'imap-mcp'));
+  });
+
+  it('treats WAYLAND_MCP_SRC as the single authoritative candidate', () => {
+    expect(gate.mcpSourceCandidates('imap-mcp', { WAYLAND_MCP_SRC: MISSING_SRC })).toEqual([MISSING_SRC]);
   });
 
   it('throws (fatal) when a connector is skipped and the opt-out is NOT set', () => {

--- a/tests/unit/scripts/buildMcpServersGate.test.ts
+++ b/tests/unit/scripts/buildMcpServersGate.test.ts
@@ -51,16 +51,23 @@ describe('build-mcp-servers optional-MCP gate (#940)', () => {
     expect(gate.optionalMcpBypassEnabled({ WAYLAND_ALLOW_MISSING_MCP: '1' })).toBe(true);
   });
 
-  // #940: the six workflows that build check FerroxLabs/waylandmcp out to
-  // ./waylandmcp INSIDE the workspace, because actions/checkout refuses any
-  // `path` above github.workspace. If that candidate ever stops being first,
-  // CI silently reverts to bundling nothing (or, worse, a stale ~/dev tree).
-  it('resolves the in-workspace CI checkout first', () => {
+  // #940 CONTAINMENT: every candidate must be a SIBLING of the app repo, never
+  // inside it. esbuild resolves bare imports by walking node_modules upward from
+  // the entry point, so a source tree inside the repo puts the app's ~2100-package
+  // node_modules on that walk - a connector importing something it does not
+  // declare then resolves SILENTLY against the app's copy instead of failing the
+  // build. Proven by A/B: identical source bundles clean in-workspace and dies
+  // with "Could not resolve" as a sibling. CI checks out to ./waylandmcp only
+  // because actions/checkout cannot write above github.workspace, then moves the
+  // tree to ROOT/.. before building. If an in-repo candidate is ever added back,
+  // that move becomes optional and the containment silently disappears.
+  it('offers only sibling candidates, never one inside the app repo', () => {
     const candidates = gate.mcpSourceCandidates('imap-mcp', {});
-    expect(candidates[0]).toBe(path.join(REPO_ROOT, 'waylandmcp', 'packages', 'imap-mcp'));
-    // The sibling layouts local dev relies on must survive alongside it.
-    expect(candidates).toContain(path.resolve(REPO_ROOT, '..', '..', 'waylandmcp', 'packages', 'imap-mcp'));
     expect(candidates).toContain(path.resolve(REPO_ROOT, '..', 'waylandmcp', 'packages', 'imap-mcp'));
+    expect(candidates).toContain(path.resolve(REPO_ROOT, '..', '..', 'waylandmcp', 'packages', 'imap-mcp'));
+    for (const candidate of candidates) {
+      expect(path.relative(REPO_ROOT, candidate).startsWith('..')).toBe(true);
+    }
   });
 
   it('treats WAYLAND_MCP_SRC as the single authoritative candidate', () => {

--- a/tests/unit/scripts/buildMcpServersGate.test.ts
+++ b/tests/unit/scripts/buildMcpServersGate.test.ts
@@ -36,6 +36,29 @@ const gate = require_(SCRIPT) as {
 /** A source root that cannot exist, so the missing-source path is deterministic. */
 const MISSING_SRC = path.join(REPO_ROOT, 'does-not-exist-940', 'packages', 'imap-mcp');
 
+/**
+ * True when `candidate` IS `root` or lives underneath it.
+ *
+ * "path.relative(root, candidate).startsWith('..')" is not a containment test,
+ * and it is wrong in both directions:
+ *  - On Windows path.relative returns an ABSOLUTE path when the two paths sit
+ *    on different drives, because no relative path can cross a drive root. CI
+ *    checks the app out to D:\a\wayland\wayland while os.homedir() is
+ *    C:\Users\runneradmin, so the homedir candidate relativises to
+ *    "C:\Users\..." - obviously outside the repo, yet it does not start with
+ *    "..". That is the whole windows-2022-only failure.
+ *  - A path INSIDE the repo whose first segment merely begins with two dots,
+ *    e.g. ROOT/..foo, relativises to "..foo" and would be waved through.
+ * Compare the first path segment instead, and treat an absolute result as the
+ * different-root (therefore outside) case it is.
+ */
+function isInsideRepo(root: string, candidate: string): boolean {
+  const rel = path.relative(root, candidate);
+  if (rel === '') return true; // the repo root itself
+  if (path.isAbsolute(rel)) return false; // different drive/root - outside
+  return rel.split(/[\\/]/)[0] !== '..';
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
   delete process.env.WAYLAND_MCP_SRC;
@@ -65,9 +88,24 @@ describe('build-mcp-servers optional-MCP gate (#940)', () => {
     const candidates = gate.mcpSourceCandidates('imap-mcp', {});
     expect(candidates).toContain(path.resolve(REPO_ROOT, '..', 'waylandmcp', 'packages', 'imap-mcp'));
     expect(candidates).toContain(path.resolve(REPO_ROOT, '..', '..', 'waylandmcp', 'packages', 'imap-mcp'));
-    for (const candidate of candidates) {
-      expect(path.relative(REPO_ROOT, candidate).startsWith('..')).toBe(true);
-    }
+    expect(candidates.filter((candidate) => isInsideRepo(REPO_ROOT, candidate))).toEqual([]);
+  });
+
+  // The containment check above is only worth having if it still FAILS on an
+  // in-repo path. Pin the predicate itself, including the two shapes the old
+  // "starts with .." string test got wrong.
+  it('detects an in-repo path as contained, on every platform', () => {
+    expect(isInsideRepo(REPO_ROOT, REPO_ROOT)).toBe(true);
+    expect(isInsideRepo(REPO_ROOT, path.join(REPO_ROOT, 'waylandmcp', 'packages', 'imap-mcp'))).toBe(true);
+    // Inside the repo, yet path.relative() yields "..foo".
+    expect(isInsideRepo(REPO_ROOT, path.join(REPO_ROOT, '..foo'))).toBe(true);
+    expect(isInsideRepo(REPO_ROOT, path.resolve(REPO_ROOT, '..', 'waylandmcp'))).toBe(false);
+    // The exact windows-2022 shape, pinned on every platform: across drives no
+    // relative path exists, so path.relative hands back an ABSOLUTE one. This
+    // is why the old "starts with .." check read an outside path as inside.
+    expect(path.win32.relative('D:\\a\\wayland\\wayland', 'C:\\Users\\runneradmin\\dev\\waylandmcp')).toBe(
+      'C:\\Users\\runneradmin\\dev\\waylandmcp'
+    );
   });
 
   it('treats WAYLAND_MCP_SRC as the single authoritative candidate', () => {

--- a/tests/unit/scripts/buildMcpServersGate.test.ts
+++ b/tests/unit/scripts/buildMcpServersGate.test.ts
@@ -91,11 +91,21 @@ describe('build-mcp-servers optional-MCP gate (#940)', () => {
   // because actions/checkout cannot write above github.workspace, then moves the
   // tree to ROOT/.. before building. If an in-repo candidate is ever added back,
   // that move becomes optional and the containment silently disappears.
-  it('offers only sibling candidates, never one inside the app repo', () => {
-    const candidates = gate.mcpSourceCandidates('imap-mcp', {});
-    expect(candidates).toContain(path.resolve(REPO_ROOT, '..', 'waylandmcp', 'packages', 'imap-mcp'));
-    expect(candidates).toContain(path.resolve(REPO_ROOT, '..', '..', 'waylandmcp', 'packages', 'imap-mcp'));
-    expect(candidates.filter((candidate) => isInsideRepo(REPO_ROOT, candidate))).toEqual([]);
+  // ORDER is load-bearing, so this asserts the exact list rather than membership.
+  // The first existing candidate wins, and the os.homedir() entry is a developer
+  // convenience: if a future reorder floated it above the two CI positions, a
+  // build on any machine with a stale ~/dev/waylandmcp would silently bundle that
+  // tree instead of the deliberate checkout - the quiet substitution #940 exists
+  // to close - and a membership-only assertion (toContain) would stay green.
+  it('offers only sibling candidates, never one inside the app repo, in a pinned order', () => {
+    expect(gate.mcpSourceCandidates('imap-mcp', {})).toEqual([
+      path.resolve(REPO_ROOT, '..', '..', 'waylandmcp', 'packages', 'imap-mcp'),
+      path.resolve(REPO_ROOT, '..', 'waylandmcp', 'packages', 'imap-mcp'),
+      path.join(os.homedir(), 'dev', 'waylandmcp', 'packages', 'imap-mcp'),
+    ]);
+    expect(gate.mcpSourceCandidates('imap-mcp', {}).filter((candidate) => isInsideRepo(REPO_ROOT, candidate))).toEqual(
+      []
+    );
   });
 
   // The containment check above is only worth having if it still FAILS on an

--- a/tests/unit/scripts/waylandmcpSourcePin.test.ts
+++ b/tests/unit/scripts/waylandmcpSourcePin.test.ts
@@ -106,6 +106,18 @@ describe('@wayland MCP connector source pin (#940)', () => {
     }
   );
 
+  it.each(withCheckout.map((entry) => [entry.file, entry] as const))(
+    '%s retries the connector bun install and still fails after 3 attempts',
+    (_file, entry) => {
+      const run = entry.relocate?.run ?? '';
+      // House retry idiom (pr-checks.yml): bounded attempts, and a trailing
+      // non-zero exit so a retry cannot mask a genuine failure.
+      expect(run).toContain('for attempt in 1 2 3; do');
+      expect(run).toContain('if bun install --frozen-lockfile; then exit 0; fi');
+      expect(run.trimEnd().endsWith('exit 1')).toBe(true);
+    }
+  );
+
   // SKIP-IS-A-PASS: on GitHub a skipped required check counts as a PASS, and a
   // continue-on-error step reports success. Neither of these steps may acquire
   // either - a #940 gate that can be skipped is not a gate.

--- a/tests/unit/scripts/waylandmcpSourcePin.test.ts
+++ b/tests/unit/scripts/waylandmcpSourcePin.test.ts
@@ -1,0 +1,121 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+/**
+ * #940 PROVENANCE: binds the four workflows that check FerroxLabs/waylandmcp out
+ * to ONE pinned commit.
+ *
+ * The connector sources are a build input that ships inside every installer, yet
+ * they live OUTSIDE the app repo and `/waylandmcp/` is gitignored - so neither
+ * `scripts/platform-package-smoke.mjs` (which attests the app's commit AND its
+ * untracked tree, on the stated principle that "a newly introduced build input is
+ * just as authoritative as a modified tracked file") nor the dirty-tree gate can
+ * see them. Without a `ref:` every build took whatever the default branch held at
+ * build time and recorded that identity nowhere.
+ *
+ * GitHub Actions has no way to share a constant across workflow FILES, so the pin
+ * is a named `env:` constant per file - the WAYLAND_HUB_TAG convention. This test
+ * is what stops the four copies drifting apart, which is the only failure mode a
+ * per-file constant introduces.
+ */
+
+const WORKFLOWS = path.resolve(__dirname, '../../../.github/workflows');
+
+/** Every workflow that checks the connector sources out. Adding a fifth without
+ *  adding it here is itself the drift this test exists to catch, so the list is
+ *  DERIVED from the files rather than hardcoded. */
+const CHECKOUT_STEP = 'Checkout @wayland MCP connector sources';
+const RELOCATE_STEP = 'Relocate and install @wayland MCP connector sources';
+
+type Step = {
+  name?: string;
+  uses?: string;
+  shell?: string;
+  run?: string;
+  if?: string;
+  'continue-on-error'?: boolean;
+  with?: Record<string, string>;
+};
+
+const parsed = ['_build-reusable.yml', 'build-and-release.yml', 'build-matrix.yml', 'publish-npm.yml'].map((file) => {
+  const doc = parse(readFileSync(path.join(WORKFLOWS, file), 'utf-8')) as {
+    env?: Record<string, string>;
+    jobs: Record<string, { steps?: Step[] }>;
+  };
+  const steps = Object.values(doc.jobs).flatMap((job) => job.steps ?? []);
+  return {
+    file,
+    ref: doc.env?.WAYLANDMCP_REF,
+    checkout: steps.find((step) => step.name === CHECKOUT_STEP),
+    relocate: steps.find((step) => step.name === RELOCATE_STEP),
+  };
+});
+
+/** Guards against the list above silently covering nothing. */
+const withCheckout = parsed.filter((entry) => entry.checkout);
+
+describe('@wayland MCP connector source pin (#940)', () => {
+  it('covers every workflow that checks the connector sources out', () => {
+    expect(withCheckout.map((entry) => entry.file)).toEqual([
+      '_build-reusable.yml',
+      'build-and-release.yml',
+      'build-matrix.yml',
+      'publish-npm.yml',
+    ]);
+  });
+
+  it.each(withCheckout.map((entry) => [entry.file, entry] as const))(
+    '%s pins the checkout to the WAYLANDMCP_REF constant',
+    (_file, entry) => {
+      // A 40-hex commit, not a branch: FerroxLabs/waylandmcp carries no tags, so
+      // a commit is the only immutable ref available.
+      expect(entry.ref).toMatch(/^[0-9a-f]{40}$/);
+      expect(entry.checkout?.with?.repository).toBe('FerroxLabs/waylandmcp');
+      expect(entry.checkout?.with?.ref).toBe('${{ env.WAYLANDMCP_REF }}');
+    }
+  );
+
+  it('keeps the four WAYLANDMCP_REF constants byte-identical', () => {
+    expect(new Set(withCheckout.map((entry) => entry.ref)).size).toBe(1);
+  });
+
+  it('keeps the four relocate step bodies byte-identical', () => {
+    expect(new Set(withCheckout.map((entry) => entry.relocate?.run)).size).toBe(1);
+  });
+
+  it.each(withCheckout.map((entry) => [entry.file, entry] as const))(
+    '%s records the bundled commit and PROVES it is the pinned one',
+    (_file, entry) => {
+      const run = entry.relocate?.run ?? '';
+      expect(entry.relocate?.shell).toBe('bash');
+      // The identity goes in the log...
+      expect(run).toContain('git rev-parse HEAD');
+      expect(run).toContain('waylandmcp source commit:');
+      // ...and is ASSERTED, because an empty WAYLANDMCP_REF would make
+      // actions/checkout fall back to the default branch silently.
+      expect(run).toContain('[[ "$WAYLANDMCP_REF" =~ ^[0-9a-f]{40}$ ]]');
+      expect(run).toContain('[[ "$mcp_sha" == "$WAYLANDMCP_REF" ]]');
+    }
+  );
+
+  // SKIP-IS-A-PASS: on GitHub a skipped required check counts as a PASS, and a
+  // continue-on-error step reports success. Neither of these steps may acquire
+  // either - a #940 gate that can be skipped is not a gate.
+  it.each(withCheckout.map((entry) => [entry.file, entry] as const))(
+    '%s leaves both connector steps unconditional and fail-closed',
+    (_file, entry) => {
+      for (const step of [entry.checkout, entry.relocate]) {
+        expect(step?.if).toBeUndefined();
+        expect(step?.['continue-on-error']).toBeUndefined();
+      }
+    }
+  );
+});


### PR DESCRIPTION
Fixes #940

## What was wrong

The four bundled @wayland MCP connectors (apple-mcp, cal-com-mcp, imap-mcp, news-mcp) build from a separate repo that had never been pushed. PR #993 made a missing connector FATAL instead of a silent warning, but to keep CI green it had to set WAYLAND_ALLOW_MISSING_MCP=1 in six workflows. The gate was armed and immediately bypassed everywhere, which is the exact state it was written to end.

FerroxLabs/waylandmcp now exists (private) with a read-only deploy key provisioned as the WAYLANDMCP_DEPLOY_KEY secret, so the checkout can be real and the bypass can go.

## How the sources reach the build

Four workflows actually invoke scripts/build-mcp-servers.js. All four now check the sources out and go RED if they cannot:

- _build-reusable.yml build job, via scripts/build-with-builder.js
- build-matrix.yml build job, via the same
- build-and-release.yml publish-getwayland-npm job, via installer build-payload.mjs
- publish-npm.yml publish job, via the same

Each does the same two steps: actions/checkout with the deploy key to ./waylandmcp, then a step that MOVES that tree to the sibling position and installs there.

The move is the interesting part, and it is a containment fix rather than tidiness. esbuild resolves a bare import by walking node_modules UPWARD from the entry point. With the connector tree inside the workspace, that walk continues into the desktop app's ~2100-package node_modules. A connector importing something it does not declare, or declares at a different major, would then resolve SILENTLY against the app's copy instead of failing. Green build, wrong artifact, which is precisely the quiet substitution #940 exists to stop, and the new source-path log line would not catch it because the tree is correct while the dependency is not.

Proven by A/B on identical source, same script, only the layout differing:

- in-workspace: an undeclared import of a package only the app tree has bundles CLEAN
- sibling: the same source fails with Could not resolve

actions/checkout refuses any path outside github.workspace, which is why the checkout cannot go straight to the sibling position. So it lands in-workspace and is moved. That makes an in-workspace candidate unnecessary, and it is removed: build-mcp-servers.js keeps exactly the three sibling candidates it always had, so local dev is untouched and WAYLAND_MCP_SRC remains authoritative-and-single. The rm -rf before the move covers a self-hosted runner, where the sibling path sits outside the workspace git clean.

The script now also logs which tree each connector was bundled from. Multiple candidates resolving silently is the same failure class, and it is only visible if it is printed.

/waylandmcp/ is gitignored. That entry turned out to be load-bearing well beyond committability: scripts/platform-package-smoke.mjs:214 throws on ANY non-ignored untracked path and runs after the connector checkout, so without the ignore a leftover tree would hard-red every packaged build.

## Dependency layout

Verified from a clean clone, and the CI log matches byte for byte (254 packages installed, printing only the two root devDependencies): bun puts the real packages in waylandmcp/node_modules/.bun/ and creates packages/<pkg>/node_modules with symlinks into that store. Nothing is hoisted to the waylandmcp root. So the nodePaths per-package hint resolves, and the upward walk stops inside waylandmcp rather than reaching the app tree.

## Where the checkout deliberately does NOT go

pr-checks.yml loses its bypass line and gains nothing, and this PR's own CI run is what proved why. pr-checks runs electron-vite in PRODUCTION mode, and electron.vite.config.ts registers buildMcpServersPlugin only when mode is development, so nothing in that workflow has ever invoked build-mcp-servers.js. Its bypass was never load-bearing. An earlier revision of this PR did add the checkout there; the run showed the connector-resolution lines never appear, so it was removed rather than left feeding a build that ignores it.

That is also the whole answer on fork PRs. A fork gets no repo secrets and now needs none: the only workflow a fork can trigger does not build the connectors. Every path that does is push, tag, schedule or workflow_dispatch on this repo. So a release build can never silently ship without the connectors, and there is no bypass left anywhere in CI to make it do so.

build-manual.yml also only loses its bypass line. It has no build steps of its own and caller-level env does not propagate into a reusable workflow, so that line was already dead.

## Verification

- Bypass settings in .github/workflows: 6 before, 0 after. Three textual hits remain repo-wide: the constant in build-mcp-servers.js, its unit test, and one explanatory comment in pr-checks.yml.
- actionlint 1.7.12 across all six files: 67 findings before, 67 after. Zero new, including on the new bash run block. All six also parse with the yaml package.
- LIVE CI PROOF: on this PR's Security Audit E2E run an earlier revision carried the checkout, and Detect access, Checkout @wayland MCP connector sources and Install @wayland MCP connector dependencies all reported success on a real ubuntu runner. The log shows git remote add origin git@github.com:FerroxLabs/waylandmcp.git followed by a successful fetch, so the deploy key, the secret and the SSH path are confirmed. persist-credentials false is honoured with no key material in the log.
- End-to-end replay of the exact workflow steps in a CI-shaped tree (clone to ./waylandmcp, then the literal run block, then the bundle): all four connectors resolved from the sibling position and all four .mjs artifacts were produced.
- Containment A/B as described above, executed both ways.
- Fatal-vs-bypass: with no candidate reachable, the bundle throws and names the opt-out; with WAYLAND_ALLOW_MISSING_MCP=1 it warns and returns.
- Local dev fallback: with no in-repo tree, all four resolve from the ~/dev sibling.
- buildMcpServersGate.test.ts: 8 passed. The new case pins the containment invariant, that no candidate resolves inside the repo root, and was mutation-checked: reintroducing an in-workspace candidate turns it red.
- bunx tsc --noEmit clean. bun run lint (oxlint) exits 0 with zero findings in the touched files. oxfmt over exactly the touched files produced no changes.

## Not verified without a real CI run

- The ssh-key checkout on the Windows and macOS legs. Proved on ubuntu by this PR's run only.
- build-matrix.yml will NOT close that gap on merge as things stand: it is currently red on main. In run 31993152345 four legs went green, macos-x64 and both preview Linux legs failed at Run packaged build, and all four Windows legs were cancelled.
- The cheapest way to retire both items is a single build-manual.yml dispatch across all six platforms. It goes through _build-reusable with secrets inherit, which is the exact release path, and it neither tags nor publishes.

## Split out

#1013: apple-mcp ships without its Swift EventKit bridge. waylandmcp gitignores dist/, so the binary is never in a CI checkout, and the copy in build-mcp-servers.js was a silent no-op. The connector still ships and still advertises 5 Calendar and 4 Reminders tools that route through that binary and cannot work; Notes, Mail, Maps and Photos use AppleScript and are fine. Before this PR no Apple connector shipped at all, so this is newly reachable rather than pre-existing. This PR does the minimum, turning the silent no-op into a loud build warning naming the connector and the absent binary. Actually building the Swift bridge on the macOS legs is #1013.
