### PR TITLE
Stop the release-asset gate test timing out on Windows shards

### DIFF
--- a/tests/unit/scripts/verifyReleaseAssets.test.ts
+++ b/tests/unit/scripts/verifyReleaseAssets.test.ts
@@ -44,7 +44,15 @@ const roots: string[] = [];
 const SPAWN_TIMEOUT_MS = 30_000;
 
 function run(script: string, args: string[]) {
-  return spawnSync('bash', [script, ...args], { cwd: process.cwd(), encoding: 'utf8' });
+  // Give the subprocess a REAL deadline. vitest's testTimeout cannot interrupt a
+  // blocking spawnSync -- #1011's case ran 12236ms under a 10000ms cap -- so
+  // without this an unbounded hang becomes a CANCELLED shard, which reds out the
+  // required checks indistinguishably from a genuine failure. Bounded red instead.
+  return spawnSync('bash', [script, ...args], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    timeout: SPAWN_TIMEOUT_MS - 5_000,
+  });
 }
 
 /**

--- a/tests/unit/scripts/verifyReleaseAssets.test.ts
+++ b/tests/unit/scripts/verifyReleaseAssets.test.ts
@@ -14,10 +14,19 @@
  * (create-mock -> prepare -> verify) and assert the gate FAILS on the absence of
  * every declared artifact class, one at a time. A gate that cannot fail is the
  * defect, so the negative cases are the point of this file.
+ *
+ * The build half of that pipeline (create-mock -> prepare) is deterministic and
+ * identical for every case, so it runs ONCE in beforeAll and each case mutates a
+ * plain filesystem copy of its output. Running it per case cost ~1.9s per case on
+ * Windows (vs ~0.2s on macOS) because each Git-Bash script forks dozens of msys
+ * binaries; with the 10s default testTimeout and spawnSync blocking the event
+ * loop so vitest cannot preempt it, one contended case on a windows-2022 shard
+ * overran and reported "Test timed out in 10000ms". Only the assertion subject -
+ * verify-release-assets.sh itself - is still spawned per case.
  */
 
-import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { cpSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -25,23 +34,51 @@ import { spawnSync } from 'node:child_process';
 const VERSION = '1.0.0';
 const roots: string[] = [];
 
+/**
+ * Every case spawns verify-release-assets.sh through spawnSync, which blocks the
+ * event loop: vitest cannot preempt it, so a stalled spawn overruns whatever the
+ * cap is and only reports afterwards. The default 10s left too little room on a
+ * contended windows-2022 shard. Matches the explicit budget other subprocess
+ * suites in this repo use.
+ */
+const SPAWN_TIMEOUT_MS = 30_000;
+
 function run(script: string, args: string[]) {
   return spawnSync('bash', [script, ...args], { cwd: process.cwd(), encoding: 'utf8' });
 }
 
-/** Build a complete release-assets directory through the real release scripts. */
-function preparedAssets(): string {
-  const root = mkdtempSync(path.join(os.tmpdir(), 'wayland-verify-assets-'));
-  roots.push(root);
-  const input = path.join(root, 'build-artifacts');
-  const output = path.join(root, 'release-assets');
+/**
+ * The one real run of the build pipeline. Every case reads or copies this; if the
+ * pipeline itself breaks, beforeAll fails and no case can report a false pass.
+ */
+let pipelineRoot: string;
+let pipelineOutput: string;
+
+beforeAll(() => {
+  pipelineRoot = mkdtempSync(path.join(os.tmpdir(), 'wayland-verify-assets-src-'));
+  const input = path.join(pipelineRoot, 'build-artifacts');
+  pipelineOutput = path.join(pipelineRoot, 'release-assets');
 
   const mock = run('scripts/create-mock-release-artifacts.sh', [input, VERSION]);
   expect(mock.status, `${mock.stdout}\n${mock.stderr}`).toBe(0);
 
-  const prepared = run('scripts/prepare-release-assets.sh', [input, output]);
+  const prepared = run('scripts/prepare-release-assets.sh', [input, pipelineOutput]);
   expect(prepared.status, `${prepared.stdout}\n${prepared.stderr}`).toBe(0);
+}, 60_000);
 
+afterAll(() => {
+  rmSync(pipelineRoot, { recursive: true, force: true });
+});
+
+/**
+ * A private, complete copy of what the real release scripts produced, for cases
+ * that delete or rewrite an entry. Byte-identical to the pipeline output.
+ */
+function preparedAssets(): string {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'wayland-verify-assets-'));
+  roots.push(root);
+  const output = path.join(root, 'release-assets');
+  cpSync(pipelineOutput, output, { recursive: true });
   return output;
 }
 
