### PR TITLE
fix(mcp): run first-party builtin MCP servers on a real JS runtime

### DIFF
--- a/src/process/acp/session/McpConfig.ts
+++ b/src/process/acp/session/McpConfig.ts
@@ -143,7 +143,9 @@ export class McpConfig {
           // Same runtime tuple as the Library probe: `npx`→bundled Bun (#827)
           // AND Wayland's own bundled MCP servers→resolved JS runtime (#1008),
           // carrying the runtime env the dev runtime needs to BE a Node runtime.
-          const spawn = resolveSessionMcpStdioSpawn(server.transport.command, server.transport.args ?? []);
+          const spawn = resolveSessionMcpStdioSpawn(server.transport.command, server.transport.args ?? [], {
+            libraryEntryId: server.libraryEntryId,
+          });
           runtimeServer = {
             name: server.name,
             command: spawn.command,

--- a/src/process/acp/session/McpConfig.ts
+++ b/src/process/acp/session/McpConfig.ts
@@ -2,7 +2,7 @@
 import type { IMcpServer } from '@/common/config/storage';
 import type { AcpMcpCapabilities } from '@/common/types/acpTypes';
 import type { McpServer } from '@agentclientprotocol/sdk';
-import { resolveMcpStdioSpawn } from '@process/services/mcpServices/mcpStdioSpawn';
+import { mergeMcpSpawnEnv, resolveSessionMcpStdioSpawn } from '@process/services/mcpServices/builtinMcpRuntime';
 import { isServerActiveForSession } from '@process/agent/acp/mcpSessionConfig';
 import {
   createMcpSessionState,
@@ -140,12 +140,15 @@ export class McpConfig {
             reason = 'ACP runtime did not advertise stdio MCP transport support';
             break;
           }
-          const spawn = resolveMcpStdioSpawn(server.transport.command, server.transport.args ?? []);
+          // Same runtime tuple as the Library probe: `npx`→bundled Bun (#827)
+          // AND Wayland's own bundled MCP servers→resolved JS runtime (#1008),
+          // carrying the runtime env the dev runtime needs to BE a Node runtime.
+          const spawn = resolveSessionMcpStdioSpawn(server.transport.command, server.transport.args ?? []);
           runtimeServer = {
             name: server.name,
             command: spawn.command,
             args: spawn.args,
-            env: toNameValueArray(server.transport.env),
+            env: toNameValueArray(mergeMcpSpawnEnv(server.transport.env, spawn.env)),
           };
           break;
         }

--- a/src/process/agent/acp/mcpSessionConfig.ts
+++ b/src/process/agent/acp/mcpSessionConfig.ts
@@ -10,6 +10,7 @@ import type { IMcpServer } from '@/common/config/storage';
 import type { AcpMcpCapabilities } from '@/common/types/acpTypes';
 import { BUILTIN_CONCIERGE_DIAG_ID } from '@process/resources/builtinMcp/constants';
 import { resolveMcpStdioSpawn } from '@process/services/mcpServices/mcpStdioSpawn';
+import { mergeMcpSpawnEnv, resolveSessionMcpStdioSpawn } from '@process/services/mcpServices/builtinMcpRuntime';
 import { sanitizeMcpServerName } from '@process/services/mcpServices/validateMcpServer';
 
 export interface AcpSessionMcpNameValue {
@@ -112,15 +113,19 @@ export function buildAcpSessionMcpServers(
         switch (server.transport.type) {
           case 'stdio': {
             if (!capabilities.stdio) return null;
-            // Use the same bundled-Bun tuple as the Library probe so a green
-            // connection test cannot depend on a different PATH/runtime.
-            const spawn = resolveMcpStdioSpawn(server.transport.command, server.transport.args ?? []);
+            // Use the same runtime tuple as the Library probe so a green
+            // connection test cannot depend on a different PATH/runtime. That
+            // covers BOTH halves: `npx`→bundled Bun (#827) and Wayland's own
+            // bundled MCP servers→resolved JS runtime (#1008). The runtime env
+            // (`ELECTRON_RUN_AS_NODE` in dev) is load-bearing — without it the
+            // child boots a second Electron app instead of the MCP server.
+            const spawn = resolveSessionMcpStdioSpawn(server.transport.command, server.transport.args ?? []);
             return {
               type: 'stdio',
               name: server.name,
               command: spawn.command,
               args: spawn.args,
-              env: toNameValueEntries(server.transport.env) ?? [],
+              env: toNameValueEntries(mergeMcpSpawnEnv(server.transport.env, spawn.env)) ?? [],
             };
           }
           case 'http':

--- a/src/process/agent/acp/mcpSessionConfig.ts
+++ b/src/process/agent/acp/mcpSessionConfig.ts
@@ -119,7 +119,9 @@ export function buildAcpSessionMcpServers(
             // bundled MCP servers→resolved JS runtime (#1008). The runtime env
             // (`ELECTRON_RUN_AS_NODE` in dev) is load-bearing — without it the
             // child boots a second Electron app instead of the MCP server.
-            const spawn = resolveSessionMcpStdioSpawn(server.transport.command, server.transport.args ?? []);
+            const spawn = resolveSessionMcpStdioSpawn(server.transport.command, server.transport.args ?? [], {
+              libraryEntryId: server.libraryEntryId,
+            });
             return {
               type: 'stdio',
               name: server.name,

--- a/src/process/resources/builtinMcp/conciergeDiagServer.ts
+++ b/src/process/resources/builtinMcp/conciergeDiagServer.ts
@@ -35,6 +35,10 @@ import os from 'node:os';
 import path from 'node:path';
 import BetterSqlite3 from 'better-sqlite3';
 import type Database from 'better-sqlite3';
+// Relative, and from the deliberately dependency-free constants module: this file
+// is esbuild-bundled into a standalone stdio server, so an alias or a module with
+// side effects would be a build/runtime hazard here.
+import { isBundledWaylandMcpEntryId } from './constants';
 
 // ---------------------------------------------------------------------------
 // Bounds (re-clamped here so output can never balloon, regardless of source).
@@ -806,11 +810,18 @@ export const createConciergeDiagServer = (deps: ConciergeDiagDeps = {}) => {
       // #1008: a bundled first-party server has no command, args or credentials
       // the user owns, so telling them to check those sends them looking for a
       // mistake they cannot have made. Say plainly that it is ours to fix.
+      // #1015: the four sibling @wayland servers (Apple/IMAP/News/Cal.com) do NOT
+      // carry `builtin`, so they fell into the user-error branch and were told to
+      // check a command and args Wayland wrote. Their spawn is ours; their
+      // credentials genuinely are the user's, so they get their own line rather
+      // than either of the other two.
       const flag =
         enabled && toolCount === 0
           ? s.builtin === true
             ? 'Enabled but exposes 0 tools — this is a server bundled with Wayland, so there is nothing for you to configure. It either failed to start or has not been probed yet. Please report it.'
-            : 'Enabled but exposes 0 tools — it likely failed to connect or registered nothing; check its command, args, or credentials.'
+            : isBundledWaylandMcpEntryId(asNullableString(s.libraryEntryId))
+              ? 'Enabled but exposes 0 tools — this server ships with Wayland, so its command and args are not yours to fix. Check any credentials you entered for it; if those are correct, please report it.'
+              : 'Enabled but exposes 0 tools — it likely failed to connect or registered nothing; check its command, args, or credentials.'
           : null;
       return {
         name: typeof s.name === 'string' ? s.name : '(unnamed)',

--- a/src/process/resources/builtinMcp/conciergeDiagServer.ts
+++ b/src/process/resources/builtinMcp/conciergeDiagServer.ts
@@ -803,9 +803,14 @@ export const createConciergeDiagServer = (deps: ConciergeDiagDeps = {}) => {
       const enabled = s.enabled === true;
       const toolCount = Array.isArray(s.tools) ? s.tools.length : 0;
       const lastError = asNullableString(s.lastError);
+      // #1008: a bundled first-party server has no command, args or credentials
+      // the user owns, so telling them to check those sends them looking for a
+      // mistake they cannot have made. Say plainly that it is ours to fix.
       const flag =
         enabled && toolCount === 0
-          ? 'Enabled but exposes 0 tools — it likely failed to connect or registered nothing; check its command, args, or credentials.'
+          ? s.builtin === true
+            ? 'Enabled but exposes 0 tools — this is a server bundled with Wayland, so there is nothing for you to configure. It either failed to start or has not been probed yet. Please report it.'
+            : 'Enabled but exposes 0 tools — it likely failed to connect or registered nothing; check its command, args, or credentials.'
           : null;
       return {
         name: typeof s.name === 'string' ? s.name : '(unnamed)',

--- a/src/process/resources/builtinMcp/constants.ts
+++ b/src/process/resources/builtinMcp/constants.ts
@@ -47,6 +47,48 @@ export function isBuiltinWaylandMcpArg(arg: string | undefined | null): arg is B
 }
 
 /**
+ * Catalog entry id -> the bundled script that entry installs.
+ *
+ * WHY PROVENANCE, NOT THE FILENAME (#1015 F2)
+ * -------------------------------------------
+ * A bare filename with no separator is indistinguishable from a user's own
+ * relative script path by string inspection alone, so the allowlist above is not
+ * sufficient authority to REPLACE `args[0]` with our own script — that would
+ * execute a DIFFERENT FILE than the one the user configured. The only code path
+ * that ever writes the bare-filename form is the MCP Library install
+ * (`entryToServerData`), and it writes `libraryEntryId` in the same record. That
+ * pair is the proof of ownership; the filename on its own is not.
+ *
+ * A Map, not an object literal, so a hostile `libraryEntryId` like
+ * `__proto__`/`constructor` cannot reach a prototype member.
+ */
+const BUILTIN_WAYLAND_MCP_ENTRY_FILES = new Map<string, BuiltinWaylandMcpFile>([
+  [BUILTIN_WAYLAND_APPLE_NAME, BUILTIN_WAYLAND_APPLE_FILE],
+  [BUILTIN_WAYLAND_IMAP_NAME, BUILTIN_WAYLAND_IMAP_FILE],
+  [BUILTIN_WAYLAND_NEWS_NAME, BUILTIN_WAYLAND_NEWS_FILE],
+  [BUILTIN_WAYLAND_CAL_COM_NAME, BUILTIN_WAYLAND_CAL_COM_FILE],
+]);
+
+/**
+ * True only when `libraryEntryId` is the catalog entry that installs exactly
+ * `arg`. Both halves must agree: a @wayland record pointed at a DIFFERENT
+ * builtin's filename is not the entry it claims to be and is left alone.
+ */
+export function isOwnBuiltinWaylandMcpScript(
+  libraryEntryId: string | undefined | null,
+  arg: string | undefined | null
+): boolean {
+  if (!libraryEntryId || !arg) return false;
+  return BUILTIN_WAYLAND_MCP_ENTRY_FILES.get(libraryEntryId) === arg;
+}
+
+/** True if `libraryEntryId` names one of the four bundled @wayland catalog entries. */
+export function isBundledWaylandMcpEntryId(libraryEntryId: string | undefined | null): boolean {
+  if (!libraryEntryId) return false;
+  return BUILTIN_WAYLAND_MCP_ENTRY_FILES.has(libraryEntryId);
+}
+
+/**
  * True if the transport is a bundled @wayland MCP spawn (node + bare filename
  * args[0] matching one of the four built-ins).
  */

--- a/src/process/resources/builtinMcp/constants.ts
+++ b/src/process/resources/builtinMcp/constants.ts
@@ -60,6 +60,37 @@ export function isBuiltinWaylandMcpTransport(transport?: {
   return isBuiltinWaylandMcpArg(first);
 }
 
+/**
+ * First-party bundled stdio MCP servers emitted by `scripts/build-mcp-servers.js`.
+ *
+ * These differ from `BUILTIN_WAYLAND_MCP_FILES` above in HOW they are stored:
+ * the four sibling @wayland servers keep a bare filename in `args[0]`, while
+ * these are seeded into `mcp.config` with an ABSOLUTE path (see
+ * `getBuiltinMcpScriptPath` in initStorage). Matching therefore has to look at
+ * the basename, not the whole argument.
+ */
+export const BUILTIN_CORE_MCP_FILES = [
+  'builtin-mcp-image-gen.js',
+  'builtin-mcp-search-skills.js',
+  'builtin-mcp-concierge-diag.js',
+] as const;
+
+export type BuiltinCoreMcpFile = (typeof BUILTIN_CORE_MCP_FILES)[number];
+
+/**
+ * True if `arg` points at one of the first-party bundled stdio servers (#1008).
+ *
+ * The stored argument is an absolute path, so compare the basename. Split on
+ * BOTH separators rather than using `path.basename`: this module is bundled
+ * into the standalone stdio servers and deliberately imports nothing, and a
+ * Windows path can reach a resolver running with POSIX semantics in tests.
+ */
+export function isBuiltinCoreMcpArg(arg: string | undefined | null): boolean {
+  if (!arg) return false;
+  const base = arg.split(/[\\/]/).pop();
+  return (BUILTIN_CORE_MCP_FILES as readonly string[]).includes(base ?? '');
+}
+
 export function isBuiltinImageGenName(name?: string | null): boolean {
   if (!name) return false;
   return (

--- a/src/process/services/mcpServices/McpProtocol.ts
+++ b/src/process/services/mcpServices/McpProtocol.ts
@@ -261,10 +261,17 @@ export abstract class AbstractMcpAgent implements IMcpProtocol {
     try {
       // Detect whether it's a full IMcpServer or just a transport
       const transport = 'transport' in serverOrTransport ? serverOrTransport.transport : serverOrTransport;
+      const libraryEntryId = 'transport' in serverOrTransport ? serverOrTransport.libraryEntryId : undefined;
 
       switch (transport.type) {
         case 'stdio':
-          return this.testStdioConnection(transport);
+          // The bare-filename @wayland builtins are only expanded on the
+          // authority of the record's catalog provenance (#1015 F2), so it has to
+          // travel with the transport. A caller that hands us a bare transport
+          // (an agent CLI's own config entry) has no provenance to give and gets
+          // no rewrite — which is the same answer every serializer gives for that
+          // record, so probe and session still agree.
+          return this.testStdioConnection(transport, libraryEntryId);
         case 'sse':
           return this.testSseConnection(transport);
         case 'http':
@@ -289,11 +296,14 @@ export abstract class AbstractMcpAgent implements IMcpProtocol {
    * Generic implementation for testing a Stdio connection
    * Uses the MCP SDK for correct protocol communication
    */
-  protected async testStdioConnection(transport: {
-    command: string;
-    args?: string[];
-    env?: Record<string, string>;
-  }): Promise<McpConnectionTestResult> {
+  protected async testStdioConnection(
+    transport: {
+      command: string;
+      args?: string[];
+      env?: Record<string, string>;
+    },
+    libraryEntryId?: string
+  ): Promise<McpConnectionTestResult> {
     let mcpClient: Client | null = null;
     // Hoisted so the catch block can report the resolved spawn argv and the
     // child's stderr even when connect() throws.
@@ -312,7 +322,7 @@ export abstract class AbstractMcpAgent implements IMcpProtocol {
       // runtime instead — bundled Bun in packaged builds (the app binary can't be
       // used: #706, the RunAsNode fuse makes ELECTRON_RUN_AS_NODE a no-op so it
       // would boot as the app), or the app binary as Node in dev (#1008).
-      const builtinSpawn = resolveBuiltinMcpRuntimeSpawn(transport.command, rawArgs);
+      const builtinSpawn = resolveBuiltinMcpRuntimeSpawn(transport.command, rawArgs, { libraryEntryId });
 
       // Use enhanced env (includes shell PATH) instead of bare process.env
       // so CLI tools installed via nvm/fnm/volta are discoverable in packaged mode

--- a/src/process/services/mcpServices/McpProtocol.ts
+++ b/src/process/services/mcpServices/McpProtocol.ts
@@ -338,7 +338,12 @@ export abstract class AbstractMcpAgent implements IMcpProtocol {
       // on macOS/Linux, allowing the Library to report green for bundled Bun
       // while the chat later attempted a bare host `npx` from a different PATH.
       // The builtin branch is the same shared resolver every serializer calls, so
-      // a green probe cannot again mean "chat still spawns bare node".
+      // a green probe cannot again mean "chat still spawns bare node". That claim
+      // is only true while the LIST of callers is complete: the wcore chat loads
+      // its connectors from a launch-local config.toml written by `WCoreManager`,
+      // which is not one of `McpService.syncMcpToAgents`' targets and needed the
+      // rewrite applied to it separately (#1015 F1). Add a new publication path
+      // and it must call this resolver too, or this comment becomes false again.
       const resolvedSpawn =
         builtinSpawn ?? resolveMcpStdioSpawn(transport.command, rawArgs, () => resolveNpxPath(enhancedEnv));
 

--- a/src/process/services/mcpServices/McpProtocol.ts
+++ b/src/process/services/mcpServices/McpProtocol.ts
@@ -18,7 +18,7 @@ import { getEnhancedEnv, resolveNpxPath } from '@/process/utils/shellEnv';
 import { resolveMcpStdioSpawn } from './mcpStdioSpawn';
 import { getMcpScriptPath } from '@/process/utils/mcpScriptDir';
 import { resolveJsRuntime } from '@/process/utils/jsRuntime';
-import { isBuiltinWaylandMcpArg } from '@/process/resources/builtinMcp/constants';
+import { isBuiltinCoreMcpArg, isBuiltinWaylandMcpArg } from '@/process/resources/builtinMcp/constants';
 
 /**
  * MCP source type - includes all ACP backends and Wayland built-ins
@@ -316,7 +316,15 @@ export abstract class AbstractMcpAgent implements IMcpProtocol {
       // the app binary as Node in dev. The bare filename is also rewritten to an
       // absolute path under out/main (dev) or app.asar.unpacked/out/main (packaged).
       const isBuiltinWaylandMcp = transport.command === 'node' && isBuiltinWaylandMcpArg(rawArgs[0]);
-      const builtinRuntime = isBuiltinWaylandMcp ? resolveJsRuntime() : null;
+      // #1008: the SAME "no system node" failure hits the first-party core
+      // builtins (search-skills, concierge-diag, image-gen). They were missed
+      // because they are seeded into mcp.config with an ABSOLUTE script path
+      // rather than the bare filename the four sibling servers use, so the
+      // filename match above never saw them. macOS ships no `/usr/bin/node`, so
+      // on an end-user Mac the probe died with ENOENT and the servers reported
+      // "Enabled but exposes 0 tools" forever.
+      const isBuiltinCoreMcp = transport.command === 'node' && isBuiltinCoreMcpArg(rawArgs[0]);
+      const builtinRuntime = isBuiltinWaylandMcp || isBuiltinCoreMcp ? resolveJsRuntime() : null;
 
       // Use enhanced env (includes shell PATH) instead of bare process.env
       // so CLI tools installed via nvm/fnm/volta are discoverable in packaged mode

--- a/src/process/services/mcpServices/McpProtocol.ts
+++ b/src/process/services/mcpServices/McpProtocol.ts
@@ -16,9 +16,7 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { getEnhancedEnv, resolveNpxPath } from '@/process/utils/shellEnv';
 import { resolveMcpStdioSpawn } from './mcpStdioSpawn';
-import { getMcpScriptPath } from '@/process/utils/mcpScriptDir';
-import { resolveJsRuntime } from '@/process/utils/jsRuntime';
-import { isBuiltinCoreMcpArg, isBuiltinWaylandMcpArg } from '@/process/resources/builtinMcp/constants';
+import { resolveBuiltinMcpRuntimeSpawn } from './builtinMcpRuntime';
 
 /**
  * MCP source type - includes all ACP backends and Wayland built-ins
@@ -307,24 +305,14 @@ export abstract class AbstractMcpAgent implements IMcpProtocol {
       // app imported statically
 
       const rawArgs = transport.args ?? [];
-      // Bundled @wayland MCPs are stored as { command: 'node', args: ['builtin-mcp-<name>.mjs'] }.
+      // Wayland's own bundled MCPs are stored as { command: 'node', args: [<script>] }.
       // End-user Macs frequently have no system `node` on PATH, so spawning the
       // bare command dies on launch and surfaces only as -32000 "Connection
-      // closed". Run our own builtins through a resolved JS runtime — bundled Bun
-      // in packaged builds (the app binary can't be used: #706, the RunAsNode
-      // fuse makes ELECTRON_RUN_AS_NODE a no-op so it would boot as the app), or
-      // the app binary as Node in dev. The bare filename is also rewritten to an
-      // absolute path under out/main (dev) or app.asar.unpacked/out/main (packaged).
-      const isBuiltinWaylandMcp = transport.command === 'node' && isBuiltinWaylandMcpArg(rawArgs[0]);
-      // #1008: the SAME "no system node" failure hits the first-party core
-      // builtins (search-skills, concierge-diag, image-gen). They were missed
-      // because they are seeded into mcp.config with an ABSOLUTE script path
-      // rather than the bare filename the four sibling servers use, so the
-      // filename match above never saw them. macOS ships no `/usr/bin/node`, so
-      // on an end-user Mac the probe died with ENOENT and the servers reported
-      // "Enabled but exposes 0 tools" forever.
-      const isBuiltinCoreMcp = transport.command === 'node' && isBuiltinCoreMcpArg(rawArgs[0]);
-      const builtinRuntime = isBuiltinWaylandMcp || isBuiltinCoreMcp ? resolveJsRuntime() : null;
+      // closed". `resolveBuiltinMcpRuntimeSpawn` runs them through a resolved JS
+      // runtime instead — bundled Bun in packaged builds (the app binary can't be
+      // used: #706, the RunAsNode fuse makes ELECTRON_RUN_AS_NODE a no-op so it
+      // would boot as the app), or the app binary as Node in dev (#1008).
+      const builtinSpawn = resolveBuiltinMcpRuntimeSpawn(transport.command, rawArgs);
 
       // Use enhanced env (includes shell PATH) instead of bare process.env
       // so CLI tools installed via nvm/fnm/volta are discoverable in packaged mode
@@ -332,17 +320,20 @@ export abstract class AbstractMcpAgent implements IMcpProtocol {
         ...getEnhancedEnv(transport.env),
         TERM: 'dumb',
         NO_COLOR: '1',
-        ...(builtinRuntime ? builtinRuntime.env : {}),
+        ...(builtinSpawn ? builtinSpawn.env : {}),
       };
 
       // The probe and the live-session serializers MUST use the same runtime
       // tuple. A previous local npx branch here diverged from session injection
       // on macOS/Linux, allowing the Library to report green for bundled Bun
       // while the chat later attempted a bare host `npx` from a different PATH.
-      const resolvedSpawn = resolveMcpStdioSpawn(transport.command, rawArgs, () => resolveNpxPath(enhancedEnv));
+      // The builtin branch is the same shared resolver every serializer calls, so
+      // a green probe cannot again mean "chat still spawns bare node".
+      const resolvedSpawn =
+        builtinSpawn ?? resolveMcpStdioSpawn(transport.command, rawArgs, () => resolveNpxPath(enhancedEnv));
 
-      command = builtinRuntime ? builtinRuntime.command : resolvedSpawn.command;
-      args = isBuiltinWaylandMcp ? [getMcpScriptPath(rawArgs[0]), ...rawArgs.slice(1)] : resolvedSpawn.args;
+      command = resolvedSpawn.command;
+      args = resolvedSpawn.args;
 
       const stdioTransport = new StdioClientTransport({
         command,

--- a/src/process/services/mcpServices/McpService.ts
+++ b/src/process/services/mcpServices/McpService.ts
@@ -21,6 +21,7 @@ import type { IMcpProtocol, DetectedMcpServer, McpConnectionTestResult, McpSyncR
 import { mcpAgentOperationSucceeded } from './McpProtocol';
 import { validateMcpServer, sanitizeMcpServerName } from './validateMcpServer';
 import { normalizeMcpServerForSpawn } from '@/common/mcp/normalizeMcpServer';
+import { applyBuiltinMcpRuntime } from '@process/services/mcpServices/builtinMcpRuntime';
 import { mcpServerCollisionKey } from '@/common/mcp';
 import { bindMcpPrepublicationProbeTruth } from './mcpSessionTruthGate';
 
@@ -332,7 +333,14 @@ export class McpService {
       // port (ERR_CONNECTION_REFUSED) and the MCP never connects even though
       // Wayland's own login succeeded. Injecting the token we already hold makes
       // the engine skip its OAuth entirely.
-      const authedServers = await this.attachOAuthTokens(enabledServers);
+      // #1008: Wayland's own bundled MCP servers are stored as bare `node`, which
+      // does not exist on a stock macOS. Rewrite them onto the resolved JS runtime
+      // (the SAME tuple the Library probe spawns) before any agent serializes them,
+      // so all eight CLI publication targets emit a command that can actually run.
+      // Applied AFTER validateMcpServer so validation still grades the user-visible
+      // declaration, never Wayland's own trusted runtime path.
+      const spawnableServers = enabledServers.map((server) => applyBuiltinMcpRuntime(server));
+      const authedServers = await this.attachOAuthTokens(spawnableServers);
 
       // Run MCP sync across all agents concurrently
       const promises = allAgents.map(async (agent) => {

--- a/src/process/services/mcpServices/agents/WCoreMcpAgent.ts
+++ b/src/process/services/mcpServices/agents/WCoreMcpAgent.ts
@@ -10,7 +10,10 @@ import { AbstractMcpAgent } from '../McpProtocol';
 import type { IMcpServer, IMcpServerTransport } from '@/common/config/storage';
 import { ensurePlaywrightChromium } from '../playwrightBrowsers';
 import { BUILTIN_PLAYWRIGHT_ID } from '@process/resources/builtinMcp/constants';
-import { resolvePersistedMcpStdioSpawn } from '@process/services/mcpServices/mcpStdioSpawn';
+import {
+  resolvePersistedMcpStdioSpawn,
+  toRestartSafeBundledRuntimeCommand,
+} from '@process/services/mcpServices/mcpStdioSpawn';
 
 /**
  * wayland-core config.toml transport type (kebab-case)
@@ -87,9 +90,23 @@ function toMcpServer(name: string, config: WCoreServerConfig): IMcpServer {
 }
 
 /**
+ * How long the config.toml being written lives.
+ *
+ * `launchLocal` is the per-launch file `WCoreManager` rewrites on every start,
+ * so an absolute bundled-runtime path in it is always the one this launch
+ * resolved — and keeping it absolute is what makes the wcore launch tuple
+ * byte-identical to the Library probe's. Everything else (the global/profile
+ * config.toml) outlives the launch that wrote it and gets the restart-safe
+ * portable command instead (#1056).
+ */
+export interface WCoreConfigSerializeOptions {
+  launchLocal?: boolean;
+}
+
+/**
  * Convert a wayland IMcpServer to a wayland-core server config entry
  */
-export function toWCoreConfig(server: IMcpServer): WCoreServerConfig {
+export function toWCoreConfig(server: IMcpServer, options: WCoreConfigSerializeOptions = {}): WCoreServerConfig {
   const wcoreType = toWCoreTransportType(server.transport.type);
 
   if (server.transport.type === 'stdio') {
@@ -98,7 +115,7 @@ export function toWCoreConfig(server: IMcpServer): WCoreServerConfig {
     const spawn = resolvePersistedMcpStdioSpawn(server.transport.command, server.transport.args ?? []);
     const config: WCoreServerConfig = {
       transport: wcoreType,
-      command: spawn.command,
+      command: options.launchLocal ? spawn.command : toRestartSafeBundledRuntimeCommand(spawn.command),
       args: spawn.args.length ? spawn.args : undefined,
     };
     if (server.transport.env && Object.keys(server.transport.env).length > 0) {
@@ -127,7 +144,16 @@ export function toWCoreConfig(server: IMcpServer): WCoreServerConfig {
  * wayland-core uses TOML format with [mcp.servers.*] sections
  */
 export class WCoreMcpAgent extends AbstractMcpAgent {
-  constructor(private readonly configPath?: string) {
+  /**
+   * @param configPath  config.toml to write. Omitted = the active profile's.
+   * @param launchLocal True only for a file the caller rewrites on every launch
+   *   (`WCoreManager`'s launch-local config). Defaults to false so any file that
+   *   survives the process gets the restart-safe portable command (#1056).
+   */
+  constructor(
+    private readonly configPath?: string,
+    private readonly launchLocal: boolean = false
+  ) {
     super('wcore');
   }
 
@@ -195,7 +221,7 @@ export class WCoreMcpAgent extends AbstractMcpAgent {
           config.mcp ??= { servers: {} };
           config.mcp.servers ??= {};
           for (const server of mcpServers) {
-            config.mcp.servers[server.name] = toWCoreConfig(server);
+            config.mcp.servers[server.name] = toWCoreConfig(server, { launchLocal: this.launchLocal });
             console.log(`[WCoreMcpAgent] Added MCP server: ${server.name}`);
           }
           return { value: undefined, changed: mcpServers.length > 0 };

--- a/src/process/services/mcpServices/builtinMcpRuntime.ts
+++ b/src/process/services/mcpServices/builtinMcpRuntime.ts
@@ -1,0 +1,174 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * ONE runtime tuple for Wayland's own bundled MCP stdio servers (#1008).
+ *
+ * WHY THIS MODULE EXISTS
+ * ----------------------
+ * Our first-party MCP servers are stored as `{ command: 'node', args: [<script>] }`.
+ * macOS ships no `/usr/bin/node`, so on an end-user Mac that spawn dies with
+ * ENOENT and the servers report "Enabled but exposes 0 tools" forever. The fix is
+ * to run them through a resolved JS runtime (`resolveJsRuntime`): the bundled Bun
+ * in packaged builds, the app binary as Node in dev.
+ *
+ * The dangerous half is WHERE that resolution happens. The Library probe
+ * (`McpProtocol.testStdioConnection`) and every live-session serializer must emit
+ * the SAME tuple. When only the probe was fixed, the probe went green, the health
+ * check saw a non-empty tool list and cleared its flag, and the chat still spawned
+ * bare `node` — a silent, unreportable failure strictly worse than the loud one.
+ * So the resolution lives here, in one function both sides call.
+ *
+ * The tuple is command + args + ENV: the dev runtime is `process.execPath` and is
+ * only a Node runtime while `ELECTRON_RUN_AS_NODE=1` rides along. Dropping the env
+ * half silently boots a second Electron app instead of the MCP server.
+ *
+ * IDENTIFYING OUR OWN SCRIPTS
+ * ---------------------------
+ * Matching on the basename alone would re-point a USER's own server that merely
+ * shares one of our filenames (e.g. `~/tools/builtin-mcp-search-skills.js`) onto
+ * our runtime — a silent substitution on a file the user owns. The core builtins
+ * are seeded with the absolute path `getMcpScriptPath()` produces, so the match is
+ * an EXACT path comparison against that same resolved path. The four sibling
+ * @wayland servers are stored as a bare filename by design (the spawn layer is
+ * what expands them), so those keep the allowlisted-filename match.
+ */
+
+import path from 'node:path';
+import type { IMcpServer } from '@/common/config/storage';
+import { isBuiltinCoreMcpArg, isBuiltinWaylandMcpArg } from '@process/resources/builtinMcp/constants';
+import { getMcpScriptPath } from '@process/utils/mcpScriptDir';
+import { resolveJsRuntime, type ResolvedJsRuntime } from '@process/utils/jsRuntime';
+import { resolveMcpStdioSpawn } from './mcpStdioSpawn';
+
+/** A spawnable stdio tuple. `env` is ADDITIVE runtime env, not the server's own. */
+export interface McpStdioSpawnTuple {
+  command: string;
+  args: string[];
+  /** Extra env the resolved runtime requires. Merge OVER the server's own env. */
+  env: Record<string, string>;
+}
+
+export interface BuiltinMcpRuntimeDeps {
+  resolveRuntime?: () => ResolvedJsRuntime;
+  scriptPath?: (name: string) => string;
+  platform?: NodeJS.Platform;
+}
+
+/**
+ * Exact path equality for "is this our own script?".
+ *
+ * Deliberately equality, never containment: a `startsWith`/prefix test on a
+ * directory is the win32 trap that a sibling PR shipped and had to revert.
+ * `path.normalize` collapses `..`/duplicate separators; Windows paths are
+ * additionally compared case-insensitively because NTFS is case-preserving but
+ * case-insensitive, so the same file legitimately reaches us differently cased.
+ */
+function isSamePath(left: string, right: string, platform: NodeJS.Platform): boolean {
+  const a = path.normalize(left);
+  const b = path.normalize(right);
+  return platform === 'win32' ? a.toLowerCase() === b.toLowerCase() : a === b;
+}
+
+/**
+ * True only when `arg` is the absolute path of one of OUR first-party bundled
+ * core MCP scripts — i.e. it matches an allowlisted filename AND resolves to the
+ * exact path this install would spawn. A user's own server that happens to share
+ * the filename is not ours and must be left alone.
+ */
+export function isOwnBuiltinCoreMcpScript(arg: string | undefined | null, deps: BuiltinMcpRuntimeDeps = {}): boolean {
+  if (!arg || !isBuiltinCoreMcpArg(arg)) return false;
+  const scriptPath = deps.scriptPath ?? getMcpScriptPath;
+  const platform = deps.platform ?? process.platform;
+  // Split on BOTH separators: a Windows-shaped stored path can reach a resolver
+  // running with POSIX semantics under test.
+  const base = arg.split(/[\\/]/).pop();
+  if (!base) return false;
+  return isSamePath(arg, scriptPath(base), platform);
+}
+
+/**
+ * Resolve the runtime tuple for one of Wayland's own bundled MCP servers.
+ * Returns `null` when the transport is NOT ours — callers then fall through to
+ * their normal resolution and must not touch the command.
+ */
+export function resolveBuiltinMcpRuntimeSpawn(
+  command: string,
+  args: readonly string[] = [],
+  deps: BuiltinMcpRuntimeDeps = {}
+): McpStdioSpawnTuple | null {
+  if (command !== 'node') return null;
+  const rawArgs = [...args];
+  const first = rawArgs[0];
+  const scriptPath = deps.scriptPath ?? getMcpScriptPath;
+
+  // Sibling @wayland servers: stored as a BARE filename, expanded here.
+  if (isBuiltinWaylandMcpArg(first)) {
+    const runtime = (deps.resolveRuntime ?? resolveJsRuntime)();
+    return { command: runtime.command, args: [scriptPath(first), ...rawArgs.slice(1)], env: { ...runtime.env } };
+  }
+
+  // First-party core servers: stored as the ABSOLUTE path we seeded, kept as-is.
+  if (isOwnBuiltinCoreMcpScript(first, deps)) {
+    const runtime = (deps.resolveRuntime ?? resolveJsRuntime)();
+    return { command: runtime.command, args: rawArgs, env: { ...runtime.env } };
+  }
+
+  return null;
+}
+
+/**
+ * The single stdio resolution every session-injection serializer uses: our own
+ * builtins get the resolved JS runtime, everything else keeps the existing
+ * `npx`→bundled-Bun rewrite (#827) untouched.
+ */
+export function resolveSessionMcpStdioSpawn(
+  command: string,
+  args: readonly string[] = [],
+  deps: BuiltinMcpRuntimeDeps & { resolveNpx?: () => string } = {}
+): McpStdioSpawnTuple {
+  const builtin = resolveBuiltinMcpRuntimeSpawn(command, args, deps);
+  if (builtin) return builtin;
+  const spawn = deps.resolveNpx
+    ? resolveMcpStdioSpawn(command, args, deps.resolveNpx)
+    : resolveMcpStdioSpawn(command, args);
+  return { ...spawn, env: {} };
+}
+
+/** Merge a server's own env with the additive runtime env (runtime wins). */
+export function mergeMcpSpawnEnv(
+  own: Record<string, string> | undefined,
+  runtime: Record<string, string>
+): Record<string, string> {
+  return { ...own, ...runtime };
+}
+
+/**
+ * Rewrite a stored declaration's stdio transport into the one that must actually
+ * be spawned, for the paths that hand a whole `IMcpServer` to a serializer they
+ * do not own (the agent-CLI publication fan-out, the Codex session config.toml).
+ *
+ * Only OUR builtins are touched. `npx` is deliberately left alone here: the
+ * downstream agents each choose between the absolute (`resolveMcpStdioSpawn`) and
+ * the restart-safe portable (`resolvePersistedMcpStdioSpawn`) form, and
+ * pre-resolving it here would silently take that choice away.
+ */
+export function applyBuiltinMcpRuntime<T extends { transport: IMcpServer['transport'] }>(
+  server: T,
+  deps: BuiltinMcpRuntimeDeps = {}
+): T {
+  const transport = server.transport;
+  if (transport.type !== 'stdio') return server;
+  const builtin = resolveBuiltinMcpRuntimeSpawn(transport.command, transport.args ?? [], deps);
+  if (!builtin) return server;
+  return {
+    ...server,
+    transport: {
+      ...transport,
+      command: builtin.command,
+      args: builtin.args,
+      env: mergeMcpSpawnEnv(transport.env, builtin.env),
+    },
+  };
+}

--- a/src/process/services/mcpServices/builtinMcpRuntime.ts
+++ b/src/process/services/mcpServices/builtinMcpRuntime.ts
@@ -26,18 +26,27 @@
  *
  * IDENTIFYING OUR OWN SCRIPTS
  * ---------------------------
- * Matching on the basename alone would re-point a USER's own server that merely
+ * Matching on a filename alone would re-point a USER's own server that merely
  * shares one of our filenames (e.g. `~/tools/builtin-mcp-search-skills.js`) onto
- * our runtime — a silent substitution on a file the user owns. The core builtins
- * are seeded with the absolute path `getMcpScriptPath()` produces, so the match is
- * an EXACT path comparison against that same resolved path. The four sibling
- * @wayland servers are stored as a bare filename by design (the spawn layer is
- * what expands them), so those keep the allowlisted-filename match.
+ * our runtime — a silent substitution on a file the user owns. Neither branch is
+ * allowed to do that:
+ *
+ *  - The core builtins are seeded with the absolute path `getMcpScriptPath()`
+ *    produces, so the match is an EXACT path comparison against that same
+ *    resolved path.
+ *  - The four sibling @wayland servers are stored as a bare filename by design
+ *    (the spawn layer is what expands them). A bare filename is indistinguishable
+ *    from a user's own relative script by string alone, and expanding it swaps in
+ *    a DIFFERENT FILE — strictly worse than the wrong runtime on the right file.
+ *    So that branch is gated on PROVENANCE: the record's `libraryEntryId` must be
+ *    the catalog entry that ships exactly that filename. The Library install is
+ *    the only writer of the bare-filename form and it always writes the entry id
+ *    alongside, so the pair proves ownership where the filename cannot.
  */
 
 import path from 'node:path';
 import type { IMcpServer } from '@/common/config/storage';
-import { isBuiltinCoreMcpArg, isBuiltinWaylandMcpArg } from '@process/resources/builtinMcp/constants';
+import { isBuiltinCoreMcpArg, isOwnBuiltinWaylandMcpScript } from '@process/resources/builtinMcp/constants';
 import { getMcpScriptPath } from '@process/utils/mcpScriptDir';
 import { resolveJsRuntime, type ResolvedJsRuntime } from '@process/utils/jsRuntime';
 import { resolveMcpStdioSpawn } from './mcpStdioSpawn';
@@ -54,6 +63,14 @@ export interface BuiltinMcpRuntimeDeps {
   resolveRuntime?: () => ResolvedJsRuntime;
   scriptPath?: (name: string) => string;
   platform?: NodeJS.Platform;
+  /**
+   * `IMcpServer.libraryEntryId` of the record being resolved — the catalog
+   * provenance that authorizes expanding the bare-filename @wayland form.
+   * Absent (a hand-added server, or a transport reached without its record) means
+   * "not provably ours", so that branch is refused. NOT consulted by the
+   * absolute-path core-builtin branch, which proves ownership from the path.
+   */
+  libraryEntryId?: string;
 }
 
 /**
@@ -103,8 +120,11 @@ export function resolveBuiltinMcpRuntimeSpawn(
   const first = rawArgs[0];
   const scriptPath = deps.scriptPath ?? getMcpScriptPath;
 
-  // Sibling @wayland servers: stored as a BARE filename, expanded here.
-  if (isBuiltinWaylandMcpArg(first)) {
+  // Sibling @wayland servers: stored as a BARE filename, expanded here — but
+  // ONLY when the record's catalog provenance says the filename is ours. Without
+  // that, a user's own relative script named `builtin-mcp-apple.mjs` would have
+  // its args[0] REPLACED by Wayland's script and we would run a different file.
+  if (isOwnBuiltinWaylandMcpScript(deps.libraryEntryId, first)) {
     const runtime = (deps.resolveRuntime ?? resolveJsRuntime)();
     return { command: runtime.command, args: [scriptPath(first), ...rawArgs.slice(1)], env: { ...runtime.env } };
   }
@@ -154,13 +174,17 @@ export function mergeMcpSpawnEnv(
  * the restart-safe portable (`resolvePersistedMcpStdioSpawn`) form, and
  * pre-resolving it here would silently take that choice away.
  */
-export function applyBuiltinMcpRuntime<T extends { transport: IMcpServer['transport'] }>(
-  server: T,
-  deps: BuiltinMcpRuntimeDeps = {}
-): T {
+export function applyBuiltinMcpRuntime<
+  T extends { transport: IMcpServer['transport']; libraryEntryId?: IMcpServer['libraryEntryId'] },
+>(server: T, deps: BuiltinMcpRuntimeDeps = {}): T {
   const transport = server.transport;
   if (transport.type !== 'stdio') return server;
-  const builtin = resolveBuiltinMcpRuntimeSpawn(transport.command, transport.args ?? [], deps);
+  // The record carries its own provenance; an explicit dep still wins so tests
+  // and the probe (which is sometimes handed a bare transport) can state it.
+  const builtin = resolveBuiltinMcpRuntimeSpawn(transport.command, transport.args ?? [], {
+    libraryEntryId: server.libraryEntryId,
+    ...deps,
+  });
   if (!builtin) return server;
   return {
     ...server,

--- a/src/process/services/mcpServices/mcpStdioSpawn.ts
+++ b/src/process/services/mcpServices/mcpStdioSpawn.ts
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import path from 'node:path';
 import { resolveNpxPath, normalizeNpxArgsForBundledBun } from '@process/utils/shellEnv';
+import { resolveJsRuntime, type ResolvedJsRuntime } from '@process/utils/jsRuntime';
 
 /**
  * Resolve a stored MCP stdio transport's runtime hint into an actually-spawnable
@@ -63,4 +65,44 @@ export function resolvePersistedMcpStdioSpawn(
     return { command: 'bun', args: resolved.args };
   }
   return resolved;
+}
+
+/**
+ * Collapse an already-resolved BUNDLED-BUN command back to the portable `bun`
+ * that Core finds on PATH, for the config files that outlive the launch which
+ * wrote them (#1056).
+ *
+ * WHY: `applyBuiltinMcpRuntime` rewrites our own builtins onto the absolute
+ * bundled-Bun binary so the Library probe and every live session spawn the SAME
+ * tuple. That absolute path resolves under `process.resourcesPath`, which on a
+ * Linux AppImage is a per-launch squashfs mount point — so persisting it into
+ * the GLOBAL `config.toml` records a command that only exists for the launch
+ * that wrote it, and nothing resyncs that file (every `syncMcpToAgents` caller
+ * is user-action driven). Core is launched with the bundled Bun directory at the
+ * front of PATH, which is exactly why the `npx` case above already persists the
+ * portable form; this gives the bundled-runtime command the same treatment.
+ *
+ * Only the command this install would ITSELF resolve is collapsed, compared by
+ * exact normalized path — a user's own absolute `bun` elsewhere on disk is not
+ * ours to rewrite. Non-bundled runtimes are left alone: the dev runtime is
+ * `process.execPath` (stable, and only a Node runtime while its ENV half rides
+ * along), and `system-node` is already a PATH lookup. Windows retains the
+ * absolute resolution for the same reason the `npx` carve-out does: install
+ * paths there are stable.
+ *
+ * `resolveRuntime` is injectable so the decision is unit-testable without a
+ * bundled Bun on disk.
+ */
+export function toRestartSafeBundledRuntimeCommand(
+  command: string,
+  platform: NodeJS.Platform = process.platform,
+  resolveRuntime: () => ResolvedJsRuntime = resolveJsRuntime
+): string {
+  if (platform === 'win32') return command;
+  // Only an absolute command can be the bundled binary. Cheap pre-filter that
+  // also keeps every bare-hint path (`npx`, `node`, `uvx`) off the resolver.
+  if (!path.isAbsolute(command)) return command;
+  const runtime = resolveRuntime();
+  if (runtime.kind !== 'bundled-bun') return command;
+  return path.normalize(command) === path.normalize(runtime.command) ? 'bun' : command;
 }

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -50,6 +50,7 @@ import type { IMcpServer } from '@/common/config/storage';
 import * as os from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { normalizeMcpServerForSpawn } from '@/common/mcp/normalizeMcpServer';
+import { applyBuiltinMcpRuntime } from '@process/services/mcpServices/builtinMcpRuntime';
 import { isServerActiveForSession, shouldInjectSessionMcpServer } from '@process/agent/acp/mcpSessionConfig';
 import { validateMcpServer } from '@process/services/mcpServices/validateMcpServer';
 import { addMessage, addOrUpdateMessage, nextTickToLocalFinish } from '@process/utils/message';
@@ -735,13 +736,18 @@ ${collectedResponses.join('\n')}`;
       .filter((server) => isServerActiveForSession(server, data.activeMcpServers))
       .map((server) => normalizeMcpServerForSpawn(server, os.homedir()));
     selected.forEach(validateMcpServer);
+    // #1008: after validation, rewrite Wayland's own bundled MCP servers onto the
+    // resolved JS runtime. Codex writes these verbatim into the session's
+    // config.toml [mcp_servers] table, so a bare `node` here is a chat with no
+    // builtin tools on any Mac — while the Library probe reported green.
+    const spawnable = selected.map((server) => applyBuiltinMcpRuntime(server));
 
     // Dynamic import avoids the OAuth module-init cycle documented in
     // McpService. The returned declarations carry current bearer tokens only
     // in memory; the scoped config references an env var, never the secret.
     const { mcpService } = await import('@process/services/mcpServices/McpService');
     return {
-      selectedServers: await mcpService.attachOAuthTokens(selected),
+      selectedServers: await mcpService.attachOAuthTokens(spawnable),
       managedServerNames: allServers.map((server) => server.name),
     };
   }

--- a/src/process/task/GeminiAgentManager.ts
+++ b/src/process/task/GeminiAgentManager.ts
@@ -88,9 +88,12 @@ export type UiMcpServerConfig = {
  */
 export function buildGeminiStdioMcpConfig(
   transport: Extract<IMcpServer['transport'], { type: 'stdio' }>,
-  description?: string
+  description?: string,
+  libraryEntryId?: string
 ): UiMcpServerConfig {
-  const { command, args, env } = resolveSessionMcpStdioSpawn(transport.command, transport.args || []);
+  const { command, args, env } = resolveSessionMcpStdioSpawn(transport.command, transport.args || [], {
+    libraryEntryId,
+  });
   return { command, args, env: mergeMcpSpawnEnv(transport.env, env), description };
 }
 
@@ -617,7 +620,11 @@ export class GeminiAgentManager extends BaseAgentManager<
 
       selectedServers.forEach((server: IMcpServer) => {
         if (server.transport.type === 'stdio') {
-          mcpConfig[server.name] = buildGeminiStdioMcpConfig(server.transport, server.description);
+          mcpConfig[server.name] = buildGeminiStdioMcpConfig(
+            server.transport,
+            server.description,
+            server.libraryEntryId
+          );
         } else if (
           server.transport.type === 'sse' ||
           server.transport.type === 'http' ||

--- a/src/process/task/GeminiAgentManager.ts
+++ b/src/process/task/GeminiAgentManager.ts
@@ -40,7 +40,7 @@ import { ConversationTurnCompletionService } from '@process/task/ConversationTur
 import { handlePreviewOpenEvent } from '@process/utils/previewUtils';
 import { getTeamGuideStdioConfig } from '@process/team/mcp/guide/teamGuideSingleton';
 import { isServerActiveForSession, shouldInjectSessionMcpServer } from '@process/agent/acp/mcpSessionConfig';
-import { resolveMcpStdioSpawn } from '@process/services/mcpServices/mcpStdioSpawn';
+import { mergeMcpSpawnEnv, resolveSessionMcpStdioSpawn } from '@process/services/mcpServices/builtinMcpRuntime';
 import BaseAgentManager from './BaseAgentManager';
 import { IpcAgentEventEmitter } from './IpcAgentEventEmitter';
 import { mainLog, mainWarn, mainError } from '@process/utils/mainLogger';
@@ -90,8 +90,8 @@ export function buildGeminiStdioMcpConfig(
   transport: Extract<IMcpServer['transport'], { type: 'stdio' }>,
   description?: string
 ): UiMcpServerConfig {
-  const { command, args } = resolveMcpStdioSpawn(transport.command, transport.args || []);
-  return { command, args, env: transport.env || {}, description };
+  const { command, args, env } = resolveSessionMcpStdioSpawn(transport.command, transport.args || []);
+  return { command, args, env: mergeMcpSpawnEnv(transport.env, env), description };
 }
 
 const sortedRecord = (value?: Record<string, string>): Array<[string, string]> =>

--- a/src/process/task/WCoreManager.ts
+++ b/src/process/task/WCoreManager.ts
@@ -629,7 +629,7 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
           // receipt-bound ToolSearch candidate gate scopes over this launch.
           this.sessionMcpServers = authedServers;
           this.beginMcpSession(expectedSessionMcpServers);
-          const publication = await new WCoreMcpAgent(join(launchWaylandHome!, 'config.toml')).installMcpServers(
+          const publication = await new WCoreMcpAgent(join(launchWaylandHome!, 'config.toml'), true).installMcpServers(
             authedServers
           );
           if (publication.success) {

--- a/src/process/task/WCoreManager.ts
+++ b/src/process/task/WCoreManager.ts
@@ -19,6 +19,7 @@ import { buildWCoreSessionMcpServers } from '@process/agent/acp/mcpSessionConfig
 import { WCoreMcpAgent } from '@process/services/mcpServices/agents/WCoreMcpAgent';
 import { mcpService } from '@process/services/mcpServices/McpService';
 import { normalizeMcpServerForSpawn } from '@/common/mcp/normalizeMcpServer';
+import { applyBuiltinMcpRuntime } from '@process/services/mcpServices/builtinMcpRuntime';
 import { validateMcpServer } from '@process/services/mcpServices/validateMcpServer';
 import { getCandidateTools } from '@process/services/mcpServices/getCandidateTools';
 import type { CandidateTool } from '@process/services/tools/toolContract';
@@ -602,7 +603,23 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
           );
           this.beginMcpSession(expectedSessionMcpServers);
           for (const server of normalizedServers) validateMcpServer(server);
-          const authedServers = await mcpService.attachOAuthTokens(normalizedServers);
+          // #1015 F1: this launch-local config.toml is the ONLY thing the wcore
+          // chat loads its connectors from, and it is NOT one of the
+          // `McpService.syncMcpToAgents` targets — so the shared builtin-runtime
+          // rewrite has to be applied here too. Without it the four bundled
+          // @wayland servers (Apple/IMAP/News/Cal.com — `builtin` is not set on
+          // them, so `buildWCoreSessionMcpServers` does select them) reached Core
+          // as `node` + a bare relative filename: ENOENT on a stock macOS, and
+          // MODULE_NOT_FOUND against Core's cwd where a system node exists, while
+          // the Library probe and every ACP serializer emitted resolved Bun plus
+          // an absolute path for the SAME record. Applied AFTER validateMcpServer
+          // for the same reason McpService does: validation grades the
+          // user-visible declaration, never Wayland's own trusted runtime path.
+          // The absolute path is safe to publish HERE (unlike the global
+          // config.toml `WCoreMcpAgent` deliberately keeps portable for Linux
+          // AppImage) because this file is rewritten on every launch.
+          const spawnableServers = normalizedServers.map((server) => applyBuiltinMcpRuntime(server));
+          const authedServers = await mcpService.attachOAuthTokens(spawnableServers);
           // OAuth refresh can change the exact launch definition. Rebind before
           // publication so a receipt can only correlate to what Core received.
           expectedSessionMcpServers = authedServers.map((server) =>

--- a/tests/unit/acpBuiltinMcp.test.ts
+++ b/tests/unit/acpBuiltinMcp.test.ts
@@ -8,8 +8,27 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IMcpServer } from '../../src/common/config/storage';
+import type { ResolvedJsRuntime } from '../../src/process/utils/jsRuntime';
 import { buildAcpSessionMcpServers } from '../../src/process/agent/acp/mcpSessionConfig';
+import { getMcpScriptPath } from '../../src/process/utils/mcpScriptDir';
 import { parseAgentCapabilities } from '../../src/common/types/acpTypes';
+
+// #1008/#1015: Wayland's OWN bundled MCP servers are stored as bare `node`, which
+// does not exist on a stock macOS. The session must spawn them through the same
+// resolved JS runtime the Library probe uses, carrying the runtime env — pinned to
+// a fixed runtime here so the assertion is deterministic on every CI shard.
+const RESOLVED_RUNTIME = '/Applications/Wayland.app/Contents/Resources/bundled-bun/darwin-arm64/bun';
+const runtimeMock = vi.hoisted(() => ({ resolveJsRuntime: vi.fn<() => ResolvedJsRuntime>() }));
+vi.mock('@process/utils/jsRuntime', () => ({ resolveJsRuntime: runtimeMock.resolveJsRuntime }));
+runtimeMock.resolveJsRuntime.mockImplementation(() => ({
+  command: RESOLVED_RUNTIME,
+  env: {},
+  kind: 'bundled-bun',
+}));
+
+/** The exact absolute path `initStorage.ensureBuiltinMcpServers` seeds. */
+const searchSkillsScript = getMcpScriptPath('builtin-mcp-search-skills.js');
+const imageGenScript = getMcpScriptPath('builtin-mcp-image-gen.js');
 
 // #827: the standalone probe and every live session resolve a bare `npx` hint
 // through Wayland's bundled Bun on every platform. Keeping raw npx on macOS or
@@ -34,7 +53,7 @@ describe('ACP built-in MCP session config - wayland_search_skills (C1)', () => {
         transport: {
           type: 'stdio',
           command: 'node',
-          args: ['/abs/builtin-mcp-search-skills.js'],
+          args: [searchSkillsScript],
           env: {},
         },
         createdAt: 1,
@@ -45,12 +64,14 @@ describe('ACP built-in MCP session config - wayland_search_skills (C1)', () => {
 
     const result = buildAcpSessionMcpServers(servers, { stdio: true, http: false, sse: false });
 
+    // Bare `node` here is the #1015 defect: the probe went green while the chat
+    // spawned a runtime that does not exist on a stock macOS.
     expect(result).toEqual([
       {
         type: 'stdio',
         name: 'wayland-search-skills',
-        command: 'node',
-        args: ['/abs/builtin-mcp-search-skills.js'],
+        command: RESOLVED_RUNTIME,
+        args: [searchSkillsScript],
         env: [],
       },
     ]);
@@ -66,7 +87,7 @@ describe('ACP built-in MCP session config - wayland_search_skills (C1)', () => {
         transport: {
           type: 'stdio',
           command: 'node',
-          args: ['/abs/builtin-mcp-search-skills.js'],
+          args: [searchSkillsScript],
           env: {},
         },
         createdAt: 1,
@@ -92,7 +113,7 @@ describe('ACP built-in MCP session config', () => {
         transport: {
           type: 'stdio',
           command: 'node',
-          args: ['/abs/builtin-mcp-image-gen.js'],
+          args: [imageGenScript],
           env: {
             WAYLAND_IMG_PLATFORM: 'openai',
             WAYLAND_IMG_MODEL: 'gpt-image-1',
@@ -171,8 +192,8 @@ describe('ACP built-in MCP session config', () => {
       {
         type: 'stdio',
         name: 'wayland-image-generation',
-        command: 'node',
-        args: ['/abs/builtin-mcp-image-gen.js'],
+        command: RESOLVED_RUNTIME,
+        args: [imageGenScript],
         env: [
           { name: 'WAYLAND_IMG_PLATFORM', value: 'openai' },
           { name: 'WAYLAND_IMG_MODEL', value: 'gpt-image-1' },

--- a/tests/unit/claudeMcpAgent.test.ts
+++ b/tests/unit/claudeMcpAgent.test.ts
@@ -6,14 +6,30 @@
  * Modified by Ferrox Labs in 2026. Changes are documented in the project history.
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { IMcpServer } from '../../src/common/config/storage';
+import type { ResolvedJsRuntime } from '../../src/process/utils/jsRuntime';
 import {
   buildClaudeStdioJsonConfig,
   isClaudeMcpAbsentDetail,
   isClaudeMcpNameTakenDetail,
 } from '../../src/process/services/mcpServices/agents/ClaudeMcpAgent';
+import { applyBuiltinMcpRuntime } from '../../src/process/services/mcpServices/builtinMcpRuntime';
+import { getMcpScriptPath } from '../../src/process/utils/mcpScriptDir';
 import { execErrorDetail } from '../../src/process/utils/safeExec';
+
+// #1008/#1015: `McpService.syncMcpToAgents` rewrites Wayland's OWN bundled MCP
+// servers onto the resolved JS runtime before any agent serializes them, because
+// a stock macOS has no `node`. Pinned to a fixed runtime so the assertion is
+// deterministic on every CI shard.
+const RESOLVED_RUNTIME = '/Applications/Wayland.app/Contents/Resources/bundled-bun/darwin-arm64/bun';
+const runtimeMock = vi.hoisted(() => ({ resolveJsRuntime: vi.fn<() => ResolvedJsRuntime>() }));
+vi.mock('@process/utils/jsRuntime', () => ({ resolveJsRuntime: runtimeMock.resolveJsRuntime }));
+runtimeMock.resolveJsRuntime.mockImplementation(() => ({
+  command: RESOLVED_RUNTIME,
+  env: { ELECTRON_RUN_AS_NODE: '1' },
+  kind: 'electron-node',
+}));
 
 /**
  * Rejection shape `safeExecFile` produces on a non-zero exit: a fixed message,
@@ -22,33 +38,63 @@ import { execErrorDetail } from '../../src/process/utils/safeExec';
 const execFailure = (stderr: string, code = 1): Error =>
   Object.assign(new Error(`Command failed with exit code ${code}`), { stdout: '', stderr, code });
 
-describe('ClaudeMcpAgent helpers', () => {
-  it('builds stdio MCP JSON config including env vars', () => {
-    const server: IMcpServer = {
-      id: 'builtin-image-gen',
-      name: 'wayland-image-generation',
-      enabled: true,
-      transport: {
-        type: 'stdio',
-        command: 'node',
-        args: ['/abs/builtin-mcp-image-gen.js'],
-        env: {
-          WAYLAND_IMG_PLATFORM: 'openai',
-          WAYLAND_IMG_MODEL: 'gpt-image-1',
-        },
-      },
-      createdAt: 1,
-      updatedAt: 1,
-      originalJson: '{}',
-    };
+const imageGenScript = getMcpScriptPath('builtin-mcp-image-gen.js');
 
-    expect(JSON.parse(buildClaudeStdioJsonConfig(server))).toEqual({
-      command: 'node',
-      args: ['/abs/builtin-mcp-image-gen.js'],
+const builtinImageGenServer = (): IMcpServer => ({
+  id: 'builtin-image-gen',
+  name: 'wayland-image-generation',
+  enabled: true,
+  transport: {
+    type: 'stdio',
+    command: 'node',
+    args: [imageGenScript],
+    env: {
+      WAYLAND_IMG_PLATFORM: 'openai',
+      WAYLAND_IMG_MODEL: 'gpt-image-1',
+    },
+  },
+  createdAt: 1,
+  updatedAt: 1,
+  originalJson: '{}',
+});
+
+describe('ClaudeMcpAgent helpers', () => {
+  it('publishes the builtin under the resolved JS runtime, never bare node', () => {
+    // The exact shape `claude mcp add-json` receives for a Wayland builtin. Bare
+    // `node` here is the #1015 defect: `claude` would spawn a runtime a stock
+    // macOS does not have, while the Library probe reported the server green.
+    // The ELECTRON_RUN_AS_NODE half is load-bearing — without it the dev runtime
+    // boots a second Electron app instead of the MCP server.
+    expect(JSON.parse(buildClaudeStdioJsonConfig(applyBuiltinMcpRuntime(builtinImageGenServer())))).toEqual({
+      command: RESOLVED_RUNTIME,
+      args: [imageGenScript],
       env: {
         WAYLAND_IMG_PLATFORM: 'openai',
         WAYLAND_IMG_MODEL: 'gpt-image-1',
+        ELECTRON_RUN_AS_NODE: '1',
       },
+    });
+  });
+
+  it('forwards a user-owned stdio server verbatim, including env vars', () => {
+    const server: IMcpServer = {
+      ...builtinImageGenServer(),
+      id: 'user-owned',
+      name: 'my-tool',
+      transport: {
+        type: 'stdio',
+        command: 'node',
+        // Shares our basename but is the USER's own file: must never be
+        // re-pointed onto Wayland's runtime (#1015 F2).
+        args: ['/Users/me/tools/builtin-mcp-image-gen.js'],
+        env: { WAYLAND_IMG_PLATFORM: 'openai' },
+      },
+    };
+
+    expect(JSON.parse(buildClaudeStdioJsonConfig(applyBuiltinMcpRuntime(server)))).toEqual({
+      command: 'node',
+      args: ['/Users/me/tools/builtin-mcp-image-gen.js'],
+      env: { WAYLAND_IMG_PLATFORM: 'openai' },
     });
   });
 });

--- a/tests/unit/mcpAsarUnpack.test.ts
+++ b/tests/unit/mcpAsarUnpack.test.ts
@@ -23,6 +23,32 @@ function getAsarUnpackEntries(): string[] {
   return matches.map((m) => m[1]);
 }
 
+/**
+ * Every npm package an MCP build marks esbuild-`external:` beyond the two
+ * SHARED_OPTIONS defaults (`electron`, `bun:sqlite`, neither of which is an
+ * unpackable node_modules dependency at runtime).
+ */
+function getExternalNpmDeps(): string[] {
+  const script = fs.readFileSync(path.join(ROOT, 'scripts/build-mcp-servers.js'), 'utf-8');
+  const matches = [...script.matchAll(/external:\s*\[([^\]]*)\]/g)];
+  const names = new Set<string>();
+  for (const m of matches) {
+    for (const raw of m[1].split(',')) {
+      const name = raw.trim().replace(/^['"]|['"]$/g, '');
+      if (!name || name.startsWith('...') || name === 'electron' || name.startsWith('bun:')) continue;
+      names.add(name);
+    }
+  }
+  return [...names];
+}
+
+/** asarUnpack entries of the `**\/node_modules/<pkg>/**\/*` shape. */
+function getAsarUnpackNodeModules(): string[] {
+  const yml = fs.readFileSync(path.join(ROOT, 'electron-builder.yml'), 'utf-8');
+  const matches = [...yml.matchAll(/-\s*'\*\*\/node_modules\/([^/']+)\/\*\*\/\*'/g)];
+  return matches.map((m) => m[1]);
+}
+
 describe('MCP asar unpack consistency', () => {
   it('every MCP build output must be listed in electron-builder.yml asarUnpack', () => {
     const buildOutputs = getBuildOutputFiles();
@@ -38,5 +64,30 @@ describe('MCP asar unpack consistency', () => {
           `\n\nAdd them to electron-builder.yml asarUnpack section.`
       );
     }
+  });
+
+  /**
+   * #1019: the concierge-diag MCP is bundled with `better-sqlite3` marked
+   * esbuild-`external:`, so the standalone stdio process `require()`s it at
+   * runtime — and a native module cannot be loaded from inside the asar. Deleting
+   * the `**\/node_modules/better-sqlite3/**\/*` asarUnpack line therefore arms a
+   * panic in a subprocess whose only user-visible symptom is "0 tools", pointing
+   * the next investigation at the MCP runtime layer instead of at packaging.
+   * Nothing asserted this: `conciergeDiagBundle.test.ts` pins the `external:`
+   * marking, which is the OTHER half of the same contract.
+   *
+   * Derived from the build script rather than hardcoded, so a future external
+   * native dep is covered the day it is added.
+   */
+  it('every npm package an MCP build marks external must be asarUnpacked', () => {
+    const externals = getExternalNpmDeps();
+    const unpacked = getAsarUnpackNodeModules();
+
+    // Confirms the method finds a KNOWN POSITIVE before any zero is believed.
+    expect(externals).toContain('better-sqlite3');
+    expect(unpacked.length).toBeGreaterThan(0);
+
+    const missing = externals.filter((dep) => !unpacked.includes(dep));
+    expect(missing).toEqual([]);
   });
 });

--- a/tests/unit/process/mcp/builtinMcpPublicationRuntime.test.ts
+++ b/tests/unit/process/mcp/builtinMcpPublicationRuntime.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #1015 F1 — the agent-CLI publication fan-out.
+ *
+ * `McpService.syncMcpToAgents` is the single chokepoint through which every
+ * agent-CLI MCP serializer (Claude, Codex, Gemini, Qwen, Codebuddy, OpenCode,
+ * Wayland Core, Wayland) receives a stored declaration. A bare `node` published
+ * there is a chat with no builtin tools on any stock Mac — while the Library
+ * probe, which spawns the resolved runtime, reports green.
+ *
+ * This drives the REAL service and asserts what the agents actually received.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IMcpServer } from '@/common/config/storage';
+import type { ResolvedJsRuntime } from '@process/utils/jsRuntime';
+import { getMcpScriptPath } from '@process/utils/mcpScriptDir';
+
+const PACKAGED_BUN = '/Applications/Wayland.app/Contents/Resources/bundled-bun/darwin-arm64/bun';
+
+const mocks = vi.hoisted(() => ({ resolveJsRuntime: vi.fn<() => ResolvedJsRuntime>() }));
+vi.mock('@process/utils/jsRuntime', () => ({ resolveJsRuntime: mocks.resolveJsRuntime }));
+
+const SCRIPT = getMcpScriptPath('builtin-mcp-image-gen.js');
+
+const builtin = (): IMcpServer => ({
+  id: 'builtin-image-gen',
+  name: 'wayland-image-generation',
+  enabled: true,
+  builtin: true,
+  transport: {
+    type: 'stdio',
+    command: 'node',
+    args: [SCRIPT],
+    env: { WAYLAND_IMG_PLATFORM: 'openai' },
+  },
+  createdAt: 1,
+  updatedAt: 1,
+  originalJson: '{}',
+});
+
+describe('McpService.syncMcpToAgents publishes the resolved runtime, not bare node', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.resolveJsRuntime.mockImplementation(() => ({ command: PACKAGED_BUN, env: {}, kind: 'bundled-bun' }));
+  });
+
+  it('hands every publication target the resolved command', async () => {
+    const received: IMcpServer[][] = [];
+    const agentClass = () =>
+      class {
+        installMcpServers = vi.fn(async (servers: IMcpServer[]) => {
+          received.push(servers);
+          return { success: true };
+        });
+        detectMcpServers = vi.fn(async () => []);
+      };
+    for (const mod of [
+      'ClaudeMcpAgent',
+      'CodebuddyMcpAgent',
+      'QwenMcpAgent',
+      'CodexMcpAgent',
+      'WCoreMcpAgent',
+      'GeminiMcpAgent',
+      'WaylandMcpAgent',
+      'OpencodeMcpAgent',
+    ]) {
+      vi.doMock(`@process/services/mcpServices/agents/${mod}`, () => ({ [mod]: agentClass() }));
+    }
+    vi.doMock('child_process', () => ({
+      execSync: vi.fn(() => {
+        throw new Error('gemini not installed');
+      }),
+    }));
+
+    const { McpService } = await import('@process/services/mcpServices/McpService');
+    const service = new McpService();
+    const result = await service.syncMcpToAgents(
+      [builtin()],
+      [{ backend: 'claude', name: 'Claude Code', cliPath: 'claude' }]
+    );
+
+    expect(result.success).toBe(true);
+    expect(received).toHaveLength(1);
+    expect(received[0][0].transport).toEqual({
+      type: 'stdio',
+      command: PACKAGED_BUN,
+      args: [SCRIPT],
+      env: { WAYLAND_IMG_PLATFORM: 'openai' },
+    });
+  });
+});

--- a/tests/unit/process/mcp/builtinMcpSessionRuntime.test.ts
+++ b/tests/unit/process/mcp/builtinMcpSessionRuntime.test.ts
@@ -1,0 +1,158 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #1015 F1 — the LIVE-SESSION proof.
+ *
+ * The probe was fixed to spawn Wayland's own bundled MCP servers under a resolved
+ * JS runtime; the serializers that build the real chat session were not. That is
+ * strictly worse than the bug it replaced: `refreshServerStatuses` persists the
+ * probe's tool list, `readMcpHealth` clears its `toolCount === 0` flag, the MCP
+ * Library and concierge-diag both go green — and the chat still spawns a bare
+ * `node` that does not exist on a stock macOS, with nothing left to report it.
+ *
+ * So every live-session serializer is driven here against the SAME builtin, in
+ * BOTH resolution shapes, asserting command AND env. The env half is load-bearing:
+ * the dev runtime is the app binary and is only a Node runtime while
+ * ELECTRON_RUN_AS_NODE=1 rides along.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IMcpServer } from '@/common/config/storage';
+import type { ResolvedJsRuntime } from '@process/utils/jsRuntime';
+
+const PACKAGED_BUN = '/Applications/Wayland.app/Contents/Resources/bundled-bun/darwin-arm64/bun';
+const DEV_ELECTRON = '/repo/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron';
+
+const mocks = vi.hoisted(() => ({ resolveJsRuntime: vi.fn<() => ResolvedJsRuntime>() }));
+
+vi.mock('@process/utils/jsRuntime', () => ({ resolveJsRuntime: mocks.resolveJsRuntime }));
+
+const packaged = (): ResolvedJsRuntime => ({ command: PACKAGED_BUN, env: {}, kind: 'bundled-bun' });
+const dev = (): ResolvedJsRuntime => ({
+  command: DEV_ELECTRON,
+  env: { ELECTRON_RUN_AS_NODE: '1' },
+  kind: 'electron-node',
+});
+
+import { getMcpScriptPath } from '@process/utils/mcpScriptDir';
+import { buildAcpSessionMcpServers } from '@process/agent/acp/mcpSessionConfig';
+import { McpConfig } from '@process/acp/session/McpConfig';
+import { buildGeminiStdioMcpConfig } from '@process/task/GeminiAgentManager';
+import { applyBuiltinMcpRuntime } from '@process/services/mcpServices/builtinMcpRuntime';
+import { buildClaudeStdioJsonConfig } from '@process/services/mcpServices/agents/ClaudeMcpAgent';
+import { buildCodexMcpServerTable } from '@process/task/codexConfig';
+
+/** The exact absolute path `initStorage.ensureBuiltinMcpServers` seeds. */
+const SCRIPT = getMcpScriptPath('builtin-mcp-search-skills.js');
+
+const builtinServer = (): IMcpServer => ({
+  id: 'builtin-search-skills',
+  name: 'wayland-search-skills',
+  enabled: true,
+  builtin: true,
+  status: 'connected',
+  transport: { type: 'stdio', command: 'node', args: [SCRIPT], env: {} },
+  createdAt: 1,
+  updatedAt: 1,
+  originalJson: '{}',
+});
+
+const publication = {
+  generation: 1,
+  conversationId: 'conv-1',
+  backend: 'claude' as const,
+  sessionKey: 'session-1',
+};
+
+describe.each([
+  ['packaged (bundled Bun)', packaged, PACKAGED_BUN, [] as Array<{ name: string; value: string }>],
+  ['dev (Electron as Node)', dev, DEV_ELECTRON, [{ name: 'ELECTRON_RUN_AS_NODE', value: '1' }]],
+])('live-session serializers — %s', (_label, runtime, expectedCommand, expectedEnvPairs) => {
+  beforeEach(() => {
+    mocks.resolveJsRuntime.mockReset();
+    mocks.resolveJsRuntime.mockImplementation(runtime);
+  });
+
+  it('buildAcpSessionMcpServers (ACP session/new: Claude, Codex, Wayland Core)', () => {
+    const [emitted] = buildAcpSessionMcpServers([builtinServer()], { stdio: true, http: false, sse: false });
+    expect(emitted).toEqual({
+      type: 'stdio',
+      name: 'wayland-search-skills',
+      command: expectedCommand,
+      args: [SCRIPT],
+      env: expectedEnvPairs,
+    });
+    expect(emitted).not.toMatchObject({ command: 'node' });
+  });
+
+  it('McpConfig.fromStorageConfig (live Claude/Codex ACP projection)', () => {
+    const [emitted] = McpConfig.fromStorageConfig([builtinServer()], { publication });
+    expect(emitted).toEqual({
+      name: 'wayland-search-skills',
+      command: expectedCommand,
+      args: [SCRIPT],
+      env: expectedEnvPairs,
+    });
+  });
+
+  it('buildGeminiStdioMcpConfig (in-process aioncli-core fork runtime)', () => {
+    const emitted = buildGeminiStdioMcpConfig(
+      builtinServer().transport as Extract<IMcpServer['transport'], { type: 'stdio' }>
+    );
+    expect(emitted.command).toBe(expectedCommand);
+    expect(emitted.args).toEqual([SCRIPT]);
+    expect(emitted.env).toEqual(Object.fromEntries(expectedEnvPairs.map((e) => [e.name, e.value])));
+  });
+
+  it('agent-CLI publication chokepoint feeds the resolved tuple to ClaudeMcpAgent', () => {
+    // McpService.syncMcpToAgents applies applyBuiltinMcpRuntime before any agent
+    // serializes, so all eight publication targets inherit the correct runtime.
+    const published = JSON.parse(buildClaudeStdioJsonConfig(applyBuiltinMcpRuntime(builtinServer())));
+    expect(published).toEqual({
+      command: expectedCommand,
+      args: [SCRIPT],
+      env: Object.fromEntries(expectedEnvPairs.map((e) => [e.name, e.value])),
+    });
+  });
+
+  it('Codex session config.toml table carries the resolved tuple', () => {
+    // AcpAgentManager.loadCodexSessionMcpServers applies the same rewrite before
+    // buildCodexMcpServerTable writes the session's [mcp_servers] table.
+    const table = buildCodexMcpServerTable([applyBuiltinMcpRuntime(builtinServer())]);
+    const entry = table['wayland-search-skills'];
+    expect(entry.command).toBe(expectedCommand);
+    expect(entry.args).toEqual([SCRIPT]);
+    if (expectedEnvPairs.length > 0) {
+      expect(entry.env).toEqual({ ELECTRON_RUN_AS_NODE: '1' });
+    }
+  });
+});
+
+describe('a user-owned server sharing our basename is never re-pointed (#1015 F2)', () => {
+  beforeEach(() => {
+    mocks.resolveJsRuntime.mockReset();
+    mocks.resolveJsRuntime.mockImplementation(packaged);
+  });
+
+  const hijackCandidate = (): IMcpServer => ({
+    ...builtinServer(),
+    id: 'user-owned',
+    name: 'my-skills',
+    builtin: false,
+    transport: { type: 'stdio', command: 'node', args: ['/Users/me/tools/builtin-mcp-search-skills.js'], env: {} },
+  });
+
+  it('reaches the session spawning exactly what the user configured', () => {
+    const [emitted] = buildAcpSessionMcpServers([hijackCandidate()], { stdio: true, http: false, sse: false });
+    expect(emitted).toEqual({
+      type: 'stdio',
+      name: 'my-skills',
+      command: 'node',
+      args: ['/Users/me/tools/builtin-mcp-search-skills.js'],
+      env: [],
+    });
+    expect(mocks.resolveJsRuntime).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/process/resources/builtinMcp/builtinMcpConstants.test.ts
+++ b/tests/unit/process/resources/builtinMcp/builtinMcpConstants.test.ts
@@ -6,9 +6,11 @@
 
 import { describe, expect, it } from 'vitest';
 import {
+  BUILTIN_CORE_MCP_FILES,
   BUILTIN_SEARCH_SKILLS_ID,
   BUILTIN_SEARCH_SKILLS_NAME,
   BUILTIN_SEARCH_SKILLS_TOOL_NAME,
+  isBuiltinCoreMcpArg,
   isBuiltinSearchSkillsName,
   isBuiltinSearchSkillsTransport,
 } from '@process/resources/builtinMcp/constants';
@@ -79,5 +81,53 @@ describe('builtinMcp/constants - search-skills', () => {
       expect(isBuiltinSearchSkillsTransport({ type: 'stdio', command: 'node', args: null })).toBe(false);
       expect(isBuiltinSearchSkillsTransport(undefined)).toBe(false);
     });
+  });
+});
+
+// #1008: the first-party core builtins are stored with an ABSOLUTE path, so the
+// spawn layer has to match them on the basename. Matching only the bare
+// filename (as the four sibling @wayland servers do) missed them entirely and
+// left them spawning bare `node`.
+describe('builtinMcp/constants - isBuiltinCoreMcpArg (#1008)', () => {
+  it('covers every first-party bundled stdio server seeded into mcp.config', () => {
+    expect([...BUILTIN_CORE_MCP_FILES]).toEqual([
+      'builtin-mcp-image-gen.js',
+      'builtin-mcp-search-skills.js',
+      'builtin-mcp-concierge-diag.js',
+    ]);
+  });
+
+  it('matches an absolute POSIX path to a bundled core server', () => {
+    expect(
+      isBuiltinCoreMcpArg(
+        '/Applications/Wayland.app/Contents/Resources/app.asar.unpacked/out/main/builtin-mcp-search-skills.js'
+      )
+    ).toBe(true);
+    expect(isBuiltinCoreMcpArg('/repo/app/out/main/builtin-mcp-concierge-diag.js')).toBe(true);
+    expect(isBuiltinCoreMcpArg('/repo/app/out/main/builtin-mcp-image-gen.js')).toBe(true);
+  });
+
+  it('matches an absolute Windows path to a bundled core server', () => {
+    expect(
+      isBuiltinCoreMcpArg(
+        String.raw`C:\Program Files\Wayland\resources\app.asar.unpacked\out\main\builtin-mcp-search-skills.js`
+      )
+    ).toBe(true);
+  });
+
+  it('matches a bare filename too', () => {
+    expect(isBuiltinCoreMcpArg('builtin-mcp-search-skills.js')).toBe(true);
+  });
+
+  it('rejects a user-defined server and the sibling @wayland bundles', () => {
+    expect(isBuiltinCoreMcpArg('/Users/me/custom-server.js')).toBe(false);
+    expect(isBuiltinCoreMcpArg('/Users/me/builtin-mcp-search-skills.ts')).toBe(false);
+    expect(isBuiltinCoreMcpArg('builtin-mcp-apple.mjs')).toBe(false);
+  });
+
+  it('handles missing input defensively', () => {
+    expect(isBuiltinCoreMcpArg(undefined)).toBe(false);
+    expect(isBuiltinCoreMcpArg(null)).toBe(false);
+    expect(isBuiltinCoreMcpArg('')).toBe(false);
   });
 });

--- a/tests/unit/process/resources/builtinMcp/builtinMcpConstants.test.ts
+++ b/tests/unit/process/resources/builtinMcp/builtinMcpConstants.test.ts
@@ -119,10 +119,21 @@ describe('builtinMcp/constants - isBuiltinCoreMcpArg (#1008)', () => {
     expect(isBuiltinCoreMcpArg('builtin-mcp-search-skills.js')).toBe(true);
   });
 
-  it('rejects a user-defined server and the sibling @wayland bundles', () => {
+  it('rejects a different filename and the sibling @wayland bundles', () => {
     expect(isBuiltinCoreMcpArg('/Users/me/custom-server.js')).toBe(false);
     expect(isBuiltinCoreMcpArg('/Users/me/builtin-mcp-search-skills.ts')).toBe(false);
     expect(isBuiltinCoreMcpArg('builtin-mcp-apple.mjs')).toBe(false);
+  });
+
+  it("is BASENAME-only and therefore cannot tell our script from the user's (#1015 F2)", () => {
+    // Deliberately asserted TRUE. This predicate is a filename primitive; it has
+    // no way to reach the filesystem (the module is bundled into the standalone
+    // stdio servers and imports nothing). A user's own server that merely shares
+    // our filename matches here, which is exactly why the spawn layer must NOT
+    // stop at this check — `isOwnBuiltinCoreMcpScript` compares against the exact
+    // resolved script path. The earlier negative used a `.ts` extension, so it
+    // could never have caught the hijack it appeared to disprove.
+    expect(isBuiltinCoreMcpArg('/Users/me/tools/builtin-mcp-search-skills.js')).toBe(true);
   });
 
   it('handles missing input defensively', () => {

--- a/tests/unit/process/resources/builtinMcp/conciergeDiagServer.test.ts
+++ b/tests/unit/process/resources/builtinMcp/conciergeDiagServer.test.ts
@@ -240,6 +240,35 @@ describe('createConciergeDiagServer — MCP health (config JSON)', () => {
     expect(disabled?.flag).toBeNull();
   });
 
+  // #1008: a bundled first-party server exposes no command, args or credentials
+  // the user controls, so the generic "check its command, args, or credentials"
+  // advice sent two reporters hunting for a mistake they could not have made.
+  it('#1008 tells a bundled builtin apart from a user-configured server', () => {
+    const configPath = tmp('wayland-config-builtin.txt');
+    fs.writeFileSync(
+      configPath,
+      encodeConfig({
+        'mcp.config': [
+          { id: 'builtin-search-skills', name: 'wayland-search-skills', enabled: true, builtin: true, tools: [] },
+          { id: 'u', name: 'user-server', enabled: true, tools: [] },
+        ],
+      })
+    );
+
+    const server = createConciergeDiagServer({ configPath });
+    const result = server.mcpHealth();
+
+    const builtin = result.items.find((s) => s.name === 'wayland-search-skills');
+    expect(builtin?.flag).toContain('0 tools');
+    expect(builtin?.flag).toContain('bundled with Wayland');
+    // It must NOT send the user off to check settings they do not own.
+    expect(builtin?.flag).not.toContain('credentials');
+
+    const user = result.items.find((s) => s.name === 'user-server');
+    expect(user?.flag).toContain('0 tools');
+    expect(user?.flag).toContain('credentials');
+  });
+
   it('degrades gracefully when the config path is missing', () => {
     const server = createConciergeDiagServer({ configPath: tmp('does-not-exist.txt') });
     const result = server.mcpHealth();

--- a/tests/unit/process/resources/builtinMcp/conciergeDiagServer.test.ts
+++ b/tests/unit/process/resources/builtinMcp/conciergeDiagServer.test.ts
@@ -269,6 +269,53 @@ describe('createConciergeDiagServer — MCP health (config JSON)', () => {
     expect(user?.flag).toContain('credentials');
   });
 
+  // #1015: the four sibling @wayland servers (Apple/IMAP/News/Cal.com) are
+  // installed from the MCP Library and carry NO `builtin` field, so the #1008
+  // gate above dropped them into the user-error branch — advice to "check its
+  // command, args" about a spawn Wayland itself wrote. Their credentials really
+  // are the user's, so they get their own line rather than either of the others.
+  it('#1015 tells a bundled @wayland sibling apart by catalog provenance', () => {
+    const configPath = tmp('wayland-config-wayland-sibling.txt');
+    fs.writeFileSync(
+      configPath,
+      encodeConfig({
+        'mcp.config': [
+          {
+            id: 'lib_apple',
+            name: 'com.wayland-apple-mcp',
+            enabled: true,
+            source: 'library',
+            libraryEntryId: 'com.wayland/apple-mcp',
+            tools: [],
+          },
+          // KNOWN POSITIVE, same run: another Library install that is NOT ours
+          // still gets the generic advice, so the new branch is not swallowing
+          // every catalog server.
+          {
+            id: 'lib_other',
+            name: 'com.vendor-thing-mcp',
+            enabled: true,
+            source: 'library',
+            libraryEntryId: 'com.vendor/thing-mcp',
+            tools: [],
+          },
+        ],
+      })
+    );
+
+    const result = createConciergeDiagServer({ configPath }).mcpHealth();
+
+    const apple = result.items.find((s) => s.name === 'com.wayland-apple-mcp');
+    expect(apple?.flag).toContain('0 tools');
+    expect(apple?.flag).toContain('ships with Wayland');
+    // It must NOT send the user hunting through a command and args we wrote.
+    expect(apple?.flag).not.toContain('check its command, args');
+
+    const other = result.items.find((s) => s.name === 'com.vendor-thing-mcp');
+    expect(other?.flag).toContain('check its command, args');
+    expect(other?.flag).not.toContain('ships with Wayland');
+  });
+
   it('degrades gracefully when the config path is missing', () => {
     const server = createConciergeDiagServer({ configPath: tmp('does-not-exist.txt') });
     const result = server.mcpHealth();

--- a/tests/unit/process/services/mcpProtocol.test.ts
+++ b/tests/unit/process/services/mcpProtocol.test.ts
@@ -55,6 +55,15 @@ vi.mock('@process/services/mcpServices/McpOAuthService', () => ({
 
 import type { McpConnectionTestResult, McpOperationResult } from '@process/services/mcpServices/McpProtocol';
 import type { IMcpServer } from '@/common/config/storage';
+import { getMcpScriptPath } from '@process/utils/mcpScriptDir';
+
+// #1015 F2: the builtin carve-out matches the EXACT path this install would
+// spawn, not just the basename, so a user's own file that happens to share one
+// of our filenames is never re-pointed onto Wayland's runtime. Fixtures must
+// therefore use the real resolved path — an invented one is (correctly) foreign.
+const SEARCH_SKILLS_SCRIPT = getMcpScriptPath('builtin-mcp-search-skills.js');
+const CONCIERGE_DIAG_SCRIPT = getMcpScriptPath('builtin-mcp-concierge-diag.js');
+const IMAGE_GEN_SCRIPT = getMcpScriptPath('builtin-mcp-image-gen.js');
 
 // Create a concrete test subclass to access protected methods
 class TestAgent {
@@ -386,7 +395,7 @@ describe('AbstractMcpAgent', () => {
       const result = await testAgent.testMcpConnection({
         type: 'stdio',
         command: 'node',
-        args: ['/Applications/Wayland.app/Contents/Resources/app.asar.unpacked/out/main/builtin-mcp-search-skills.js'],
+        args: [SEARCH_SKILLS_SCRIPT],
       });
 
       expect(result.success).toBe(true);
@@ -396,9 +405,7 @@ describe('AbstractMcpAgent', () => {
       );
       expect(cfg.command).not.toBe('node');
       // The stored absolute path is spawned unchanged — only the runtime moves.
-      expect(cfg.args).toEqual([
-        '/Applications/Wayland.app/Contents/Resources/app.asar.unpacked/out/main/builtin-mcp-search-skills.js',
-      ]);
+      expect(cfg.args).toEqual([SEARCH_SKILLS_SCRIPT]);
       expect(cfg.env.ELECTRON_RUN_AS_NODE).toBeUndefined();
     });
 
@@ -411,7 +418,7 @@ describe('AbstractMcpAgent', () => {
       const result = await testAgent.testMcpConnection({
         type: 'stdio',
         command: 'node',
-        args: ['/Applications/Wayland.app/Contents/Resources/app.asar.unpacked/out/main/builtin-mcp-concierge-diag.js'],
+        args: [CONCIERGE_DIAG_SCRIPT],
       });
 
       expect(result.success).toBe(true);
@@ -429,14 +436,14 @@ describe('AbstractMcpAgent', () => {
       const result = await testAgent.testMcpConnection({
         type: 'stdio',
         command: 'node',
-        args: ['/repo/app/out/main/builtin-mcp-image-gen.js'],
+        args: [IMAGE_GEN_SCRIPT],
       });
 
       expect(result.success).toBe(true);
       const cfg = vi.mocked(StdioClientTransport).mock.calls[0]![0] as any;
       expect(cfg.command).toBe(process.execPath);
       expect(cfg.env.ELECTRON_RUN_AS_NODE).toBe('1');
-      expect(cfg.args).toEqual(['/repo/app/out/main/builtin-mcp-image-gen.js']);
+      expect(cfg.args).toEqual([IMAGE_GEN_SCRIPT]);
     });
 
     it('does NOT rewrite a user-defined node stdio server (only our bundled builtins)', async () => {
@@ -452,6 +459,24 @@ describe('AbstractMcpAgent', () => {
       const cfg = vi.mocked(StdioClientTransport).mock.calls[0]![0] as any;
       expect(cfg.command).toBe('node');
       expect(cfg.args).toEqual(['/Users/me/custom-server.js']);
+      expect(cfg.env.ELECTRON_RUN_AS_NODE).toBeUndefined();
+    });
+
+    // #1015 F2: same filename, the USER's own directory, the user's own file.
+    // Matching on the basename alone silently re-pointed it onto our runtime.
+    it('does NOT rewrite a user-owned server that merely shares a builtin basename', async () => {
+      await setupClientOk();
+      const { StdioClientTransport } = await setupTransport();
+
+      await testAgent.testMcpConnection({
+        type: 'stdio',
+        command: 'node',
+        args: ['/Users/me/tools/builtin-mcp-search-skills.js'],
+      });
+
+      const cfg = vi.mocked(StdioClientTransport).mock.calls[0]![0] as any;
+      expect(cfg.command).toBe('node');
+      expect(cfg.args).toEqual(['/Users/me/tools/builtin-mcp-search-skills.js']);
       expect(cfg.env.ELECTRON_RUN_AS_NODE).toBeUndefined();
     });
 

--- a/tests/unit/process/services/mcpProtocol.test.ts
+++ b/tests/unit/process/services/mcpProtocol.test.ts
@@ -371,6 +371,74 @@ describe('AbstractMcpAgent', () => {
       expect(cfg.env.ELECTRON_RUN_AS_NODE).toBeUndefined();
     });
 
+    // #1008: the FIRST-PARTY core builtins (search-skills, concierge-diag,
+    // image-gen) are seeded into mcp.config with an ABSOLUTE script path, not
+    // the bare filename the four sibling @wayland servers use. They were
+    // therefore never matched by the builtin carve-out above and kept spawning
+    // bare `node` — which macOS does not ship — so on an end-user Mac they
+    // reported "Enabled but exposes 0 tools" forever.
+    it('#1008 packaged: launches a first-party core builtin under bundled Bun, not bare node', async () => {
+      h.isPackaged = true;
+      h.bundledBunDir = '/res/bundled-bun/darwin-arm64';
+      await setupClientOk();
+      const { StdioClientTransport } = await setupTransport();
+
+      const result = await testAgent.testMcpConnection({
+        type: 'stdio',
+        command: 'node',
+        args: ['/Applications/Wayland.app/Contents/Resources/app.asar.unpacked/out/main/builtin-mcp-search-skills.js'],
+      });
+
+      expect(result.success).toBe(true);
+      const cfg = vi.mocked(StdioClientTransport).mock.calls[0]![0] as any;
+      expect(cfg.command).toBe(
+        path.join('/res/bundled-bun/darwin-arm64', process.platform === 'win32' ? 'bun.exe' : 'bun')
+      );
+      expect(cfg.command).not.toBe('node');
+      // The stored absolute path is spawned unchanged — only the runtime moves.
+      expect(cfg.args).toEqual([
+        '/Applications/Wayland.app/Contents/Resources/app.asar.unpacked/out/main/builtin-mcp-search-skills.js',
+      ]);
+      expect(cfg.env.ELECTRON_RUN_AS_NODE).toBeUndefined();
+    });
+
+    it('#1008 packaged: launches the concierge-diag builtin under bundled Bun, not bare node', async () => {
+      h.isPackaged = true;
+      h.bundledBunDir = '/res/bundled-bun/darwin-arm64';
+      await setupClientOk();
+      const { StdioClientTransport } = await setupTransport();
+
+      const result = await testAgent.testMcpConnection({
+        type: 'stdio',
+        command: 'node',
+        args: ['/Applications/Wayland.app/Contents/Resources/app.asar.unpacked/out/main/builtin-mcp-concierge-diag.js'],
+      });
+
+      expect(result.success).toBe(true);
+      const cfg = vi.mocked(StdioClientTransport).mock.calls[0]![0] as any;
+      expect(cfg.command).not.toBe('node');
+      expect(cfg.command).toBe(
+        path.join('/res/bundled-bun/darwin-arm64', process.platform === 'win32' ? 'bun.exe' : 'bun')
+      );
+    });
+
+    it('#1008 dev: launches a first-party core builtin via Electron-as-Node, not bare node', async () => {
+      await setupClientOk();
+      const { StdioClientTransport } = await setupTransport();
+
+      const result = await testAgent.testMcpConnection({
+        type: 'stdio',
+        command: 'node',
+        args: ['/repo/app/out/main/builtin-mcp-image-gen.js'],
+      });
+
+      expect(result.success).toBe(true);
+      const cfg = vi.mocked(StdioClientTransport).mock.calls[0]![0] as any;
+      expect(cfg.command).toBe(process.execPath);
+      expect(cfg.env.ELECTRON_RUN_AS_NODE).toBe('1');
+      expect(cfg.args).toEqual(['/repo/app/out/main/builtin-mcp-image-gen.js']);
+    });
+
     it('does NOT rewrite a user-defined node stdio server (only our bundled builtins)', async () => {
       await setupClientOk();
       const { StdioClientTransport } = await setupTransport();

--- a/tests/unit/process/services/mcpProtocol.test.ts
+++ b/tests/unit/process/services/mcpProtocol.test.ts
@@ -65,6 +65,27 @@ const SEARCH_SKILLS_SCRIPT = getMcpScriptPath('builtin-mcp-search-skills.js');
 const CONCIERGE_DIAG_SCRIPT = getMcpScriptPath('builtin-mcp-concierge-diag.js');
 const IMAGE_GEN_SCRIPT = getMcpScriptPath('builtin-mcp-image-gen.js');
 
+// #1015 F2b: the four sibling @wayland builtins are stored as a BARE FILENAME
+// and the resolver REPLACES args[0] with our own script, so the filename alone is
+// not authority to do it — a user's relative script of the same name would have a
+// different file substituted. The authority is catalog PROVENANCE, and the
+// Library install writes it in the same record it writes the bare filename into.
+// Fixtures must therefore be the whole installed record, not a bare transport.
+const bundledWaylandServer = (file: string, libraryEntryId: string): IMcpServer => ({
+  id: `lib_${libraryEntryId}`,
+  name: libraryEntryId.replace(/[^A-Za-z0-9_.-]/g, '-'),
+  enabled: true,
+  status: 'disconnected',
+  source: 'library',
+  libraryEntryId,
+  transport: { type: 'stdio', command: 'node', args: [file], env: {} },
+  tools: [],
+  createdAt: 1,
+  updatedAt: 1,
+  originalJson: '{}',
+});
+const APPLE_SERVER = () => bundledWaylandServer('builtin-mcp-apple.mjs', 'com.wayland/apple-mcp');
+
 // Create a concrete test subclass to access protected methods
 class TestAgent {
   private agent: InstanceType<typeof import('@process/services/mcpServices/McpProtocol').AbstractMcpAgent>;
@@ -339,11 +360,7 @@ describe('AbstractMcpAgent', () => {
       await setupClientOk();
       const { StdioClientTransport } = await setupTransport();
 
-      const result = await testAgent.testMcpConnection({
-        type: 'stdio',
-        command: 'node',
-        args: ['builtin-mcp-apple.mjs'],
-      });
+      const result = await testAgent.testMcpConnection(APPLE_SERVER());
 
       expect(result.success).toBe(true);
       const cfg = vi.mocked(StdioClientTransport).mock.calls[0]![0] as any;
@@ -362,11 +379,7 @@ describe('AbstractMcpAgent', () => {
       await setupClientOk();
       const { StdioClientTransport } = await setupTransport();
 
-      const result = await testAgent.testMcpConnection({
-        type: 'stdio',
-        command: 'node',
-        args: ['builtin-mcp-apple.mjs'],
-      });
+      const result = await testAgent.testMcpConnection(APPLE_SERVER());
 
       expect(result.success).toBe(true);
       const cfg = vi.mocked(StdioClientTransport).mock.calls[0]![0] as any;
@@ -378,6 +391,41 @@ describe('AbstractMcpAgent', () => {
       expect(cfg.args[0]).toMatch(/[/\\]builtin-mcp-apple\.mjs$/);
       // A real runtime must NOT carry the Electron-as-Node env var.
       expect(cfg.env.ELECTRON_RUN_AS_NODE).toBeUndefined();
+    });
+
+    it('#1015 F2b: a bare @wayland filename with NO catalog provenance is spawned verbatim', async () => {
+      // Same filename, same run, provenance removed: the probe must not swap in
+      // Wayland's script. A user's own relative `builtin-mcp-apple.mjs` is theirs.
+      h.isPackaged = true;
+      h.bundledBunDir = '/res/bundled-bun/darwin-arm64';
+      await setupClientOk();
+      const { StdioClientTransport } = await setupTransport();
+
+      const result = await testAgent.testMcpConnection({
+        type: 'stdio',
+        command: 'node',
+        args: ['builtin-mcp-apple.mjs'],
+      });
+
+      expect(result.success).toBe(true);
+      const cfg = vi.mocked(StdioClientTransport).mock.calls[0]![0] as any;
+      expect(cfg.command).toBe('node');
+      expect(cfg.args).toEqual(['builtin-mcp-apple.mjs']);
+    });
+
+    it('#1015 F2b KNOWN POSITIVE: the same install WITH provenance is rewritten', async () => {
+      h.isPackaged = true;
+      h.bundledBunDir = '/res/bundled-bun/darwin-arm64';
+      await setupClientOk();
+      const { StdioClientTransport } = await setupTransport();
+
+      const result = await testAgent.testMcpConnection(APPLE_SERVER());
+
+      expect(result.success).toBe(true);
+      const cfg = vi.mocked(StdioClientTransport).mock.calls[0]![0] as any;
+      expect(cfg.command).not.toBe('node');
+      expect(cfg.args[0]).toMatch(/[/\\]builtin-mcp-apple\.mjs$/);
+      expect(cfg.args[0]).not.toBe('builtin-mcp-apple.mjs');
     });
 
     // #1008: the FIRST-PARTY core builtins (search-skills, concierge-diag,
@@ -497,11 +545,7 @@ describe('AbstractMcpAgent', () => {
         } as any;
       } as any);
 
-      const result = await testAgent.testMcpConnection({
-        type: 'stdio',
-        command: 'node',
-        args: ['builtin-mcp-apple.mjs'],
-      });
+      const result = await testAgent.testMcpConnection(APPLE_SERVER());
 
       expect(result.success).toBe(false);
       expect((result as { error?: string }).error).toContain('-32000');

--- a/tests/unit/process/services/mcpServices/builtinMcpRuntime.test.ts
+++ b/tests/unit/process/services/mcpServices/builtinMcpRuntime.test.ts
@@ -17,8 +17,15 @@
  *      runtime while ELECTRON_RUN_AS_NODE=1 rides along.
  *
  *  F2: matching our scripts by BASENAME re-pointed a user's own server that
- *      merely shares one of our filenames onto our runtime. The match must be an
- *      exact comparison against the path this install would actually spawn.
+ *      merely shares one of our filenames onto our runtime. For the core builtins
+ *      (stored as an absolute path) the match must be an exact comparison against
+ *      the path this install would actually spawn.
+ *
+ *  F2b: the four sibling @wayland servers are stored as a BARE FILENAME and the
+ *      branch that handles them REPLACES args[0] with our own script — so a
+ *      filename-only match runs a DIFFERENT FILE than the user configured, which
+ *      is worse than F2's wrong-runtime-on-the-right-file. That branch is gated on
+ *      catalog PROVENANCE (`libraryEntryId`), never on the filename.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -46,6 +53,9 @@ const devRuntime = (): ResolvedJsRuntime => ({
 
 const posixScriptPath = (name: string) => `${OUT_MAIN}/${name}`;
 const OURS = posixScriptPath('builtin-mcp-search-skills.js');
+/** Catalog entry ids of two of the four bundled @wayland siblings. */
+const APPLE_ENTRY = 'com.wayland/apple-mcp';
+const IMAP_ENTRY = 'com.wayland/imap-mcp';
 
 const winPath = (name: string) => `C:\\Program Files\\Wayland\\out\\main\\${name}`;
 
@@ -126,8 +136,13 @@ describe('F1 — the resolved runtime tuple carries command AND env', () => {
     });
   });
 
-  it('expands the sibling @wayland servers from their bare stored filename', () => {
-    expect(resolveBuiltinMcpRuntimeSpawn('node', ['builtin-mcp-apple.mjs', '--flag'], deps())).toEqual({
+  it('expands the sibling @wayland servers from their bare stored filename ON CATALOG PROVENANCE', () => {
+    // The bare filename alone is NOT authority to substitute our script (see the
+    // F2b block below) — the record's catalog entry id is. This is the shape the
+    // Library install actually persists: bare filename + its entry id.
+    expect(
+      resolveBuiltinMcpRuntimeSpawn('node', ['builtin-mcp-apple.mjs', '--flag'], deps({ libraryEntryId: APPLE_ENTRY }))
+    ).toEqual({
       command: PACKAGED_BUN,
       args: [posixScriptPath('builtin-mcp-apple.mjs'), '--flag'],
       env: {},
@@ -138,6 +153,60 @@ describe('F1 — the resolved runtime tuple carries command AND env', () => {
     expect(resolveBuiltinMcpRuntimeSpawn('npx', ['-y', 'chrome-devtools-mcp@latest'], deps())).toBeNull();
     expect(resolveBuiltinMcpRuntimeSpawn('node', ['/opt/other/server.js'], deps())).toBeNull();
     expect(resolveBuiltinMcpRuntimeSpawn('/usr/bin/mcp-server', [], deps())).toBeNull();
+  });
+});
+
+describe('F2b — a bare @wayland filename is expanded ONLY on catalog provenance', () => {
+  // A bare filename with no separator is indistinguishable from a user's own
+  // relative script by string alone, and the sibling branch REPLACES args[0]
+  // with Wayland's script — so it executes a DIFFERENT FILE than the user
+  // configured. That is worse than F2's original "same file, wrong runtime".
+  // `libraryEntryId` is written only by the Library install that also writes the
+  // bare filename, so the pair — never the filename — is the authority.
+  const userOwned = (args: string[]) => stdioServer('node', args);
+
+  it('refuses a user-owned relative script that shares one of our filenames', () => {
+    expect(resolveBuiltinMcpRuntimeSpawn('node', ['builtin-mcp-apple.mjs'], deps())).toBeNull();
+    // Reaches the live session spawning exactly what the user configured.
+    expect(resolveSessionMcpStdioSpawn('node', ['builtin-mcp-apple.mjs'], deps())).toEqual({
+      command: 'node',
+      args: ['builtin-mcp-apple.mjs'],
+      env: {},
+    });
+    const input = userOwned(['builtin-mcp-apple.mjs']);
+    expect(applyBuiltinMcpRuntime(input, deps())).toBe(input);
+  });
+
+  it('refuses a @wayland record whose entry id does not ship that filename', () => {
+    // Both halves must agree: the imap entry never installs the apple script.
+    expect(
+      resolveBuiltinMcpRuntimeSpawn('node', ['builtin-mcp-apple.mjs'], deps({ libraryEntryId: IMAP_ENTRY }))
+    ).toBeNull();
+    // KNOWN POSITIVE, same run: the imap entry DOES ship the imap script.
+    expect(
+      resolveBuiltinMcpRuntimeSpawn('node', ['builtin-mcp-imap.mjs'], deps({ libraryEntryId: IMAP_ENTRY }))
+    ).toEqual({ command: PACKAGED_BUN, args: [posixScriptPath('builtin-mcp-imap.mjs')], env: {} });
+  });
+
+  it('refuses a foreign entry id, including prototype keys', () => {
+    for (const id of ['com.evil/apple-mcp', '__proto__', 'constructor', 'toString']) {
+      expect(resolveBuiltinMcpRuntimeSpawn('node', ['builtin-mcp-apple.mjs'], deps({ libraryEntryId: id }))).toBeNull();
+    }
+  });
+
+  it('applyBuiltinMcpRuntime reads provenance off the record itself', () => {
+    // The publication chokepoints (McpService, AcpAgentManager, WCoreManager)
+    // hand over a whole IMcpServer and pass no deps, so the record must carry it.
+    const installed = { ...stdioServer('node', ['builtin-mcp-apple.mjs']), libraryEntryId: APPLE_ENTRY };
+    expect(applyBuiltinMcpRuntime(installed, deps()).transport).toEqual({
+      type: 'stdio',
+      command: PACKAGED_BUN,
+      args: [posixScriptPath('builtin-mcp-apple.mjs')],
+      env: {},
+    });
+    // KNOWN NEGATIVE, same run: strip the provenance and the record is untouched.
+    const withoutProvenance = stdioServer('node', ['builtin-mcp-apple.mjs']);
+    expect(applyBuiltinMcpRuntime(withoutProvenance, deps())).toBe(withoutProvenance);
   });
 });
 

--- a/tests/unit/process/services/mcpServices/builtinMcpRuntime.test.ts
+++ b/tests/unit/process/services/mcpServices/builtinMcpRuntime.test.ts
@@ -1,0 +1,188 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #1015 — the ONE runtime tuple shared by the Library probe and every
+ * live-session serializer.
+ *
+ * Two defects are pinned here:
+ *
+ *  F1: the probe was fixed to spawn Wayland's own bundled MCP servers under a
+ *      resolved JS runtime while the live-session serializers still emitted bare
+ *      `node`. That combination is worse than the original bug: the probe returns
+ *      tools, the health check clears its "0 tools" flag, and the chat silently
+ *      has no builtin tools with nothing left to report it. The runtime ENV is
+ *      half the tuple — in dev the command is the app binary and is only a Node
+ *      runtime while ELECTRON_RUN_AS_NODE=1 rides along.
+ *
+ *  F2: matching our scripts by BASENAME re-pointed a user's own server that
+ *      merely shares one of our filenames onto our runtime. The match must be an
+ *      exact comparison against the path this install would actually spawn.
+ */
+
+import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import {
+  applyBuiltinMcpRuntime,
+  isOwnBuiltinCoreMcpScript,
+  resolveBuiltinMcpRuntimeSpawn,
+  resolveSessionMcpStdioSpawn,
+} from '@process/services/mcpServices/builtinMcpRuntime';
+import type { ResolvedJsRuntime } from '@process/utils/jsRuntime';
+
+const PACKAGED_BUN = '/Applications/Wayland.app/Contents/Resources/bundled-bun/darwin-arm64/bun';
+const DEV_ELECTRON = '/repo/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron';
+const OUT_MAIN = '/Applications/Wayland.app/Contents/Resources/app.asar.unpacked/out/main';
+
+/** Packaged resolution: bundled Bun, no extra env. */
+const packagedRuntime = (): ResolvedJsRuntime => ({ command: PACKAGED_BUN, env: {}, kind: 'bundled-bun' });
+/** Dev resolution: the app binary as Node — ONLY valid with ELECTRON_RUN_AS_NODE. */
+const devRuntime = (): ResolvedJsRuntime => ({
+  command: DEV_ELECTRON,
+  env: { ELECTRON_RUN_AS_NODE: '1' },
+  kind: 'electron-node',
+});
+
+const posixScriptPath = (name: string) => `${OUT_MAIN}/${name}`;
+const OURS = posixScriptPath('builtin-mcp-search-skills.js');
+
+const winPath = (name: string) => `C:\\Program Files\\Wayland\\out\\main\\${name}`;
+
+const stdioServer = (command: string, args: string[], env?: Record<string, string>) => ({
+  id: 'builtin-search-skills',
+  name: 'wayland-search-skills',
+  transport: { type: 'stdio' as const, command, args, ...(env ? { env } : {}) },
+});
+
+const deps = (over: Record<string, unknown> = {}) => ({
+  resolveRuntime: packagedRuntime,
+  scriptPath: posixScriptPath,
+  platform: 'darwin' as NodeJS.Platform,
+  ...over,
+});
+
+describe('F2 — our own script is matched by exact path, never by basename', () => {
+  it('accepts the absolute path this install actually seeds', () => {
+    expect(isOwnBuiltinCoreMcpScript(OURS, deps())).toBe(true);
+  });
+
+  it("REFUSES a user's own server that merely shares our basename", () => {
+    // The hijack: same filename, the user's own directory, the user's own file.
+    // Basename matching silently re-pointed this onto Wayland's runtime.
+    expect(isOwnBuiltinCoreMcpScript('/Users/me/tools/builtin-mcp-search-skills.js', deps())).toBe(false);
+    expect(resolveBuiltinMcpRuntimeSpawn('node', ['/Users/me/tools/builtin-mcp-search-skills.js'], deps())).toBeNull();
+  });
+
+  it('leaves a hijack candidate spawning exactly what the user configured', () => {
+    const spawn = resolveSessionMcpStdioSpawn('node', ['/Users/me/tools/builtin-mcp-search-skills.js'], deps());
+    expect(spawn).toEqual({
+      command: 'node',
+      args: ['/Users/me/tools/builtin-mcp-search-skills.js'],
+      env: {},
+    });
+  });
+
+  it('refuses an unrelated filename in our own directory', () => {
+    expect(isOwnBuiltinCoreMcpScript(posixScriptPath('not-ours.js'), deps())).toBe(false);
+  });
+
+  it('normalizes traversal rather than string-comparing raw input', () => {
+    expect(isOwnBuiltinCoreMcpScript(`${OUT_MAIN}/sub/../builtin-mcp-search-skills.js`, deps())).toBe(true);
+  });
+
+  it('win32: matches case-insensitively (NTFS is case-preserving, not case-sensitive)', () => {
+    const stored = 'c:\\program files\\wayland\\out\\main\\builtin-mcp-search-skills.js';
+    expect(isOwnBuiltinCoreMcpScript(stored, deps({ scriptPath: winPath, platform: 'win32' }))).toBe(true);
+    // Still an EQUALITY test, not a prefix/containment test: a sibling directory
+    // that merely starts with ours must not match (the win32 containment trap).
+    expect(
+      isOwnBuiltinCoreMcpScript(
+        'C:\\Program Files\\Wayland\\out\\main-evil\\builtin-mcp-search-skills.js',
+        deps({ scriptPath: winPath, platform: 'win32' })
+      )
+    ).toBe(false);
+  });
+
+  it('posix: does NOT fold case (two different files on a case-sensitive volume)', () => {
+    expect(isOwnBuiltinCoreMcpScript(OURS.toUpperCase(), deps())).toBe(false);
+  });
+});
+
+describe('F1 — the resolved runtime tuple carries command AND env', () => {
+  it('packaged: our core builtin runs under the bundled Bun', () => {
+    expect(resolveBuiltinMcpRuntimeSpawn('node', [OURS], deps())).toEqual({
+      command: PACKAGED_BUN,
+      args: [OURS],
+      env: {},
+    });
+  });
+
+  it('dev: our core builtin runs the app binary as Node, WITH ELECTRON_RUN_AS_NODE', () => {
+    expect(resolveBuiltinMcpRuntimeSpawn('node', [OURS], deps({ resolveRuntime: devRuntime }))).toEqual({
+      command: DEV_ELECTRON,
+      args: [OURS],
+      env: { ELECTRON_RUN_AS_NODE: '1' },
+    });
+  });
+
+  it('expands the sibling @wayland servers from their bare stored filename', () => {
+    expect(resolveBuiltinMcpRuntimeSpawn('node', ['builtin-mcp-apple.mjs', '--flag'], deps())).toEqual({
+      command: PACKAGED_BUN,
+      args: [posixScriptPath('builtin-mcp-apple.mjs'), '--flag'],
+      env: {},
+    });
+  });
+
+  it('returns null for anything that is not ours, so callers keep their own resolution', () => {
+    expect(resolveBuiltinMcpRuntimeSpawn('npx', ['-y', 'chrome-devtools-mcp@latest'], deps())).toBeNull();
+    expect(resolveBuiltinMcpRuntimeSpawn('node', ['/opt/other/server.js'], deps())).toBeNull();
+    expect(resolveBuiltinMcpRuntimeSpawn('/usr/bin/mcp-server', [], deps())).toBeNull();
+  });
+});
+
+describe('applyBuiltinMcpRuntime — transport rewrite for serializers we do not own', () => {
+  const server = stdioServer;
+
+  it('dev: rewrites command and MERGES the runtime env over the server env', () => {
+    const out = applyBuiltinMcpRuntime(
+      server('node', [OURS], { WAYLAND_IMG_PLATFORM: 'openai' }),
+      deps({ resolveRuntime: devRuntime })
+    );
+    expect(out.transport).toEqual({
+      type: 'stdio',
+      command: DEV_ELECTRON,
+      args: [OURS],
+      env: { WAYLAND_IMG_PLATFORM: 'openai', ELECTRON_RUN_AS_NODE: '1' },
+    });
+  });
+
+  it('packaged: rewrites command and preserves the server env untouched', () => {
+    const out = applyBuiltinMcpRuntime(server('node', [OURS], { WAYLAND_IMG_MODEL: 'gpt-image-1' }), deps());
+    expect(out.transport).toEqual({
+      type: 'stdio',
+      command: PACKAGED_BUN,
+      args: [OURS],
+      env: { WAYLAND_IMG_MODEL: 'gpt-image-1' },
+    });
+  });
+
+  it('returns the SAME object for a server that is not ours (no npx pre-resolution)', () => {
+    const input = server('npx', ['-y', 'chrome-devtools-mcp@latest']);
+    expect(applyBuiltinMcpRuntime(input, deps())).toBe(input);
+    const userOwned = server('node', ['/Users/me/tools/builtin-mcp-search-skills.js']);
+    expect(applyBuiltinMcpRuntime(userOwned, deps())).toBe(userOwned);
+  });
+});
+
+describe('real resolution (no injected deps) still identifies our own scripts', () => {
+  // Confirms the method finds a KNOWN POSITIVE against the live resolver, so the
+  // negatives above cannot be passing merely because nothing ever matches.
+  it('accepts the path getMcpScriptPath actually produces on this host', async () => {
+    const { getMcpScriptPath } = await import('@process/utils/mcpScriptDir');
+    const real = getMcpScriptPath('builtin-mcp-concierge-diag.js');
+    expect(path.isAbsolute(real)).toBe(true);
+    expect(isOwnBuiltinCoreMcpScript(real)).toBe(true);
+    expect(isOwnBuiltinCoreMcpScript(path.join('/Users/me/tools', 'builtin-mcp-concierge-diag.js'))).toBe(false);
+  });
+});

--- a/tests/unit/process/services/mcpServices/builtinMcpRuntime.test.ts
+++ b/tests/unit/process/services/mcpServices/builtinMcpRuntime.test.ts
@@ -33,6 +33,7 @@ import path from 'node:path';
 import {
   applyBuiltinMcpRuntime,
   isOwnBuiltinCoreMcpScript,
+  mergeMcpSpawnEnv,
   resolveBuiltinMcpRuntimeSpawn,
   resolveSessionMcpStdioSpawn,
 } from '@process/services/mcpServices/builtinMcpRuntime';
@@ -115,7 +116,38 @@ describe('F2 — our own script is matched by exact path, never by basename', ()
   });
 
   it('posix: does NOT fold case (two different files on a case-sensitive volume)', () => {
+    // NOTE the fixture: only the DIRECTORY is uppercased. Uppercasing the whole
+    // path also uppercases the basename, which `isBuiltinCoreMcpArg`'s
+    // case-sensitive allowlist rejects first — so `isSamePath` is never reached
+    // and a mutant that case-folds on posix too would survive unseen.
+    const dirUpperOnly = path.join(path.dirname(OURS).toUpperCase(), 'builtin-mcp-search-skills.js');
+    expect(isOwnBuiltinCoreMcpScript(dirUpperOnly, deps())).toBe(false);
+    // KNOWN POSITIVE, same run: the correctly-cased path IS ours, so the false
+    // above is a real refusal and not a fixture that can never match anything.
+    expect(isOwnBuiltinCoreMcpScript(OURS, deps())).toBe(true);
+    // The whole-path form is also refused, for the earlier allowlist reason.
     expect(isOwnBuiltinCoreMcpScript(OURS.toUpperCase(), deps())).toBe(false);
+  });
+});
+
+describe('mergeMcpSpawnEnv — the runtime env must WIN on a collision', () => {
+  // The module's own contract: the dev runtime is only a Node runtime while
+  // ELECTRON_RUN_AS_NODE=1 rides along, so a server env that shadowed it would
+  // boot a second Electron app instead of the MCP server. Both existing merge
+  // tests use NON-COLLIDING keys, so flipping the spread order survives them.
+  it('overrides a colliding key from the server env', () => {
+    expect(mergeMcpSpawnEnv({ ELECTRON_RUN_AS_NODE: '0', KEEP: 'me' }, { ELECTRON_RUN_AS_NODE: '1' })).toEqual({
+      ELECTRON_RUN_AS_NODE: '1',
+      KEEP: 'me',
+    });
+  });
+
+  it('applies the same precedence through applyBuiltinMcpRuntime', () => {
+    const out = applyBuiltinMcpRuntime(
+      stdioServer('node', [OURS], { ELECTRON_RUN_AS_NODE: '0' }),
+      deps({ resolveRuntime: devRuntime })
+    );
+    expect((out.transport as { env?: Record<string, string> }).env).toEqual({ ELECTRON_RUN_AS_NODE: '1' });
   });
 });
 
@@ -153,6 +185,16 @@ describe('F1 — the resolved runtime tuple carries command AND env', () => {
     expect(resolveBuiltinMcpRuntimeSpawn('npx', ['-y', 'chrome-devtools-mcp@latest'], deps())).toBeNull();
     expect(resolveBuiltinMcpRuntimeSpawn('node', ['/opt/other/server.js'], deps())).toBeNull();
     expect(resolveBuiltinMcpRuntimeSpawn('/usr/bin/mcp-server', [], deps())).toBeNull();
+  });
+
+  it('refuses a non-`node` command even when args[0] IS one of our own scripts', () => {
+    // Kills the mutant that drops the `command !== 'node'` gate. The other
+    // negative-command case passes EMPTY args, so `first` is undefined and the
+    // gate is never reached — that test cannot see this.
+    expect(resolveBuiltinMcpRuntimeSpawn('/usr/bin/deno', [OURS], deps())).toBeNull();
+    expect(resolveBuiltinMcpRuntimeSpawn('bun', [OURS], deps())).toBeNull();
+    // KNOWN POSITIVE, same run: the identical args[0] under `node` IS ours.
+    expect(resolveBuiltinMcpRuntimeSpawn('node', [OURS], deps())).not.toBeNull();
   });
 });
 

--- a/tests/unit/process/task/wcoreBuiltinMcpPublication.test.ts
+++ b/tests/unit/process/task/wcoreBuiltinMcpPublication.test.ts
@@ -1,0 +1,268 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * #1015 F1 — the WAYLAND CORE launch path, driven through `WCoreManager.start()`.
+ *
+ * The flagship backend's connectors do not come from
+ * `McpService.syncMcpToAgents`. `WCoreManager` constructs its OWN
+ * `WCoreMcpAgent(<launch-local config.toml>)` and publishes into that file, and
+ * the wcore chat loads its connectors from there. So the eight publication
+ * targets being covered says NOTHING about this path — it needed the shared
+ * builtin-runtime rewrite applied to it separately.
+ *
+ * The victims are NOT the three core builtins: `buildWCoreSessionMcpServers`
+ * filters `builtin !== true`, which excludes them. They are the four bundled
+ * @wayland siblings (Apple/IMAP/News/Cal.com), which are installed from the MCP
+ * Library and carry no `builtin` field, so they pass the filter and arrive as
+ * `node` + a bare relative filename. On a stock macOS that is ENOENT; where a
+ * system node exists it is MODULE_NOT_FOUND resolved against Core's cwd.
+ *
+ * Every assertion below is produced in ONE run alongside its known positives, so
+ * a green result cannot be a harness artifact:
+ *   - the @wayland sibling (the defect) — must be resolved runtime + absolute path
+ *   - an `npx` connector (known positive for the rewrite layer) — must stay the
+ *     PORTABLE `bun x --bun` form, because `WCoreMcpAgent` deliberately refuses to
+ *     persist an absolute bundled-Bun path that a Linux AppImage remounts
+ *   - a core builtin (known negative for the selection filter) — must not be here
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IMcpServer } from '@/common/config/storage';
+import type { ResolvedJsRuntime } from '@process/utils/jsRuntime';
+
+const PACKAGED_BUN = '/Applications/Wayland.app/Contents/Resources/bundled-bun/darwin-arm64/bun';
+const DEV_ELECTRON = '/repo/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron';
+
+const h = vi.hoisted(() => ({
+  /** Every `IMcpServer` list handed to the launch-local `WCoreMcpAgent`. */
+  published: [] as IMcpServer[][],
+  /** The config.toml path that agent was constructed against. */
+  configPaths: [] as Array<string | undefined>,
+  resolveJsRuntime: vi.fn<() => ResolvedJsRuntime>(),
+  runtimeServers: [] as IMcpServer[],
+}));
+
+vi.mock('@process/utils/jsRuntime', () => ({ resolveJsRuntime: h.resolveJsRuntime }));
+
+// Keep the REAL `toWCoreConfig` (the config.toml serializer under test) and swap
+// only the agent, so what lands on disk is still produced by production code.
+vi.mock('@process/services/mcpServices/agents/WCoreMcpAgent', async (orig) => {
+  const actual = await orig<typeof import('@process/services/mcpServices/agents/WCoreMcpAgent')>();
+  return {
+    ...actual,
+    WCoreMcpAgent: class {
+      constructor(configPath?: string) {
+        h.configPaths.push(configPath);
+      }
+      installMcpServers(servers: IMcpServer[]) {
+        h.published.push(servers);
+        return Promise.resolve({ success: true });
+      }
+    },
+  };
+});
+
+vi.mock('@process/services/mcpServices/runtimeMcpServers', () => ({
+  loadRuntimeMcpServers: vi.fn(async () => h.runtimeServers),
+}));
+
+vi.mock('@process/services/mcpServices/McpService', () => ({
+  mcpService: {
+    // Identity, exactly like the real implementation for servers with no OAuth
+    // token — so this test observes the tuple WCoreManager built, not ours.
+    attachOAuthTokens: vi.fn(async (servers: IMcpServer[]) => servers),
+  },
+}));
+
+vi.mock('@process/agent/wcore/profilePaths', () => ({
+  acquireRuntimeLaunchAuthority: vi.fn(async () => ({
+    raw: false,
+    identity: { dir: '/launch/wayland-home' },
+    release: async () => {},
+  })),
+}));
+
+vi.mock('@process/agent/wcore/effectiveRuntimeActions', () => ({
+  readRawEngineModePreference: vi.fn(async () => false),
+  readOutputBudgetPreference: vi.fn(async () => undefined),
+}));
+
+// Stop the launch immediately AFTER the publication block: the engine spawn and
+// everything downstream is irrelevant here and `start()` rethrows, which the test
+// catches. Nothing in the publication block runs after this point.
+function stopAfterPublication(): never {
+  throw new Error('STOP_AFTER_MCP_PUBLICATION');
+}
+vi.mock('@process/agent/wcore', () => ({ WCoreAgent: stopAfterPublication }));
+
+vi.mock('@process/services/database', () => ({
+  getDatabase: vi.fn(async () => ({
+    getConversationMessages: () => ({ data: [] }),
+    getConversation: () => ({ success: false }),
+    updateConversation: vi.fn(),
+    insertMessage: vi.fn(),
+    updateMessage: vi.fn(),
+  })),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    conversation: {
+      responseStream: { emit: vi.fn() },
+      confirmation: { add: { emit: vi.fn() }, update: { emit: vi.fn() }, remove: { emit: vi.fn() } },
+    },
+    cron: { onJobCreated: { emit: vi.fn() }, onJobRemoved: { emit: vi.fn() } },
+  },
+}));
+
+vi.mock('@/common/platform', () => ({
+  getPlatformServices: () => ({
+    paths: {
+      isPackaged: () => false,
+      getAppPath: () => null,
+      getDataDir: () => '/tmp/wayland-test-data',
+      getHomeDir: () => '/tmp/wayland-test-home',
+      getTempDir: () => '/tmp',
+      getName: () => 'Wayland',
+      getVersion: () => '1.0.0',
+    },
+    worker: { fork: vi.fn() },
+  }),
+}));
+
+// `initStorage` builds real on-disk stores at import time; only `ProcessConfig`
+// is reachable from this path, and the two preference readers that use it are
+// already mocked above.
+vi.mock('@process/utils/initStorage', () => ({
+  ProcessConfig: { get: vi.fn(async () => undefined), set: vi.fn(async () => {}), remove: vi.fn(async () => {}) },
+  ProcessChat: { get: vi.fn(async () => []) },
+}));
+
+vi.mock('@process/utils/mainLogger', () => ({ mainError: vi.fn(), mainLog: vi.fn(), mainWarn: vi.fn() }));
+vi.mock('@process/services/cron/cronServiceSingleton', () => ({
+  cronService: { addJob: vi.fn(), removeJob: vi.fn(), listJobsByConversation: vi.fn(async () => []) },
+}));
+vi.mock('@process/task/agentUtils', () => ({
+  buildSystemInstructionsWithSkillsIndex: vi.fn(async () => undefined),
+  buildTurnSkillContext: vi.fn(async () => undefined),
+  consumePendingSessionSkills: vi.fn(() => []),
+  mergeLoadedSkillsExtra: vi.fn((x: unknown) => x),
+  resolveCapabilitiesManifest: vi.fn(async () => undefined),
+}));
+
+import { WCoreManager } from '@process/task/WCoreManager';
+import { toWCoreConfig } from '@process/services/mcpServices/agents/WCoreMcpAgent';
+import { getMcpScriptPath } from '@process/utils/mcpScriptDir';
+
+const server = (over: Partial<IMcpServer>): IMcpServer => ({
+  id: 'id',
+  name: 'name',
+  enabled: true,
+  status: 'connected',
+  transport: { type: 'stdio', command: 'node', args: [], env: {} },
+  tools: [],
+  createdAt: 1,
+  updatedAt: 1,
+  originalJson: '{}',
+  ...over,
+});
+
+/** Exactly what the MCP Library persists for a bundled @wayland install. */
+const APPLE = server({
+  id: 'lib_apple',
+  name: 'com.wayland-apple-mcp',
+  source: 'library',
+  libraryEntryId: 'com.wayland/apple-mcp',
+  transport: { type: 'stdio', command: 'node', args: ['builtin-mcp-apple.mjs'], env: {} },
+});
+/** KNOWN POSITIVE for the rewrite layer; must keep the restart-safe form. */
+const NPX = server({
+  id: 'npx',
+  name: 'npx-connector',
+  transport: { type: 'stdio', command: 'npx', args: ['-y', 'some-mcp'], env: {} },
+});
+/** KNOWN NEGATIVE for the selection filter: a core builtin never reaches wcore. */
+const CORE_BUILTIN = server({
+  id: 'builtin-search-skills',
+  name: 'wayland-search-skills',
+  builtin: true,
+  transport: { type: 'stdio', command: 'node', args: [getMcpScriptPath('builtin-mcp-search-skills.js')], env: {} },
+});
+
+const startManager = async () => {
+  const manager = new WCoreManager({
+    id: 'conv-1',
+    data: {
+      workspace: '/ws',
+      model: { name: 'm', useModel: 'm', platform: 'openai', baseUrl: '' },
+      activeMcpServers: [APPLE.id, NPX.id, CORE_BUILTIN.id],
+    },
+  } as never);
+  await expect(manager.start()).rejects.toThrow('STOP_AFTER_MCP_PUBLICATION');
+  // `BaseAgentManager` may retry the bootstrap; each attempt republishes, and
+  // every attempt must be correct, so assert over ALL of them.
+  expect(h.published.length).toBeGreaterThan(0);
+  expect(h.published.map((list) => JSON.stringify(list))).toEqual(
+    h.published.map(() => JSON.stringify(h.published[0]))
+  );
+  return h.published[0]!;
+};
+
+describe.each([
+  [
+    'packaged (bundled Bun)',
+    (): ResolvedJsRuntime => ({ command: PACKAGED_BUN, env: {}, kind: 'bundled-bun' }),
+    PACKAGED_BUN,
+    undefined,
+  ],
+  [
+    'dev (Electron as Node)',
+    (): ResolvedJsRuntime => ({ command: DEV_ELECTRON, env: { ELECTRON_RUN_AS_NODE: '1' }, kind: 'electron-node' }),
+    DEV_ELECTRON,
+    { ELECTRON_RUN_AS_NODE: '1' },
+  ],
+])('WCoreManager publishes the resolved runtime into the launch config.toml — %s', (_l, runtime, command, env) => {
+  beforeEach(() => {
+    h.published.length = 0;
+    h.configPaths.length = 0;
+    h.runtimeServers = [APPLE, NPX, CORE_BUILTIN];
+    h.resolveJsRuntime.mockReset().mockImplementation(runtime);
+  });
+
+  it('rewrites the bundled @wayland sibling onto the resolved JS runtime', async () => {
+    const published = await startManager();
+    const apple = published.find((s) => s.name === 'com.wayland-apple-mcp');
+    expect(apple).toBeDefined();
+    const transport = apple!.transport as Extract<IMcpServer['transport'], { type: 'stdio' }>;
+    expect(transport.command).toBe(command);
+    expect(transport.command).not.toBe('node');
+    // Absolute, not the bare relative filename Core would resolve against its cwd.
+    expect(transport.args?.[0]).not.toBe('builtin-mcp-apple.mjs');
+    expect(transport.args?.[0]).toMatch(/[/\\]builtin-mcp-apple\.mjs$/);
+
+    // ...and it survives the REAL config.toml serializer, ENV half included: the
+    // dev runtime is the app binary and is only a Node runtime with
+    // ELECTRON_RUN_AS_NODE=1 riding along.
+    const toml = toWCoreConfig(apple!);
+    expect(toml.command).toBe(command);
+    expect(toml.args?.[0]).toMatch(/[/\\]builtin-mcp-apple\.mjs$/);
+    expect(toml.env).toEqual(env);
+  });
+
+  it('leaves the npx connector on the restart-safe portable form (AppImage carve-out)', async () => {
+    const published = await startManager();
+    const npx = published.find((s) => s.name === 'npx-connector');
+    expect(npx).toBeDefined();
+    // applyBuiltinMcpRuntime deliberately does NOT pre-resolve npx, so
+    // WCoreMcpAgent keeps its own choice of the portable form.
+    expect(toWCoreConfig(npx!)).toEqual({ transport: 'stdio', command: 'bun', args: ['x', '--bun', 'some-mcp'] });
+  });
+
+  it('never publishes a core builtin into the wcore launch config', async () => {
+    const published = await startManager();
+    expect(published.map((s) => s.name)).not.toContain('wayland-search-skills');
+    // The publication targeted the launch-local profile, not the global config.
+    expect(h.configPaths[0]).toContain('/launch/wayland-home');
+  });
+});

--- a/tests/unit/process/task/wcoreBuiltinMcpPublication.test.ts
+++ b/tests/unit/process/task/wcoreBuiltinMcpPublication.test.ts
@@ -32,6 +32,13 @@ import type { IMcpServer } from '@/common/config/storage';
 import type { ResolvedJsRuntime } from '@process/utils/jsRuntime';
 
 const PACKAGED_BUN = '/Applications/Wayland.app/Contents/Resources/bundled-bun/darwin-arm64/bun';
+/**
+ * The portable runtime name Core resolves off PATH. Windows keeps the `.exe`
+ * suffix because `toRestartSafeBundledRuntimeCommand` returns win32 commands
+ * unchanged: install paths are stable there and there is no AppImage remount
+ * to defend against.
+ */
+const PORTABLE_BUN = process.platform === 'win32' ? 'bun.exe' : 'bun';
 const DEV_ELECTRON = '/repo/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron';
 
 const h = vi.hoisted(() => ({
@@ -264,14 +271,18 @@ describe.each([
     expect(npx).toBeDefined();
     // applyBuiltinMcpRuntime deliberately does NOT pre-resolve npx, so
     // WCoreMcpAgent keeps its own choice of the portable form.
-    expect(toWCoreConfig(npx!)).toEqual({ transport: 'stdio', command: 'bun', args: ['x', '--bun', 'some-mcp'] });
+    expect(toWCoreConfig(npx!)).toEqual({
+      transport: 'stdio',
+      command: PORTABLE_BUN,
+      args: ['x', '--bun', 'some-mcp'],
+    });
   });
 
   it('never publishes a core builtin into the wcore launch config', async () => {
     const published = await startManager();
     expect(published.map((s) => s.name)).not.toContain('wayland-search-skills');
     // The publication targeted the launch-local profile, not the global config.
-    expect(h.configPaths[0]).toContain('/launch/wayland-home');
+    expect(h.configPaths[0].replace(/\\/g, '/')).toContain('/launch/wayland-home');
     // ...and said so, which is what licenses the absolute bundled-runtime path
     // asserted above: this file is rewritten on every launch (#1056).
     expect(h.launchLocalFlags[0]).toBe(true);

--- a/tests/unit/process/task/wcoreBuiltinMcpPublication.test.ts
+++ b/tests/unit/process/task/wcoreBuiltinMcpPublication.test.ts
@@ -27,7 +27,7 @@
  *     persist an absolute bundled-Bun path that a Linux AppImage remounts
  *   - a core builtin (known negative for the selection filter) — must not be here
  */
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IMcpServer } from '@/common/config/storage';
 import type { ResolvedJsRuntime } from '@process/utils/jsRuntime';
 
@@ -39,6 +39,8 @@ const h = vi.hoisted(() => ({
   published: [] as IMcpServer[][],
   /** The config.toml path that agent was constructed against. */
   configPaths: [] as Array<string | undefined>,
+  /** Whether that agent was told the file is rewritten on every launch (#1056). */
+  launchLocalFlags: [] as Array<boolean | undefined>,
   resolveJsRuntime: vi.fn<() => ResolvedJsRuntime>(),
   runtimeServers: [] as IMcpServer[],
 }));
@@ -52,8 +54,9 @@ vi.mock('@process/services/mcpServices/agents/WCoreMcpAgent', async (orig) => {
   return {
     ...actual,
     WCoreMcpAgent: class {
-      constructor(configPath?: string) {
+      constructor(configPath?: string, launchLocal?: boolean) {
         h.configPaths.push(configPath);
+        h.launchLocalFlags.push(launchLocal);
       }
       installMcpServers(servers: IMcpServer[]) {
         h.published.push(servers);
@@ -151,7 +154,11 @@ vi.mock('@process/task/agentUtils', () => ({
   resolveCapabilitiesManifest: vi.fn(async () => undefined),
 }));
 
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 import { WCoreManager } from '@process/task/WCoreManager';
+import { applyBuiltinMcpRuntime } from '@process/services/mcpServices/builtinMcpRuntime';
 import { toWCoreConfig } from '@process/services/mcpServices/agents/WCoreMcpAgent';
 import { getMcpScriptPath } from '@process/utils/mcpScriptDir';
 
@@ -226,6 +233,7 @@ describe.each([
   beforeEach(() => {
     h.published.length = 0;
     h.configPaths.length = 0;
+    h.launchLocalFlags.length = 0;
     h.runtimeServers = [APPLE, NPX, CORE_BUILTIN];
     h.resolveJsRuntime.mockReset().mockImplementation(runtime);
   });
@@ -244,7 +252,7 @@ describe.each([
     // ...and it survives the REAL config.toml serializer, ENV half included: the
     // dev runtime is the app binary and is only a Node runtime with
     // ELECTRON_RUN_AS_NODE=1 riding along.
-    const toml = toWCoreConfig(apple!);
+    const toml = toWCoreConfig(apple!, { launchLocal: true });
     expect(toml.command).toBe(command);
     expect(toml.args?.[0]).toMatch(/[/\\]builtin-mcp-apple\.mjs$/);
     expect(toml.env).toEqual(env);
@@ -264,5 +272,121 @@ describe.each([
     expect(published.map((s) => s.name)).not.toContain('wayland-search-skills');
     // The publication targeted the launch-local profile, not the global config.
     expect(h.configPaths[0]).toContain('/launch/wayland-home');
+    // ...and said so, which is what licenses the absolute bundled-runtime path
+    // asserted above: this file is rewritten on every launch (#1056).
+    expect(h.launchLocalFlags[0]).toBe(true);
+  });
+});
+
+/**
+ * #1015 F3 / #1056 — the GLOBAL config.toml, the OTHER writer of `toWCoreConfig`.
+ *
+ * `McpService.syncMcpToAgents` publishes through `new WCoreMcpAgent()` with no
+ * launch-local flag, and NOTHING resyncs that file: every `syncMcpToAgents`
+ * caller is user-action driven, so whatever one launch writes stays until the
+ * user next touches MCP settings. On a Linux AppImage (a shipped target,
+ * `electron-builder.yml`) `process.resourcesPath` is a per-launch squashfs mount
+ * point, so the absolute bundled-Bun command `applyBuiltinMcpRuntime` produces
+ * names a binary that stops existing the moment the app restarts.
+ *
+ * The remount is simulated for real: the tuple is serialized while mount A is on
+ * disk, mount A is then removed (unmounted) and mount B is the live one, and
+ * both sides of every comparison are produced in the SAME run.
+ */
+describe('#1056 global config.toml survives an AppImage remount', () => {
+  const realPlatform = process.platform;
+  let root = '';
+  let mountA = '';
+  let mountB = '';
+  const bunIn = (mount: string) => join(mount, 'bundled-bun', 'linux-x64', 'bun');
+  const scriptIn = (mount: string) => (name: string) => join(mount, 'app.asar.unpacked', 'out', 'main', name);
+  /** Exactly what launch A resolves for the sibling, before any serializer. */
+  const resolvedOnA = () =>
+    applyBuiltinMcpRuntime(APPLE, { scriptPath: scriptIn(mountA), platform: 'linux' }).transport as Extract<
+      IMcpServer['transport'],
+      { type: 'stdio' }
+    >;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'wl-1056-'));
+    mountA = join(root, '.mount_WaylanAAAAAA');
+    mountB = join(root, '.mount_WaylanBBBBBB');
+    for (const mount of [mountA, mountB]) {
+      mkdirSync(dirname(bunIn(mount)), { recursive: true });
+      writeFileSync(bunIn(mount), '#!/bin/sh\n');
+      const script = scriptIn(mount)('builtin-mcp-apple.mjs');
+      mkdirSync(dirname(script), { recursive: true });
+      writeFileSync(script, '');
+    }
+    h.resolveJsRuntime.mockReset().mockImplementation(() => ({ command: bunIn(mountA), env: {}, kind: 'bundled-bun' }));
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: realPlatform, configurable: true });
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('persists a command that is still resolvable after the mount point changes', () => {
+    const persisted = toWCoreConfig(applyBuiltinMcpRuntime(APPLE, { scriptPath: scriptIn(mountA), platform: 'linux' }));
+    const absolute = resolvedOnA().command;
+
+    expect(absolute).toBe(bunIn(mountA));
+    expect(existsSync(absolute)).toBe(true); // known positive: valid on the launch that wrote it
+    rmSync(mountA, { recursive: true, force: true }); // ...the AppImage unmounts
+    expect(existsSync(absolute)).toBe(false); // so the persisted absolute command is gone
+    expect(existsSync(bunIn(mountB))).toBe(true); // known positive: the check does find a live mount
+
+    // The persisted command is not a mount path at all: it is the portable `bun`
+    // Core finds on the PATH it is launched with, exactly like the npx form.
+    expect(persisted.command).toBe('bun');
+    expect(persisted.command).not.toContain(root);
+
+    // Stated, not blessed: the SCRIPT path is still mount-local, so this entry
+    // does not become spawnable again on its own after a remount — no file
+    // Desktop never resyncs can be. That half is unchanged by this fix and
+    // predates it (the core builtins have persisted an absolute
+    // `app.asar.unpacked` args[0] since long before the runtime rewrite). What
+    // the fix removes is the runtime path this PR newly introduced.
+    expect(persisted.args?.[0]).toBe(scriptIn(mountA)('builtin-mcp-apple.mjs'));
+    expect(existsSync(persisted.args![0]!)).toBe(false);
+  });
+
+  it('keeps the absolute runtime on Windows, where install paths are stable', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    const persisted = toWCoreConfig(applyBuiltinMcpRuntime(APPLE, { scriptPath: scriptIn(mountA), platform: 'linux' }));
+    expect(persisted.command).toBe(bunIn(mountA));
+  });
+
+  it('leaves the launch-local file on the absolute tuple the probe spawns', () => {
+    const spawnable = applyBuiltinMcpRuntime(APPLE, { scriptPath: scriptIn(mountA), platform: 'linux' });
+    const persisted = toWCoreConfig(spawnable, { launchLocal: true });
+    expect(persisted.command).toBe(resolvedOnA().command);
+    expect(persisted.args).toEqual(resolvedOnA().args);
+  });
+
+  it('rewrites only OUR bundled runtime, and leaves the npx form untouched', () => {
+    const foreign = server({
+      id: 'foreign',
+      name: 'foreign-bun',
+      transport: { type: 'stdio', command: '/opt/tools/bun', args: ['server.js'], env: {} },
+    });
+    expect(toWCoreConfig(foreign).command).toBe('/opt/tools/bun');
+    expect(toWCoreConfig(NPX)).toEqual({ transport: 'stdio', command: 'bun', args: ['x', '--bun', 'some-mcp'] });
+
+    // A non-bundled runtime is never collapsed either: the dev runtime is the app
+    // binary and is only a Node runtime while its ENV half rides along, so `bun`
+    // would be a different program entirely.
+    h.resolveJsRuntime.mockImplementation(() => ({
+      command: DEV_ELECTRON,
+      env: { ELECTRON_RUN_AS_NODE: '1' },
+      kind: 'electron-node',
+    }));
+    const dev = server({
+      id: 'dev',
+      name: 'dev-runtime',
+      transport: { type: 'stdio', command: DEV_ELECTRON, args: ['s.mjs'], env: { ELECTRON_RUN_AS_NODE: '1' } },
+    });
+    expect(toWCoreConfig(dev).command).toBe(DEV_ELECTRON);
   });
 });


### PR DESCRIPTION
Refs #1008. Fixes the reported symptom and one real spawn defect; does NOT close the issue — see "What remains" below.

## Root cause (established by execution, not by reading)

The three first-party bundled MCP servers are seeded into mcp.config as
{ command: 'node', args: [<absolute path to out/main/builtin-mcp-*.js>] }
and were spawned with that bare command.

macOS ships no /usr/bin/node. On any Mac without a developer Node install the
probe dies with ENOENT, so the server's tool inventory is never written back to
mcp.config, and the in-app diagnostics report "Enabled but exposes 0 tools"
forever. That is exactly the line both reporters produced.

A carve-out that routes our own builtins through a resolved JS runtime already
existed in the probe path (bundled Bun when packaged, Electron-as-Node in dev),
added for precisely this failure mode. It only matched the four sibling @wayland
servers, which store a BARE FILENAME in args[0]. The core builtins store an
absolute path, so the filename match never saw them.

## Evidence

Run against the bundled artifacts in out/main, driving a real MCP handshake
(initialize, notifications/initialized, tools/list):

- builtin-mcp-search-skills.js under node: 2 tools (wayland_search_skills, wayland_read_skill)
- builtin-mcp-concierge-diag.js under node: 1 tool (wayland_concierge_diag)
- all three under bun 1.3.11: same tool counts
- spawn of bare "node" with the PATH a Finder-launched app inherits
  (/usr/bin:/bin:/usr/sbin:/sbin): spawn node ENOENT

So the artifacts are fine and the runtime selection is the defect.

The app ships a bundled Bun and no Node (electron-builder.yml extraResources),
which is why Bun is the correct runtime here.

## concierge-diag and better-sqlite3

Verified: under Bun, require('better-sqlite3') resolves but opening a database
throws "not yet supported in Bun". openReadonlyDb already catches that and
degrades, so the sqlite-backed sections report "db unavailable" while the
config- and log-backed sections still work, and a tool call returns a report
rather than throwing. This is not a regression: the packaged binding is built
for Electron's ABI, so a system node cannot load it either (reproduced locally
as NODE_MODULE_VERSION 145 vs 127).

## Diagnostic message

The old flag told every zero-tool server to "check its command, args, or
credentials". A bundled builtin has none of those that the user owns, so that
advice sent two reporters hunting for a mistake they could not have made.
Bundled builtins now say so and ask for a report. The string lives in the
standalone stdio server and the bug-report collector, not in the i18n system,
so no locale keys change; localeKeyParity was run and is green.

## Fail-before proof

Source files reverted to HEAD via git show (no stash), new tests kept:

- mcpProtocol.test.ts, 3 new tests FAIL: "expected 'node' to be
  '/res/bundled-bun/darwin-arm64/bun'", "expected 'node' not to be 'node'",
  "expected 'node' to be '<execPath>'"
- conciergeDiagServer.test.ts, 1 new test FAIL: flag did not contain
  "bundled with Wayland"
- builtinMcpConstants.test.ts, new tests FAIL: isBuiltinCoreMcpArg is not a function

After restoring the fix: 70 pass, 0 fail across the three files.
Wider sweep tests/unit/process/services/mcpServices + tests/unit/process/resources/builtinMcp:
188 pass, 0 fail. Typecheck clean.

## What remains (do not close on this PR)

This fixes the PROBE path, which is what writes the tool inventory the
diagnostic reads. The LIVE SESSION injection paths still forward command 'node'
verbatim, so on a Mac with no Node the builtins remain uncallable in an actual
chat. Twelve such paths were mapped, including McpConfig.projectStorageConfig,
buildAcpSessionMcpServers, buildGeminiStdioMcpConfig, buildCodexMcpServerTable
and the six per-CLI config writers. None of them call resolveJsRuntime, and none
carry the runtime env it returns (which is load-bearing in dev).

I did not change them because three existing tests explicitly assert the current
behaviour, and the repo rule is to report rather than relax a test:

- tests/unit/acpBuiltinMcp.test.ts:52 and :174 assert command 'node'
- tests/unit/claudeMcpAgent.test.ts:46 asserts command 'node'

That needs its own decision, because the session serializers pass no env and
would need the ELECTRON_RUN_AS_NODE half of resolveJsRuntime threaded through
for dev to keep working.

Also unresolved and worth a follow-up: formatDiagnostics renders
server.flag ?? server.lastError, so the flag masks the real error. Had it shown
lastError too, this issue would have been root-caused from the two reports
directly. And the third-party playwright entry in the same reports is a separate
cause, untouched here.

## Not reproduced end-to-end on a packaged build

Stated plainly: I could not reproduce the user-visible failure on this machine,
because this machine HAS Node on the login shell PATH, which getEnhancedEnv
hydrates. A packaged build here would spawn successfully and show tools. The
causal chain was instead verified by its parts, as above. What would settle it
from the reporters: whether "node --version" works in their Terminal, and the
lastError value for those two servers in the MCP Library.
