### PR TITLE
fix(acp): stop reporting a transport drop as a process exit

### DIFF
--- a/src/process/acp/compat/AcpAgentV2.ts
+++ b/src/process/acp/compat/AcpAgentV2.ts
@@ -24,6 +24,7 @@ import {
 } from '@process/acp/compat/typeBridge';
 import { AcpError as AcpSessionError } from '@process/acp/errors/AcpError';
 import { AcpSession, type SessionOptions } from '@process/acp/session/AcpSession';
+import { CRASH_MARKER_PROCESS_EXIT, CRASH_MARKER_TRANSPORT_CLOSE } from '@process/acp/session/crashMarkers';
 import { readClaudeModelInfoFromCcSwitch } from '@process/services/ccSwitchModelSource';
 import { buildClaudeSlotModelInfo } from '@process/agent/acp/utils';
 // TODO(ACP Discovery): Re-enable when acp_session persistence is restored.
@@ -622,8 +623,12 @@ export class AcpAgentV2 {
           case 'error': {
             // Detect process crash from error message keywords to emit agentCrash
             // flag that TeammateManager.handleResponseStream relies on (V1 parity).
+            // CRASH_MARKER_TRANSPORT_CLOSE is the #1020 wording for a disconnect
+            // with no observed process exit. Without it here a transport drop
+            // stopped matching, and the renderer's loading state never cleared.
             const isCrash =
-              event.message.includes('process exited unexpectedly') ||
+              event.message.includes(CRASH_MARKER_PROCESS_EXIT) ||
+              event.message.includes(CRASH_MARKER_TRANSPORT_CLOSE) ||
               event.message.includes('PROCESS_CRASHED') ||
               event.message.includes('Process disconnected');
 

--- a/src/process/acp/infra/IAcpClient.ts
+++ b/src/process/acp/infra/IAcpClient.ts
@@ -93,9 +93,24 @@ export type AgentLifecycleSnapshot = {
 
 export type DisconnectInfo = {
   reason: AgentDisconnectReason;
+  /**
+   * Null for BOTH of these only when no process exit was ever observed - i.e. a
+   * transport-level drop while the child was, as far as Node could see, still
+   * running. The disconnect is not reported until the exit event has had a
+   * bounded window to arrive, so null/null is now evidence of absence rather
+   * than a lost race (#1020).
+   */
   exitCode: number | null;
   signal: string | null;
   stderr: string;
+  /**
+   * True if a prompt request was in flight when the transport dropped. That turn
+   * is NOT replayed - `PromptExecutor.handlePromptError` deliberately refuses to
+   * re-queue an in-flight prompt on a dead stream, because a `tool_call` it had
+   * already run can be lost with the pipe - so the user has to be told it did
+   * not land (#1020).
+   */
+  unexpectedDuringPrompt: boolean;
 };
 
 // ─── Client Factory ─────────────────────────────────────────────

--- a/src/process/acp/infra/IAcpClient.ts
+++ b/src/process/acp/infra/IAcpClient.ts
@@ -101,8 +101,10 @@ export type DisconnectInfo = {
    * The report is deliberately NOT delayed to wait for a late 'exit' event (see
    * `ProcessAcpClient.recordAgentExit` - delaying it inverts the ordering the
    * session depends on), so a genuine fast crash can land here too. That is why
-   * `buildCrashMessage` hedges ("the process may still be running") instead of
-   * asserting an exit it has no evidence for (#1020).
+   * `buildCrashMessage` reports only what was observed ("no exit code or signal was
+   * reported") instead of asserting an exit it has no evidence for (#1020), and does
+   * NOT reassure the user that the child is probably alive - measured against each
+   * child's own 'exit' event, that reassurance was wrong for 6 of 20 real crashes.
    */
   exitCode: number | null;
   signal: string | null;

--- a/src/process/acp/infra/IAcpClient.ts
+++ b/src/process/acp/infra/IAcpClient.ts
@@ -94,11 +94,15 @@ export type AgentLifecycleSnapshot = {
 export type DisconnectInfo = {
   reason: AgentDisconnectReason;
   /**
-   * Null for BOTH of these only when no process exit was ever observed - i.e. a
-   * transport-level drop while the child was, as far as Node could see, still
-   * running. The disconnect is not reported until the exit event has had a
-   * bounded window to arrive, so null/null is now evidence of absence rather
-   * than a lost race (#1020).
+   * Null for BOTH of these means no process exit had been observed AT THE MOMENT
+   * the disconnect was reported - typically a transport-level drop while the
+   * child was, as far as Node could see, still running.
+   *
+   * The report is deliberately NOT delayed to wait for a late 'exit' event (see
+   * `ProcessAcpClient.recordAgentExit` - delaying it inverts the ordering the
+   * session depends on), so a genuine fast crash can land here too. That is why
+   * `buildCrashMessage` hedges ("the process may still be running") instead of
+   * asserting an exit it has no evidence for (#1020).
    */
   exitCode: number | null;
   signal: string | null;

--- a/src/process/acp/infra/ProcessAcpClient.ts
+++ b/src/process/acp/infra/ProcessAcpClient.ts
@@ -476,9 +476,10 @@ export class ProcessAcpClient implements AcpClient {
     // The tradeoff this buys is accepted deliberately: because nothing waits for
     // the child's 'exit' event, a genuine fast crash whose exit is still a
     // millisecond away is reported as a transport close rather than a confirmed
-    // exit. That is the correct direction. A hedged "no exit was reported, the
-    // process may still be running" is honest about what was observed; asserting
-    // "process exited" with no code and no signal is the #1020 bug itself.
+    // exit. That is the correct direction. Reporting "no exit code or signal was
+    // reported" is honest about what was observed; asserting "process exited" with
+    // no code and no signal is the #1020 bug itself. The banner stops there and does
+    // not claim the child is probably alive, because for a fast crash it is not.
     const error = new AgentDisconnectedError(reason, exitCode, signal ? String(signal) : null, {
       outputAlreadyEmitted: this.hasActivePrompt,
     });

--- a/src/process/acp/infra/ProcessAcpClient.ts
+++ b/src/process/acp/infra/ProcessAcpClient.ts
@@ -55,25 +55,6 @@ const STARTUP_STDERR_MAX = 8192;
 const MISSED_EXIT_REPLAY_MS = 250;
 
 /**
- * How long a transport-level disconnect that carries NO exit code and NO signal
- * waits for the child's own exit event before it is reported as a transport drop.
- *
- * The four lifecycle signals are first-write-wins, and the SDK's connection abort
- * structurally beats Node's exit event: the abort fires on the readable's 'end',
- * which precedes both `stdout`'s 'close' and 'exit'. Measured on macOS/node 22, a
- * child that called `process.exit(7)` reported `connection_close / exitCode: null
- * / signal: null` on ~3 runs in 5, and a SIGKILL lost its signal every time -
- * while `child.exitCode`/`child.signalCode` were populated 0-1ms later. So the
- * banner asserted "code: unknown, signal: none" for ordinary, fully-diagnosable
- * crashes (#1020).
- *
- * `normalizeInitializeError` already resolves this exact race with the same 200ms
- * budget; that fix only ever covered the initialize path. This extends it to the
- * post-init disconnect path.
- */
-const EXIT_CONFIRM_MS = 200;
-
-/**
  * Resolve `target` to a real filesystem path, symlinks included.
  *
  * bun names the REAL path of the module it could not resolve. On macOS that is
@@ -467,62 +448,51 @@ export class ProcessAcpClient implements AcpClient {
       console.warn(`[ACP ${this.options.backend}] Process exited with code ${exitCode} [reason: ${reason}]`);
     }
 
+    const unexpectedDuringPrompt = !this.closing && this.hasActivePrompt;
+
     this._lastExit = {
       exitCode,
       signal: signal ? String(signal) : null,
       reason,
       stderr: this.stderrBuffer,
-      unexpectedDuringPrompt: !this.closing && this.hasActivePrompt,
+      unexpectedDuringPrompt,
     };
 
-    // Reject all pending SDK requests with our own error type. This stays
-    // synchronous: a request left hanging is worse than a slightly less precise
-    // exit summary, and the in-flight prompt needs to fail now.
+    // Reject the pending SDK requests, then notify the disconnect handler - both
+    // SYNCHRONOUSLY, in that order.
+    //
+    // That order is load-bearing, and it is not what it looks like. A rejection's
+    // continuation is a microtask, so `AcpSession.onDisconnect` still runs BEFORE
+    // `PromptExecutor.handlePromptError` sees the rejected prompt. That is exactly
+    // what arms `handlePromptError`'s "someone else owns recovery" guard
+    // (`status !== 'prompting'`): `onDisconnect` has already moved the session on.
+    //
+    // Put ANY await, timer or deferral between these two statements and the
+    // ordering inverts: `handlePromptError` runs first, takes its retryable
+    // branch, emits its own raw banner, flushes the queued follow-up at the dead
+    // client (#774), and the session-level #1020 banner becomes dead code. Do not
+    // add one.
+    //
+    // The tradeoff that buys is accepted deliberately: because nothing waits for
+    // the child's 'exit' event, a genuine fast crash whose exit is still a
+    // millisecond away is reported as a transport close rather than a confirmed
+    // exit. That is the correct direction. A hedged "no exit was reported, the
+    // process may still be running" is honest about what was observed; asserting
+    // "process exited" with no code and no signal is the #1020 bug itself.
     const error = new AgentDisconnectedError(reason, exitCode, signal ? String(signal) : null, {
       outputAlreadyEmitted: this.hasActivePrompt,
     });
     this.rejectPendingRequests(error);
 
-    // No exit detail and a child still attached: the exit event may simply not
-    // have landed yet. Give it a bounded window before reporting "no process exit
-    // observed", so the banner never asserts the absence of something that was
-    // one millisecond away (#1020). Everything else reports immediately, exactly
-    // as before.
-    if (exitCode === null && !signal && this.child) {
-      void this.confirmExitThenNotify(reason);
-      return;
+    if (this.disconnectHandler) {
+      this.disconnectHandler({
+        reason,
+        exitCode,
+        signal: signal ? String(signal) : null,
+        stderr: this.stderrBuffer,
+        unexpectedDuringPrompt,
+      });
     }
-    this.notifyDisconnect(reason);
-  }
-
-  /**
-   * Wait out {@link EXIT_CONFIRM_MS} for the child's exit, then report whatever is
-   * actually known. `_lastExit` is upgraded in place: `reason` keeps first-write-wins
-   * (the transport close IS what we saw first), but the exit detail is filled in
-   * rather than pinned at null, so `lifecycleSnapshot` agrees with the banner.
-   */
-  private async confirmExitThenNotify(reason: AgentDisconnectReason): Promise<void> {
-    const child = this.child;
-    if (child) {
-      await waitForExit(child, EXIT_CONFIRM_MS);
-      const exitCode = child.exitCode ?? null;
-      const signal = child.signalCode ? String(child.signalCode) : null;
-      if (this._lastExit && (exitCode !== null || signal !== null)) {
-        this._lastExit = { ...this._lastExit, exitCode, signal };
-      }
-    }
-    this.notifyDisconnect(reason);
-  }
-
-  private notifyDisconnect(reason: AgentDisconnectReason): void {
-    if (!this.disconnectHandler) return;
-    this.disconnectHandler({
-      reason,
-      exitCode: this._lastExit?.exitCode ?? null,
-      signal: this._lastExit?.signal ?? null,
-      stderr: this.stderrBuffer,
-      unexpectedDuringPrompt: this._lastExit?.unexpectedDuringPrompt ?? false,
-    });
   }
 
   // ─── Internals: Startup failure watcher ────────────────────

--- a/src/process/acp/infra/ProcessAcpClient.ts
+++ b/src/process/acp/infra/ProcessAcpClient.ts
@@ -41,11 +41,31 @@ import type {
 } from '@process/acp/infra/IAcpClient';
 import { NdjsonTransport } from '@process/acp/infra/NdjsonTransport';
 import { gracefulShutdown, waitForExit, waitForSpawn } from '@process/acp/infra/processUtils';
+import { redactSecrets } from '@process/utils/secretRedaction';
 import type { PromptContent, ProtocolHandlers } from '@process/acp/types';
 import type { ChildProcess } from 'node:child_process';
 import * as fs from 'node:fs';
 
 const STARTUP_STDERR_MAX = 8192;
+
+/**
+ * How much of the stderr ring's trailing non-whitespace run is held back from the
+ * collection-site scrub.
+ *
+ * A credential can straddle two stderr chunks. Scrubbing the buffer the moment it
+ * overflows would mask the half that has arrived, replacing its ANCHOR with
+ * `[redacted]` and orphaning the half that arrives next - which no later scrub can
+ * match, because the thing that identified it is gone. Measured through the real
+ * path: 51 characters of a live-shaped Anthropic key reached the banner that way.
+ *
+ * So the trailing run is left raw for the next chunk to complete. That is safe
+ * because it sits at the ring's TAIL, which the cap keeps rather than cuts, and
+ * because a partial with its PREFIX still intact is redactable
+ * (`redactSecrets('sk-ant-api03-AbCdEfGhIjK')` masks) - it is only the anchorless
+ * REMAINDER that is invisible to the scrubber. A run longer than this is a blob, not
+ * a straddled credential, so it is scrubbed normally.
+ */
+const STDERR_CHUNK_SPLIT_CARRY_MAX = 256;
 
 /**
  * How long to wait for a child that had ALREADY exited when the lifecycle
@@ -407,32 +427,43 @@ export class ProcessAcpClient implements AcpClient {
       console.error(`[ACP ${this.options.backend} STDERR]:`, chunk);
       this.stderrBuffer += chunk;
       if (this.stderrBuffer.length > STARTUP_STDERR_MAX) {
-        // Truncate on a RECORD boundary, never mid-token (#1023). #1020 routes this
-        // ring into the chat transcript via `buildCrashMessage`, so a cut at an
-        // arbitrary character is a disclosure path: `redactSecrets` only matches a
-        // WHOLE credential, and shaving one character off `sk-ant-api03-` defeats
-        // the vendor-prefix rule, so the remainder of a real key survives every
-        // downstream scrub. Dropping the partial leading record removes the half-token
-        // before anything can miss it.
+        // SCRUB, then cap on a RECORD boundary (#1023). #1020 routes this ring into the
+        // chat transcript through `buildCrashMessage`, which makes the ring's truncation a
+        // disclosure path: `redactSecrets` only matches a WHOLE credential, so any cut
+        // through one leaves a remainder that every downstream scrub misses.
         //
-        // A boundary is `\r` as well as `\n`. Bare-CR output - progress bars, old-Mac
-        // line endings - has real record boundaries with no `\n` anywhere, and taking
-        // whichever comes FIRST also keeps more diagnostics when a `\r` record sits in
-        // front of a `\n` one.
+        // The order is the fix. Scrubbing HERE, before the cap, means a credential is
+        // masked while it is still whole and the cap can only ever cut through
+        // `[redacted]` or through text the scrubber already declined to match. Capping
+        // first and scrubbing at read time - the order this used to use - cannot be made
+        // safe by any choice of cut, because the scrubber's anchor is not always attached
+        // to the secret: `Bearer <token>`, `Authorization: <token>` and `api_key = <value>`
+        // each keep the anchor in a SEPARATE whitespace-delimited word. A cut landing
+        // inside the anchor left the secret whole and un-anchored, and dropping the leading
+        // non-whitespace run then removed the anchor rather than the secret. Executed
+        // through the real path, all four of those shapes leaked into the banner.
         //
-        // With no boundary at all in the retained 8KB there is nothing to cut at, so
-        // drop just the leading run of non-whitespace. That run is exactly the span a
-        // half-token can occupy, because a credential contains no whitespace, so this
-        // costs one token out of 8KB instead of the whole buffer. Keeping the whole
-        // buffer was the original hole: `indexOf` returned -1, `slice(0)` was a no-op,
-        // and the half-token stayed at character 0 of a ring that redaction had already
-        // shrunk under the banner's own 2048-character tail - on screen, in the chat.
-        // One 8KB token with no whitespace at all does empty the ring, and that is the
-        // right call: nothing there distinguishes a blob from a secret, and the banner
-        // still names the disconnect reason without a stderr line.
-        const sliced = this.stderrBuffer.slice(-STARTUP_STDERR_MAX);
+        // The remaining boundary cut is no longer a security measure - the scrub above is -
+        // but it is still worth doing, because a ring that begins mid-record reads as
+        // corrupt. A boundary is `\r` as well as `\n`: bare-CR output (progress bars,
+        // old-Mac line endings) has real record boundaries with no `\n` anywhere, and
+        // taking whichever comes FIRST also keeps more diagnostics when a `\r` record sits
+        // in front of a `\n` one.
+        //
+        // `cutRing || sliced` keeps the scrubbed window whenever the cut would empty it.
+        // A single record larger than the ring - a minified stack frame, a JSON config
+        // echo, a base64 dump - puts its only boundary at the very last character, so
+        // `slice(boundary + 1)` returned `''` and the user got a banner with no `Agent
+        // stderr:` section at all. Measured: 21KB in one line gave `ringLen=0` where main
+        // delivered 8192 characters including the real error. Falling back is safe here
+        // only because the scrub already ran.
+        const trailingRun = /\S*$/.exec(this.stderrBuffer)?.[0] ?? '';
+        const carry = trailingRun.length <= STDERR_CHUNK_SPLIT_CARRY_MAX ? trailingRun : '';
+        const scrubbed = redactSecrets(this.stderrBuffer.slice(0, this.stderrBuffer.length - carry.length)) + carry;
+        const sliced = scrubbed.slice(-STARTUP_STDERR_MAX);
         const boundary = sliced.search(/[\r\n]/);
-        this.stderrBuffer = boundary >= 0 ? sliced.slice(boundary + 1) : sliced.replace(/^\S+/, '');
+        const cutRing = boundary >= 0 ? sliced.slice(boundary + 1) : sliced.replace(/^\S+/, '');
+        this.stderrBuffer = cutRing || sliced;
       }
     });
   }

--- a/src/process/acp/infra/ProcessAcpClient.ts
+++ b/src/process/acp/infra/ProcessAcpClient.ts
@@ -473,7 +473,7 @@ export class ProcessAcpClient implements AcpClient {
     // client (#774), and the session-level #1020 banner becomes dead code. Do not
     // add one.
     //
-    // The tradeoff that buys is accepted deliberately: because nothing waits for
+    // The tradeoff this buys is accepted deliberately: because nothing waits for
     // the child's 'exit' event, a genuine fast crash whose exit is still a
     // millisecond away is reported as a transport close rather than a confirmed
     // exit. That is the correct direction. A hedged "no exit was reported, the

--- a/src/process/acp/infra/ProcessAcpClient.ts
+++ b/src/process/acp/infra/ProcessAcpClient.ts
@@ -412,12 +412,27 @@ export class ProcessAcpClient implements AcpClient {
         // arbitrary character is a disclosure path: `redactSecrets` only matches a
         // WHOLE credential, and shaving one character off `sk-ant-api03-` defeats
         // the vendor-prefix rule, so the remainder of a real key survives every
-        // downstream scrub. Dropping the partial leading line removes the half-token
-        // before anything can miss it. A tail with no newline at all keeps its whole
-        // 8KB rather than emptying itself (indexOf returns -1, slice(0) is a no-op),
-        // because an unbroken blob is still the only diagnostic we have.
+        // downstream scrub. Dropping the partial leading record removes the half-token
+        // before anything can miss it.
+        //
+        // A boundary is `\r` as well as `\n`. Bare-CR output - progress bars, old-Mac
+        // line endings - has real record boundaries with no `\n` anywhere, and taking
+        // whichever comes FIRST also keeps more diagnostics when a `\r` record sits in
+        // front of a `\n` one.
+        //
+        // With no boundary at all in the retained 8KB there is nothing to cut at, so
+        // drop just the leading run of non-whitespace. That run is exactly the span a
+        // half-token can occupy, because a credential contains no whitespace, so this
+        // costs one token out of 8KB instead of the whole buffer. Keeping the whole
+        // buffer was the original hole: `indexOf` returned -1, `slice(0)` was a no-op,
+        // and the half-token stayed at character 0 of a ring that redaction had already
+        // shrunk under the banner's own 2048-character tail - on screen, in the chat.
+        // One 8KB token with no whitespace at all does empty the ring, and that is the
+        // right call: nothing there distinguishes a blob from a secret, and the banner
+        // still names the disconnect reason without a stderr line.
         const sliced = this.stderrBuffer.slice(-STARTUP_STDERR_MAX);
-        this.stderrBuffer = sliced.slice(sliced.indexOf('\n') + 1);
+        const boundary = sliced.search(/[\r\n]/);
+        this.stderrBuffer = boundary >= 0 ? sliced.slice(boundary + 1) : sliced.replace(/^\S+/, '');
       }
     });
   }

--- a/src/process/acp/infra/ProcessAcpClient.ts
+++ b/src/process/acp/infra/ProcessAcpClient.ts
@@ -407,7 +407,17 @@ export class ProcessAcpClient implements AcpClient {
       console.error(`[ACP ${this.options.backend} STDERR]:`, chunk);
       this.stderrBuffer += chunk;
       if (this.stderrBuffer.length > STARTUP_STDERR_MAX) {
-        this.stderrBuffer = this.stderrBuffer.slice(-STARTUP_STDERR_MAX);
+        // Truncate on a RECORD boundary, never mid-token (#1023). #1020 routes this
+        // ring into the chat transcript via `buildCrashMessage`, so a cut at an
+        // arbitrary character is a disclosure path: `redactSecrets` only matches a
+        // WHOLE credential, and shaving one character off `sk-ant-api03-` defeats
+        // the vendor-prefix rule, so the remainder of a real key survives every
+        // downstream scrub. Dropping the partial leading line removes the half-token
+        // before anything can miss it. A tail with no newline at all keeps its whole
+        // 8KB rather than emptying itself (indexOf returns -1, slice(0) is a no-op),
+        // because an unbroken blob is still the only diagnostic we have.
+        const sliced = this.stderrBuffer.slice(-STARTUP_STDERR_MAX);
+        this.stderrBuffer = sliced.slice(sliced.indexOf('\n') + 1);
       }
     });
   }

--- a/src/process/acp/infra/ProcessAcpClient.ts
+++ b/src/process/acp/infra/ProcessAcpClient.ts
@@ -439,6 +439,43 @@ export class ProcessAcpClient implements AcpClient {
 
   // ─── Internals: 4-signal lifecycle detection ───────────────
 
+  /**
+   * KNOWN PRODUCT LIMITATION, WINDOWS: a live agent whose transport dies is NOT
+   * detected here (#1020 follow-up).
+   *
+   * Three of the four signals below are transport signals - `pipe_close` fires on the
+   * child's stdout 'close', and `connection_close` (attached in start()) fires when the
+   * SDK aborts on that readable's 'end'. On win32 neither ever fires while the child is
+   * still running. Executed on a real Windows box, with a known positive in the same
+   * run:
+   *
+   *   child does `process.stdout.end()`, stays alive -> parent sees nothing
+   *   child does `fs.closeSync(1)`, stays alive      -> parent sees nothing
+   *   child really exits (control)                   -> parent sees
+   *      stdout 'end', stdout 'close', 'exit', 'close'
+   *
+   * The same probe on darwin reports stdout 'end' + 'close' with the child still alive
+   * for both of the first two cases, so this is a platform difference, not a bug in the
+   * probe.
+   *
+   * What still works on Windows: a genuinely crashed or killed agent IS reported,
+   * because process death closes the pipe (the control above). What does not: an agent
+   * process that lives on but stops speaking ACP - the #1020 customer shape - produces
+   * no disconnect at all on win32, so the session neither drops the client nor shows the
+   * transport-close banner, and the in-flight prompt hangs until the caller gives up.
+   * Detecting it needs a signal that does not depend on the pipe (an ACP-level
+   * request/heartbeat timeout); a failing write does not help, because the parent writes
+   * to the child's STDIN, which is still open.
+   *
+   * Two effects on Windows even when the child DOES die: `connection_close` reliably
+   * wins the first-write-wins race below, so `exitCode` and `signal` reach
+   * `buildCrashMessage` as null and the banner never carries an exit code from this
+   * path; the CRLF stderr ring is preserved either way.
+   *
+   * The tests that drive the live-child shape are `skipIf(win32)` for this reason -
+   * `tests/unit/acpDisconnectTransport.test.ts` and
+   * `tests/integration/process/acp/session/AcpSession.disconnectBanner.test.ts`.
+   */
   private attachLifecycleObservers(child: ChildProcess): void {
     child.once('exit', (code, signal) => {
       this.recordAgentExit('process_exit', code, signal);

--- a/src/process/acp/infra/ProcessAcpClient.ts
+++ b/src/process/acp/infra/ProcessAcpClient.ts
@@ -55,6 +55,25 @@ const STARTUP_STDERR_MAX = 8192;
 const MISSED_EXIT_REPLAY_MS = 250;
 
 /**
+ * How long a transport-level disconnect that carries NO exit code and NO signal
+ * waits for the child's own exit event before it is reported as a transport drop.
+ *
+ * The four lifecycle signals are first-write-wins, and the SDK's connection abort
+ * structurally beats Node's exit event: the abort fires on the readable's 'end',
+ * which precedes both `stdout`'s 'close' and 'exit'. Measured on macOS/node 22, a
+ * child that called `process.exit(7)` reported `connection_close / exitCode: null
+ * / signal: null` on ~3 runs in 5, and a SIGKILL lost its signal every time -
+ * while `child.exitCode`/`child.signalCode` were populated 0-1ms later. So the
+ * banner asserted "code: unknown, signal: none" for ordinary, fully-diagnosable
+ * crashes (#1020).
+ *
+ * `normalizeInitializeError` already resolves this exact race with the same 200ms
+ * budget; that fix only ever covered the initialize path. This extends it to the
+ * post-init disconnect path.
+ */
+const EXIT_CONFIRM_MS = 200;
+
+/**
  * Resolve `target` to a real filesystem path, symlinks included.
  *
  * bun names the REAL path of the module it could not resolve. On macOS that is
@@ -456,21 +475,54 @@ export class ProcessAcpClient implements AcpClient {
       unexpectedDuringPrompt: !this.closing && this.hasActivePrompt,
     };
 
-    // Reject all pending SDK requests with our own error type
+    // Reject all pending SDK requests with our own error type. This stays
+    // synchronous: a request left hanging is worse than a slightly less precise
+    // exit summary, and the in-flight prompt needs to fail now.
     const error = new AgentDisconnectedError(reason, exitCode, signal ? String(signal) : null, {
       outputAlreadyEmitted: this.hasActivePrompt,
     });
     this.rejectPendingRequests(error);
 
-    // Notify disconnect handler
-    if (this.disconnectHandler) {
-      this.disconnectHandler({
-        reason,
-        exitCode,
-        signal: signal ? String(signal) : null,
-        stderr: this.stderrBuffer,
-      });
+    // No exit detail and a child still attached: the exit event may simply not
+    // have landed yet. Give it a bounded window before reporting "no process exit
+    // observed", so the banner never asserts the absence of something that was
+    // one millisecond away (#1020). Everything else reports immediately, exactly
+    // as before.
+    if (exitCode === null && !signal && this.child) {
+      void this.confirmExitThenNotify(reason);
+      return;
     }
+    this.notifyDisconnect(reason);
+  }
+
+  /**
+   * Wait out {@link EXIT_CONFIRM_MS} for the child's exit, then report whatever is
+   * actually known. `_lastExit` is upgraded in place: `reason` keeps first-write-wins
+   * (the transport close IS what we saw first), but the exit detail is filled in
+   * rather than pinned at null, so `lifecycleSnapshot` agrees with the banner.
+   */
+  private async confirmExitThenNotify(reason: AgentDisconnectReason): Promise<void> {
+    const child = this.child;
+    if (child) {
+      await waitForExit(child, EXIT_CONFIRM_MS);
+      const exitCode = child.exitCode ?? null;
+      const signal = child.signalCode ? String(child.signalCode) : null;
+      if (this._lastExit && (exitCode !== null || signal !== null)) {
+        this._lastExit = { ...this._lastExit, exitCode, signal };
+      }
+    }
+    this.notifyDisconnect(reason);
+  }
+
+  private notifyDisconnect(reason: AgentDisconnectReason): void {
+    if (!this.disconnectHandler) return;
+    this.disconnectHandler({
+      reason,
+      exitCode: this._lastExit?.exitCode ?? null,
+      signal: this._lastExit?.signal ?? null,
+      stderr: this.stderrBuffer,
+      unexpectedDuringPrompt: this._lastExit?.unexpectedDuringPrompt ?? false,
+    });
   }
 
   // ─── Internals: Startup failure watcher ────────────────────

--- a/src/process/acp/session/AcpSession.ts
+++ b/src/process/acp/session/AcpSession.ts
@@ -124,8 +124,9 @@ function buildStderrTail(stderr: string): string | null {
  * The in-flight line does not tell the user to resend. `PromptExecutor` refuses to
  * replay that turn precisely because a dead pipe can swallow the `tool_call` that
  * would say what already ran, so the turn may have already executed an approved
- * `rm`. Copy that says "send it again" instructs the human to do by hand the exact
- * thing the code declines to do for them.
+ * `rm`. So the copy tells the user to CHECK the result before sending it again,
+ * rather than offering the bare "send it again" that would have them redo by hand the
+ * exact thing the code declines to do for them.
  *
  * Deliberately NOT routed through i18n - this matches the surrounding diagnostics
  * (`AgentDisconnectedError`, `AgentStartupError`, `enterError`), which are all raw

--- a/src/process/acp/session/AcpSession.ts
+++ b/src/process/acp/session/AcpSession.ts
@@ -113,6 +113,20 @@ function buildStderrTail(stderr: string): string | null {
  * So: claim an exit only when a code or a signal is present, name the reason either
  * way, and carry a scrubbed stderr tail so the real cause is recoverable.
  *
+ * The no-exit branch states only what was observed and stops there. It used to add
+ * that the process "may still be running", which was measured FALSE for 6 of 20 real
+ * crashes (an exit(7) or a SIGKILL whose 'exit' event was still a tick away when the
+ * transport aborted). There is no fix for that beyond dropping the reassurance:
+ * `kill(pid, 0)` returns true for the exited-but-unreaped child, so no synchronous
+ * probe can tell the two apart, and deferring the report inverts the ordering the
+ * session depends on (`ProcessAcpClient.recordAgentExit`).
+ *
+ * The in-flight line does not tell the user to resend. `PromptExecutor` refuses to
+ * replay that turn precisely because a dead pipe can swallow the `tool_call` that
+ * would say what already ran, so the turn may have already executed an approved
+ * `rm`. Copy that says "send it again" instructs the human to do by hand the exact
+ * thing the code declines to do for them.
+ *
  * Deliberately NOT routed through i18n - this matches the surrounding diagnostics
  * (`AgentDisconnectedError`, `AgentStartupError`, `enterError`), which are all raw
  * English strings, and the reason/stderr payload is untranslatable anyway.
@@ -124,11 +138,13 @@ export function buildCrashMessage(info?: DisconnectInfo): string | null {
   const lines: string[] = [
     exitObserved
       ? `${CRASH_MARKER_PROCESS_EXIT} (code: ${info.exitCode ?? 'unknown'}, signal: ${info.signal ?? 'none'}) [reason: ${info.reason}]`
-      : `${CRASH_MARKER_TRANSPORT_CLOSE} [reason: ${info.reason}]. No exit code or signal was reported, so the agent process may still be running - this is a transport-level disconnect, not a confirmed crash.`,
+      : `${CRASH_MARKER_TRANSPORT_CLOSE} [reason: ${info.reason}]. No exit code or signal was reported, so we cannot tell whether the agent crashed or the connection dropped.`,
   ];
 
   if (info.unexpectedDuringPrompt) {
-    lines.push('The message that was in flight did not complete and was not resent automatically - send it again.');
+    lines.push(
+      'The reply was lost before it could complete, and it was not resent automatically. The agent may already have carried out part of this message, so check the result before sending it again.'
+    );
   }
 
   const tail = buildStderrTail(info.stderr);

--- a/src/process/acp/session/AcpSession.ts
+++ b/src/process/acp/session/AcpSession.ts
@@ -11,6 +11,9 @@ import { buildAcpAdapterCorruptionGuidance, buildAcpSetupGuidance } from '@proce
 import type { ClientFactory, DisconnectInfo } from '@process/acp/infra/IAcpClient';
 import { noopMetrics, type AcpMetrics } from '@process/acp/metrics/AcpMetrics';
 import { ConfigTracker } from '@process/acp/session/ConfigTracker';
+import { CRASH_MARKER_PROCESS_EXIT, CRASH_MARKER_TRANSPORT_CLOSE } from '@process/acp/session/crashMarkers';
+import { stripAnsi } from '@process/agent/wcore/stderrLog';
+import { redactSecrets } from '@process/utils/secretRedaction';
 import { InputPreprocessor } from '@process/acp/session/InputPreprocessor';
 import { MessageTranslator } from '@process/acp/session/MessageTranslator';
 import { PermissionResolver } from '@process/acp/session/PermissionResolver';
@@ -75,9 +78,63 @@ function wrapCallbacks(raw: SessionCallbacks): SessionCallbacks {
   return wrapped as SessionCallbacks;
 }
 
+/**
+ * Bound on the scrubbed stderr tail carried into the banner, mirroring
+ * `WCORE_STDERR_TAIL_MAX`. `ProcessAcpClient` already caps its ring buffer at 8KB;
+ * this trims again for a chat row.
+ */
+const DISCONNECT_STDERR_TAIL_MAX = 2048;
+
+/**
+ * Last {@link DISCONNECT_STDERR_TAIL_MAX} characters of the agent's stderr, ANSI
+ * stripped and secret-scrubbed.
+ *
+ * Scrubbing is not optional: this is untrusted subprocess output on its way to the
+ * chat transcript and the log file, and an agent bridge prints to stderr exactly
+ * when credentials are in play. Routed through the shared scrubber (#984) rather
+ * than any local pattern list.
+ */
+function buildStderrTail(stderr: string): string | null {
+  const cleaned = redactSecrets(stripAnsi(stderr)).trim();
+  if (!cleaned) return null;
+  return cleaned.length > DISCONNECT_STDERR_TAIL_MAX ? cleaned.slice(-DISCONNECT_STDERR_TAIL_MAX) : cleaned;
+}
+
+/**
+ * Describe a disconnect WITHOUT asserting anything that was not observed (#1020).
+ *
+ * The old single line claimed `process exited unexpectedly (code: unknown, signal:
+ * none)` whenever both fields were null - which is precisely the case where no
+ * process exit was observed at all. A customer on the Claude Code backend was shown
+ * that for a transport drop, asked what it meant, and got a confabulated answer
+ * about the process dying, because the message named the only two facts that were
+ * not known and discarded the two that were: `reason` and the stderr buffer.
+ *
+ * So: claim an exit only when a code or a signal is present, name the reason either
+ * way, and carry a scrubbed stderr tail so the real cause is recoverable.
+ *
+ * Deliberately NOT routed through i18n - this matches the surrounding diagnostics
+ * (`AgentDisconnectedError`, `AgentStartupError`, `enterError`), which are all raw
+ * English strings, and the reason/stderr payload is untranslatable anyway.
+ */
 export function buildCrashMessage(info?: DisconnectInfo): string | null {
   if (!info) return null;
-  return `process exited unexpectedly (code: ${info.exitCode ?? 'unknown'}, signal: ${info.signal ?? 'none'})`;
+
+  const exitObserved = info.exitCode !== null || info.signal !== null;
+  const lines: string[] = [
+    exitObserved
+      ? `${CRASH_MARKER_PROCESS_EXIT} (code: ${info.exitCode ?? 'unknown'}, signal: ${info.signal ?? 'none'}) [reason: ${info.reason}]`
+      : `${CRASH_MARKER_TRANSPORT_CLOSE} [reason: ${info.reason}]. No exit code or signal was reported, so the agent process may still be running - this is a transport-level disconnect, not a confirmed crash.`,
+  ];
+
+  if (info.unexpectedDuringPrompt) {
+    lines.push('The message that was in flight did not complete and was not resent automatically - send it again.');
+  }
+
+  const tail = buildStderrTail(info.stderr);
+  if (tail) lines.push(`Agent stderr:\n${tail}`);
+
+  return lines.join('\n');
 }
 
 export class AcpSession {
@@ -419,6 +476,20 @@ export class AcpSession {
         return;
 
       case 'prompting': {
+        // Surfaced, NOT silently recovered (#1020). `resumeFromDisconnect` below
+        // respawns the agent and re-flushes the pending QUEUE, but the turn that
+        // was in flight is gone: `flush()` shifted it off the queue before
+        // `execute()`, and `handlePromptError` deliberately refuses to hand it
+        // back on a dead stream, because a `tool_call` it had already run can be
+        // lost with the pipe. So the user's turn genuinely did not land, and
+        // staying quiet would leave them believing it did - which is how the
+        // customer's approval disappeared. The banner now says so explicitly (via
+        // `unexpectedDuringPrompt`) rather than asserting a process exit.
+        //
+        // Tradeoff accepted: a benign inactivity-shaped transport close that
+        // happens to land mid-prompt still shows a banner, where the 'active'
+        // branch below stays silent. That asymmetry is correct - in 'active'
+        // nothing was lost, here a turn was.
         this.lifecycle.clearClient();
         this.emitCrashSignalIfProcessDied(info);
         this.promptExecutor.stopTimer();

--- a/src/process/acp/session/crashMarkers.ts
+++ b/src/process/acp/session/crashMarkers.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Stable opening phrases of the two disconnect banners `buildCrashMessage`
+ * produces, factored out because they are a de-facto protocol: two downstream
+ * consumers classify a turn as "the agent died" by substring-matching the
+ * user-facing text.
+ *
+ *  - `AcpAgentV2` (compat/AcpAgentV2.ts) matches to decide whether to synthesize
+ *    the `finish` frame carrying `agentCrash: true`. Without that frame the
+ *    renderer's loading state never clears.
+ *  - `TeammateManager` matches to route the agent into `handleAgentCrash`.
+ *
+ * #1020 added the second phrase (a transport drop with no observed process
+ * exit). Any new banner wording MUST be added here and to both matchers, or the
+ * disconnect stops terminating the turn.
+ *
+ * Kept dependency-free so `TeammateManager` can import it without dragging the
+ * ACP session tree in.
+ */
+
+/** An exit code or a signal was actually observed. */
+export const CRASH_MARKER_PROCESS_EXIT = 'process exited unexpectedly';
+
+/**
+ * The transport dropped and NO exit code or signal was observed, so a process
+ * death is unproven - the child may still be running.
+ */
+export const CRASH_MARKER_TRANSPORT_CLOSE = 'lost the connection to the agent process';

--- a/src/process/acp/session/crashMarkers.ts
+++ b/src/process/acp/session/crashMarkers.ts
@@ -27,7 +27,8 @@
 export const CRASH_MARKER_PROCESS_EXIT = 'process exited unexpectedly';
 
 /**
- * The transport dropped and NO exit code or signal was observed, so a process
- * death is unproven - the child may still be running.
+ * The transport dropped and NO exit code or signal was observed, so neither a
+ * process death nor a live child is proven. The banner says only that, and
+ * deliberately does not reassure the user that the child is probably alive.
  */
 export const CRASH_MARKER_TRANSPORT_CLOSE = 'lost the connection to the agent process';

--- a/src/process/team/TeammateManager.ts
+++ b/src/process/team/TeammateManager.ts
@@ -18,6 +18,7 @@ import type { ITaskRepository } from './repository/ITeamRepository';
 import { buildRolePrompt } from './prompts/buildRolePrompt';
 import { formatMessages } from './prompts/formatHelpers';
 import { agentRegistry } from '@process/agent/AgentRegistry';
+import { CRASH_MARKER_PROCESS_EXIT, CRASH_MARKER_TRANSPORT_CLOSE } from '@process/acp/session/crashMarkers';
 // W4 audit CRIT-1 (2026-05-19): register / unregister team context for
 // each agent conversation so the ACP file-op gate can resolve the team
 // when sandboxed imported agents request file ops.
@@ -661,7 +662,14 @@ export class TeammateManager extends EventEmitter {
     }
     if (msg.type === 'error') {
       const errorText = typeof msg.data === 'string' ? msg.data : (msgData?.error ?? '');
-      if (errorText.includes('process exited unexpectedly') || errorText.includes('Session not found')) {
+      // CRASH_MARKER_TRANSPORT_CLOSE covers the #1020 wording for a disconnect
+      // with no observed process exit, which used to arrive as the process-exit
+      // phrase and so already routed here.
+      if (
+        errorText.includes(CRASH_MARKER_PROCESS_EXIT) ||
+        errorText.includes(CRASH_MARKER_TRANSPORT_CLOSE) ||
+        errorText.includes('Session not found')
+      ) {
         void this.handleAgentCrash(agent, errorText);
         return;
       }

--- a/tests/fixtures/acp/fakeAcpAgent.cjs
+++ b/tests/fixtures/acp/fakeAcpAgent.cjs
@@ -1,10 +1,35 @@
-// Minimal ACP-speaking child used to drive ProcessAcpClient's four disconnect
-// signals from real OS process behaviour. MODE selects what it does after it
-// answers `initialize`.
+// Minimal ACP-speaking child used to drive ProcessAcpClient's disconnect signals
+// from real OS process behaviour. MODE selects what it does.
+//
+//   exit-code       exit(7) shortly after answering `initialize`
+//   signal          SIGKILL itself shortly after answering `initialize`
+//   pipe-close      end stdout after `initialize` but STAY ALIVE
+//   drop-on-prompt  answer `initialize` + `session/new`, then end stdout on
+//                   `session/prompt` and STAY ALIVE - the customer shape of
+//                   #1020, and the shape the disconnect-ordering proof needs
+//   stay (default)  answer everything and stay alive
+//
+// Any other request carrying an `id` is answered with an empty result, so a
+// session can reach `session/prompt` without hanging on config re-assertion.
 const MODE = process.env.FAKE_ACP_MODE || 'stay';
 const NOISE = process.env.FAKE_ACP_STDERR || '';
 
 if (NOISE) process.stderr.write(NOISE);
+
+/** Keep the process alive without holding the event loop busy. */
+function stayAlive() {
+  setTimeout(() => {}, 60_000);
+}
+
+function send(id, result) {
+  process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id, result }) + '\n');
+}
+
+/** Drop the stdio pipe but keep running: nothing about a process exit is true. */
+function dropTransport() {
+  process.stdout.end();
+  stayAlive();
+}
 
 let buf = '';
 process.stdin.on('data', (chunk) => {
@@ -20,18 +45,39 @@ process.stdin.on('data', (chunk) => {
     } catch {
       continue;
     }
-    if (msg.method === 'initialize') {
-      process.stdout.write(
-        JSON.stringify({
-          jsonrpc: '2.0',
-          id: msg.id,
-          result: { protocolVersion: msg.params?.protocolVersion ?? 1, agentCapabilities: {}, authMethods: [] },
-        }) + '\n'
-      );
-      setTimeout(act, 30);
-    }
+    if (msg.id === undefined || msg.id === null) continue;
+    handle(msg);
   }
 });
+
+function handle(msg) {
+  switch (msg.method) {
+    case 'initialize':
+      send(msg.id, {
+        protocolVersion: msg.params?.protocolVersion ?? 1,
+        agentCapabilities: { loadSession: true },
+        authMethods: [],
+      });
+      setTimeout(act, 30);
+      return;
+    case 'session/new':
+      send(msg.id, { sessionId: 'fake-session-1' });
+      return;
+    case 'session/load':
+      send(msg.id, {});
+      return;
+    case 'session/prompt':
+      if (MODE === 'drop-on-prompt') {
+        dropTransport();
+        return;
+      }
+      send(msg.id, { stopReason: 'end_turn' });
+      return;
+    default:
+      send(msg.id, {});
+      return;
+  }
+}
 
 function act() {
   switch (MODE) {
@@ -42,15 +88,9 @@ function act() {
       process.kill(process.pid, 'SIGKILL');
       break;
     case 'pipe-close':
-      // Drop the stdio pipe but keep running: this is the shape the customer hit.
-      process.stdout.end();
-      setTimeout(() => {}, 60_000);
-      break;
-    case 'garbage':
-      process.stdout.write('this is not ndjson\n');
-      setTimeout(() => {}, 60_000);
+      dropTransport();
       break;
     default:
-      setTimeout(() => {}, 60_000);
+      stayAlive();
   }
 }

--- a/tests/fixtures/acp/fakeAcpAgent.cjs
+++ b/tests/fixtures/acp/fakeAcpAgent.cjs
@@ -1,0 +1,56 @@
+// Minimal ACP-speaking child used to drive ProcessAcpClient's four disconnect
+// signals from real OS process behaviour. MODE selects what it does after it
+// answers `initialize`.
+const MODE = process.env.FAKE_ACP_MODE || 'stay';
+const NOISE = process.env.FAKE_ACP_STDERR || '';
+
+if (NOISE) process.stderr.write(NOISE);
+
+let buf = '';
+process.stdin.on('data', (chunk) => {
+  buf += chunk.toString();
+  let idx;
+  while ((idx = buf.indexOf('\n')) >= 0) {
+    const line = buf.slice(0, idx).trim();
+    buf = buf.slice(idx + 1);
+    if (!line) continue;
+    let msg;
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (msg.method === 'initialize') {
+      process.stdout.write(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: msg.id,
+          result: { protocolVersion: msg.params?.protocolVersion ?? 1, agentCapabilities: {}, authMethods: [] },
+        }) + '\n'
+      );
+      setTimeout(act, 30);
+    }
+  }
+});
+
+function act() {
+  switch (MODE) {
+    case 'exit-code':
+      process.exit(7);
+      break;
+    case 'signal':
+      process.kill(process.pid, 'SIGKILL');
+      break;
+    case 'pipe-close':
+      // Drop the stdio pipe but keep running: this is the shape the customer hit.
+      process.stdout.end();
+      setTimeout(() => {}, 60_000);
+      break;
+    case 'garbage':
+      process.stdout.write('this is not ndjson\n');
+      setTimeout(() => {}, 60_000);
+      break;
+    default:
+      setTimeout(() => {}, 60_000);
+  }
+}

--- a/tests/integration/process/acp/session/AcpSession.disconnectBanner.test.ts
+++ b/tests/integration/process/acp/session/AcpSession.disconnectBanner.test.ts
@@ -33,6 +33,24 @@ import type { AgentConfig, SessionCallbacks } from '@process/acp/types';
 
 const FIXTURE = path.resolve(__dirname, '../../../../fixtures/acp/fakeAcpAgent.cjs');
 
+/**
+ * The mid-prompt drop this test drives cannot happen on Windows, so there is nothing for
+ * it to observe there.
+ *
+ * Executed on the win32 box: a child that closes stdout (via `process.stdout.end()` AND
+ * via the definitive `fs.closeSync(1)`) while STAYING ALIVE produces no 'end' and no
+ * 'close' on the parent's read end, while a child that really exits produces the full
+ * `[stdout:end, stdout:close, exit, close]` set in the same run - so the known-positive
+ * control fires and the negative is a platform fact, not a dead fixture. The same probe
+ * on darwin reports `[stdout:end, stdout:close]` with the child still alive.
+ *
+ * The PRODUCT limitation is recorded next to the detection code in
+ * `ProcessAcpClient.attachLifecycleObservers`: on Windows this banner is reachable only
+ * when the agent's process actually dies, never for a live agent whose transport went
+ * away. Tracked as a #1020 follow-up - do not read this skip as "the test was flaky".
+ */
+const itLiveChildDrop = it.skipIf(process.platform === 'win32');
+
 /** A real credential shape, so the scrubber is exercised on the real path. */
 const LEAKED_SECRET = 'sk-abcdefghijklmnopqrstuvwx';
 const STDERR_NOISE = `bridge failed: Cannot find module zod/v4 (token ${LEAKED_SECRET})\n`;
@@ -102,62 +120,66 @@ function errorMessages(callbacks: SessionCallbacks): string[] {
 }
 
 describe('#1020 end-to-end mid-prompt transport drop (real child, real client, real session)', () => {
-  it('the banner the SESSION emits describes a transport drop, not an invented exit', async () => {
-    const callbacks = createCallbacks();
-    const session = new AcpSession(baseConfig, realClientFactory('drop-on-prompt'), callbacks);
+  itLiveChildDrop(
+    'the banner the SESSION emits describes a transport drop, not an invented exit',
+    async () => {
+      const callbacks = createCallbacks();
+      const session = new AcpSession(baseConfig, realClientFactory('drop-on-prompt'), callbacks);
 
-    session.start();
-    await vi.waitFor(() => expect(session.status).toBe('active'), { timeout: 15000 });
+      session.start();
+      await vi.waitFor(() => expect(session.status).toBe('active'), { timeout: 15000 });
 
-    // The turn rejects with AgentDisconnectedError once the pipe goes.
-    await expect(session.sendMessage('please approve this')).rejects.toBeTruthy();
+      // The turn rejects with AgentDisconnectedError once the pipe goes.
+      await expect(session.sendMessage('please approve this')).rejects.toBeTruthy();
 
-    const errors = await vi.waitFor(
-      () => {
-        const msgs = errorMessages(callbacks);
-        expect(msgs.length).toBeGreaterThan(0);
-        return msgs;
-      },
-      { timeout: 15000 }
-    );
+      const errors = await vi.waitFor(
+        () => {
+          const msgs = errorMessages(callbacks);
+          expect(msgs.length).toBeGreaterThan(0);
+          return msgs;
+        },
+        { timeout: 15000 }
+      );
 
-    // FIRST, not merely present: whichever error banner lands first is the one the
-    // user reads. If `handlePromptError` beats `onDisconnect`, this is instead the
-    // raw "Agent disconnected (connection_close, code: null)" and the whole #1020
-    // payload below never reaches a screen.
-    const banner = errors[0];
+      // FIRST, not merely present: whichever error banner lands first is the one the
+      // user reads. If `handlePromptError` beats `onDisconnect`, this is instead the
+      // raw "Agent disconnected (connection_close, code: null)" and the whole #1020
+      // payload below never reaches a screen.
+      const banner = errors[0];
 
-    expect(banner).toContain(CRASH_MARKER_TRANSPORT_CLOSE);
-    expect(banner).toContain('[reason: connection_close]');
-    expect(banner).toContain('we cannot tell whether the agent crashed or the connection dropped');
-    expect(banner).not.toContain('may still be running');
+      expect(banner).toContain(CRASH_MARKER_TRANSPORT_CLOSE);
+      expect(banner).toContain('[reason: connection_close]');
+      expect(banner).toContain('we cannot tell whether the agent crashed or the connection dropped');
+      expect(banner).not.toContain('may still be running');
 
-    // The old message asserted exactly the two facts that were NOT known.
-    expect(banner).not.toContain(CRASH_MARKER_PROCESS_EXIT);
-    expect(banner).not.toContain('code: unknown');
-    expect(banner).not.toContain('signal: none');
+      // The old message asserted exactly the two facts that were NOT known.
+      expect(banner).not.toContain(CRASH_MARKER_PROCESS_EXIT);
+      expect(banner).not.toContain('code: unknown');
+      expect(banner).not.toContain('signal: none');
 
-    // A turn was in flight and is not replayed, so the user has to be told - and
-    // told to CHECK before resending, because the turn may already have run a tool
-    // whose notification died with the pipe (#1023).
-    expect(banner).toContain('lost before it could complete');
-    expect(banner).toContain('was not resent automatically');
-    expect(banner).toContain('The agent may already have carried out part of this message');
-    expect(banner).toContain('check the result before sending it again');
+      // A turn was in flight and is not replayed, so the user has to be told - and
+      // told to CHECK before resending, because the turn may already have run a tool
+      // whose notification died with the pipe (#1023).
+      expect(banner).toContain('lost before it could complete');
+      expect(banner).toContain('was not resent automatically');
+      expect(banner).toContain('The agent may already have carried out part of this message');
+      expect(banner).toContain('check the result before sending it again');
 
-    // The stderr that names the real cause rides along - scrubbed.
-    expect(banner).toContain('Agent stderr:');
-    expect(banner).toContain('Cannot find module zod/v4');
-    expect(banner).toContain('[redacted]');
-    expect(banner).not.toContain(LEAKED_SECRET);
+      // The stderr that names the real cause rides along - scrubbed.
+      expect(banner).toContain('Agent stderr:');
+      expect(banner).toContain('Cannot find module zod/v4');
+      expect(banner).toContain('[redacted]');
+      expect(banner).not.toContain(LEAKED_SECRET);
 
-    // This child really IS still running - but the banner does not say so, because
-    // for a fast crash the same null/null report arrives while the child is dead
-    // (measured 6 of 20, #1023) and nothing synchronous can tell the two apart.
-    const first = spawned[0];
-    expect(first.pid).toBeTruthy();
-    expect(isProcessAlive(first.pid!)).toBe(true);
+      // This child really IS still running - but the banner does not say so, because
+      // for a fast crash the same null/null report arrives while the child is dead
+      // (measured 6 of 20, #1023) and nothing synchronous can tell the two apart.
+      const first = spawned[0];
+      expect(first.pid).toBeTruthy();
+      expect(isProcessAlive(first.pid!)).toBe(true);
 
-    await session.stop();
-  }, 40000);
+      await session.stop();
+    },
+    40000
+  );
 });

--- a/tests/integration/process/acp/session/AcpSession.disconnectBanner.test.ts
+++ b/tests/integration/process/acp/session/AcpSession.disconnectBanner.test.ts
@@ -129,16 +129,21 @@ describe('#1020 end-to-end mid-prompt transport drop (real child, real client, r
 
     expect(banner).toContain(CRASH_MARKER_TRANSPORT_CLOSE);
     expect(banner).toContain('[reason: connection_close]');
-    expect(banner).toContain('may still be running');
+    expect(banner).toContain('we cannot tell whether the agent crashed or the connection dropped');
+    expect(banner).not.toContain('may still be running');
 
     // The old message asserted exactly the two facts that were NOT known.
     expect(banner).not.toContain(CRASH_MARKER_PROCESS_EXIT);
     expect(banner).not.toContain('code: unknown');
     expect(banner).not.toContain('signal: none');
 
-    // A turn was in flight and is not replayed, so the user has to be told.
-    expect(banner).toContain('did not complete');
-    expect(banner).toContain('send it again');
+    // A turn was in flight and is not replayed, so the user has to be told - and
+    // told to CHECK before resending, because the turn may already have run a tool
+    // whose notification died with the pipe (#1023).
+    expect(banner).toContain('lost before it could complete');
+    expect(banner).toContain('was not resent automatically');
+    expect(banner).toContain('The agent may already have carried out part of this message');
+    expect(banner).toContain('check the result before sending it again');
 
     // The stderr that names the real cause rides along - scrubbed.
     expect(banner).toContain('Agent stderr:');
@@ -146,7 +151,9 @@ describe('#1020 end-to-end mid-prompt transport drop (real child, real client, r
     expect(banner).toContain('[redacted]');
     expect(banner).not.toContain(LEAKED_SECRET);
 
-    // The child really is still running: "may still be running" is not a hedge.
+    // This child really IS still running - but the banner does not say so, because
+    // for a fast crash the same null/null report arrives while the child is dead
+    // (measured 6 of 20, #1023) and nothing synchronous can tell the two apart.
     const first = spawned[0];
     expect(first.pid).toBeTruthy();
     expect(isProcessAlive(first.pid!)).toBe(true);

--- a/tests/integration/process/acp/session/AcpSession.disconnectBanner.test.ts
+++ b/tests/integration/process/acp/session/AcpSession.disconnectBanner.test.ts
@@ -1,0 +1,156 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * #1020 END TO END: a mid-prompt transport drop, driven by a real child process
+ * through a real ProcessAcpClient into a real AcpSession, asserting the banner the
+ * SESSION emits.
+ *
+ * This is the test whose absence let the first cut of the fix through review. Every
+ * other test in this area asserts `DisconnectInfo`, which is one layer too low: the
+ * client can hand the session a perfect payload and the user can still be shown a
+ * completely different string, because `PromptExecutor.handlePromptError` also emits
+ * an error banner and whichever of the two runs first wins the screen.
+ *
+ * The fixture is the customer's shape (#1020, and #60 before it): it answers
+ * `initialize` and `session/new`, then ends stdout on `session/prompt` and STAYS
+ * ALIVE. So there is genuinely no exit code and no signal, and the banner must not
+ * invent one.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { spawn, type ChildProcess } from 'node:child_process';
+import * as path from 'node:path';
+import { AcpSession } from '@process/acp/session/AcpSession';
+import { CRASH_MARKER_PROCESS_EXIT, CRASH_MARKER_TRANSPORT_CLOSE } from '@process/acp/session/crashMarkers';
+import { ProcessAcpClient } from '@process/acp/infra/ProcessAcpClient';
+import { isProcessAlive } from '@process/acp/infra/processUtils';
+import type { ClientFactory } from '@process/acp/infra/IAcpClient';
+import type { AgentConfig, SessionCallbacks } from '@process/acp/types';
+
+const FIXTURE = path.resolve(__dirname, '../../../../fixtures/acp/fakeAcpAgent.cjs');
+
+/** A real credential shape, so the scrubber is exercised on the real path. */
+const LEAKED_SECRET = 'sk-abcdefghijklmnopqrstuvwx';
+const STDERR_NOISE = `bridge failed: Cannot find module zod/v4 (token ${LEAKED_SECRET})\n`;
+
+function createCallbacks(): SessionCallbacks {
+  return {
+    onMessage: vi.fn(),
+    onSessionId: vi.fn(),
+    onStatusChange: vi.fn(),
+    onConfigUpdate: vi.fn(),
+    onModelUpdate: vi.fn(),
+    onModeUpdate: vi.fn(),
+    onContextUsage: vi.fn(),
+    onPermissionRequest: vi.fn(),
+    onSignal: vi.fn(),
+  };
+}
+
+const baseConfig: AgentConfig = {
+  agentBackend: 'probe',
+  agentSource: 'builtin',
+  agentId: 'builtin:probe',
+  cwd: process.cwd(),
+  command: process.execPath,
+  args: [FIXTURE],
+};
+
+const spawned: ChildProcess[] = [];
+
+/**
+ * `SessionLifecycle.clearClient()` drops a live child on a transport drop without
+ * killing it (pre-existing, tracked separately), so the test reaps by hand.
+ */
+afterEach(() => {
+  for (const child of spawned.splice(0)) {
+    if (child.pid && isProcessAlive(child.pid)) {
+      try {
+        process.kill(child.pid, 'SIGKILL');
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+});
+
+function realClientFactory(mode: string): ClientFactory {
+  return {
+    create: (config, handlers) =>
+      new ProcessAcpClient(
+        async () => {
+          const child = spawn(process.execPath, [FIXTURE], {
+            stdio: 'pipe',
+            env: { ...process.env, FAKE_ACP_MODE: mode, FAKE_ACP_STDERR: STDERR_NOISE },
+          });
+          spawned.push(child);
+          return child;
+        },
+        { backend: config.agentBackend, handlers }
+      ),
+  };
+}
+
+function errorMessages(callbacks: SessionCallbacks): string[] {
+  return (callbacks.onSignal as ReturnType<typeof vi.fn>).mock.calls
+    .map(([sig]: [{ type: string; message?: string }]) => (sig.type === 'error' ? (sig.message ?? '') : null))
+    .filter((m): m is string => m !== null);
+}
+
+describe('#1020 end-to-end mid-prompt transport drop (real child, real client, real session)', () => {
+  it('the banner the SESSION emits describes a transport drop, not an invented exit', async () => {
+    const callbacks = createCallbacks();
+    const session = new AcpSession(baseConfig, realClientFactory('drop-on-prompt'), callbacks);
+
+    session.start();
+    await vi.waitFor(() => expect(session.status).toBe('active'), { timeout: 15000 });
+
+    // The turn rejects with AgentDisconnectedError once the pipe goes.
+    await expect(session.sendMessage('please approve this')).rejects.toBeTruthy();
+
+    const errors = await vi.waitFor(
+      () => {
+        const msgs = errorMessages(callbacks);
+        expect(msgs.length).toBeGreaterThan(0);
+        return msgs;
+      },
+      { timeout: 15000 }
+    );
+
+    // FIRST, not merely present: whichever error banner lands first is the one the
+    // user reads. If `handlePromptError` beats `onDisconnect`, this is instead the
+    // raw "Agent disconnected (connection_close, code: null)" and the whole #1020
+    // payload below never reaches a screen.
+    const banner = errors[0];
+
+    expect(banner).toContain(CRASH_MARKER_TRANSPORT_CLOSE);
+    expect(banner).toContain('[reason: connection_close]');
+    expect(banner).toContain('may still be running');
+
+    // The old message asserted exactly the two facts that were NOT known.
+    expect(banner).not.toContain(CRASH_MARKER_PROCESS_EXIT);
+    expect(banner).not.toContain('code: unknown');
+    expect(banner).not.toContain('signal: none');
+
+    // A turn was in flight and is not replayed, so the user has to be told.
+    expect(banner).toContain('did not complete');
+    expect(banner).toContain('send it again');
+
+    // The stderr that names the real cause rides along - scrubbed.
+    expect(banner).toContain('Agent stderr:');
+    expect(banner).toContain('Cannot find module zod/v4');
+    expect(banner).toContain('[redacted]');
+    expect(banner).not.toContain(LEAKED_SECRET);
+
+    // The child really is still running: "may still be running" is not a hedge.
+    const first = spawned[0];
+    expect(first.pid).toBeTruthy();
+    expect(isProcessAlive(first.pid!)).toBe(true);
+
+    await session.stop();
+  }, 40000);
+});

--- a/tests/integration/process/acp/session/AcpSession.lifecycle.test.ts
+++ b/tests/integration/process/acp/session/AcpSession.lifecycle.test.ts
@@ -193,7 +193,13 @@ describe('AcpSession lifecycle', () => {
     await vi.waitFor(() => expect(session.status).toBe('active'));
 
     // Simulate process exit while session is idle (active, no prompt in flight)
-    disconnectHandler!({ reason: 'process_exit', exitCode: 1, signal: null, stderr: '' });
+    disconnectHandler!({
+      reason: 'process_exit',
+      exitCode: 1,
+      signal: null,
+      stderr: '',
+      unexpectedDuringPrompt: false,
+    });
 
     expect(session.status).toBe('suspended');
     // onSignal should NOT have been called with an error crash message
@@ -225,7 +231,13 @@ describe('AcpSession lifecycle', () => {
     await vi.waitFor(() => expect(session.status).toBe('prompting'));
 
     // Simulate process crash during prompting
-    disconnectHandler!({ reason: 'process_exit', exitCode: 1, signal: null, stderr: '' });
+    disconnectHandler!({
+      reason: 'process_exit',
+      exitCode: 1,
+      signal: null,
+      stderr: '',
+      unexpectedDuringPrompt: false,
+    });
 
     // onSignal SHOULD have been called with a crash error
     const signalCalls = (callbacks.onSignal as ReturnType<typeof vi.fn>).mock.calls;

--- a/tests/integration/process/acp/session/AcpSession.prompt.test.ts
+++ b/tests/integration/process/acp/session/AcpSession.prompt.test.ts
@@ -58,6 +58,37 @@ const baseConfig: AgentConfig = {
   args: ['--stdio'],
 };
 
+/**
+ * The two orderings a real client can actually produce, driven the way
+ * `ProcessAcpClient.recordAgentExit` produces them: in ONE synchronous block, with
+ * nothing at all between the two statements.
+ *
+ * Which statement comes first is not the interesting variable. A rejection's
+ * continuation is a microtask, so `AcpSession.onDisconnect` runs before
+ * `PromptExecutor.handlePromptError` either way, and every guarantee below holds
+ * under both. What breaks them is an await, a timer or a deferral BETWEEN the two:
+ * then `handlePromptError` runs first, while the status is still 'prompting', takes
+ * its retryable branch and flushes the queued follow-up at the DEAD client - the
+ * message is lost and the respawn never happens.
+ *
+ * These tests used to hardcode one order, which is exactly why they stayed green
+ * while a 200ms disconnect deferral silently reintroduced #774. Parameterising them
+ * means no single ordering can satisfy them on its own.
+ */
+const CRASH_EMIT_ORDERS = ['notify-then-reject', 'reject-then-notify'] as const;
+type CrashEmitOrder = (typeof CRASH_EMIT_ORDERS)[number];
+
+function emitCrash(order: CrashEmitOrder, disconnect: () => void, killTurn: (e: unknown) => void): void {
+  const crash = new AcpError('PROCESS_CRASHED', 'ACP connection closed', { retryable: true });
+  if (order === 'notify-then-reject') {
+    disconnect();
+    killTurn(crash);
+  } else {
+    killTurn(crash);
+    disconnect();
+  }
+}
+
 describe('AcpSession prompt flow', () => {
   let callbacks: SessionCallbacks;
   let client: AcpClient;
@@ -377,69 +408,70 @@ describe('AcpSession prompt flow', () => {
    * prompt was then silently dropped: exactly the #774 headline, reintroduced by
    * its own fix.
    */
-  it('a crash mid-turn does not fire the queued prompt into a half-initialized client (#774)', async () => {
-    const events: string[] = [];
-    const clients: AcpClient[] = [];
-    let disconnect!: () => void;
+  for (const order of CRASH_EMIT_ORDERS) {
+    it(`a crash mid-turn does not fire the queued prompt into a half-initialized client (#774, ${order})`, async () => {
+      const events: string[] = [];
+      const clients: AcpClient[] = [];
+      let disconnect!: () => void;
 
-    clientFactory = {
-      create: vi.fn(() => {
-        const c = createMockClient();
-        const idx = clients.length;
-        if (idx > 0) {
-          // The respawn is SLOW (spawn + initialize). This is the window the bug
-          // lived in: with a mock that resolves instantly it never opens, and the
-          // race is unobservable.
-          (c.start as ReturnType<typeof vi.fn>).mockImplementation(async () => {
-            await new Promise((r) => setTimeout(r, 150));
-            events.push(`start:${idx}`);
-            return { protocolVersion: '0.1', capabilities: {} };
+      clientFactory = {
+        create: vi.fn(() => {
+          const c = createMockClient();
+          const idx = clients.length;
+          if (idx > 0) {
+            // The respawn is SLOW (spawn + initialize). This is the window the bug
+            // lived in: with a mock that resolves instantly it never opens, and the
+            // race is unobservable.
+            (c.start as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+              await new Promise((r) => setTimeout(r, 150));
+              events.push(`start:${idx}`);
+              return { protocolVersion: '0.1', capabilities: {} };
+            });
+          }
+          (c.onDisconnect as ReturnType<typeof vi.fn>).mockImplementation((cb: () => void) => {
+            disconnect = cb;
           });
-        }
-        (c.onDisconnect as ReturnType<typeof vi.fn>).mockImplementation((cb: () => void) => {
-          disconnect = cb;
-        });
-        (c.loadSession as ReturnType<typeof vi.fn>).mockImplementation(async () => {
-          events.push(`loadSession:${idx}`);
-          return { sessionId: 'sess-1' };
-        });
-        (c.prompt as ReturnType<typeof vi.fn>).mockImplementation(async () => {
-          events.push(`prompt:${idx}`);
-          return { stopReason: 'end_turn' };
-        });
-        clients.push(c);
-        return c;
-      }),
-    };
+          (c.loadSession as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+            events.push(`loadSession:${idx}`);
+            return { sessionId: 'sess-1' };
+          });
+          (c.prompt as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+            events.push(`prompt:${idx}`);
+            return { stopReason: 'end_turn' };
+          });
+          clients.push(c);
+          return c;
+        }),
+      };
 
-    const session = new AcpSession(baseConfig, clientFactory, callbacks);
-    session.start();
-    await vi.waitFor(() => expect(session.status).toBe('active'));
+      const session = new AcpSession(baseConfig, clientFactory, callbacks);
+      session.start();
+      await vi.waitFor(() => expect(session.status).toBe('active'));
 
-    // Turn in flight on client 0, with a follow-up queued behind it.
-    let killTurn!: (e: unknown) => void;
-    (clients[0].prompt as ReturnType<typeof vi.fn>).mockImplementationOnce(
-      () =>
-        new Promise((_r, reject) => {
-          killTurn = reject;
-        })
-    );
-    const firstSend = session.sendMessage('first').catch(() => {});
-    await vi.waitFor(() => expect(session.status).toBe('prompting'));
-    void session.sendMessage('queued-follow-up');
+      // Turn in flight on client 0, with a follow-up queued behind it.
+      let killTurn!: (e: unknown) => void;
+      (clients[0].prompt as ReturnType<typeof vi.fn>).mockImplementationOnce(
+        () =>
+          new Promise((_r, reject) => {
+            killTurn = reject;
+          })
+      );
+      const firstSend = session.sendMessage('first').catch(() => {});
+      await vi.waitFor(() => expect(session.status).toBe('prompting'));
+      void session.sendMessage('queued-follow-up');
 
-    // The agent process dies: the transport reports it, and the turn rejects.
-    disconnect();
-    killTurn(new AcpError('PROCESS_CRASHED', 'ACP connection closed', { retryable: true }));
-    await firstSend;
+      // The agent process dies: the transport reports it, and the turn rejects.
+      emitCrash(order, disconnect, killTurn);
+      await firstSend;
 
-    // The respawned client must have loaded the session BEFORE it is ever prompted.
-    await vi.waitFor(() => expect(clients.length).toBe(2));
-    await vi.waitFor(() => expect(events).toContain('prompt:1'), { timeout: 3000 });
+      // The respawned client must have loaded the session BEFORE it is ever prompted.
+      await vi.waitFor(() => expect(clients.length).toBe(2));
+      await vi.waitFor(() => expect(events).toContain('prompt:1'), { timeout: 3000 });
 
-    expect(events.indexOf('loadSession:1')).toBeGreaterThanOrEqual(0);
-    expect(events.indexOf('loadSession:1')).toBeLessThan(events.indexOf('prompt:1'));
-  });
+      expect(events.indexOf('loadSession:1')).toBeGreaterThanOrEqual(0);
+      expect(events.indexOf('loadSession:1')).toBeLessThan(events.indexOf('prompt:1'));
+    });
+  }
 
   /**
    * The re-queue on a non-prompting exit must be gated on "nothing has happened yet".
@@ -450,87 +482,89 @@ describe('AcpSession prompt flow', () => {
    * had already run `rm -rf` got run again. These two tests pin the distinction that
    * makes it safe: the dead turn's prompt is dropped, a queued follow-up is not.
    */
-  it('a crashed turn that already ran a tool is NOT replayed on the respawned session (#774)', async () => {
-    const clients: AcpClient[] = [];
-    let disconnect!: () => void;
-    clientFactory = {
-      create: vi.fn(() => {
-        const c = createMockClient();
-        (c.onDisconnect as ReturnType<typeof vi.fn>).mockImplementation((cb: () => void) => {
-          disconnect = cb;
-        });
-        clients.push(c);
-        return c;
-      }),
-    };
+  for (const order of CRASH_EMIT_ORDERS) {
+    it(`a crashed turn that already ran a tool is NOT replayed on the respawned session (#774, ${order})`, async () => {
+      const clients: AcpClient[] = [];
+      let disconnect!: () => void;
+      clientFactory = {
+        create: vi.fn(() => {
+          const c = createMockClient();
+          (c.onDisconnect as ReturnType<typeof vi.fn>).mockImplementation((cb: () => void) => {
+            disconnect = cb;
+          });
+          clients.push(c);
+          return c;
+        }),
+      };
 
-    const session = new AcpSession(baseConfig, clientFactory, callbacks);
-    session.start();
-    await vi.waitFor(() => expect(session.status).toBe('active'));
+      const session = new AcpSession(baseConfig, clientFactory, callbacks);
+      session.start();
+      await vi.waitFor(() => expect(session.status).toBe('active'));
 
-    let killTurn!: (e: unknown) => void;
-    (clients[0].prompt as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
-      // The tool RAN. Whatever happens next, this turn must never be sent again.
-      handlersOf().onSessionUpdate({
-        sessionId: 'sess-1',
-        update: { sessionUpdate: 'tool_call', toolCallId: 't1', title: 'rm -rf build', status: 'in_progress' },
-      } as unknown as SessionNotification);
-      return new Promise((_r, reject) => {
-        killTurn = reject;
-      });
-    });
-
-    const send = session.sendMessage('rm -rf build').catch(() => {});
-    await vi.waitFor(() => expect(session.status).toBe('prompting'));
-
-    disconnect();
-    killTurn(new AcpError('PROCESS_CRASHED', 'ACP connection closed', { retryable: true }));
-    await send;
-
-    await vi.waitFor(() => expect(clients.length).toBe(2));
-    await new Promise((r) => setTimeout(r, 250)); // let the respawn finish and flush
-
-    expect(clients[1].prompt).not.toHaveBeenCalled();
-  });
-
-  it('but a QUEUED follow-up still survives the crash and is delivered after the respawn (#774)', async () => {
-    const clients: AcpClient[] = [];
-    let disconnect!: () => void;
-    clientFactory = {
-      create: vi.fn(() => {
-        const c = createMockClient();
-        (c.onDisconnect as ReturnType<typeof vi.fn>).mockImplementation((cb: () => void) => {
-          disconnect = cb;
-        });
-        clients.push(c);
-        return c;
-      }),
-    };
-
-    const session = new AcpSession(baseConfig, clientFactory, callbacks);
-    session.start();
-    await vi.waitFor(() => expect(session.status).toBe('active'));
-
-    let killTurn!: (e: unknown) => void;
-    (clients[0].prompt as ReturnType<typeof vi.fn>).mockImplementationOnce(
-      () =>
-        new Promise((_r, reject) => {
+      let killTurn!: (e: unknown) => void;
+      (clients[0].prompt as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+        // The tool RAN. Whatever happens next, this turn must never be sent again.
+        handlersOf().onSessionUpdate({
+          sessionId: 'sess-1',
+          update: { sessionUpdate: 'tool_call', toolCallId: 't1', title: 'rm -rf build', status: 'in_progress' },
+        } as unknown as SessionNotification);
+        return new Promise((_r, reject) => {
           killTurn = reject;
-        })
-    );
+        });
+      });
 
-    const send = session.sendMessage('first').catch(() => {});
-    await vi.waitFor(() => expect(session.status).toBe('prompting'));
-    void session.sendMessage('queued-follow-up'); // never sent — nothing ran for it
+      const send = session.sendMessage('rm -rf build').catch(() => {});
+      await vi.waitFor(() => expect(session.status).toBe('prompting'));
 
-    disconnect();
-    killTurn(new AcpError('PROCESS_CRASHED', 'ACP connection closed', { retryable: true }));
-    await send;
+      emitCrash(order, disconnect, killTurn);
+      await send;
 
-    await vi.waitFor(() => expect(clients.length).toBe(2));
-    await vi.waitFor(() => expect(clients[1].prompt).toHaveBeenCalled(), { timeout: 3000 });
+      await vi.waitFor(() => expect(clients.length).toBe(2));
+      await new Promise((r) => setTimeout(r, 250)); // let the respawn finish and flush
 
-    const sent = (clients[1].prompt as ReturnType<typeof vi.fn>).mock.calls[0][1] as Array<{ text: string }>;
-    expect(sent[0].text).toBe('queued-follow-up');
-  });
+      expect(clients[1].prompt).not.toHaveBeenCalled();
+    });
+  }
+
+  for (const order of CRASH_EMIT_ORDERS) {
+    it(`but a QUEUED follow-up still survives the crash and is delivered after the respawn (#774, ${order})`, async () => {
+      const clients: AcpClient[] = [];
+      let disconnect!: () => void;
+      clientFactory = {
+        create: vi.fn(() => {
+          const c = createMockClient();
+          (c.onDisconnect as ReturnType<typeof vi.fn>).mockImplementation((cb: () => void) => {
+            disconnect = cb;
+          });
+          clients.push(c);
+          return c;
+        }),
+      };
+
+      const session = new AcpSession(baseConfig, clientFactory, callbacks);
+      session.start();
+      await vi.waitFor(() => expect(session.status).toBe('active'));
+
+      let killTurn!: (e: unknown) => void;
+      (clients[0].prompt as ReturnType<typeof vi.fn>).mockImplementationOnce(
+        () =>
+          new Promise((_r, reject) => {
+            killTurn = reject;
+          })
+      );
+
+      const send = session.sendMessage('first').catch(() => {});
+      await vi.waitFor(() => expect(session.status).toBe('prompting'));
+      void session.sendMessage('queued-follow-up'); // never sent — nothing ran for it
+
+      emitCrash(order, disconnect, killTurn);
+      await send;
+
+      await vi.waitFor(() => expect(clients.length).toBe(2));
+      await vi.waitFor(() => expect(clients[1].prompt).toHaveBeenCalled(), { timeout: 3000 });
+
+      const sent = (clients[1].prompt as ReturnType<typeof vi.fn>).mock.calls[0][1] as Array<{ text: string }>;
+      expect(sent[0].text).toBe('queued-follow-up');
+    });
+  }
 });

--- a/tests/unit/acpDisconnectTransport.test.ts
+++ b/tests/unit/acpDisconnectTransport.test.ts
@@ -116,7 +116,10 @@ function assertHonest(d: Driven, expected: RealExit, label: string): 'exit-obser
   expect(info.reason, label).toBe('connection_close');
   expect(msg, label).toContain(CRASH_MARKER_TRANSPORT_CLOSE);
   expect(msg, label).not.toContain(CRASH_MARKER_PROCESS_EXIT);
-  expect(msg, label).toContain('may still be running');
+  expect(msg, label).toContain('we cannot tell whether the agent crashed or the connection dropped');
+  // #1023: 6 of these 20 real children were genuinely dead at report time, so the
+  // banner must not reassure the user that the child is probably alive.
+  expect(msg, label).not.toContain('may still be running');
   expect(msg, label).not.toContain('code: unknown');
   expect(msg, label).not.toContain('signal: none');
   return 'transport-drop';

--- a/tests/unit/acpDisconnectTransport.test.ts
+++ b/tests/unit/acpDisconnectTransport.test.ts
@@ -1,0 +1,136 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * #1020 - drive ProcessAcpClient's disconnect signals from REAL OS process
+ * behaviour and assert what `DisconnectInfo` actually carries.
+ *
+ * Executed findings that motivated the fix (macOS arm64, node 22):
+ *
+ *  - `process_exit` and `connection_close` are the only two reasons that ever win
+ *    the first-write-wins race. `process_close` cannot (Node emits 'exit' before
+ *    'close') and `pipe_close` cannot (the SDK aborts the connection on the
+ *    readable's 'end', which precedes the stdout stream's 'close'). Those two are
+ *    driven directly below instead of through the OS.
+ *  - Before the fix, a child that exited cleanly with code 7 reported
+ *    `connection_close / exitCode: null / signal: null` on roughly 3 runs in 5,
+ *    because the SDK's abort listener beat Node's 'exit' event. A SIGKILL lost its
+ *    signal the same way, every time. The exit detail was populated 0-1ms later.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { spawn, type ChildProcess } from 'node:child_process';
+import * as path from 'node:path';
+import { ProcessAcpClient } from '@process/acp/infra/ProcessAcpClient';
+import type { AgentDisconnectReason, DisconnectInfo } from '@process/acp/infra/IAcpClient';
+import { isProcessAlive } from '@process/acp/infra/processUtils';
+
+const FIXTURE = path.resolve(__dirname, '../fixtures/acp/fakeAcpAgent.cjs');
+
+const handlers = {
+  onSessionUpdate: async () => {},
+  onRequestPermission: async () => ({ outcome: { outcome: 'cancelled' } }) as never,
+  onReadTextFile: async () => ({ content: '' }),
+  onWriteTextFile: async () => ({}),
+} as never;
+
+type Driven = {
+  info: DisconnectInfo | null;
+  client: ProcessAcpClient;
+  aliveAfter: boolean;
+  pid: number | null;
+};
+
+async function drive(mode: string, stderrNoise = ''): Promise<Driven> {
+  let child: ChildProcess | null = null;
+  const client = new ProcessAcpClient(
+    async () => {
+      child = spawn(process.execPath, [FIXTURE], {
+        stdio: 'pipe',
+        env: { ...process.env, FAKE_ACP_MODE: mode, FAKE_ACP_STDERR: stderrNoise },
+      });
+      return child;
+    },
+    { backend: 'probe', handlers }
+  );
+  let info: DisconnectInfo | null = null;
+  client.onDisconnect((i) => {
+    info ??= i;
+  });
+  await client.start();
+  const deadline = Date.now() + 6000;
+  while (!info && Date.now() < deadline) await new Promise((r) => setTimeout(r, 10));
+  const pid = child?.pid ?? null;
+  const aliveAfter = pid ? isProcessAlive(pid) : false;
+  return { info, client, aliveAfter, pid };
+}
+
+function reap(d: Driven): void {
+  if (d.pid && isProcessAlive(d.pid)) {
+    try {
+      process.kill(d.pid, 'SIGKILL');
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+describe('#1020 ProcessAcpClient disconnect diagnostics (executed)', () => {
+  it('KNOWN POSITIVE: a clean exit(7) reports code 7 every time', async () => {
+    // Repeated because this was a ~60% coin flip before the fix.
+    for (let i = 0; i < 4; i++) {
+      const d = await drive('exit-code', 'startup noise\n');
+      reap(d);
+      expect(d.info, `run ${i}`).not.toBeNull();
+      expect(d.info!.exitCode, `run ${i} reason=${d.info!.reason}`).toBe(7);
+      expect(d.info!.signal).toBeNull();
+      expect(d.info!.stderr).toContain('startup noise');
+    }
+  }, 30000);
+
+  it('a SIGKILLed child reports its signal, not "none"', async () => {
+    const d = await drive('signal');
+    reap(d);
+    expect(d.info).not.toBeNull();
+    expect(d.info!.signal).toBe('SIGKILL');
+  }, 15000);
+
+  it('a transport drop with a LIVE child reports no exit code and no signal', async () => {
+    const d = await drive('pipe-close');
+    expect(d.info).not.toBeNull();
+    // The child is genuinely still running: nothing about a process exit is known.
+    expect(d.aliveAfter).toBe(true);
+    expect(d.info!.reason).toBe('connection_close');
+    expect(d.info!.exitCode).toBeNull();
+    expect(d.info!.signal).toBeNull();
+    reap(d);
+  }, 15000);
+
+  it('carries unexpectedDuringPrompt so the message path can see it', async () => {
+    const d = await drive('pipe-close');
+    reap(d);
+    expect(d.info).not.toBeNull();
+    expect(d.info!.unexpectedDuringPrompt).toBe(false);
+  }, 15000);
+
+  it('pipe_close and process_close carry the same null/null shape', async () => {
+    // Unreachable as first-writers through the OS (see the file header), so they
+    // are driven straight at the recorder to pin their DisconnectInfo shape.
+    for (const reason of ['pipe_close', 'process_close'] as AgentDisconnectReason[]) {
+      const client = new ProcessAcpClient(async () => ({}) as ChildProcess, { backend: 'probe', handlers });
+      let info: DisconnectInfo | null = null;
+      client.onDisconnect((i) => {
+        info ??= i;
+      });
+      (client as unknown as { recordAgentExit(r: AgentDisconnectReason, c: number | null, s: string | null): void }).recordAgentExit(reason, null, null);
+      await new Promise((r) => setTimeout(r, 50));
+      expect(info, reason).not.toBeNull();
+      expect(info!.reason).toBe(reason);
+      expect(info!.exitCode).toBeNull();
+      expect(info!.signal).toBeNull();
+    }
+  }, 15000);
+});

--- a/tests/unit/acpDisconnectTransport.test.ts
+++ b/tests/unit/acpDisconnectTransport.test.ts
@@ -48,6 +48,47 @@ const handlers = {
 
 type RealExit = { code: number | null; signal: string | null };
 
+/**
+ * What the OS reports when the fixture hard-kills itself.
+ *
+ * Windows has no POSIX signals: `process.kill(pid, 'SIGKILL')` there is
+ * `TerminateProcess`, which libuv issues with exit code 1 ("on Windows, killed
+ * processes normally return 1", `uv__kill`), so the child's own 'exit' event carries
+ * `{code: 1, signal: null}` and never a signal name. Executed on the win32 runner:
+ * `{code: 1, signal: null}`. Executed on darwin with the same probe: `exit(null, SIGKILL)`.
+ *
+ * This is a control, not a product assertion - but demanding the POSIX shape on win32
+ * made the control itself fail, so `assertHonest` below (the actual #1020 assertion)
+ * was never reached on that platform at all.
+ */
+const HARD_KILL_EXIT: RealExit =
+  process.platform === 'win32' ? { code: 1, signal: null } : { code: null, signal: 'SIGKILL' };
+
+/**
+ * A child that closes stdout while STAYING ALIVE is unobservable on Windows, so the
+ * scenario the three tests below drive does not exist on that platform.
+ *
+ * Executed on the win32 box, with a known positive in the same run:
+ *
+ *   A  child does `process.stdout.end()`, stays alive -> parent sees []  (stillAlive=true)
+ *   B  child does `fs.closeSync(1)`, stays alive      -> parent sees []  (stillAlive=true)
+ *   C  KNOWN POSITIVE: the child really exits         -> parent sees
+ *      [stdout:end, stdout:close, exit(3,null), child:close]
+ *
+ * The same probe on darwin reports `[stdout:end, stdout:close]` with the child still
+ * alive for BOTH A and B, so this is a platform difference and not a fixture bug.
+ *
+ * Consequence: neither `pipe_close` (the child's stdout 'close') nor `connection_close`
+ * (the SDK aborting on that readable's 'end') can fire for a LIVE child on win32. The
+ * PRODUCT limitation that follows is recorded next to the detection code in
+ * `ProcessAcpClient.attachLifecycleObservers` - read that before treating these skips as
+ * a test-only problem. A genuinely CRASHED agent is still detected on Windows, because
+ * process death closes the pipe (case C above); only the live-child-with-a-dead-transport
+ * half is skipped, and the `DisconnectInfo` shape for `pipe_close`/`process_close` stays
+ * covered on win32 by the drive-the-recorder test further down.
+ */
+const itLiveChildDrop = it.skipIf(process.platform === 'win32');
+
 type Driven = {
   info: DisconnectInfo | null;
   client: ProcessAcpClient;
@@ -151,36 +192,45 @@ describe('#1020 ProcessAcpClient disconnect diagnostics (executed)', () => {
     console.log(`[#1020 exit(7) race] ${outcomes.join(', ')}`);
   }, 45000);
 
-  it('a SIGKILLed child is either reported as SIGKILL or hedged - never fabricated', async () => {
+  it('a hard-killed child is either reported as the real kill shape or hedged - never fabricated', async () => {
     const outcomes: string[] = [];
     for (let i = 0; i < 6; i++) {
       const d = await drive('signal');
       reap(d);
-      // KNOWN POSITIVE: the OS really did deliver SIGKILL.
-      expect(d.realExit, `run ${i} real exit`).toEqual({ code: null, signal: 'SIGKILL' });
+      // KNOWN POSITIVE: the OS really did tear the child down - as a SIGKILL on POSIX,
+      // as a TerminateProcess exit on win32 (see HARD_KILL_EXIT).
+      expect(d.realExit, `run ${i} real exit`).toEqual(HARD_KILL_EXIT);
       expect(d.info, `run ${i}`).not.toBeNull();
-      outcomes.push(assertHonest(d, { code: null, signal: 'SIGKILL' }, `run ${i}`));
+      outcomes.push(assertHonest(d, HARD_KILL_EXIT, `run ${i}`));
     }
-    console.log(`[#1020 SIGKILL race] ${outcomes.join(', ')}`);
+    console.log(`[#1020 hard-kill race] ${outcomes.join(', ')}`);
   }, 45000);
 
-  it('a transport drop with a LIVE child reports no exit code and no signal', async () => {
-    const d = await drive('pipe-close');
-    expect(d.info).not.toBeNull();
-    // The child is genuinely still running: nothing about a process exit is known.
-    expect(d.aliveAfter).toBe(true);
-    expect(d.info!.reason).toBe('connection_close');
-    expect(d.info!.exitCode).toBeNull();
-    expect(d.info!.signal).toBeNull();
-    reap(d);
-  }, 15000);
+  itLiveChildDrop(
+    'a transport drop with a LIVE child reports no exit code and no signal',
+    async () => {
+      const d = await drive('pipe-close');
+      expect(d.info).not.toBeNull();
+      // The child is genuinely still running: nothing about a process exit is known.
+      expect(d.aliveAfter).toBe(true);
+      expect(d.info!.reason).toBe('connection_close');
+      expect(d.info!.exitCode).toBeNull();
+      expect(d.info!.signal).toBeNull();
+      reap(d);
+    },
+    15000
+  );
 
-  it('carries unexpectedDuringPrompt so the message path can see it', async () => {
-    const d = await drive('pipe-close');
-    reap(d);
-    expect(d.info).not.toBeNull();
-    expect(d.info!.unexpectedDuringPrompt).toBe(false);
-  }, 15000);
+  itLiveChildDrop(
+    'carries unexpectedDuringPrompt so the message path can see it',
+    async () => {
+      const d = await drive('pipe-close');
+      reap(d);
+      expect(d.info).not.toBeNull();
+      expect(d.info!.unexpectedDuringPrompt).toBe(false);
+    },
+    15000
+  );
 
   it('pipe_close and process_close carry the same null/null shape on a STARTED client', async () => {
     // Unreachable as first-writers through the OS (see the file header), so they
@@ -244,59 +294,63 @@ describe('#1020 ProcessAcpClient disconnect diagnostics (executed)', () => {
    * Measured with the customer's shape: the child answers initialize and
    * session/new, then ends stdout on session/prompt and STAYS ALIVE.
    */
-  it('reports the disconnect BEFORE the in-flight prompt rejects', async () => {
-    let child: ChildProcess | null = null;
-    const client = new ProcessAcpClient(
-      async () => {
-        child = spawn(process.execPath, [FIXTURE], {
-          stdio: 'pipe',
-          env: { ...process.env, FAKE_ACP_MODE: 'drop-on-prompt' },
-        });
-        return child;
-      },
-      { backend: 'probe', handlers }
-    );
+  itLiveChildDrop(
+    'reports the disconnect BEFORE the in-flight prompt rejects',
+    async () => {
+      let child: ChildProcess | null = null;
+      const client = new ProcessAcpClient(
+        async () => {
+          child = spawn(process.execPath, [FIXTURE], {
+            stdio: 'pipe',
+            env: { ...process.env, FAKE_ACP_MODE: 'drop-on-prompt' },
+          });
+          return child;
+        },
+        { backend: 'probe', handlers }
+      );
 
-    const t0 = Date.now();
-    const order: string[] = [];
-    let tDisconnect = -1;
-    let tReject = -1;
-    let seen: DisconnectInfo | null = null;
-    client.onDisconnect((i) => {
-      if (tDisconnect >= 0) return;
-      seen = i;
-      tDisconnect = Date.now() - t0;
-      order.push('disconnect');
-    });
+      const t0 = Date.now();
+      const order: string[] = [];
+      let tDisconnect = -1;
+      let tReject = -1;
+      let seen: DisconnectInfo | null = null;
+      client.onDisconnect((i) => {
+        if (tDisconnect >= 0) return;
+        seen = i;
+        tDisconnect = Date.now() - t0;
+        order.push('disconnect');
+      });
 
-    await client.start();
-    const session = await client.createSession({ cwd: process.cwd() });
-    await client.prompt(session.sessionId, [{ type: 'text', text: 'hello' }]).then(
-      () => {
-        order.push('prompt-resolved');
-      },
-      () => {
-        if (tReject >= 0) return;
-        tReject = Date.now() - t0;
-        order.push('prompt-rejected');
-      }
-    );
+      await client.start();
+      const session = await client.createSession({ cwd: process.cwd() });
+      await client.prompt(session.sessionId, [{ type: 'text', text: 'hello' }]).then(
+        () => {
+          order.push('prompt-resolved');
+        },
+        () => {
+          if (tReject >= 0) return;
+          tReject = Date.now() - t0;
+          order.push('prompt-rejected');
+        }
+      );
 
-    console.log(
-      `[#1020 ordering] disconnect t=${tDisconnect}ms -> prompt-rejected t=${tReject}ms ` +
-        `(gap ${tReject - tDisconnect}ms) order=${order.join(' -> ')}`
-    );
+      console.log(
+        `[#1020 ordering] disconnect t=${tDisconnect}ms -> prompt-rejected t=${tReject}ms ` +
+          `(gap ${tReject - tDisconnect}ms) order=${order.join(' -> ')}`
+      );
 
-    expect(order).toEqual(['disconnect', 'prompt-rejected']);
-    // Same tick: the two are separated only by a microtask, never by a timer.
-    expect(tReject - tDisconnect).toBeLessThan(50);
-    expect(seen).not.toBeNull();
-    expect(seen!.exitCode).toBeNull();
-    expect(seen!.signal).toBeNull();
-    expect(seen!.unexpectedDuringPrompt).toBe(true);
+      expect(order).toEqual(['disconnect', 'prompt-rejected']);
+      // Same tick: the two are separated only by a microtask, never by a timer.
+      expect(tReject - tDisconnect).toBeLessThan(50);
+      expect(seen).not.toBeNull();
+      expect(seen!.exitCode).toBeNull();
+      expect(seen!.signal).toBeNull();
+      expect(seen!.unexpectedDuringPrompt).toBe(true);
 
-    const pid = (child as unknown as ChildProcess).pid!;
-    expect(isProcessAlive(pid)).toBe(true);
-    process.kill(pid, 'SIGKILL');
-  }, 20000);
+      const pid = (child as unknown as ChildProcess).pid!;
+      expect(isProcessAlive(pid)).toBe(true);
+      process.kill(pid, 'SIGKILL');
+    },
+    20000
+  );
 });

--- a/tests/unit/acpDisconnectTransport.test.ts
+++ b/tests/unit/acpDisconnectTransport.test.ts
@@ -15,10 +15,17 @@
  *    'close') and `pipe_close` cannot (the SDK aborts the connection on the
  *    readable's 'end', which precedes the stdout stream's 'close'). Those two are
  *    driven directly below instead of through the OS.
- *  - Before the fix, a child that exited cleanly with code 7 reported
- *    `connection_close / exitCode: null / signal: null` on roughly 3 runs in 5,
- *    because the SDK's abort listener beat Node's 'exit' event. A SIGKILL lost its
- *    signal the same way, every time. The exit detail was populated 0-1ms later.
+ *  - A child that exits cleanly with code 7 reports `process_exit / 7 / null` on
+ *    some runs and `connection_close / null / null` on others (measured 5/12 vs
+ *    7/12 here), because the SDK's abort listener races Node's 'exit' event. A
+ *    SIGKILL races the same way. The child's exit detail becomes readable 0-1ms
+ *    later - but reading it costs a wait, and a wait between the disconnect and
+ *    the notification inverts the ordering the session depends on (see
+ *    `recordAgentExit`). So the race is NOT closed here, deliberately: a fast
+ *    crash may be reported as a transport drop, and `buildCrashMessage` hedges
+ *    accordingly instead of asserting an exit it has no evidence for. What the
+ *    tests below pin is that the report is never WRONG - never a fabricated code,
+ *    never a fabricated signal, never a claimed exit that was not observed.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -27,6 +34,8 @@ import * as path from 'node:path';
 import { ProcessAcpClient } from '@process/acp/infra/ProcessAcpClient';
 import type { AgentDisconnectReason, DisconnectInfo } from '@process/acp/infra/IAcpClient';
 import { isProcessAlive } from '@process/acp/infra/processUtils';
+import { buildCrashMessage } from '@process/acp/session/AcpSession';
+import { CRASH_MARKER_PROCESS_EXIT, CRASH_MARKER_TRANSPORT_CLOSE } from '@process/acp/session/crashMarkers';
 
 const FIXTURE = path.resolve(__dirname, '../fixtures/acp/fakeAcpAgent.cjs');
 
@@ -37,20 +46,34 @@ const handlers = {
   onWriteTextFile: async () => ({}),
 } as never;
 
+type RealExit = { code: number | null; signal: string | null };
+
 type Driven = {
   info: DisconnectInfo | null;
   client: ProcessAcpClient;
   aliveAfter: boolean;
   pid: number | null;
+  /**
+   * What the OS actually reported for the child, read straight off its own 'exit'
+   * event and independent of anything `ProcessAcpClient` decided. This is the
+   * known-positive control: it proves the fixture really did exit the way the test
+   * asked, so a null in `DisconnectInfo` is a reporting choice rather than a
+   * broken fixture.
+   */
+  realExit: RealExit | null;
 };
 
 async function drive(mode: string, stderrNoise = ''): Promise<Driven> {
   let child: ChildProcess | null = null;
+  let realExit: RealExit | null = null;
   const client = new ProcessAcpClient(
     async () => {
       child = spawn(process.execPath, [FIXTURE], {
         stdio: 'pipe',
         env: { ...process.env, FAKE_ACP_MODE: mode, FAKE_ACP_STDERR: stderrNoise },
+      });
+      child.once('exit', (code, signal) => {
+        realExit ??= { code: code ?? null, signal: signal ? String(signal) : null };
       });
       return child;
     },
@@ -63,9 +86,40 @@ async function drive(mode: string, stderrNoise = ''): Promise<Driven> {
   await client.start();
   const deadline = Date.now() + 6000;
   while (!info && Date.now() < deadline) await new Promise((r) => setTimeout(r, 10));
+  // The child's own exit event can trail the disconnect report by a millisecond;
+  // that is the whole point of these tests, so give it a moment before reading it.
+  const exitDeadline = Date.now() + 1000;
+  while (!realExit && Date.now() < exitDeadline) await new Promise((r) => setTimeout(r, 5));
   const pid = child?.pid ?? null;
   const aliveAfter = pid ? isProcessAlive(pid) : false;
-  return { info, client, aliveAfter, pid };
+  return { info, client, aliveAfter, pid, realExit };
+}
+
+/**
+ * The invariant that replaced "always reports the code": whatever the race
+ * outcome, the report must be self-consistent and must never assert an exit that
+ * was not observed.
+ */
+function assertHonest(d: Driven, expected: RealExit, label: string): 'exit-observed' | 'transport-drop' {
+  const info = d.info!;
+  const msg = buildCrashMessage(info)!;
+  if (info.exitCode !== null || info.signal !== null) {
+    // The exit won the race: it must be the REAL exit, not an approximation.
+    expect(info.exitCode, `${label} exitCode`).toBe(expected.code);
+    expect(info.signal, `${label} signal`).toBe(expected.signal);
+    expect(msg, label).toContain(CRASH_MARKER_PROCESS_EXIT);
+    expect(msg, label).not.toContain(CRASH_MARKER_TRANSPORT_CLOSE);
+    return 'exit-observed';
+  }
+  // The transport abort won: nothing about a process exit is known, so nothing
+  // about a process exit may be claimed (#1020).
+  expect(info.reason, label).toBe('connection_close');
+  expect(msg, label).toContain(CRASH_MARKER_TRANSPORT_CLOSE);
+  expect(msg, label).not.toContain(CRASH_MARKER_PROCESS_EXIT);
+  expect(msg, label).toContain('may still be running');
+  expect(msg, label).not.toContain('code: unknown');
+  expect(msg, label).not.toContain('signal: none');
+  return 'transport-drop';
 }
 
 function reap(d: Driven): void {
@@ -79,24 +133,33 @@ function reap(d: Driven): void {
 }
 
 describe('#1020 ProcessAcpClient disconnect diagnostics (executed)', () => {
-  it('KNOWN POSITIVE: a clean exit(7) reports code 7 every time', async () => {
-    // Repeated because this was a ~60% coin flip before the fix.
-    for (let i = 0; i < 4; i++) {
+  it('a clean exit(7) is either reported as code 7 or hedged - never fabricated', async () => {
+    const outcomes: string[] = [];
+    for (let i = 0; i < 6; i++) {
       const d = await drive('exit-code', 'startup noise\n');
       reap(d);
+      // KNOWN POSITIVE: the harness really did drive a code-7 exit. Without this
+      // control a null in DisconnectInfo could just mean the fixture never ran.
+      expect(d.realExit, `run ${i} real exit`).toEqual({ code: 7, signal: null });
       expect(d.info, `run ${i}`).not.toBeNull();
-      expect(d.info!.exitCode, `run ${i} reason=${d.info!.reason}`).toBe(7);
-      expect(d.info!.signal).toBeNull();
-      expect(d.info!.stderr).toContain('startup noise');
+      expect(d.info!.stderr, `run ${i}`).toContain('startup noise');
+      outcomes.push(assertHonest(d, { code: 7, signal: null }, `run ${i}`));
     }
-  }, 30000);
+    console.log(`[#1020 exit(7) race] ${outcomes.join(', ')}`);
+  }, 45000);
 
-  it('a SIGKILLed child reports its signal, not "none"', async () => {
-    const d = await drive('signal');
-    reap(d);
-    expect(d.info).not.toBeNull();
-    expect(d.info!.signal).toBe('SIGKILL');
-  }, 15000);
+  it('a SIGKILLed child is either reported as SIGKILL or hedged - never fabricated', async () => {
+    const outcomes: string[] = [];
+    for (let i = 0; i < 6; i++) {
+      const d = await drive('signal');
+      reap(d);
+      // KNOWN POSITIVE: the OS really did deliver SIGKILL.
+      expect(d.realExit, `run ${i} real exit`).toEqual({ code: null, signal: 'SIGKILL' });
+      expect(d.info, `run ${i}`).not.toBeNull();
+      outcomes.push(assertHonest(d, { code: null, signal: 'SIGKILL' }, `run ${i}`));
+    }
+    console.log(`[#1020 SIGKILL race] ${outcomes.join(', ')}`);
+  }, 45000);
 
   it('a transport drop with a LIVE child reports no exit code and no signal', async () => {
     const d = await drive('pipe-close');
@@ -116,23 +179,121 @@ describe('#1020 ProcessAcpClient disconnect diagnostics (executed)', () => {
     expect(d.info!.unexpectedDuringPrompt).toBe(false);
   }, 15000);
 
-  it('pipe_close and process_close carry the same null/null shape', async () => {
+  it('pipe_close and process_close carry the same null/null shape on a STARTED client', async () => {
     // Unreachable as first-writers through the OS (see the file header), so they
-    // are driven straight at the recorder to pin their DisconnectInfo shape.
+    // are driven straight at the recorder to pin their DisconnectInfo shape - but
+    // against a client that has really start()ed, so `this.child` is a live
+    // process and the stderr buffer is the real one. An earlier version of this
+    // test constructed the client WITHOUT start(): `this.child` stayed null, so
+    // the recorder ran over a hollow object and the live-child state the
+    // disconnect path reads was never exercised at all.
     for (const reason of ['pipe_close', 'process_close'] as AgentDisconnectReason[]) {
-      const client = new ProcessAcpClient(async () => ({}) as ChildProcess, { backend: 'probe', handlers });
+      let child: ChildProcess | null = null;
+      const client = new ProcessAcpClient(
+        async () => {
+          child = spawn(process.execPath, [FIXTURE], {
+            stdio: 'pipe',
+            env: { ...process.env, FAKE_ACP_MODE: 'stay', FAKE_ACP_STDERR: 'live child noise\n' },
+          });
+          return child;
+        },
+        { backend: 'probe', handlers }
+      );
       let info: DisconnectInfo | null = null;
       client.onDisconnect((i) => {
         info ??= i;
       });
+      await client.start();
+
+      // The client really is started and the child really is alive, which is what
+      // the un-started fixture could not claim.
+      const pid = (child as unknown as ChildProcess).pid!;
+      expect(client.lifecycleSnapshot.pid, reason).toBe(pid);
+      expect(client.lifecycleSnapshot.running, reason).toBe(true);
+      expect(isProcessAlive(pid), reason).toBe(true);
+
       (
         client as unknown as { recordAgentExit(r: AgentDisconnectReason, c: number | null, s: string | null): void }
       ).recordAgentExit(reason, null, null);
-      await new Promise((r) => setTimeout(r, 50));
+
+      // Asserted with NO await: the disconnect must be reported synchronously.
+      // A deferral here is what disabled the whole #1020 fix at session level.
       expect(info, reason).not.toBeNull();
       expect(info!.reason).toBe(reason);
       expect(info!.exitCode).toBeNull();
       expect(info!.signal).toBeNull();
+      expect(info!.stderr, reason).toContain('live child noise');
+      // Still alive: null/null really did mean "no exit observed", not "exited".
+      expect(isProcessAlive(pid), reason).toBe(true);
+      process.kill(pid, 'SIGKILL');
     }
-  }, 15000);
+  }, 20000);
+
+  /**
+   * The ordering the session depends on, measured rather than reasoned about.
+   *
+   * `AcpSession.onDisconnect` must see the drop BEFORE `PromptExecutor` sees the
+   * in-flight prompt reject. Otherwise `handlePromptError` runs while the status is
+   * still 'prompting', takes its retryable branch, emits its own raw banner and
+   * flushes the queued follow-up at the dead client (#774) - and every #1020
+   * banner becomes unreachable.
+   *
+   * Measured with the customer's shape: the child answers initialize and
+   * session/new, then ends stdout on session/prompt and STAYS ALIVE.
+   */
+  it('reports the disconnect BEFORE the in-flight prompt rejects', async () => {
+    let child: ChildProcess | null = null;
+    const client = new ProcessAcpClient(
+      async () => {
+        child = spawn(process.execPath, [FIXTURE], {
+          stdio: 'pipe',
+          env: { ...process.env, FAKE_ACP_MODE: 'drop-on-prompt' },
+        });
+        return child;
+      },
+      { backend: 'probe', handlers }
+    );
+
+    const t0 = Date.now();
+    const order: string[] = [];
+    let tDisconnect = -1;
+    let tReject = -1;
+    let seen: DisconnectInfo | null = null;
+    client.onDisconnect((i) => {
+      if (tDisconnect >= 0) return;
+      seen = i;
+      tDisconnect = Date.now() - t0;
+      order.push('disconnect');
+    });
+
+    await client.start();
+    const session = await client.createSession({ cwd: process.cwd() });
+    await client.prompt(session.sessionId, [{ type: 'text', text: 'hello' }]).then(
+      () => {
+        order.push('prompt-resolved');
+      },
+      () => {
+        if (tReject >= 0) return;
+        tReject = Date.now() - t0;
+        order.push('prompt-rejected');
+      }
+    );
+
+    console.log(
+      `[#1020 ordering] disconnect t=${tDisconnect}ms -> prompt-rejected t=${tReject}ms ` +
+        `(gap ${tReject - tDisconnect}ms) order=${order.join(' -> ')}`
+    );
+
+    expect(order).toEqual(['disconnect', 'prompt-rejected']);
+    // Same tick: the two are separated only by a microtask, never by a timer.
+    expect(tReject - tDisconnect).toBeLessThan(50);
+    expect(seen).not.toBeNull();
+    expect(seen!.exitCode).toBeNull();
+    expect(seen!.signal).toBeNull();
+    expect(seen!.unexpectedDuringPrompt).toBe(true);
+
+    const pid = (child as unknown as ChildProcess).pid!;
+    expect(isProcessAlive(pid)).toBe(true);
+    process.kill(pid, 'SIGKILL');
+  }, 20000);
 });

--- a/tests/unit/acpDisconnectTransport.test.ts
+++ b/tests/unit/acpDisconnectTransport.test.ts
@@ -125,7 +125,9 @@ describe('#1020 ProcessAcpClient disconnect diagnostics (executed)', () => {
       client.onDisconnect((i) => {
         info ??= i;
       });
-      (client as unknown as { recordAgentExit(r: AgentDisconnectReason, c: number | null, s: string | null): void }).recordAgentExit(reason, null, null);
+      (
+        client as unknown as { recordAgentExit(r: AgentDisconnectReason, c: number | null, s: string | null): void }
+      ).recordAgentExit(reason, null, null);
       await new Promise((r) => setTimeout(r, 50));
       expect(info, reason).not.toBeNull();
       expect(info!.reason).toBe(reason);

--- a/tests/unit/acpStderrRingTruncationLeak.test.ts
+++ b/tests/unit/acpStderrRingTruncationLeak.test.ts
@@ -25,6 +25,13 @@
  * Fixed at the ring rather than at the banner: drop the partial leading record, so
  * no half-token ever exists for the scrubber to miss.
  *
+ * A record boundary is `\r` as well as `\n`, and a ring with NO boundary anywhere
+ * still has to drop its leading run of non-whitespace. The first cut of this fix
+ * handled only `\n` and kept the entire 8KB when there was none, which left the
+ * half-token exactly where it started - reproduced live, `LEAK=true`, on a
+ * space-separated config echo and on bare-CR output. So both paths are exercised
+ * here WITH a credential in the payload, not just for diagnostic survival.
+ *
  * Driven through a REAL child process writing to REAL stderr.
  */
 
@@ -90,19 +97,23 @@ async function driveChildStderr(payload: string): Promise<{ ring: string; banner
 
 /**
  * A payload whose last {@link RING_MAX} characters begin exactly `offset` characters
- * INTO a credential, followed by whole newline-separated credentials so redaction
+ * INTO a credential, followed by whole `sep`-separated credentials so redaction
  * shrinks the ring under the banner's 2048-character tail.
+ *
+ * `sep` is the separator standing in for a newline. A single space is the case that
+ * matters most: a structured logger emitting one JSON line of over 8KB with a config
+ * echo in it has no `\n` in the retained window at all.
  *
  * The arithmetic is ASSERTED, not assumed: the first cut of this test put the cut in
  * the filler instead and passed against the unfixed code.
  */
-function payloadCutting(offset: number): string {
+function payloadCutting(offset: number, sep = '\n'): string {
   const restLen = RING_MAX - (SECRET.length - offset);
-  let rest = '\n';
-  while (rest.length + SECRET.length + 1 <= restLen) rest += `${SECRET}\n`;
+  let rest = sep;
+  while (rest.length + SECRET.length + sep.length <= restLen) rest += `${SECRET}${sep}`;
   rest += 'o'.repeat(restLen - rest.length);
 
-  const payload = `noise ${'x'.repeat(70)}\n`.repeat(30) + `token ${SECRET}${rest}`;
+  const payload = `noise ${'x'.repeat(70)}${sep}`.repeat(30) + `token ${SECRET}${rest}`;
   const cut = payload.slice(-RING_MAX);
   if (cut !== SECRET.slice(offset) + rest) throw new Error(`payload arithmetic wrong for offset ${offset}`);
   return payload;
@@ -140,11 +151,59 @@ describe('#1023 the stderr ring must not leak a truncated credential', () => {
     });
   }
 
+  // The separators that are NOT `\n`. A single space is the no-boundary case, where
+  // the first cut of this fix kept all 8192 characters including the half-token; a
+  // bare `\r` is a real record boundary that a `\n`-only search walks straight past.
+  // Both were reproduced leaking against the `\n`-only code, so a pass here is the
+  // second cut of the fix and not an untested payload.
+  for (const [label, sep] of [
+    ['no newline anywhere, space-separated', ' '],
+    ['bare carriage returns, no newline', '\r'],
+  ] as const) {
+    describe(`a ring cut mid-credential with ${label}`, () => {
+      it('leaves no half-token in the ring itself', async () => {
+        const { ring } = await driveChildStderr(payloadCutting(6, sep));
+        expect(ring.length).toBeLessThanOrEqual(RING_MAX);
+        expect(ring.startsWith(SECRET.slice(6))).toBe(false);
+        expect(redactSecrets(ring)).not.toContain(SECRET.slice(6));
+      }, 20000);
+
+      it('leaves no half-token in the user-visible banner', async () => {
+        const { banner } = await driveChildStderr(payloadCutting(6, sep));
+        expect(banner).not.toContain(SECRET.slice(6));
+        // Known positive in the same banner: the whole credentials DID redact, so a
+        // pass is the truncation being fixed and not the scrubber being absent.
+        expect(banner).toContain('[redacted]');
+      }, 20000);
+    });
+  }
+
   it('a stderr tail with NO newline at all still reaches the banner', async () => {
-    // 9KB of unbroken text has no record boundary to cut at, so the ring must keep
-    // what it has rather than emptying itself.
-    const { ring, banner } = await driveChildStderr('y'.repeat(9000) + 'THE-REAL-ERROR');
+    // 9KB of unbroken text has no record boundary to cut at. Dropping the leading
+    // run of non-whitespace costs one token, so the real error still lands on screen.
+    const { ring, banner } = await driveChildStderr('y'.repeat(9000) + ' THE-REAL-ERROR');
     expect(ring).toContain('THE-REAL-ERROR');
     expect(banner).toContain('THE-REAL-ERROR');
+  }, 20000);
+
+  it('a boundary-free run of 8KB with no whitespace at all empties the ring', async () => {
+    // The accepted cost, pinned so it cannot drift silently: when the whole retained
+    // window is a single whitespace-free token there is nothing there that separates
+    // a base64 blob from a secret, so it all goes. The banner still names the reason.
+    const { ring, banner } = await driveChildStderr('y'.repeat(9000) + 'GLUED-ON-ERROR');
+    expect(ring).toBe('');
+    expect(banner).not.toContain('GLUED-ON-ERROR');
+    expect(banner).toContain('connection_close');
+  }, 20000);
+
+  it('cuts at a leading \\r rather than a later \\n, keeping the records in between', async () => {
+    // Taking whichever boundary comes FIRST is what makes bare-CR output safe, and it
+    // is also the cheaper cut: the `\n`-only search discarded everything up to the
+    // newline, which measured 2801 characters of real diagnostics on this payload.
+    const head = `${SECRET}\r${'diag line one '.repeat(200)}\n${'diag line two '.repeat(200)}`;
+    const pad = 'p'.repeat(RING_MAX - (SECRET.length - 6) - (head.length - SECRET.length));
+    const { ring } = await driveChildStderr('lead '.repeat(100) + head + pad);
+    expect(ring.startsWith(SECRET.slice(6))).toBe(false);
+    expect(ring).toContain('diag line one');
   }, 20000);
 });

--- a/tests/unit/acpStderrRingTruncationLeak.test.ts
+++ b/tests/unit/acpStderrRingTruncationLeak.test.ts
@@ -1,0 +1,150 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * #1023 FINDING 4: the stderr ring must not hand the banner a HALF credential.
+ *
+ * #1020 newly routes `ProcessAcpClient`'s 8KB stderr ring into the chat transcript
+ * through `buildCrashMessage`, which makes the ring's truncation a disclosure path.
+ * `redactSecrets` fires correctly on WHOLE credentials, but the ring kept the last
+ * 8192 characters and cut at an arbitrary character: shave even one character off
+ * `sk-ant-api03-` and the vendor-prefix rule stops matching, so the remainder of a
+ * real key survives every downstream scrub. Cuts 1, 3, 6, 10, 13 and 20 characters
+ * in all leaked.
+ *
+ * The half-token sits at the START of the ring, so the banner's own 2048-character
+ * tail usually hides it. It stops hiding it the moment redaction SHRINKS the ring
+ * below 2048, which is exactly what a bridge dumping a block of credentials to
+ * stderr produces: every whole key collapses to `[redacted]`, the ring drops from
+ * 8192 to about 1300 characters, no tail slice happens, and the one token that was
+ * NOT redacted is the half one at the cut - on screen, in the chat transcript.
+ *
+ * Fixed at the ring rather than at the banner: drop the partial leading record, so
+ * no half-token ever exists for the scrubber to miss.
+ *
+ * Driven through a REAL child process writing to REAL stderr.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { ProcessAcpClient } from '@process/acp/infra/ProcessAcpClient';
+import { buildCrashMessage } from '@process/acp/session/AcpSession';
+import { isProcessAlive } from '@process/acp/infra/processUtils';
+import { redactSecrets } from '@process/utils/secretRedaction';
+
+/** A real Anthropic key shape. Only the WHOLE token is redactable. */
+const SECRET = 'sk-ant-api03-AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCdEfGhIjKlMnOpQrStUvWxYz';
+
+/** Mirrors `STARTUP_STDERR_MAX` in ProcessAcpClient. */
+const RING_MAX = 8192;
+
+const spawned: ChildProcess[] = [];
+
+afterEach(() => {
+  for (const child of spawned.splice(0)) {
+    if (child.pid && isProcessAlive(child.pid)) {
+      try {
+        process.kill(child.pid, 'SIGKILL');
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+});
+
+/**
+ * Real child writes `payload` to real stderr through the real `setupStderrCapture`.
+ * Returns both the surviving ring and the banner #1020 would put on screen for it.
+ */
+async function driveChildStderr(payload: string): Promise<{ ring: string; banner: string }> {
+  const client = new ProcessAcpClient(
+    async () => {
+      const child = spawn(process.execPath, ['-e', 'process.stderr.write(process.env.ACP_PAYLOAD ?? "");'], {
+        stdio: 'pipe',
+        env: { ...process.env, ACP_PAYLOAD: payload },
+      });
+      spawned.push(child);
+      return child;
+    },
+    { backend: 'probe', handlers: {} as never }
+  );
+
+  // The probe child never speaks ACP, so initialize rejects. Stderr capture is
+  // attached at step 2 of start(), before the handshake, and that is the code here.
+  await client.start().catch(() => undefined);
+  await new Promise((r) => setTimeout(r, 300));
+
+  const ring = (client as unknown as { stderrBuffer: string }).stderrBuffer;
+  const banner = buildCrashMessage({
+    reason: 'connection_close',
+    exitCode: null,
+    signal: null,
+    stderr: ring,
+    unexpectedDuringPrompt: false,
+  })!;
+  return { ring, banner };
+}
+
+/**
+ * A payload whose last {@link RING_MAX} characters begin exactly `offset` characters
+ * INTO a credential, followed by whole newline-separated credentials so redaction
+ * shrinks the ring under the banner's 2048-character tail.
+ *
+ * The arithmetic is ASSERTED, not assumed: the first cut of this test put the cut in
+ * the filler instead and passed against the unfixed code.
+ */
+function payloadCutting(offset: number): string {
+  const restLen = RING_MAX - (SECRET.length - offset);
+  let rest = '\n';
+  while (rest.length + SECRET.length + 1 <= restLen) rest += `${SECRET}\n`;
+  rest += 'o'.repeat(restLen - rest.length);
+
+  const payload = `noise ${'x'.repeat(70)}\n`.repeat(30) + `token ${SECRET}${rest}`;
+  const cut = payload.slice(-RING_MAX);
+  if (cut !== SECRET.slice(offset) + rest) throw new Error(`payload arithmetic wrong for offset ${offset}`);
+  return payload;
+}
+
+describe('#1023 the stderr ring must not leak a truncated credential', () => {
+  it('KNOWN POSITIVE: a WHOLE credential in a real child stderr is redacted out of the banner', async () => {
+    const { banner } = await driveChildStderr(`bridge token: ${SECRET}\n`);
+    expect(banner).not.toContain(SECRET);
+    expect(banner).toContain('[redacted]');
+    // Not vacuous: the surrounding diagnostic really did reach the banner.
+    expect(banner).toContain('bridge token');
+  }, 20000);
+
+  for (const offset of [1, 3, 6, 10, 13, 20]) {
+    describe(`a ring cut ${offset} characters into a credential`, () => {
+      it('leaves no half-token in the ring itself', async () => {
+        const { ring } = await driveChildStderr(payloadCutting(offset));
+        expect(ring.length).toBeLessThanOrEqual(RING_MAX);
+        // The record-boundary invariant: the ring never BEGINS mid-token.
+        expect(ring.startsWith(SECRET.slice(offset))).toBe(false);
+        // And the consequence that matters: nothing in the ring survives the
+        // scrubber. Asserted on the SCRUBBED ring, because an intact credential
+        // trivially contains its own suffix.
+        expect(redactSecrets(ring)).not.toContain(SECRET.slice(offset));
+      }, 20000);
+
+      it('leaves no half-token in the user-visible banner', async () => {
+        const { banner } = await driveChildStderr(payloadCutting(offset));
+        expect(banner).not.toContain(SECRET.slice(offset));
+        // Known positive in the same banner: the whole credentials DID redact, so a
+        // pass here is the truncation being fixed, not the scrubber being absent.
+        expect(banner).toContain('[redacted]');
+      }, 20000);
+    });
+  }
+
+  it('a stderr tail with NO newline at all still reaches the banner', async () => {
+    // 9KB of unbroken text has no record boundary to cut at, so the ring must keep
+    // what it has rather than emptying itself.
+    const { ring, banner } = await driveChildStderr('y'.repeat(9000) + 'THE-REAL-ERROR');
+    expect(ring).toContain('THE-REAL-ERROR');
+    expect(banner).toContain('THE-REAL-ERROR');
+  }, 20000);
+});

--- a/tests/unit/acpStderrRingTruncationLeak.test.ts
+++ b/tests/unit/acpStderrRingTruncationLeak.test.ts
@@ -48,6 +48,13 @@ const SECRET = 'sk-ant-api03-AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCdEfGhIjKlMnO
 /** Mirrors `STARTUP_STDERR_MAX` in ProcessAcpClient. */
 const RING_MAX = 8192;
 
+/**
+ * A bare 32-hex secret, used deliberately INSTEAD of a prefixed key: no rule matches it
+ * on its own, so a row built on it tests the scrubber's ANCHOR STRUCTURE rather than
+ * prefix luck.
+ */
+const HEX = 'f0e9d8c7b6a5948372615041302f1e0d';
+
 const spawned: ChildProcess[] = [];
 
 afterEach(() => {
@@ -93,6 +100,71 @@ async function driveChildStderr(payload: string): Promise<{ ring: string; banner
     unexpectedDuringPrompt: false,
   })!;
   return { ring, banner };
+}
+
+/**
+ * Two real stderr writes separated by a real gap, so they arrive as SEPARATE chunks and
+ * split `whole` across the ring's overflow. `first` must already exceed {@link RING_MAX}
+ * or the overflow branch never runs on it and the test proves nothing - asserted, because
+ * a first cut of this test used a 8130-character chunk and passed vacuously.
+ */
+async function driveSplitChildStderr(first: string, second: string): Promise<{ ring: string; banner: string }> {
+  if (first.length <= RING_MAX) throw new Error('the first chunk must overflow the ring');
+  const client = new ProcessAcpClient(
+    async () => {
+      const child = spawn(
+        process.execPath,
+        [
+          '-e',
+          'process.stderr.write(process.env.ACP_A ?? "");' +
+            'setTimeout(() => process.stderr.write(process.env.ACP_B ?? ""), 150);',
+        ],
+        { stdio: 'pipe', env: { ...process.env, ACP_A: first, ACP_B: second } }
+      );
+      spawned.push(child);
+      return child;
+    },
+    { backend: 'probe', handlers: {} as never }
+  );
+
+  await client.start().catch(() => undefined);
+  await new Promise((r) => setTimeout(r, 600));
+
+  const ring = (client as unknown as { stderrBuffer: string }).stderrBuffer;
+  const banner = buildCrashMessage({
+    reason: 'connection_close',
+    exitCode: null,
+    signal: null,
+    stderr: ring,
+    unexpectedDuringPrompt: false,
+  })!;
+  return { ring, banner };
+}
+
+/**
+ * A payload whose last {@link RING_MAX} characters begin exactly `offset` characters INTO
+ * `head` - an ANCHOR followed by its secret - with NO record boundary anywhere in that
+ * window, then whole credentials so redaction shrinks the ring under the banner's
+ * 2048-character tail.
+ *
+ * The leading padding is space-separated on purpose. `\bBearer`, `\bAuthorization` and
+ * `\bapi_key` each need a word boundary in FRONT of the anchor, and padding that ends on a
+ * word character silently defeats all three - which made a first cut of this probe report
+ * a post-fix leak that its own padding, not the code, had caused. Both that and the cut
+ * arithmetic are ASSERTED rather than assumed.
+ */
+function anchorCutPayload(head: string, offset: number): string {
+  const restLen = RING_MAX - (head.length - offset);
+  let rest = ' ';
+  while (rest.length + SECRET.length + 1 <= restLen) rest += `${SECRET} `;
+  rest += 'o'.repeat(restLen - rest.length);
+
+  const payload = `${'q '.repeat(250)}${head}${rest}`;
+  const window = payload.slice(-RING_MAX);
+  if (window !== head.slice(offset) + rest) throw new Error(`payload arithmetic wrong for ${head}`);
+  if (/[\r\n]/.test(window)) throw new Error('the retained window must contain no record boundary');
+  if (!payload.includes(` ${head}`)) throw new Error('the anchor needs a word boundary in front of it');
+  return payload;
 }
 
 /**
@@ -186,14 +258,108 @@ describe('#1023 the stderr ring must not leak a truncated credential', () => {
     expect(banner).toContain('THE-REAL-ERROR');
   }, 20000);
 
-  it('a boundary-free run of 8KB with no whitespace at all empties the ring', async () => {
-    // The accepted cost, pinned so it cannot drift silently: when the whole retained
-    // window is a single whitespace-free token there is nothing there that separates
-    // a base64 blob from a secret, so it all goes. The banner still names the reason.
+  it('a boundary-free run of 8KB with no whitespace at all still delivers the diagnostic', async () => {
+    // This pinned an accepted COST, not an invariant: the whole retained window was one
+    // whitespace-free token, `^\S+` ate all of it and the ring emptied, and the user got a
+    // banner with no stderr section. The cost stopped existing when the scrub moved to the
+    // collection site - every credential in the window is already `[redacted]` by the time
+    // the cut is chosen, so keeping the window is safe and `cutRing || sliced` keeps it.
     const { ring, banner } = await driveChildStderr('y'.repeat(9000) + 'GLUED-ON-ERROR');
-    expect(ring).toBe('');
-    expect(banner).not.toContain('GLUED-ON-ERROR');
+    expect(ring).toContain('GLUED-ON-ERROR');
+    expect(banner).toContain('GLUED-ON-ERROR');
     expect(banner).toContain('connection_close');
+  }, 20000);
+
+  it('KNOWN POSITIVE: the scrubber needs its ANCHOR, so an anchorless secret is invisible', () => {
+    // The premise the rows below rest on. `redactSecrets` masks `Bearer <token>` because of
+    // the word `Bearer`, not because of anything in the token - so a cut that damages the
+    // ANCHOR is just as much a disclosure as a cut that damages the secret, and dropping
+    // the leading non-whitespace run removes the anchor rather than the secret.
+    expect(redactSecrets(HEX)).toBe(HEX);
+    expect(redactSecrets(`Bearer ${HEX}`)).toContain('[redacted]');
+    expect(redactSecrets(`earer ${HEX}`)).toContain(HEX);
+    expect(redactSecrets('api_key = hunter2hunter2')).toContain('[redacted]');
+    expect(redactSecrets('_key = hunter2hunter2')).toContain('hunter2hunter2');
+  });
+
+  // The scrubber's anchor is not always attached to its secret: `Bearer`, `Authorization:`
+  // and `api_key =` all keep it in a separate whitespace-delimited word. A ring cut landing
+  // inside the ANCHOR therefore left the secret WHOLE and merely un-anchored, and the
+  // no-boundary fallback then dropped the mangled anchor and kept the secret. All four rows
+  // below reached the banner intact before the scrub moved to the collection site.
+  for (const [label, head, offset, secret] of [
+    ['inside "Bearer"', `Bearer ${HEX}`, 2, HEX],
+    ['inside "api_key"', 'api_key = hunter2hunter2', 3, 'hunter2hunter2'],
+    ['at the "api_key = " separator', 'api_key = hunter2hunter2', 7, 'hunter2hunter2'],
+    ['inside "Authorization"', `Authorization: ${HEX}`, 4, HEX],
+    // Already safe before the fix, and kept as the contrast: this shape puts the anchor and
+    // the secret in ONE whitespace-free run, so dropping that run took the secret with it.
+    ['inside "password=" (anchor and secret in one run)', 'password=SuperSecret99', 2, 'SuperSecret99'],
+  ] as const) {
+    it(`a ring cut ${label} leaves no anchorless secret behind`, async () => {
+      const { ring, banner } = await driveChildStderr(anchorCutPayload(head, offset));
+      expect(redactSecrets(ring)).not.toContain(secret);
+      expect(banner).not.toContain(secret);
+      // Known positive in the SAME payload: the whole `sk-ant-` keys did redact, so a pass
+      // here is the anchor being preserved and not the scrubber being absent.
+      expect(banner).toContain('[redacted]');
+    }, 20000);
+  }
+
+  it('a single record larger than the whole ring still delivers a diagnostic', async () => {
+    // A 21KB minified stack frame, JSON config echo or base64 dump terminated by one `\n`
+    // leaves the retained window with its only boundary at the very last character, so
+    // `slice(boundary + 1)` returned '' and the banner lost its stderr section entirely -
+    // a diagnostic main delivered. Measured before: ringLen=0. Main: 8192 with the error.
+    const payload = `${'z'.repeat(20000)} THE-REAL-ERROR${'z'.repeat(1000)}\n`;
+    const { ring, banner } = await driveChildStderr(payload);
+    expect(ring.length).toBe(RING_MAX);
+    expect(ring).toContain('THE-REAL-ERROR');
+    expect(banner).toContain('Agent stderr:');
+    expect(banner).toContain('THE-REAL-ERROR');
+  }, 20000);
+
+  it('a credential split across two stderr chunks is not orphaned by the scrub', async () => {
+    // The hazard the collection-site scrub introduces, and the reason it holds back the
+    // ring's trailing non-whitespace run. Scrubbing the buffer the instant it overflows
+    // would mask the half of a credential that has arrived, replacing its ANCHOR with
+    // `[redacted]`, and the half arriving in the NEXT chunk would then be unmatchable by
+    // any later scrub. Measured that way: 51 characters of this key reached the banner.
+    const split = 24;
+    const first = `${'pad line\n'.repeat(950)}token ${SECRET.slice(0, split)}`;
+    const { ring, banner } = await driveSplitChildStderr(first, `${SECRET.slice(split)} trailing diagnostic\n`);
+
+    expect(ring).not.toContain(SECRET.slice(split));
+    expect(banner).not.toContain(SECRET.slice(split));
+    // Known positives: the credential was masked as a WHOLE one rather than lost, and the
+    // diagnostic that arrived with it still reached the user.
+    expect(ring).not.toContain(SECRET);
+    expect(banner).toContain('[redacted]');
+    expect(banner).toContain('trailing diagnostic');
+  }, 30000);
+
+  it('an oversized Bearer token is scrubbed rather than held back raw past its anchor', async () => {
+    // The bound on the chunk-split carry. The carry leaves the ring's trailing
+    // non-whitespace run raw so a credential straddling two chunks is not half-masked. Left
+    // UNBOUNDED that backfires: a single 9KB `Bearer` value is one non-whitespace run, so the
+    // whole thing would be held back raw, the cap would land inside it, and the `Bearer`
+    // anchor sitting just before it would be cut away - leaving exactly the anchorless
+    // remainder the carry exists to prevent. A run longer than a credential prefix is a
+    // value, not a straddle, so it is scrubbed normally.
+    const token = 'Zk9'.repeat(3000);
+    const payload = `${'q '.repeat(50)}Bearer ${token}`;
+    if (payload.length <= RING_MAX) throw new Error('the payload must overflow the ring');
+    if (/[\r\n]/.test(payload.slice(-RING_MAX))) throw new Error('the window must have no boundary');
+    if (!payload.slice(-RING_MAX).startsWith('Zk9') && !payload.slice(-RING_MAX).startsWith('k9Z')) {
+      throw new Error('the window must start INSIDE the token, past the Bearer anchor');
+    }
+
+    const { ring, banner } = await driveChildStderr(payload);
+    expect(redactSecrets(ring)).not.toContain(token.slice(-1000));
+    expect(banner).not.toContain(token.slice(-1000));
+    // Known positive: this value IS redactable when its anchor survives, so a pass here is
+    // the anchor being kept rather than the scrubber having no rule for it.
+    expect(redactSecrets(`Bearer ${token}`)).toContain('[redacted]');
   }, 20000);
 
   it('cuts at a leading \\r rather than a later \\n, keeping the records in between', async () => {

--- a/tests/unit/process/acp/compat/AcpAgentV2.crashMarker.test.ts
+++ b/tests/unit/process/acp/compat/AcpAgentV2.crashMarker.test.ts
@@ -1,0 +1,153 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * #1023 REGRESSION LOCK: the transport-drop banner must still classify as a crash
+ * at `AcpAgentV2`'s error handler.
+ *
+ * The gap this closes: deleting the `CRASH_MARKER_TRANSPORT_CLOSE` arm of `isCrash`
+ * survived the whole 204-test suite. The transport banner matches NONE of the other
+ * three substrings, so without that arm `isCrash` is false, no `finish` frame with
+ * `agentCrash: true` is synthesized, and per `crashMarkers.ts` the renderer's
+ * loading state never clears - a permanently stuck spinner on the exact #1020
+ * customer path.
+ *
+ * The banner text is taken from the REAL `buildCrashMessage`, never a hand-written
+ * literal. A hand-written literal is what let this through: the sibling suite's
+ * `const CRASH = 'process exited unexpectedly (code: 1, signal: none)'` cannot
+ * notice a reword of the production string, and #1023 rewords it twice.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AcpAgentV2 } from '@process/acp/compat/AcpAgentV2';
+import { buildCrashMessage } from '@process/acp/session/AcpSession';
+import type { DisconnectInfo } from '@process/acp/infra/IAcpClient';
+import type { SessionCallbacks } from '@process/acp/types';
+import type { OldAcpAgentConfig } from '@process/acp/compat/typeBridge';
+
+let capturedCallbacks: SessionCallbacks;
+let mockStart: ReturnType<typeof vi.fn>;
+
+// Spread the real module so `buildCrashMessage` stays REAL; only the class is stubbed.
+vi.mock('@process/acp/session/AcpSession', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@process/acp/session/AcpSession')>();
+  return {
+    ...actual,
+    AcpSession: class MockAcpSession {
+      constructor(_config: unknown, _factory: unknown, callbacks: SessionCallbacks) {
+        capturedCallbacks = callbacks;
+      }
+      start = (...args: unknown[]) => mockStart(...args);
+      stop = vi.fn().mockResolvedValue(undefined);
+      get status() {
+        return 'idle';
+      }
+      get sessionId() {
+        return null;
+      }
+    },
+  };
+});
+
+vi.mock('@process/acp/compat/LegacyConnectorFactory', () => ({
+  LegacyConnectorFactory: class {
+    constructor() {}
+  },
+}));
+
+vi.mock('@process/acp/compat/typeBridge', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@process/acp/compat/typeBridge')>();
+  return { ...actual, loadAuthCredentials: vi.fn().mockResolvedValue(undefined) };
+});
+
+vi.mock('@process/services/mcpServices/runtimeMcpServers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@process/services/mcpServices/runtimeMcpServers')>();
+  return { ...actual, loadRuntimeMcpServers: vi.fn(async () => []) };
+});
+
+vi.mock('@process/services/mcpServices/McpService', () => ({
+  mcpService: { attachOAuthTokens: vi.fn(async (servers: unknown) => servers) },
+}));
+
+/** The #1020 shape: the pipe went, so there is no code and no signal. */
+const TRANSPORT_DROP: DisconnectInfo = {
+  reason: 'connection_close',
+  exitCode: null,
+  signal: null,
+  stderr: '',
+  unexpectedDuringPrompt: true,
+};
+
+/** An observed exit, for the control that proves the assertion can distinguish. */
+const OBSERVED_EXIT: DisconnectInfo = { ...TRANSPORT_DROP, reason: 'process_exit', exitCode: 7 };
+
+async function startedAgent(): Promise<{ agent: AcpAgentV2; onSignalEvent: ReturnType<typeof vi.fn> }> {
+  const onSignalEvent = vi.fn();
+  const config: OldAcpAgentConfig = {
+    id: 'test-conv-1',
+    backend: 'claude',
+    workingDir: '/workspace/test',
+    onStreamEvent: vi.fn(),
+    onSignalEvent,
+  };
+  const agent = new AcpAgentV2(config);
+  mockStart.mockImplementation(() => {
+    setTimeout(() => capturedCallbacks.onStatusChange('active'), 0);
+  });
+  await agent.start();
+  mockStart.mockReset();
+  onSignalEvent.mockClear();
+  return { agent, onSignalEvent };
+}
+
+/** The synthesized turn-terminating frames, which are what clear the spinner. */
+function crashFinishFrames(spy: ReturnType<typeof vi.fn>): Array<{ error?: string; agentCrash?: boolean }> {
+  return spy.mock.calls
+    .map((c) => c[0])
+    .filter((m) => m?.type === 'finish')
+    .map((m) => (m.data ?? {}) as { error?: string; agentCrash?: boolean })
+    .filter((d) => d.agentCrash === true);
+}
+
+describe('#1023 AcpAgentV2 classifies the real disconnect banners as crashes', () => {
+  beforeEach(() => {
+    mockStart = vi.fn();
+  });
+
+  it('a REAL transport-drop banner (null code, null signal) synthesizes the agentCrash finish frame', async () => {
+    const { onSignalEvent } = await startedAgent();
+    const banner = buildCrashMessage(TRANSPORT_DROP)!;
+
+    // Guard the guard: if the banner ever starts matching one of the legacy
+    // substrings, this test would pass for the wrong reason.
+    expect(banner).not.toContain('PROCESS_CRASHED');
+    expect(banner).not.toContain('Process disconnected');
+    expect(banner).not.toContain('process exited unexpectedly');
+
+    capturedCallbacks.onSignal({ type: 'error', message: banner, recoverable: true });
+
+    const frames = crashFinishFrames(onSignalEvent);
+    expect(frames).toHaveLength(1);
+    expect(frames[0].error).toBe(banner);
+  });
+
+  it('a REAL observed-exit banner also synthesizes the agentCrash finish frame', async () => {
+    const { onSignalEvent } = await startedAgent();
+    const banner = buildCrashMessage(OBSERVED_EXIT)!;
+
+    capturedCallbacks.onSignal({ type: 'error', message: banner, recoverable: true });
+
+    expect(crashFinishFrames(onSignalEvent)).toHaveLength(1);
+  });
+
+  it('an unrelated error is NOT a crash, so the assertions above are not vacuous', async () => {
+    const { onSignalEvent } = await startedAgent();
+
+    capturedCallbacks.onSignal({ type: 'error', message: 'Rate limited (429)', recoverable: true });
+
+    expect(crashFinishFrames(onSignalEvent)).toHaveLength(0);
+  });
+});

--- a/tests/unit/process/acp/compat/AcpAgentV2.crashMarker.test.ts
+++ b/tests/unit/process/acp/compat/AcpAgentV2.crashMarker.test.ts
@@ -53,9 +53,7 @@ vi.mock('@process/acp/session/AcpSession', async (importOriginal) => {
 });
 
 vi.mock('@process/acp/compat/LegacyConnectorFactory', () => ({
-  LegacyConnectorFactory: class {
-    constructor() {}
-  },
+  LegacyConnectorFactory: class {},
 }));
 
 vi.mock('@process/acp/compat/typeBridge', async (importOriginal) => {

--- a/tests/unit/process/acp/session/emitCrashSignal.test.ts
+++ b/tests/unit/process/acp/session/emitCrashSignal.test.ts
@@ -73,8 +73,12 @@ describe('buildCrashMessage', () => {
         expect(msg).not.toContain(CRASH_MARKER_PROCESS_EXIT);
         expect(msg).not.toContain('code: unknown');
         expect(msg).not.toContain('signal: none');
-        // And it must say the process death is unproven.
-        expect(msg).toContain('may still be running');
+        // And it must say the process death is unproven WITHOUT reassuring the
+        // user that the child is probably alive: that reassurance was measured
+        // false for 6 of 20 real crashes (#1023).
+        expect(msg).toContain('we cannot tell whether the agent crashed or the connection dropped');
+        expect(msg).not.toContain('may still be running');
+        expect(msg).not.toContain('not a confirmed crash');
       });
     }
   });
@@ -82,13 +86,26 @@ describe('buildCrashMessage', () => {
   describe('prompt in flight vs idle', () => {
     it('tells the user the turn did not land when a prompt was in flight', () => {
       const msg = buildCrashMessage(info({ reason: 'connection_close', unexpectedDuringPrompt: true }))!;
-      expect(msg).toContain('did not complete');
-      expect(msg).toContain('send it again');
+      expect(msg).toContain('lost before it could complete');
+      expect(msg).toContain('was not resent automatically');
+    });
+
+    // #1023: `PromptExecutor.handlePromptError` refuses to replay this turn because a
+    // dead pipe can swallow the `tool_call` that would say what already ran, so the
+    // turn may have already executed an approved `rm`. The copy must not instruct the
+    // human to do by hand the thing the code declines to do for them.
+    it('warns that part of the turn may already have run instead of telling the user to resend', () => {
+      const msg = buildCrashMessage(info({ reason: 'connection_close', unexpectedDuringPrompt: true }))!;
+      expect(msg).toContain('The agent may already have carried out part of this message');
+      expect(msg).toContain('check the result before sending it again');
+      // The old copy was a bare instruction to resend.
+      expect(msg).not.toContain('was not resent automatically - send it again');
     });
 
     it('says nothing about a lost turn when none was in flight', () => {
       const msg = buildCrashMessage(info({ reason: 'connection_close', unexpectedDuringPrompt: false }))!;
-      expect(msg).not.toContain('did not complete');
+      expect(msg).not.toContain('lost before it could complete');
+      expect(msg).not.toContain('was not resent automatically');
     });
   });
 

--- a/tests/unit/process/acp/session/emitCrashSignal.test.ts
+++ b/tests/unit/process/acp/session/emitCrashSignal.test.ts
@@ -9,30 +9,153 @@
 import { describe, it, expect } from 'vitest';
 
 import { buildCrashMessage } from '../../../../../src/process/acp/session/AcpSession';
+import {
+  CRASH_MARKER_PROCESS_EXIT,
+  CRASH_MARKER_TRANSPORT_CLOSE,
+} from '../../../../../src/process/acp/session/crashMarkers';
+import type { AgentDisconnectReason, DisconnectInfo } from '../../../../../src/process/acp/infra/IAcpClient';
+
+function info(over: Partial<DisconnectInfo> = {}): DisconnectInfo {
+  return {
+    reason: 'process_exit',
+    exitCode: null,
+    signal: null,
+    stderr: '',
+    unexpectedDuringPrompt: false,
+    ...over,
+  };
+}
+
+const ALL_REASONS: AgentDisconnectReason[] = ['process_exit', 'process_close', 'pipe_close', 'connection_close'];
 
 describe('buildCrashMessage', () => {
-  it('returns message for process_exit with code', () => {
-    const result = buildCrashMessage({ reason: 'process_exit', exitCode: 1, signal: null, stderr: '' });
-    expect(result).toBe('process exited unexpectedly (code: 1, signal: none)');
-  });
-
-  it('returns message for process_exit with signal', () => {
-    const result = buildCrashMessage({ reason: 'process_exit', exitCode: null, signal: 'SIGSEGV', stderr: '' });
-    expect(result).toBe('process exited unexpectedly (code: unknown, signal: SIGSEGV)');
-  });
-
-  it('returns message for connection_close with no info', () => {
-    const result = buildCrashMessage({ reason: 'connection_close', exitCode: null, signal: null, stderr: '' });
-    expect(result).toBe('process exited unexpectedly (code: unknown, signal: none)');
-  });
-
-  it('returns message for pipe_close', () => {
-    const result = buildCrashMessage({ reason: 'pipe_close', exitCode: null, signal: 'SIGILL', stderr: '' });
-    expect(result).toBe('process exited unexpectedly (code: unknown, signal: SIGILL)');
-  });
-
   it('returns null when info is undefined', () => {
-    const result = buildCrashMessage(undefined);
-    expect(result).toBeNull();
+    expect(buildCrashMessage(undefined)).toBeNull();
+  });
+
+  describe('an OBSERVED process exit still says so', () => {
+    it('exit code', () => {
+      expect(buildCrashMessage(info({ reason: 'process_exit', exitCode: 1 }))).toBe(
+        'process exited unexpectedly (code: 1, signal: none) [reason: process_exit]'
+      );
+    });
+
+    it('signal', () => {
+      expect(buildCrashMessage(info({ reason: 'process_exit', signal: 'SIGSEGV' }))).toBe(
+        'process exited unexpectedly (code: unknown, signal: SIGSEGV) [reason: process_exit]'
+      );
+    });
+
+    it('exit code 0 counts as observed', () => {
+      const msg = buildCrashMessage(info({ reason: 'process_close', exitCode: 0 }))!;
+      expect(msg).toContain(CRASH_MARKER_PROCESS_EXIT);
+      expect(msg).toContain('code: 0');
+      expect(msg).not.toContain(CRASH_MARKER_TRANSPORT_CLOSE);
+    });
+
+    it('a signal seen on a transport-reason disconnect is still an exit', () => {
+      const msg = buildCrashMessage(info({ reason: 'pipe_close', signal: 'SIGILL' }))!;
+      expect(msg).toContain('signal: SIGILL');
+      expect(msg).toContain('[reason: pipe_close]');
+    });
+  });
+
+  describe('#1020 an UNOBSERVED exit must not be asserted', () => {
+    // The two reasons that can carry null/null in practice are the transport
+    // ones, but the rule is about the evidence, not the reason - so all four are
+    // checked.
+    for (const reason of ALL_REASONS) {
+      it(`${reason} with no code and no signal reports a transport drop`, () => {
+        const msg = buildCrashMessage(info({ reason }))!;
+        expect(msg).toContain(CRASH_MARKER_TRANSPORT_CLOSE);
+        expect(msg).toContain(`[reason: ${reason}]`);
+        // The defect: these literals were the entire old message.
+        expect(msg).not.toContain(CRASH_MARKER_PROCESS_EXIT);
+        expect(msg).not.toContain('code: unknown');
+        expect(msg).not.toContain('signal: none');
+        // And it must say the process death is unproven.
+        expect(msg).toContain('may still be running');
+      });
+    }
+  });
+
+  describe('prompt in flight vs idle', () => {
+    it('tells the user the turn did not land when a prompt was in flight', () => {
+      const msg = buildCrashMessage(info({ reason: 'connection_close', unexpectedDuringPrompt: true }))!;
+      expect(msg).toContain('did not complete');
+      expect(msg).toContain('send it again');
+    });
+
+    it('says nothing about a lost turn when none was in flight', () => {
+      const msg = buildCrashMessage(info({ reason: 'connection_close', unexpectedDuringPrompt: false }))!;
+      expect(msg).not.toContain('did not complete');
+    });
+  });
+
+  describe('stderr tail', () => {
+    it('surfaces the reason the agent actually gave', () => {
+      const msg = buildCrashMessage(info({ reason: 'connection_close', stderr: 'Cannot find module zod/v4\n' }))!;
+      expect(msg).toContain('Agent stderr:');
+      expect(msg).toContain('Cannot find module zod/v4');
+    });
+
+    it('scrubs secrets through the shared redactor', () => {
+      const secrets = [
+        'sk-abcdefghijklmnopqrstuvwx',
+        'Bearer abcdefghijklmnopqrst',
+        'ghp_abcdefghijklmnopqrstuvwxyz01',
+        'AKIA0123456789ABCDEF',
+        'api_key = hunter2hunter2',
+      ].join('\n');
+      const msg = buildCrashMessage(info({ reason: 'connection_close', stderr: secrets }))!;
+      expect(msg).toContain('[redacted]');
+      expect(msg).not.toContain('sk-abcdefghijklmnopqrstuvwx');
+      expect(msg).not.toContain('ghp_abcdefghijklmnopqrstuvwxyz01');
+      expect(msg).not.toContain('AKIA0123456789ABCDEF');
+      expect(msg).not.toContain('hunter2hunter2');
+      // The label survives so the diagnostic still reads sensibly.
+      expect(msg).toContain('api_key');
+    });
+
+    it('strips ANSI so the banner stays plain text', () => {
+      const coloured = `[31mboom[0m`;
+      const msg = buildCrashMessage(info({ reason: 'connection_close', stderr: coloured }))!;
+      expect(msg).toContain('boom');
+      expect(msg).not.toContain('');
+    });
+
+    it('bounds the tail and keeps the END of it', () => {
+      const stderr = 'x'.repeat(9000) + 'THE-REAL-ERROR';
+      const msg = buildCrashMessage(info({ reason: 'connection_close', stderr }))!;
+      expect(msg).toContain('THE-REAL-ERROR');
+      // 2048-char tail plus the head line, nowhere near the 9KB input.
+      expect(msg.length).toBeLessThan(2500);
+    });
+
+    it('omits the section entirely when stderr is blank', () => {
+      expect(buildCrashMessage(info({ reason: 'connection_close', stderr: '   \n\n' }))!).not.toContain('Agent stderr');
+    });
+  });
+
+  describe('downstream crash detectors keep matching', () => {
+    // Both banners must stay classifiable as a crash or the renderer's loading
+    // state never clears (AcpAgentV2) and a teammate is never restarted
+    // (TeammateManager).
+    it('both markers are non-empty and distinct', () => {
+      expect(CRASH_MARKER_PROCESS_EXIT).toBeTruthy();
+      expect(CRASH_MARKER_TRANSPORT_CLOSE).toBeTruthy();
+      expect(CRASH_MARKER_TRANSPORT_CLOSE).not.toBe(CRASH_MARKER_PROCESS_EXIT);
+    });
+
+    it('every disconnect carries exactly one marker', () => {
+      for (const reason of ALL_REASONS) {
+        for (const exit of [{}, { exitCode: 3 }, { signal: 'SIGTERM' }]) {
+          const msg = buildCrashMessage(info({ reason, ...exit }))!;
+          const hits =
+            Number(msg.includes(CRASH_MARKER_PROCESS_EXIT)) + Number(msg.includes(CRASH_MARKER_TRANSPORT_CLOSE));
+          expect(hits, `${reason} ${JSON.stringify(exit)}`).toBe(1);
+        }
+      }
+    });
   });
 });

--- a/tests/unit/team-TeammateManager.test.ts
+++ b/tests/unit/team-TeammateManager.test.ts
@@ -50,6 +50,8 @@ vi.mock('@process/services/database', () => ({
 }));
 
 import { TeammateManager, computeUsageDelta } from '@process/team/TeammateManager';
+import { buildCrashMessage } from '@process/acp/session/AcpSession';
+import type { DisconnectInfo } from '@process/acp/infra/IAcpClient';
 import { teamEventBus } from '@process/team/teamEventBus';
 import type { TeamAgent } from '@process/team/types';
 import type { Mailbox } from '@process/team/Mailbox';
@@ -1894,6 +1896,56 @@ describe('TeammateManager', () => {
 
       // Agent still exists
       expect(mgr.getAgents().find((a) => a.slotId === 'slot-member')).toBeDefined();
+
+      mgr.dispose();
+    });
+
+    // #1023 REGRESSION LOCK. Deleting the CRASH_MARKER_TRANSPORT_CLOSE arm of the
+    // error matcher survived the whole suite: the transport banner matches neither
+    // the process-exit phrase nor 'Session not found', so without that arm a #1020
+    // transport drop never routes to handleAgentCrash and the teammate is left
+    // wedged. The banner text comes from the REAL buildCrashMessage, so a reword of
+    // the production string cannot silently drift away from the matcher.
+    it('#1023 routes a REAL transport-drop banner (null code, null signal) to the crash flow', async () => {
+      const leader = makeAgent({ slotId: 'slot-lead', conversationId: 'conv-lead', role: 'leader' });
+      const member = makeAgent({
+        slotId: 'slot-member',
+        conversationId: 'conv-member',
+        role: 'teammate',
+        agentName: 'Worker',
+        conversationType: 'acp',
+      });
+      const { mgr, mailbox, workerTaskManager } = makeTeammateManager([leader, member]);
+
+      const drop: DisconnectInfo = {
+        reason: 'connection_close',
+        exitCode: null,
+        signal: null,
+        stderr: '',
+        unexpectedDuringPrompt: true,
+      };
+      const banner = buildCrashMessage(drop)!;
+
+      // Guard the guard: if the banner ever matched one of the other substrings
+      // this test would pass without exercising the transport arm at all.
+      expect(banner).not.toContain('process exited unexpectedly');
+      expect(banner).not.toContain('Session not found');
+
+      teamEventBus.emit('responseStream', {
+        type: 'error',
+        conversation_id: 'conv-member',
+        msg_id: 'transport-drop-1',
+        data: banner,
+      });
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      // handleAgentCrash ran: testament to the leader, member failed, process killed.
+      expect(mailbox.write).toHaveBeenCalledWith(
+        expect.objectContaining({ toAgentId: 'slot-lead', fromAgentId: 'slot-member' })
+      );
+      expect(mgr.getAgents().find((a) => a.slotId === 'slot-member')?.status).toBe('failed');
+      expect(workerTaskManager.kill).toHaveBeenCalledWith('conv-member');
 
       mgr.dispose();
     });


### PR DESCRIPTION
Fixes #1020.

A customer on the Claude Code backend was shown

    process exited unexpectedly (code: unknown, signal: none)

asked what it meant, and got a confident, wrong answer about the process having died. They also
lost an approval turn: their "approved: verification complete" was never acted on and no
approval file was written.

## The message asserted something it had no evidence for

buildCrashMessage (AcpSession.ts:80) rendered those literals only when BOTH exitCode and signal
were null. Of the disconnect reasons, pipe_close (ProcessAcpClient.ts:425) and connection_close
(:170) read the code and signal off a child that may still be running, so both come back null.
process_exit (:419) and process_close (:422) take them from Node's exit and close events, where
one is always populated, and the fifth site at :511 only fires when at least one is already set.

So the banner claimed a process exit precisely in the cases where no exit had been observed.

## The two fields that identify the cause were discarded

DisconnectInfo carries reason and the full stderr buffer. Both were populated and both were
thrown away by the message, so the real cause was unknowable by construction. That is what let
the assistant confabulate.

## What changed

- Claim an exit only when a code or a signal is actually present. Otherwise say plainly that
  this is a transport-level disconnect, that no exit was reported, and that the agent process
  may still be running.
- Name the reason in both cases.
- Carry a bounded stderr tail, ANSI-stripped and routed through the shared secret scrubber in
  src/process/utils/secretRedaction.ts. Untrusted subprocess output is on its way to the chat
  transcript and the log file, and an agent bridge prints to stderr exactly when credentials are
  in play, so scrubbing is not optional. No new pattern list was introduced.
- Disclose the lost turn. The prompting path respawns via resumeFromDisconnect and re-flushes
  the queue, but the turn that was in flight is gone: flush() shifts it off the queue before
  execute(), and handlePromptError deliberately refuses to hand it back on a dead stream because
  a tool_call it already ran can be lost with the pipe. Silently recovering would leave the user
  believing their message landed, which is the half of this bug that actually cost the customer
  work.

Diagnostics here are deliberately not routed through i18n, matching the surrounding
AgentDisconnectedError, AgentStartupError and enterError strings. No locale keys change.

## Split after the NO-GO cross-audit: the EXIT_CONFIRM_MS deferral is OUT

The four-leg audit returned NO-GO on an `EXIT_CONFIRM_MS` deferral that had been bolted onto this
branch. It waited up to 200ms for the child's exit event before reporting the disconnect, to
recover an exit code the transport abort had raced. It has been removed entirely, and it is
**deliberately deferred to separate follow-up work** rather than reworked here.

Why it had to come out: `recordAgentExit` rejects the pending SDK requests and then notifies the
disconnect handler. That looks like the wrong order and is not - a rejection's continuation is a
microtask, so `AcpSession.onDisconnect` runs BEFORE `PromptExecutor` sees the rejected prompt,
which is what arms `handlePromptError`'s "someone else owns recovery" guard. Deferring the
notification inverted it: `handlePromptError` ran while the status was still `prompting`, took its
retryable branch, emitted its own raw `Agent disconnected (connection_close, code: null)` banner
and flushed the queued follow-up at the dead client. Net effect, measured: every banner this PR
adds was unreachable on the live-child transport drop that motivated it, and a queued message was
silently lost - #774, reintroduced by the fix for #1020. The floating confirm promise also
outlived `close()`, so our own `gracefulShutdown` SIGTERM could render as an unexpected exit.

Notification is synchronous again, byte-for-byte main's shape plus the new
`unexpectedDuringPrompt` field. Removing the deferral removed the second and third audit findings
as consequences, verified by execution rather than assumed.

### The tradeoff, accepted deliberately

Without a wait, a genuine fast crash whose `exit` event is a millisecond away can be reported as a
transport close rather than a confirmed exit. Measured here: an `exit(7)` child reports
`process_exit / 7` on some runs and `connection_close / null / null` on others. That is the correct
direction. A hedged "no exit was reported, the process may still be running" is honest about what
was observed; asserting "process exited" with no code and no signal is the #1020 bug itself. The
reasoning is in a comment at the call site so nobody re-adds a deferral to chase precision at the
cost of the ordering.

Any rework of `EXIT_CONFIRM_MS` must keep the disconnect notification synchronous - upgrade the
detail some other way, or not at all.

## Verification

All executed on this head, not reasoned about.

**Ordering, restored and measured** on the customer's shape (a fixture that answers `initialize`
and `session/new`, then ends stdout on `session/prompt` and stays alive):

    this head:      disconnect t=48ms  ->  prompt-rejected t=48ms   (gap 0ms, handler FIRST)
    with deferral:  prompt-rejected t=34ms, disconnect never inside the window (gap >200ms)

**The test gap that let the defect through is closed.** Every existing test asserted
`DisconnectInfo`, which is one layer below where the bug lived: the client can hand the session a
perfect payload and the user can still read a completely different string, because
`handlePromptError` also emits a banner and whichever runs first wins the screen. So there is now
an end-to-end test that drives a real child through a real `ProcessAcpClient` into a real
`AcpSession` and asserts the banner **the session emits**. Fail-before, both ways:

    with the deferral:  first banner = "Agent disconnected (connection_close, code: null)"
    against main:       first banner = "process exited unexpectedly (code: unknown, signal: none)"

**Other test changes**

- The `pipe_close` / `process_close` case previously constructed `ProcessAcpClient` without
  calling `start()`, so `this.child` was never assigned and the live-child state the disconnect
  path reads was never exercised. It now drives a really-started client against the fixture, and
  asserts the report lands with no `await` at all.
- The two race tests no longer assert that an exit code is always recovered - that was only true
  because of the deferral. They assert the report is never *wrong* instead: either the real
  code/signal, or a hedged transport drop that claims no exit. Each carries a known-positive
  control read off the child's own `exit` event, so a null can never be a silently broken fixture.
- The three #774 crash-recovery tests are parameterised over both orderings a real client can
  produce. Pinning one ordering is exactly why they stayed green while the deferral reintroduced
  the bug they exist to prevent. Verified load-bearing: all three fail under a deliberately
  deferred ordering.
- Fixture: added the drop-on-prompt mode, removed the never-driven `garbage` mode. All four modes
  are now driven by a test.
- `AcpSession.lifecycle.test.ts` now passes the required `unexpectedDuringPrompt`. Note this was
  never a compile break - `tsconfig.json` includes only `src/**/*` - so it is tidying, not a fix.

`tsc --noEmit` clean. `oxfmt` run on exactly the seven touched files. `oxlint`: 0 errors.
`bridgeAllowlist.ts` is 0 lines changed against `ferrox/main`; no generated or locale files touched.

## What is unchanged from the audited-clean half

The `buildCrashMessage` rewrite, `crashMarkers.ts`, the `DisconnectInfo` additions and both
string-matching consumers (`AcpAgentV2`, `TeammateManager`) are as audited: genuinely fail-before,
nothing weakened, scrubbing sound, the 2048 bound applied to the scrubbed text, and `AcpAgentV2`'s
burst dedup unaffected because it keys on `errorBannerId` rather than message text.

## Tracked separately

- `EXIT_CONFIRM_MS`, per above.
- A scrubber gap where a labelled secret cannot match after an underscore, so `ANTHROPIC_API_KEY`
  survives. Pre-existing, same class as #1004.
- `SessionLifecycle.clearClient` orphaning a live agent process on a transport drop. Pre-existing,
  now proven - the tests here reap the child by hand.
