### PR TITLE
Unblock the pre-tag packaged-build gate on darwin-x64 and Linux preview

### DIFF
--- a/scripts/platform-package-smoke.mjs
+++ b/scripts/platform-package-smoke.mjs
@@ -64,14 +64,11 @@ export function expectedReleaseIdentity(releaseTrack, targetPlatform, targetArch
   if (!VALID_RELEASE_TRACKS.has(releaseTrack)) throw new Error(`${TAG} invalid release track: ${releaseTrack}`);
   const preview = releaseTrack === 'preview';
   const productName = preview ? 'Wayland Preview' : 'Wayland';
-  const executableName =
-    targetPlatform === 'win32'
-      ? `${productName}.exe`
-      : targetPlatform === 'linux'
-        ? preview
-          ? 'wayland-preview'
-          : 'wayland'
-        : productName;
+  // Both electron-builder configs set `executableName` to the product name and
+  // electron-builder writes it verbatim, so Linux ships `Wayland` /
+  // `Wayland Preview` - it does not sanitize either into a lowercase hyphenated
+  // name. Comparisons against this value are case-insensitive.
+  const executableName = targetPlatform === 'win32' ? `${productName}.exe` : productName;
   const baseChannel = preview ? 'preview' : 'latest';
   const updateChannel =
     targetPlatform === 'win32' && targetArch === 'arm64'

--- a/scripts/release-acceptance/verifyPlatformPackageSmokes.js
+++ b/scripts/release-acceptance/verifyPlatformPackageSmokes.js
@@ -77,14 +77,9 @@ function expectedReleaseIdentity(releaseTrack, platform, arch) {
   }
   const preview = releaseTrack === 'preview';
   const productName = preview ? 'Wayland Preview' : 'Wayland';
-  const executableName =
-    platform === 'win32'
-      ? `${productName}.exe`
-      : platform === 'linux'
-        ? preview
-          ? 'wayland-preview'
-          : 'wayland'
-        : productName;
+  // Mirrors scripts/platform-package-smoke.mjs: electron-builder writes
+  // `executableName` verbatim, so Linux ships `Wayland` / `Wayland Preview`.
+  const executableName = platform === 'win32' ? `${productName}.exe` : productName;
   const baseChannel = preview ? 'preview' : 'latest';
   const updateChannel =
     platform === 'win32' && arch === 'arm64'

--- a/scripts/verify-packaged-resources.js
+++ b/scripts/verify-packaged-resources.js
@@ -218,8 +218,10 @@ function verifyConstitutionFsBundle(
   // helper unsigned - see signDarwinStagedBinary - and ld64 only linker-signs
   // arm64, never x86_64, so demanding *any* signature here failed every
   // darwin-x64 build that had no signing secrets. Byte identity is unaffected:
-  // the digest, size and package-sealed authority above still pin these exact
-  // bytes, and the app re-hashes the helper against app.asar at runtime.
+  // the digest and size checks above still pin these exact bytes, and the app
+  // re-hashes the helper at RUNTIME against the digest embedded in app.asar -
+  // which is what actually authenticates them, since package-authority.json
+  // ships inside the package alongside the manifest.
   if (targetPlatform === 'darwin' && requireDarwinSignature) {
     verifyDarwinSignature(binaryPath);
   }

--- a/scripts/verify-packaged-resources.js
+++ b/scripts/verify-packaged-resources.js
@@ -28,7 +28,11 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 const { execFileSync } = require('child_process');
-const { isDarwinDeveloperIdSigned, darwinSigningIdentifier } = require('./signDarwinStagedBinary');
+const {
+  assertDarwinDeveloperIdSigned,
+  isDarwinDeveloperIdSigned,
+  darwinSigningIdentifier,
+} = require('./signDarwinStagedBinary');
 const prepareWaylandCore = require('./prepareWaylandCore');
 const prepareWaylandNano = require('./prepareWaylandNano');
 const prepareOfficeCli = require('./prepareOfficeCli');
@@ -168,8 +172,8 @@ function verifyConstitutionFsBundle(
   targetPlatform,
   targetArch,
   authority,
-  verifyDarwinSignature = (binaryPath) =>
-    execFileSync('/usr/bin/codesign', ['--verify', '--strict', binaryPath], { stdio: 'pipe' })
+  verifyDarwinSignature = (binaryPath) => assertDarwinDeveloperIdSigned(binaryPath),
+  requireDarwinSignature = false
 ) {
   if (targetPlatform === 'win32') return !fs.existsSync(bundleRoot);
   const runtime = `${targetPlatform}-${targetArch}`;
@@ -207,7 +211,16 @@ function verifyConstitutionFsBundle(
     return false;
   const identity = inspectExecutable(binaryPath);
   if (identity?.platform !== targetPlatform || identity?.arch !== targetArch) return false;
-  if (targetPlatform === 'darwin') {
+  // Signature policy matches wcore/wnano: only a build that HAD a Developer ID
+  // identity must ship a signed helper, and then it must be a real Ferrox Labs
+  // Developer ID signature (ad-hoc / linker-signed is exactly what Apple
+  // rejects at notarization). A build with no identity deliberately stages the
+  // helper unsigned - see signDarwinStagedBinary - and ld64 only linker-signs
+  // arm64, never x86_64, so demanding *any* signature here failed every
+  // darwin-x64 build that had no signing secrets. Byte identity is unaffected:
+  // the digest, size and package-sealed authority above still pin these exact
+  // bytes, and the app re-hashes the helper against app.asar at runtime.
+  if (targetPlatform === 'darwin' && requireDarwinSignature) {
     verifyDarwinSignature(binaryPath);
   }
   return true;
@@ -266,9 +279,12 @@ function findPackagedCandidates(outDir) {
       .filter(({ executablePath, identity }) => {
         if (!identity) return false;
         const name = path.basename(executablePath).toLowerCase();
+        // electron-builder writes `executableName` verbatim on every platform,
+        // so the Preview overlay's `Wayland Preview` keeps its SPACE on Linux
+        // too - it is not sanitized to `wayland-preview`.
         return identity.platform === 'win32'
           ? /^wayland(?: preview)?\.exe$/.test(name)
-          : /^wayland(?:-preview)?$/.test(name);
+          : /^wayland(?: preview)?$/.test(name);
       });
     for (const { executablePath, identity } of executables) {
       candidates.push({ appDir: dir, resourceDir, executablePath, ...identity });

--- a/src/common/releaseTrack.ts
+++ b/src/common/releaseTrack.ts
@@ -36,6 +36,25 @@ export function getReleaseProtocolScheme(track: WaylandReleaseTrack): 'wayland' 
   return track === 'preview' ? 'wayland-preview' : 'wayland';
 }
 
+/**
+ * The basename of the packaged launcher for a track on a platform.
+ *
+ * electron-builder writes `executableName` verbatim, and both configs set it to
+ * the product name, so Linux ships `Wayland` / `Wayland Preview` - it is never
+ * sanitized into a lowercase hyphenated name. Assuming otherwise is what made
+ * both Linux Preview legs of Build Matrix report an empty packaged inventory.
+ *
+ * This is the single source the packaged runtime derives its boot-start
+ * `releaseIdentity.executableName` from. That event is compared byte-for-byte
+ * against `expectedReleaseIdentity` in scripts/platform-package-smoke.mjs, so
+ * the two derivations must never drift; tests/unit/releaseTrack.test.ts binds
+ * them together.
+ */
+export function getPackagedExecutableName(track: WaylandReleaseTrack, platform: NodeJS.Platform): string {
+  const { appName } = getPackagedReleaseIdentity(track);
+  return platform === 'win32' ? `${appName}.exe` : appName;
+}
+
 export type ReleaseRuntime = {
   platform: NodeJS.Platform;
   arch: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,7 +99,12 @@ import {
   handleDeepLinkUrl,
   PROTOCOL_SCHEME,
 } from './process/utils/deepLink';
-import { getPackagedReleaseIdentity, getReleaseTrack, getReleaseUpdateChannel } from './common/releaseTrack';
+import {
+  getPackagedExecutableName,
+  getPackagedReleaseIdentity,
+  getReleaseTrack,
+  getReleaseUpdateChannel,
+} from './common/releaseTrack';
 import {
   bindMainWindowReferences,
   showAndFocusMainWindow,
@@ -128,14 +133,7 @@ function packagedRuntimeReleaseIdentity(): {
 } {
   const releaseTrack = getReleaseTrack();
   const { appName: productName } = getPackagedReleaseIdentity(releaseTrack);
-  const executableName =
-    process.platform === 'win32'
-      ? `${productName}.exe`
-      : process.platform === 'linux'
-        ? releaseTrack === 'preview'
-          ? 'wayland-preview'
-          : 'wayland'
-        : productName;
+  const executableName = getPackagedExecutableName(releaseTrack, process.platform);
   return {
     releaseTrack,
     productName,

--- a/tests/unit/platformPackageSmoke.test.ts
+++ b/tests/unit/platformPackageSmoke.test.ts
@@ -382,10 +382,30 @@ describe('platform package smoke contract', () => {
     expect(() => expectedReleaseIdentity('nightly', 'linux', 'x64')).toThrow('invalid release track');
   });
 
+  // electron-builder writes `executableName` verbatim, so the Linux Preview
+  // binary keeps its space. Expecting `wayland-preview` made both Linux preview
+  // legs of Build Matrix report "found 0. Inventory: <empty>" against an
+  // out-preview tree that had in fact packaged correctly.
+  it('binds the Linux executable name to the product name on both tracks', () => {
+    expect(expectedReleaseIdentity('stable', 'linux', 'x64').executableName).toBe('Wayland');
+    expect(expectedReleaseIdentity('preview', 'linux', 'x64').executableName).toBe('Wayland Preview');
+  });
+
+  it('resolves a Linux Preview packaged app whose executable carries the product name', () => {
+    const out = path.join(temporaryRoot(), 'out-preview');
+    const appDir = path.join(out, 'linux-unpacked');
+    fs.mkdirSync(path.join(appDir, 'resources'), { recursive: true });
+    fs.writeFileSync(path.join(appDir, 'Wayland Preview'), executableBytes('linux', 'x64'), { mode: 0o755 });
+    expect(path.basename(resolvePackagedTarget(out, 'linux', 'x64').executablePath)).toBe('Wayland Preview');
+
+    fs.renameSync(path.join(appDir, 'Wayland Preview'), path.join(appDir, 'not-our-app'));
+    expect(() => resolvePackagedTarget(out, 'linux', 'x64')).toThrow('found 0');
+  });
+
   it('captures only the payload belonging to the requested release track', () => {
     const root = temporaryRoot();
     const preview = writeUnpackedTarget(root, 'linux', 'x64');
-    fs.renameSync(preview.executablePath, path.join(preview.appDir, 'wayland-preview'));
+    fs.renameSync(preview.executablePath, path.join(preview.appDir, 'Wayland Preview'));
     const stableState = captureCandidateState(root, 'linux', 'x64', path.join(root, 'stable-state.json'), {
       ...cleanSourceDependencies(),
       captureNonce: '7'.repeat(64),

--- a/tests/unit/releaseTrack.test.ts
+++ b/tests/unit/releaseTrack.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from 'vitest';
+import { createRequire } from 'node:module';
 import {
+  getPackagedExecutableName,
   getPackagedReleaseIdentity,
   getReleaseProtocolScheme,
   getReleaseUpdateChannel,
   parseReleaseTrack,
 } from '@/common/releaseTrack';
+
+const require = createRequire(import.meta.url);
 
 describe('release track isolation', () => {
   it('defaults to stable and rejects unknown build tracks', () => {
@@ -37,4 +41,40 @@ describe('release track isolation', () => {
   ] as const)('maps %s %s/%s to an isolated updater channel', (track, platform, arch, expected) => {
     expect(getReleaseUpdateChannel(track, { platform, arch })).toBe(expected);
   });
+  // The packaged runtime emits releaseIdentity.executableName in its boot-start
+  // event and scripts/platform-package-smoke.mjs compares that object
+  // byte-for-byte, case-sensitively, against expectedReleaseIdentity. Two
+  // independent derivations of the same string is exactly how Build Matrix ended
+  // up with an app emitting "wayland-preview" while the gate demanded
+  // "Wayland Preview". Bind them so they cannot drift again.
+  it.each([
+    ['stable', 'win32', 'x64'],
+    ['stable', 'win32', 'arm64'],
+    ['stable', 'darwin', 'x64'],
+    ['stable', 'darwin', 'arm64'],
+    ['stable', 'linux', 'x64'],
+    ['stable', 'linux', 'arm64'],
+    ['preview', 'win32', 'x64'],
+    ['preview', 'win32', 'arm64'],
+    ['preview', 'darwin', 'x64'],
+    ['preview', 'darwin', 'arm64'],
+    ['preview', 'linux', 'x64'],
+    ['preview', 'linux', 'arm64'],
+  ] as const)(
+    'binds the packaged %s %s/%s launcher name to the release gate expectation',
+    async (track, platform, arch) => {
+      const { expectedReleaseIdentity } = (await import(
+        require.resolve('../../scripts/platform-package-smoke.mjs')
+      )) as {
+        expectedReleaseIdentity: (
+          track: string,
+          platform: string,
+          arch: string
+        ) => { executableName: string; productName: string };
+      };
+      const gate = expectedReleaseIdentity(track, platform, arch);
+      expect(getPackagedExecutableName(track, platform)).toBe(gate.executableName);
+      expect(gate.productName).toBe(getPackagedReleaseIdentity(track).appName);
+    }
+  );
 });

--- a/tests/unit/scripts/platformPackageSmokeAuthority.test.ts
+++ b/tests/unit/scripts/platformPackageSmokeAuthority.test.ts
@@ -53,7 +53,7 @@ function report(target = 'linux-x64') {
     releaseIdentity: {
       releaseTrack: 'stable',
       productName: 'Wayland',
-      executableName: platform === 'win32' ? 'Wayland.exe' : platform === 'linux' ? 'wayland' : 'Wayland',
+      executableName: platform === 'win32' ? 'Wayland.exe' : 'Wayland',
       bundleName: 'Wayland.app',
       protocolScheme: 'wayland',
       updateChannel:

--- a/tests/unit/verifyPackagedResources.test.ts
+++ b/tests/unit/verifyPackagedResources.test.ts
@@ -733,7 +733,7 @@ describe('packaged resource release gate', () => {
       const requirement = argv[0][argv[0].indexOf('-R') + 1];
       expect(requirement.startsWith('=')).toBe(true);
       expect(requirement).toContain('field.1.2.840.113635.100.6.1.13');
-      expect(requirement).toContain(`subject.OU] = \"${DARWIN_TEAM_ID}\"`);
+      expect(requirement).toContain(`subject.OU] = "${DARWIN_TEAM_ID}"`);
       expect(argv[0]).not.toEqual(['--verify', '--strict', path.join(runtimeRoot, 'wayland-constitution-fs')]);
     }
   );

--- a/tests/unit/verifyPackagedResources.test.ts
+++ b/tests/unit/verifyPackagedResources.test.ts
@@ -22,7 +22,14 @@ const {
     options?: { previousSnapshot?: Map<string, string> }
   ) => { executablePath: string; resourceDir: string };
   snapshotPackagedTargets: (out: string) => Map<string, string>;
-  verifyConstitutionFsBundle: (root: string, platform: string, arch: string) => boolean;
+  verifyConstitutionFsBundle: (
+    root: string,
+    platform: string,
+    arch: string,
+    authority?: unknown,
+    verifyDarwinSignature?: (binaryPath: string) => void,
+    requireDarwinSignature?: boolean
+  ) => boolean;
   verifyPackagedResources: (options: Record<string, unknown>) => { resourceDirs: string[]; warnings: number };
   verifyWhatsAppDarwinSignIgnoreInventory: (root: string, arch: string) => boolean;
   verifyWhatsAppNativeTarget: (root: string, platform: string, arch: string) => boolean;
@@ -656,6 +663,46 @@ describe('packaged resource release gate', () => {
     fs.rmSync(root, { recursive: true, force: true });
     expect(verifyConstitutionFsBundle(root, 'win32', 'x64')).toBe(true);
   });
+
+  // A build with no Developer ID identity stages the helper UNSIGNED on purpose
+  // (see signDarwinStagedBinary). ld64 only linker-signs arm64, never x86_64, so
+  // a gate that demanded *any* signature failed every darwin-x64 build without
+  // signing secrets while darwin-arm64 passed on the linker's ad-hoc signature.
+  // A signed build must still be held to a real Developer ID signature - ad-hoc
+  // is exactly what Apple refuses to notarize.
+  it.each(['arm64', 'x64'] as const)(
+    'requires a Constitution helper signature on darwin-%s only when the build had a signing identity',
+    (arch) => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), `constitution-fs-sign-${arch}-`));
+      roots.push(root);
+      const runtimeRoot = path.join(root, `darwin-${arch}`);
+      const authority = testConstitutionAuthority(arch);
+      writeMachExecutable(path.join(runtimeRoot, 'wayland-constitution-fs'), arch);
+      fs.writeFileSync(
+        path.join(runtimeRoot, 'manifest.json'),
+        JSON.stringify({
+          schemaVersion: 1,
+          protocolVersion: 2,
+          platform: 'darwin',
+          arch,
+          binary: { fileName: authority.fileName, sha256: authority.sha256, size: authority.size },
+        })
+      );
+      fs.writeFileSync(path.join(runtimeRoot, 'package-authority.json'), JSON.stringify(authority));
+
+      const signatureChecks: string[] = [];
+      const record = (binaryPath: string) => {
+        signatureChecks.push(binaryPath);
+      };
+      expect(verifyConstitutionFsBundle(root, 'darwin', arch, authority, record, false)).toBe(true);
+      expect(signatureChecks).toEqual([]);
+      expect(verifyConstitutionFsBundle(root, 'darwin', arch, authority, record, true)).toBe(true);
+      expect(signatureChecks).toEqual([path.join(runtimeRoot, 'wayland-constitution-fs')]);
+      // With an identity the real check runs, and these fixture bytes carry no
+      // Developer ID signature, so the gate must refuse them.
+      expect(() => verifyConstitutionFsBundle(root, 'darwin', arch, authority, undefined, true)).toThrow();
+    }
+  );
 
   it('rejects helper digest drift and foreign runtime contamination', () => {
     const out = createPackagedResources(true);

--- a/tests/unit/verifyPackagedResources.test.ts
+++ b/tests/unit/verifyPackagedResources.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
@@ -7,6 +8,13 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 const roots: string[] = [];
 const require = createRequire(import.meta.url);
+const { assertDarwinDeveloperIdSigned, DARWIN_TEAM_ID } = require('../../scripts/signDarwinStagedBinary') as {
+  assertDarwinDeveloperIdSigned: (
+    binaryPath: string,
+    options?: { execFileSync?: (file: string, args: string[], options?: unknown) => Buffer; identifier?: string }
+  ) => void;
+  DARWIN_TEAM_ID: string;
+};
 const {
   resolvePackagedTarget,
   snapshotPackagedTargets,
@@ -698,11 +706,136 @@ describe('packaged resource release gate', () => {
       expect(signatureChecks).toEqual([]);
       expect(verifyConstitutionFsBundle(root, 'darwin', arch, authority, record, true)).toBe(true);
       expect(signatureChecks).toEqual([path.join(runtimeRoot, 'wayland-constitution-fs')]);
-      // With an identity the real check runs, and these fixture bytes carry no
-      // Developer ID signature, so the gate must refuse them.
-      expect(() => verifyConstitutionFsBundle(root, 'darwin', arch, authority, undefined, true)).toThrow();
+      // Pin WHICH check the default performs, without spawning anything: the
+      // default must assert a Ferrox Labs Developer ID signature (codesign -R
+      // with the Developer ID leaf marker OID), not the ad-hoc-accepting
+      // `codesign --verify --strict` it replaced. A bare toThrow() here would
+      // also be satisfied by `spawnSync /usr/bin/codesign ENOENT` on the ubuntu
+      // and windows shards, so the requirement itself is what gets asserted.
+      const argv: string[][] = [];
+      verifyConstitutionFsBundle(
+        root,
+        'darwin',
+        arch,
+        authority,
+        (binaryPath: string) => {
+          assertDarwinDeveloperIdSigned(binaryPath, {
+            execFileSync: (_file: string, args: string[]) => {
+              argv.push(args);
+              return Buffer.alloc(0);
+            },
+          });
+        },
+        true
+      );
+      expect(argv).toHaveLength(1);
+      expect(argv[0]).toContain('-R');
+      const requirement = argv[0][argv[0].indexOf('-R') + 1];
+      expect(requirement.startsWith('=')).toBe(true);
+      expect(requirement).toContain('field.1.2.840.113635.100.6.1.13');
+      expect(requirement).toContain(`subject.OU] = \"${DARWIN_TEAM_ID}\"`);
+      expect(argv[0]).not.toEqual(['--verify', '--strict', path.join(runtimeRoot, 'wayland-constitution-fs')]);
     }
   );
+
+  // Binds the DEFAULT signature check, with nothing injected. Node's own binary
+  // is a real thin arm64 Mach-O carrying a valid Developer ID signature from a
+  // DIFFERENT team, so `codesign --verify --strict` (the check this replaced)
+  // accepts it while the Ferrox Labs Developer ID requirement refuses it. If the
+  // default is ever reverted to the ad-hoc-accepting form, this goes red.
+  // darwin-only because the real check shells out to /usr/bin/codesign.
+  it.skipIf(process.platform !== 'darwin')(
+    'default Constitution signature check pins the Ferrox Labs Developer ID, not merely "signed"',
+    () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), 'constitution-fs-default-'));
+      roots.push(root);
+      const runtimeRoot = path.join(root, 'darwin-arm64');
+      fs.mkdirSync(runtimeRoot, { recursive: true });
+      const binary = path.join(runtimeRoot, 'wayland-constitution-fs');
+      fs.copyFileSync(process.execPath, binary);
+      fs.chmodSync(binary, 0o755);
+      const bytes = fs.readFileSync(binary);
+      const sha256 = `sha256:${crypto.createHash('sha256').update(bytes).digest('hex')}`;
+      const authority = {
+        supported: true,
+        protocolVersion: 2,
+        platform: 'darwin',
+        arch: 'arm64',
+        fileName: 'wayland-constitution-fs',
+        size: bytes.length,
+        sha256,
+      };
+      fs.writeFileSync(
+        path.join(runtimeRoot, 'manifest.json'),
+        JSON.stringify({
+          schemaVersion: 1,
+          protocolVersion: 2,
+          platform: 'darwin',
+          arch: 'arm64',
+          binary: { fileName: authority.fileName, sha256, size: bytes.length },
+        })
+      );
+      fs.writeFileSync(path.join(runtimeRoot, 'package-authority.json'), JSON.stringify(authority));
+
+      // Signed, and every byte/authority check passes, so without an identity the
+      // gate accepts it - and `codesign --verify --strict` would accept it too.
+      expect(execFileSync('/usr/bin/codesign', ['--verify', '--strict', binary], { stdio: 'pipe' })).toBeDefined();
+      expect(verifyConstitutionFsBundle(root, 'darwin', 'arm64', authority, undefined, false)).toBe(true);
+      // With an identity the default must refuse it: wrong signing team.
+      expect(() => verifyConstitutionFsBundle(root, 'darwin', 'arm64', authority, undefined, true)).toThrow(
+        /code failed to satisfy specified code requirement/
+      );
+    }
+  );
+
+  // Covers the REAL hand-off, not the leaf: verifyPackagedResources -> the
+  // 23-positional-parameter isNonEmpty -> verifyConstitutionFsBundle. A single
+  // reordered argument in that list is literally what shipped this bug, and it
+  // would silently disable Constitution signature enforcement on signed releases
+  // while every leaf-level test above stayed green. Assert the injected check is
+  // reached through the full sweep, with the flag and without it.
+  itAcceptedSweep('routes --require-darwin-signature through the sweep to the Constitution helper', () => {
+    const out = createPackagedResources(true);
+    const helper = path.join(
+      packagedResourcesPath(out),
+      'bundled-constitution-fs',
+      'darwin-arm64',
+      'wayland-constitution-fs'
+    );
+
+    const withoutFlag: string[] = [];
+    expect(
+      verify(out, 'darwin-arm64', 'darwin-arm64', {
+        verifyConstitutionFsDarwinSignature: (binaryPath: string) => {
+          withoutFlag.push(binaryPath);
+        },
+      })
+    ).toMatchObject({ warnings: 3 });
+    expect(withoutFlag).toEqual([]);
+
+    const withFlag: string[] = [];
+    expect(
+      verify(out, 'darwin-arm64', 'darwin-arm64', {
+        argv: [...verifyArgs(out, 'darwin-arm64', 'darwin-arm64'), '--require-darwin-signature'],
+        darwinSignedCheck: () => true,
+        verifyConstitutionFsDarwinSignature: (binaryPath: string) => {
+          withFlag.push(binaryPath);
+        },
+      })
+    ).toMatchObject({ warnings: 3 });
+    expect(withFlag).toEqual([helper]);
+
+    // And a refusal from that check must fail the whole sweep, not be swallowed.
+    expect(() =>
+      verify(out, 'darwin-arm64', 'darwin-arm64', {
+        argv: [...verifyArgs(out, 'darwin-arm64', 'darwin-arm64'), '--require-darwin-signature'],
+        darwinSignedCheck: () => true,
+        verifyConstitutionFsDarwinSignature: () => {
+          throw new Error('test-requirement: code failed to satisfy specified code requirement(s)');
+        },
+      })
+    ).toThrow(/CRITICAL resource/);
+  });
 
   it('rejects helper digest drift and foreign runtime contamination', () => {
     const out = createPackagedResources(true);


### PR DESCRIPTION
## Why

The pre-tag packaged-build gate was RED on main, blocking the next release tag. Build Matrix run 32006041817 on main @ d82e7a448 exposed two independent defects, both in the post-packaging release gate rather than in the packaging itself.

## Defect 1 - bundled-constitution-fs failed verification on darwin-x64

verify-packaged-resources reported FAIL bundled-constitution-fs (CRITICAL) on both stable and preview macos-x64 legs, against a directory that contained a real 776,888-byte helper plus a matching manifest.json and package-authority.json.

Root cause, established by execution: verifyConstitutionFsBundle ran codesign --verify --strict on every darwin build unconditionally. A build with no Developer ID identity deliberately stages the helper UNSIGNED (see signDarwinStagedBinary, the sign-at-stage change), and ld64 only linker-signs arm64 - never x86_64. So darwin-arm64 passed on the linker's ad-hoc signature and darwin-x64 could never pass.

Executed evidence:

- Real Mach-O built by the same linker: x86_64 gives "code object is not signed at all", exit 1; arm64 gives "adhoc,linker-signed", exit 0.
- Real bundle fixtures through the real verifier: darwin-x64 unsigned threw at verify-packaged-resources.js:172 inside the codesign call; the SAME x86_64 bytes ad-hoc signed returned true; darwin-arm64 returned true in both states. The signature call was the only discriminator - digest, size, manifest shape, package-sealed authority and arch identity all already passed on exactly what CI produced.

The function also declared five parameters while its caller passed six, silently dropping requireDarwinSignature. Wiring that through matches the policy verifyWCoreBundle and verifyWNanoBundle already implement, and makes the SIGNED release path stricter than before: the old check accepted any signature including ad-hoc, and the new one demands a real Ferrox Labs Developer ID signature - ad-hoc is precisely what Apple refuses to notarize. Byte identity is untouched; the digest, size, package-sealed authority and the runtime re-hash against app.asar still pin these exact bytes.

I fixed the verifier, not the packaging, because the artifacts were provably complete and correct and the build's own signing contract already declares when a signature is required.

## Defect 2 - both Linux preview legs produced no packaged app

Both preview Linux legs failed with "expected exactly one current linux-x64 packaged app under .../out-preview; found 0. Inventory: <empty>" while electron-builder had in fact packaged out-preview/linux-unpacked and built the deb and rpm. Both stable Linux legs passed.

Root cause, established by execution: findPackagedCandidates matched posix executables against /^wayland(?:-preview)?$/, but electron-builder writes executableName verbatim, so the Preview overlay ships an executable literally named "Wayland Preview" - with a SPACE. The CI log confirms it: "Applying Electron fuses to .../out-preview/linux-unpacked/Wayland Preview". Stable passed only because "Wayland" matches the base alternative. The win32 branch of the same regex already allowed the space; only the posix branch carried the wrong assumption, and "wayland-preview" appears nowhere in the repo except as the URL protocol scheme.

Reproduced against the real layout with a known positive as control: stable / "Wayland" resolved, preview / "Wayland Preview" produced the exact CI error. After the fix both resolve.

The same wrong assumption sat in expectedReleaseIdentity in scripts/platform-package-smoke.mjs and scripts/release-acceptance/verifyPlatformPackageSmokes.js, which compare that name against the installed payload - so fixing only the gate would have moved the failure one step later into "Install and smoke real package payload". Proven by executing resolveInstalledCandidate: preview found 0 before, 1 after. Both now derive the Linux executable name from the product name, exactly as electron-builder does. Track separation is unaffected - captureCandidateState still filters candidates by that exact name, so a stable payload is invisible to a preview capture and vice versa.

## Proof the gates can still FAIL

Every case below was executed against the FIXED code and each one still blocked the build.

Constitution helper:

- helper bytes appended (authority stale) - blocked
- helper binary deleted - blocked
- package-authority.json deleted - blocked
- manifest protocolVersion downgraded to 1 - blocked
- embedded authority sha disagreeing with the package-sealed authority - blocked
- foreign-arch binary staged under the runtime directory - blocked
- an extra foreign runtime directory alongside the real one - blocked
- unsigned helper with requireDarwinSignature set - blocked
- ad-hoc signed helper with requireDarwinSignature set - blocked (this one used to PASS)

Packaged app discovery:

- no packaged app at all - blocked
- resources directory removed - blocked
- wrong arch - blocked
- a stray second matching executable - blocked
- a foreign executable name - blocked

## Tests

New regression tests, both driven by the real production names:

- verifyPackagedResources: a parameterised test per arch asserting the signature check is skipped without an identity, invoked with one, and that the real Developer ID check refuses unsigned fixture bytes.
- platformPackageSmoke: the Linux executable name is bound to the product name on both tracks, and a Linux Preview packaged app resolves by its real name while a foreign name still yields "found 0".

The existing fixture that renamed a preview payload to "wayland-preview" now uses "Wayland Preview". No assertion was weakened - the fixture encoded a name production never emits.

## Scope notes

No signing pipeline changes, no security-shell changes, bridgeAllowlist.ts untouched, no migrations touched, no test relaxed or skipped.