@@ -91,46 +128,64 @@ afterEach(() => {
 });
 
 describe('verify-release-assets expected-set completeness', () => {
-  it('passes on the complete artifact set the mock pipeline produces', () => {
-    const result = verify(preparedAssets());
-    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
-    expect(result.stdout).toContain('ALL CHECKS PASSED');
-  });
+  it(
+    'passes on the complete artifact set the mock pipeline produces',
+    () => {
+      // Deliberately the pipeline output itself, not a copy: this is the case that
+      // proves the real scripts produce the complete declared set.
+      const result = verify(pipelineOutput);
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(result.stdout).toContain('ALL CHECKS PASSED');
+    },
+    SPAWN_TIMEOUT_MS
+  );
 
-  it.each(EXPECTED_ARTIFACTS)('fails closed when %s is absent', (artifact) => {
-    const output = preparedAssets();
-    unlinkSync(path.join(output, artifact));
+  it.each(EXPECTED_ARTIFACTS)(
+    'fails closed when %s is absent',
+    (artifact) => {
+      const output = preparedAssets();
+      unlinkSync(path.join(output, artifact));
 
-    const result = verify(output);
-    expect(result.status, `expected a non-zero exit, got:\n${result.stdout}`).toBe(1);
-    expect(result.stdout).toContain(`FAIL: missing release artifact: ${artifact}`);
-  });
+      const result = verify(output);
+      expect(result.status, `expected a non-zero exit, got:\n${result.stdout}`).toBe(1);
+      expect(result.stdout).toContain(`FAIL: missing release artifact: ${artifact}`);
+    },
+    SPAWN_TIMEOUT_MS
+  );
 
-  it.each(EXPECTED_METADATA)('fails closed when %s is absent', (metadata, message) => {
-    const output = preparedAssets();
-    unlinkSync(path.join(output, metadata));
+  it.each(EXPECTED_METADATA)(
+    'fails closed when %s is absent',
+    (metadata, message) => {
+      const output = preparedAssets();
+      unlinkSync(path.join(output, metadata));
 
-    const result = verify(output);
-    expect(result.status, `expected a non-zero exit, got:\n${result.stdout}`).toBe(1);
-    expect(result.stdout).toContain(`FAIL: ${message}: ${metadata}`);
-  });
+      const result = verify(output);
+      expect(result.status, `expected a non-zero exit, got:\n${result.stdout}`).toBe(1);
+      expect(result.stdout).toContain(`FAIL: ${message}: ${metadata}`);
+    },
+    SPAWN_TIMEOUT_MS
+  );
 
   /**
    * The version drives every expected filename, so an unresolvable version must
    * fail loudly rather than silently expand to a set of names nothing matches.
    */
-  it('fails closed when the release version cannot be resolved', () => {
-    const output = preparedAssets();
-    // Keep the feed present and pointing at a real file so the metadata checks
-    // still pass - only the version: line, which the expected set is derived
-    // from, is gone.
-    writeFileSync(
-      path.join(output, 'latest.yml'),
-      `path: Wayland-${VERSION}-win-x64.exe\nsha512: fake\nreleaseDate: '2025-01-01'\n`
-    );
+  it(
+    'fails closed when the release version cannot be resolved',
+    () => {
+      const output = preparedAssets();
+      // Keep the feed present and pointing at a real file so the metadata checks
+      // still pass - only the version: line, which the expected set is derived
+      // from, is gone.
+      writeFileSync(
+        path.join(output, 'latest.yml'),
+        `path: Wayland-${VERSION}-win-x64.exe\nsha512: fake\nreleaseDate: '2025-01-01'\n`
+      );
 
-    const result = verify(output);
-    expect(result.status, `expected a non-zero exit, got:\n${result.stdout}`).toBe(1);
-    expect(result.stdout).toContain('FAIL: cannot resolve release version');
-  });
+      const result = verify(output);
+      expect(result.status, `expected a non-zero exit, got:\n${result.stdout}`).toBe(1);
+      expect(result.stdout).toContain('FAIL: cannot resolve release version');
+    },
+    SPAWN_TIMEOUT_MS
+  );
 });


### PR DESCRIPTION
## What broke

PR #1011 (windows-2022 shard 4/4, run 32016793825) failed on a test already merged to main:

    FAIL  node  tests/unit/scripts/verifyReleaseAssets.test.ts
      > fails closed when Wayland-1.0.0-mac-arm64.zip.blockmap is absent
    Error: Test timed out in 10000ms.

Not an assertion failure. A **timeout**.

## Root cause: per-case fixture cost, not pollution and not a shard reshuffle

The leading hypothesis was that adding test files reshuffled the vitest shards and a new
neighbour polluted shared state. That is **refuted by execution**. Reproducing vitest's own
sha1 file-hash split (BaseSequencer.shard) exactly - validated against vitest's own collection,
1642 specs, zero diff - shows windows-2022 shard 4/4 has **byte-identical membership** across
PR #1004, PR #1007, main 29b71da20 and PR #1011: 410 specs, same files, and the file #1011 adds
lands in a different shard. The briefing's "408 vs 410" was also wrong: the green runs on #1004
(job 95318993214) and #1007 (job 95331346210) both report Test Files (410).

The real cause is that the test paid the whole fixture cost 28 times. Each case ran the full
create-mock then prepare then verify pipeline, and on Windows each Git-Bash script forks dozens
of msys binaries (touch, cp, find, basename, sort, uniq). Measured cost per case:

| where | per case |
| --- | --- |
| macOS, file alone | ~0.21s |
| Windows, file alone, idle box | ~1.9s |
| Windows CI, green runs on #1004 / #1007 | worst case 4163ms / 3809ms |
| Windows CI, #1011 | 2.1-3.5s, one case 12236ms |

Against the 10s default testTimeout the green runs were already burning 38-42% of the budget on
a fixed shard - one bad excursion away from red for anybody. Because spawnSync blocks the event
loop, vitest cannot preempt it, so the stall overran and was only reported afterwards.

## Fix

The build half of the pipeline is deterministic and identical for every case, so it now runs
**once** in beforeAll and each mutating case gets a plain fs.cpSync copy of its output. Only the
assertion subject - verify-release-assets.sh itself - is still spawned per case. Cases also carry
an explicit 30s budget, matching the other subprocess suites in this repo, because a blocked
spawn cannot be interrupted.

Same Windows box, same full shard 4/4 (410 specs), identical concurrency:

| | min | median | max | file total |
| --- | --- | --- | --- | --- |
| before | 1842ms | 2024ms | 4738ms | 67.5s |
| after | 391ms | 464ms | **709ms** | 13.8s |

Worst case drops from 47% of the 10s budget to 7%. Measured again on the same box while Windows
Defender was pegging a core (the additive-stall mechanism that produced the 12.2s outlier):
median 1037ms, max 1968ms, all 28 green.

## The gate still fails closed

No assertion, expectation, message or artifact name changed - the diff is fixture plumbing only.
Proven in both directions by mutation:

- Deleting the `Wayland-$VERSION-mac-arm64.zip.blockmap` entry from verify-release-assets.sh
  reds exactly that one case (1 failed / 27 passed) and nothing else. The test still binds the
  script's declared expected set.
- Deleting that artifact's touch from create-mock-release-artifacts.sh reds the complete-set
  case as well, so fixture drift is still caught by the beforeAll build.
- Driven directly from a shell: complete set exits 0 with ALL CHECKS PASSED; remove one
  artifact and it prints FAIL: missing release artifact and exits non-zero.

## Verification

- Windows (real box, bun 1.3.11, node 24): file alone 28/28 green; full `bunx vitest run --shard=4/4`
  (410 specs) 28/28 green, zero FAIL lines for this file.
- macOS: file alone 28/28 green, 6.74s to 1.03s.
- Full suite, 1642 files / 18190 tests: 18026 passed, 161 skipped, 3 failed. All 3 failures are
  in tests/unit/process/task/acpAgentManagerNpmFallback.test.ts, are pre-existing, unrelated to
  this diff, and are a real-PATH leak - that suite consults the developer's actual PATH and picks
  up a locally installed wayland-nano. Re-run with a scrubbed PATH: 5/5 green. Worth a separate
  fix; not touched here.
- tsc --noEmit clean, oxlint clean, oxfmt applied to the single touched file.
