### PR TITLE
Sanitise engine config parse errors before they reach the UI

### DIFF
--- a/src/process/agent/wcore/desktopProfileSplice.ts
+++ b/src/process/agent/wcore/desktopProfileSplice.ts
@@ -17,6 +17,7 @@
  * formatting.
  */
 import { parse } from 'smol-toml';
+import { summarizeTomlError } from '@process/utils/tomlErrorSummary';
 import { WCORE_DESKTOP_MCP_PROFILE } from './envBuilder';
 
 /**
@@ -44,27 +45,6 @@ export class DesktopProfileSpliceError extends Error {
 
 /** Any TOML table-header line, e.g. `[providers.anthropic]` or `[[a.b]] # c`. */
 const TABLE_HEADER_LINE_RE = /^\[{1,2}\s*([^\]]+?)\s*\]{1,2}/;
-
-/**
- * A `smol-toml` parse error message echoes the OFFENDING SOURCE LINE verbatim
- * after a blank line, e.g.:
- *
- *   Invalid TOML document: each key-value declaration must be followed by ...
- *
- *   1:  api_key = "sk-ant-REDACTED-EXAMPLE" oops
- *                                           ^
- *
- * This file operates on the user's REAL global `config.toml`, which holds
- * `api_key` values. Embedding the raw message would carry a live credential
- * into an Error that is surfaced, logged, and (via K-02) shown in the UI. Keep
- * only the first line - the human-readable reason - and drop the echoed source
- * block entirely. Found by the K-01 4-leg cross-audit (Gemini 3.1 Pro leg) and
- * confirmed by executing the parser against a key-bearing malformed line.
- */
-function summarizeTomlError(error: unknown): string {
-  const raw = error instanceof Error ? error.message : String(error);
-  return raw.split('\n', 1)[0].trim();
-}
 
 /**
  * Line indices that begin INSIDE a TOML multi-line string (`"""` or `'''`).

--- a/src/process/doctor/checks/backendChecks.ts
+++ b/src/process/doctor/checks/backendChecks.ts
@@ -49,7 +49,9 @@ export async function checkBackends(reader: BackendReader): Promise<DoctorCheckO
       // `AgentRegistry.loadErrors` are raw `error.message` strings from reading the
       // managed-install manifests and the remote-agent rows, both of which carry
       // auth material. Scrub before they reach a Doctor report that gets copied to
-      // support - same class as GHSA-2g2m-r86j-jg6h.
+      // support - same class as GHSA-2g2m-r86j-jg6h. Best-effort: `redactSecrets`
+      // misses the prefixed label form (#1026), and free-form loader text has no
+      // structure to strip instead.
       detail: `${available.length} backend(s) detected (${names}); ${loadErrors.length} loader error(s): ${redactSecrets(loadErrors.join('; '))}.`,
       remediation: 'A configured backend failed to load — check its configuration in Settings → Agents.',
     };

--- a/src/process/doctor/checks/backendChecks.ts
+++ b/src/process/doctor/checks/backendChecks.ts
@@ -14,6 +14,7 @@
  * sub-detector reported a load error.
  */
 
+import { redactSecrets } from '@process/utils/secretRedaction';
 import type { DetectedAgent } from '@/common/types/detectedAgent';
 import type { DoctorCheckOutcome } from '../types';
 
@@ -45,7 +46,11 @@ export async function checkBackends(reader: BackendReader): Promise<DoctorCheckO
   if (loadErrors.length > 0) {
     return {
       status: 'warn',
-      detail: `${available.length} backend(s) detected (${names}); ${loadErrors.length} loader error(s): ${loadErrors.join('; ')}.`,
+      // `AgentRegistry.loadErrors` are raw `error.message` strings from reading the
+      // managed-install manifests and the remote-agent rows, both of which carry
+      // auth material. Scrub before they reach a Doctor report that gets copied to
+      // support - same class as GHSA-2g2m-r86j-jg6h.
+      detail: `${available.length} backend(s) detected (${names}); ${loadErrors.length} loader error(s): ${redactSecrets(loadErrors.join('; '))}.`,
       remediation: 'A configured backend failed to load — check its configuration in Settings → Agents.',
     };
   }

--- a/src/process/doctor/checks/configChecks.ts
+++ b/src/process/doctor/checks/configChecks.ts
@@ -17,6 +17,7 @@
  *     (a fresh install has none).
  */
 
+import { redactSecrets } from '@process/utils/secretRedaction';
 import type { DoctorCheckOutcome } from '../types';
 
 /** Config check dependencies — all injectable so the checks are unit-testable. */
@@ -25,9 +26,17 @@ export type ConfigCheckDeps = {
   isEncryptionAvailable: () => boolean;
   /**
    * Read + parse the engine's user `config.toml`. Resolves `'ok'` (parsed or
-   * absent), or `'corrupt'` with the parse error message. Never throws.
+   * absent), or `'corrupt'` with the parse failure's reason and, when the parser
+   * reported one, its position. Never throws.
+   *
+   * `message` is the reason ONLY. It must never carry the offending source line:
+   * that line is the user's own config, credentials included
+   * (GHSA-2g2m-r86j-jg6h). `line`/`column` are how this check stays actionable
+   * without echoing any of the file. `probeEngineConfig` is the real producer.
    */
-  readEngineConfig: () => Promise<{ status: 'ok'; existed: boolean } | { status: 'corrupt'; message: string }>;
+  readEngineConfig: () => Promise<
+    { status: 'ok'; existed: boolean } | { status: 'corrupt'; message: string; line?: number; column?: number }
+  >;
 };
 
 /**
@@ -48,18 +57,45 @@ export async function checkSecretStorage(isEncryptionAvailable: () => boolean): 
 }
 
 /**
+ * Render `line`/`column` as a position phrase, or `null` when the parser gave
+ * neither. Deliberately NUMBERS only - naming the position is what keeps the
+ * remediation actionable now that the offending line's TEXT is withheld
+ * (GHSA-2g2m-r86j-jg6h).
+ */
+function describePosition(result: { line?: number; column?: number }): string | null {
+  if (typeof result.line !== 'number' || !Number.isFinite(result.line)) return null;
+  if (typeof result.column !== 'number' || !Number.isFinite(result.column)) return `line ${result.line}`;
+  return `line ${result.line}, column ${result.column}`;
+}
+
+/**
  * Engine config integrity — the user `config.toml` parses. FAIL when it exists
  * but is corrupt; PASS when it parses or is absent (a fresh install).
+ *
+ * The corrupt branch names the POSITION of the fault and never its text. The
+ * Doctor panel has a "Copy report" button and exists to be shared with support,
+ * so echoing the offending config line would hand out whatever credential
+ * happened to sit next to it (GHSA-2g2m-r86j-jg6h).
  */
 export async function checkEngineConfigIntegrity(
   readEngineConfig: ConfigCheckDeps['readEngineConfig']
 ): Promise<DoctorCheckOutcome> {
   const result = await readEngineConfig();
   if (result.status === 'corrupt') {
+    // `readEngineConfig` is INJECTED, and the real producer already strips and
+    // scrubs. Scrub again anyway: every future caller of this check inherits the
+    // copy-to-support blast radius, and a defence that depends on the injection
+    // being the right one is not a defence. `redactSecrets` is idempotent.
+    const reason = redactSecrets(result.message);
+    const position = describePosition(result);
     return {
       status: 'fail',
-      detail: `The engine's config.toml could not be parsed: ${result.message}`,
-      remediation: 'Fix the TOML syntax in the engine config.toml, or remove the file to regenerate defaults.',
+      detail: position
+        ? `The engine's config.toml could not be parsed at ${position}: ${reason}`
+        : `The engine's config.toml could not be parsed: ${reason}`,
+      remediation: position
+        ? `Fix the TOML syntax at ${position} in the engine config.toml, or remove the file to regenerate defaults.`
+        : 'Fix the TOML syntax in the engine config.toml, or remove the file to regenerate defaults.',
     };
   }
   return {

--- a/src/process/doctor/checks/configChecks.ts
+++ b/src/process/doctor/checks/configChecks.ts
@@ -35,7 +35,9 @@ export type ConfigCheckDeps = {
    * without echoing any of the file. `probeEngineConfig` is the real producer.
    */
   readEngineConfig: () => Promise<
-    { status: 'ok'; existed: boolean } | { status: 'corrupt'; message: string; line?: number; column?: number }
+    | { status: 'ok'; existed: boolean; path?: string }
+    | { status: 'corrupt'; message: string; path?: string; line?: number; column?: number }
+    | { status: 'unresolved'; message: string }
   >;
 };
 
@@ -81,6 +83,16 @@ export async function checkEngineConfigIntegrity(
   readEngineConfig: ConfigCheckDeps['readEngineConfig']
 ): Promise<DoctorCheckOutcome> {
   const result = await readEngineConfig();
+  // A profile that cannot be resolved is a DIFFERENT fault from a config that
+  // will not parse, and calling it a parse failure is the same misdiagnosis this
+  // check already shipped once by reading the wrong file (see `probeEngineConfig`).
+  if (result.status === 'unresolved') {
+    return {
+      status: 'fail',
+      detail: `The active profile's config directory could not be resolved: ${redactSecrets(result.message)}`,
+      remediation: 'Switch back to the default profile, or repair the active profile directory, then re-run Doctor.',
+    };
+  }
   if (result.status === 'corrupt') {
     // `readEngineConfig` is INJECTED, and the real producer already strips and
     // scrubs. Scrub again anyway: every future caller of this check inherits the
@@ -93,21 +105,26 @@ export async function checkEngineConfigIntegrity(
     // scrub over an unstripped parse error would still leak.
     const reason = redactSecrets(result.message);
     const position = describePosition(result);
+    // The PATH is named in the detail because the check and the recovery panel
+    // that mounts under this row must visibly agree on which file they mean; when
+    // they silently disagreed, Reveal opened a file nobody was complaining about.
+    const where = result.path ? ` (${result.path})` : '';
     return {
       status: 'fail',
       detail: position
-        ? `The engine's config.toml could not be parsed at ${position}: ${reason}`
-        : `The engine's config.toml could not be parsed: ${reason}`,
+        ? `The engine's config.toml${where} could not be parsed at ${position}: ${reason}`
+        : `The engine's config.toml${where} could not be parsed: ${reason}`,
       remediation: position
-        ? `Fix the TOML syntax at ${position} in the engine config.toml, or remove the file to regenerate defaults.`
-        : 'Fix the TOML syntax in the engine config.toml, or remove the file to regenerate defaults.',
+        ? `Fix the TOML syntax at ${position} in ${result.path ?? 'the engine config.toml'}, or remove the file to regenerate defaults.`
+        : `Fix the TOML syntax in ${result.path ?? 'the engine config.toml'}, or remove the file to regenerate defaults.`,
     };
   }
+  const target = result.path ? ` (${result.path})` : '';
   return {
     status: 'pass',
     detail: result.existed
-      ? 'Engine config.toml parses cleanly.'
-      : 'No engine config.toml yet (fresh install) — defaults apply.',
+      ? `Engine config.toml${target} parses cleanly.`
+      : `No engine config.toml yet${target} (fresh install) — defaults apply.`,
   };
 }
 

--- a/src/process/doctor/checks/configChecks.ts
+++ b/src/process/doctor/checks/configChecks.ts
@@ -86,6 +86,11 @@ export async function checkEngineConfigIntegrity(
     // scrubs. Scrub again anyway: every future caller of this check inherits the
     // copy-to-support blast radius, and a defence that depends on the injection
     // being the right one is not a defence. `redactSecrets` is idempotent.
+    //
+    // This is a BACKSTOP, not the fix. The fix is the producer DROPPING the
+    // echoed source block (`probeEngineConfig`): `redactSecrets` misses the
+    // prefixed label spelling `ANTHROPIC_API_KEY=<value>` entirely (#1026), so a
+    // scrub over an unstripped parse error would still leak.
     const reason = redactSecrets(result.message);
     const position = describePosition(result);
     return {

--- a/src/process/doctor/checks/configChecks.ts
+++ b/src/process/doctor/checks/configChecks.ts
@@ -33,10 +33,16 @@ export type ConfigCheckDeps = {
    * that line is the user's own config, credentials included
    * (GHSA-2g2m-r86j-jg6h). `line`/`column` are how this check stays actionable
    * without echoing any of the file. `probeEngineConfig` is the real producer.
+   *
+   * `displayPath` is RENDERED IN PLACE OF `path` whenever the producer sets it.
+   * Under a named profile the path's own segment is the user-authored profile
+   * name, so naming the real path names the name; `path` still exists because the
+   * recovery panel and Reveal-in-Finder need the real file. Same split, same
+   * reason, as `WorkspaceEntry.displayPath`.
    */
   readEngineConfig: () => Promise<
-    | { status: 'ok'; existed: boolean; path?: string }
-    | { status: 'corrupt'; message: string; path?: string; line?: number; column?: number }
+    | { status: 'ok'; existed: boolean; path?: string; displayPath?: string }
+    | { status: 'corrupt'; message: string; path?: string; displayPath?: string; line?: number; column?: number }
     | { status: 'unresolved'; message: string }
   >;
 };
@@ -68,6 +74,18 @@ function describePosition(result: { line?: number; column?: number }): string | 
   if (typeof result.line !== 'number' || !Number.isFinite(result.line)) return null;
   if (typeof result.column !== 'number' || !Number.isFinite(result.column)) return `line ${result.line}`;
   return `line ${result.line}, column ${result.column}`;
+}
+
+/**
+ * The path to render, preferring the producer's withheld `displayPath`. `null`
+ * when the producer named no path at all.
+ *
+ * A helper rather than four inline `??`s because there ARE four render sites - two
+ * fields on the corrupt branch and two spellings on the healthy one - and the leak
+ * this closes existed because a reader assumed there was one.
+ */
+function renderedPath(result: { path?: string; displayPath?: string }): string | null {
+  return result.displayPath ?? result.path ?? null;
 }
 
 /**
@@ -108,18 +126,29 @@ export async function checkEngineConfigIntegrity(
     // The PATH is named in the detail because the check and the recovery panel
     // that mounts under this row must visibly agree on which file they mean; when
     // they silently disagreed, Reveal opened a file nobody was complaining about.
-    const where = result.path ? ` (${result.path})` : '';
+    //
+    // `displayPath` FIRST, always. Under a named profile the real path's own
+    // segment is the user-authored profile name, and a profile name accepts a
+    // 32-hex key or an `sk-ant-` token whole (`PROFILE_NAME_RE`), which no scrubber
+    // sees as a bare path segment [executed: `redactSecrets` returns a bare 32-hex
+    // untouched]. Both fields below rendered it, so a single site was never the fix.
+    const rendered = renderedPath(result);
+    const where = rendered ? ` (${rendered})` : '';
     return {
       status: 'fail',
       detail: position
         ? `The engine's config.toml${where} could not be parsed at ${position}: ${reason}`
         : `The engine's config.toml${where} could not be parsed: ${reason}`,
       remediation: position
-        ? `Fix the TOML syntax at ${position} in ${result.path ?? 'the engine config.toml'}, or remove the file to regenerate defaults.`
-        : `Fix the TOML syntax in ${result.path ?? 'the engine config.toml'}, or remove the file to regenerate defaults.`,
+        ? `Fix the TOML syntax at ${position} in ${rendered ?? 'the engine config.toml'}, or remove the file to regenerate defaults.`
+        : `Fix the TOML syntax in ${rendered ?? 'the engine config.toml'}, or remove the file to regenerate defaults.`,
     };
   }
-  const target = result.path ? ` (${result.path})` : '';
+  // The healthy branch names the path too, so it leaked the profile name on EVERY
+  // run rather than only on a fault - which is why this cannot be treated as an
+  // error-path concern.
+  const shown = renderedPath(result);
+  const target = shown ? ` (${shown})` : '';
   return {
     status: 'pass',
     detail: result.existed

--- a/src/process/doctor/checks/engineChecks.ts
+++ b/src/process/doctor/checks/engineChecks.ts
@@ -34,9 +34,25 @@ export type RoutableModelReader = {
 };
 
 /**
+ * The version NUMBER inside a `--version` banner. `detectWCore` returns
+ * unvalidated, unbounded `execFileSync` stdout (`binaryResolver.ts`), and this
+ * check used to interpolate the whole of it, so anything the resolved binary
+ * chose to print — including a credential from its own environment — rendered
+ * verbatim in a report the Doctor panel offers to copy (the
+ * GHSA-2g2m-r86j-jg6h class). Surfacing only the capture is structural: an
+ * allowlisted shape rather than a scrub, so nothing about #1026 applies.
+ *
+ * The optional `v` is part of the capture, not decoration: the engine's own
+ * banner is `v0.10.0`-shaped and the existing reachability test asserts that
+ * spelling survives, so dropping it would have been a silent contract change.
+ */
+const ENGINE_VERSION_PATTERN = /v?\d+\.\d+\.\d+[\w.+-]*/;
+
+/**
  * Engine reachability — the `wayland-core` binary resolves and answers
- * `--version`. FAIL when no binary is found; WARN when a binary exists but did
- * not report a version (it may be the wrong arch or a broken build).
+ * `--version` with a recognisable version number. FAIL when no binary is found;
+ * WARN when a binary exists but reported no usable version (it may be the wrong
+ * arch or a broken build).
  */
 export async function checkEngineReachable(detect: () => WCoreDetection): Promise<DoctorCheckOutcome> {
   const result = detect();
@@ -47,14 +63,18 @@ export async function checkEngineReachable(detect: () => WCoreDetection): Promis
       remediation: 'Reinstall the app, or install the wayland-core engine on your PATH.',
     };
   }
-  if (!result.version) {
+  // Unparseable stdout is treated exactly like no stdout, and the raw text is
+  // NOT echoed to say so. A binary whose `--version` carries no version number is
+  // the same broken build either way, so the user loses no signal.
+  const version = result.version ? ENGINE_VERSION_PATTERN.exec(result.version)?.[0] : undefined;
+  if (!version) {
     return {
       status: 'warn',
-      detail: `Engine binary found at ${result.path ?? 'an unknown path'} but it did not report a version.`,
+      detail: `Engine binary found at ${result.path ?? 'an unknown path'} but it did not report a usable version.`,
       remediation: 'The binary may be the wrong architecture or a broken build — reinstall the app.',
     };
   }
-  return { status: 'pass', detail: `Wayland Core engine ${result.version} is reachable.` };
+  return { status: 'pass', detail: `Wayland Core engine ${version} is reachable.` };
 }
 
 /**

--- a/src/process/doctor/checks/engineChecks.ts
+++ b/src/process/doctor/checks/engineChecks.ts
@@ -19,6 +19,7 @@
  *     model exists — rather than spawning a real turn.
  */
 
+import { redactSecrets } from '@process/utils/secretRedaction';
 import type { DoctorCheckOutcome } from '../types';
 
 /** Engine binary detection result — shape of `detectWCore()`. */
@@ -129,9 +130,14 @@ export async function checkEngineContractPin(
   } catch (error) {
     return {
       status: 'warn',
-      detail: `The engine binary could not be read to verify its contract version: ${
+      // Scrubbed for UNIFORMITY, not because this source is known to be
+      // credential-bearing: it is an fs failure reading the engine binary. The
+      // Doctor surface now holds one rule - no raw error text reaches a report
+      // that gets copied to support (GHSA-2g2m-r86j-jg6h) - because a per-check
+      // judgement call is exactly what the next check author gets wrong.
+      detail: `The engine binary could not be read to verify its contract version: ${redactSecrets(
         error instanceof Error ? error.message : String(error)
-      }`,
+      )}`,
       remediation: 'Check that the app has permission to read its own bundled engine.',
     };
   }

--- a/src/process/doctor/checks/engineChecks.ts
+++ b/src/process/doctor/checks/engineChecks.ts
@@ -34,19 +34,44 @@ export type RoutableModelReader = {
 };
 
 /**
- * The version NUMBER inside a `--version` banner. `detectWCore` returns
- * unvalidated, unbounded `execFileSync` stdout (`binaryResolver.ts`), and this
- * check used to interpolate the whole of it, so anything the resolved binary
- * chose to print — including a credential from its own environment — rendered
- * verbatim in a report the Doctor panel offers to copy (the
- * GHSA-2g2m-r86j-jg6h class). Surfacing only the capture is structural: an
- * allowlisted shape rather than a scrub, so nothing about #1026 applies.
+ * The version NUMBER inside a `--version` banner, and nothing else.
  *
- * The optional `v` is part of the capture, not decoration: the engine's own
- * banner is `v0.10.0`-shaped and the existing reachability test asserts that
- * spelling survives, so dropping it would have been a silent contract change.
+ * `detectWCore` returns unvalidated, unbounded `execFileSync` stdout
+ * (`binaryResolver.ts`), so anything the resolved binary chooses to print can
+ * reach a report the Doctor panel offers to copy (GHSA-2g2m-r86j-jg6h).
+ *
+ * The first attempt at this ended the pattern with an unanchored, unbounded
+ * `[\w.+-]` run and it was NOT a fix - a cross-audit broke it by execution. That
+ * character class is the alphabet of most credentials, and with no anchors and no
+ * bound the match happily ran straight through one:
+ * `1.0.0-sk-ant-<40ch>` surfaced the whole token, `0.13.0+build.<JWT>`
+ * surfaced the whole JWT, `9.9.9-<200k chars>` surfaced all 200k, and
+ * `token=sk-ant-1.2.3-<58ch>` needed no version banner at all because the
+ * unanchored search simply started INSIDE the credential. Every one returned
+ * `pass`. Three properties fix that and all three are load-bearing:
+ *
+ *  - the leading `(?<![\w.+-])` forbids a match that starts mid-token, which is
+ *    what killed the `token=sk-ant-1.2.3-...` case;
+ *  - the trailing `(?![\w.+-])` forbids a glued suffix, so `0.13.0_<32 hex>`
+ *    cannot extend the match;
+ *  - the prerelease/build tail is `{0,10}` and must OPEN with an alphanumeric,
+ *    which bounds it instead of letting it run to end-of-input.
+ *
+ * `MAX_VERSION_LENGTH` is then a belt-and-braces cap on what is surfaced: the
+ * pattern is already bounded, and a second bound that does not depend on reading
+ * a regex correctly is cheap. This is an allowlisted shape plus a hard length
+ * limit - which is why it does not rely on `redactSecrets` and #1026 does not
+ * reach it. It is NOT immunity in general: it is immunity to whatever cannot fit
+ * through this shape.
+ *
+ * The optional `v` is part of the capture, not decoration: the engine's banner is
+ * `v0.10.0`-shaped and an existing reachability test asserts that spelling
+ * survives, so dropping it would have been a silent contract change.
  */
-const ENGINE_VERSION_PATTERN = /v?\d+\.\d+\.\d+[\w.+-]*/;
+const ENGINE_VERSION_PATTERN = /(?<![\w.+-])v?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z][0-9A-Za-z.]{0,10})?(?![\w.+-])/;
+
+/** Hard cap on the surfaced version text, independent of the pattern above. */
+const MAX_VERSION_LENGTH = 32;
 
 /**
  * Engine reachability — the `wayland-core` binary resolves and answers
@@ -66,7 +91,9 @@ export async function checkEngineReachable(detect: () => WCoreDetection): Promis
   // Unparseable stdout is treated exactly like no stdout, and the raw text is
   // NOT echoed to say so. A binary whose `--version` carries no version number is
   // the same broken build either way, so the user loses no signal.
-  const version = result.version ? ENGINE_VERSION_PATTERN.exec(result.version)?.[0] : undefined;
+  const version = result.version
+    ? ENGINE_VERSION_PATTERN.exec(result.version)?.[0].slice(0, MAX_VERSION_LENGTH)
+    : undefined;
   if (!version) {
     return {
       status: 'warn',
@@ -124,7 +151,7 @@ export type EngineContractPinProbe = {
  *
  * That also makes the check safe on platforms where the manifest may not be
  * ASCII-recoverable from the binary. Only `darwin-arm64` has been confirmed
- * [verified: pinned digest found, the shipped-v0.12.26 digest `23fb3048…`
+ * [verified: pinned digest found, the shipped-v0.12.26 digest `23fb3048...`
  * absent, with a known-positive control]. Anywhere the digest cannot be read,
  * this degrades to the legacy branch and says nothing, rather than crying wolf.
  *

--- a/src/process/doctor/checks/mcpChecks.ts
+++ b/src/process/doctor/checks/mcpChecks.ts
@@ -103,7 +103,7 @@ function unwrapVariants(value: string): string[] {
  * credential, longest first so an overlapping value is replaced whole rather
  * than half-substituted from the inside out.
  *
- * The three sources are deliberately NOT treated alike:
+ * The four sources are deliberately NOT treated alike:
  *
  *  - `env` values and `headers` values are masked WHOLE (and unwrapped), subject
  *    only to {@link MIN_DECLARED_SECRET_LENGTH}. These are the credential slots.
@@ -111,6 +111,10 @@ function unwrapVariants(value: string): string[] {
  *    IN THE URL - path-embedded is the standard shape for Zapier, Smithery and
  *    Composio - and undici's own error text echoes the URL, as does a DNS
  *    failure's `getaddrinfo`. Missing this was a live leak.
+ *  - `server.name` contributes only its DOUBLE-QUOTED form. It is not a credential
+ *    slot, but it is user-authored free text that the validator interpolates into
+ *    thrown messages this check renders. Masking it bare regressed FF-6 - see the
+ *    note at its push below.
  *  - `args` contribute ONLY their unwrapped remainder past a separator, never the
  *    whole argument. This is the FF-6 line: masking whole args covered
  *    `--api-key=<v>` but also masked `@modelcontextprotocol/server-filesystem`
@@ -183,31 +187,61 @@ function declaredSecretValues(server: IMcpServer): string[] {
         command?: string;
       }
     | undefined;
-  if (!transport) return [];
-
+  // NOT an early `return []`: `server.name` below is masked regardless of transport,
+  // and the name-grammar throw (`Invalid MCP server name "<name>"`) fires before
+  // `validateMcpServer` ever looks at the transport.
   const values: string[] = [];
   // Credential slots: whole value, plus every unwrapped suffix.
   for (const value of [
-    ...asStrings(Object.values(transport.env ?? {})),
-    ...asStrings(Object.values(transport.headers ?? {})),
-    ...asStrings([transport.url]),
+    ...asStrings(Object.values(transport?.env ?? {})),
+    ...asStrings(Object.values(transport?.headers ?? {})),
+    ...asStrings([transport?.url]),
   ]) {
     values.push(...unwrapVariants(value));
   }
   // A path-embedded or query-embedded token, reachable only by splitting on `/`.
-  for (const url of asStrings([transport.url])) {
+  for (const url of asStrings([transport?.url])) {
     for (const segment of urlTokenSegments(url)) {
       values.push(...unwrapVariants(segment));
     }
   }
+  // `server.name` is not a declared VALUE, and it is here anyway because it reaches
+  // this exact sink by a route the id-based label does not cover. `validateMcpServer`
+  // interpolates the name into FOUR thrown messages (`Invalid MCP server URL for
+  // "<name>": ...`, the name-grammar throw, and both env-entry throws),
+  // `testMcpConnection` calls it synchronously, and `probeWithTimeout` converts the
+  // throw into `{ success: false, error: error.message }` - which lands in the
+  // errored branch below. So the label was the id while the message carried the name
+  // whole [executed end to end through `runDoctor`: `mcp_5c1a7e64-... (Invalid MCP
+  // server URL for "f0e9d8c7b6a5948372615041302f1e0d": [redacted])` - id right, url
+  // masked, name leaked]. `SAFE_MCP_NAME` accepts a bare 32-hex name so it is
+  // storable, and the older installs and JSON imports that motivate the catch above
+  // are exactly the declarations that trip these throws.
+  //
+  // Masked in its QUOTED form, and the bare form was TRIED AND REJECTED by
+  // execution. Pushing the bare name regressed FF-6 immediately: a server named
+  // `filesystem` turned `npm ERR! 404 Not Found - GET
+  // https://registry.npmjs.org/@modelcontextprotocol/server-filesystem` into
+  // `...server-[redacted]`, i.e. it destroyed one of the two commonest MCP failures
+  // this function exists to keep readable - the existing acceptance oracle caught it.
+  // A name is ordinary English far more often than a credential, so masking it
+  // everywhere costs more than it buys.
+  //
+  // All FIVE validator throws write the name as `"<name>"` with double quotes
+  // [read: `validateMcpServer`, `validateMcpEnvEntry`, `assertSafeMcpUrl`], and a
+  // package name or path echoes without them, so the quoted form separates the echo
+  // of the declaration from an incidental word. The floor is applied to the NAME
+  // rather than the quoted string so a 2-character name is not masked on the
+  // strength of its own quotes.
+  if (server.name.length >= MIN_DECLARED_SECRET_LENGTH) values.push(`"${server.name}"`);
   // Arguments: the remainder past a separator only, so paths and package names
   // survive intact - UNLESS the preceding token names a credential, in which case
   // this whole argument is the value. `command` counts as the token before
   // `args[0]`, so `command: 'x-auth-helper'` covers its first argument too.
-  const args = asStrings(transport.args ?? []);
+  const args = asStrings(transport?.args ?? []);
   for (let index = 0; index < args.length; index += 1) {
     const variants = unwrapVariants(args[index]);
-    const preceding = index === 0 ? transport.command : args[index - 1];
+    const preceding = index === 0 ? transport?.command : args[index - 1];
     const flagged = typeof preceding === 'string' && CREDENTIAL_FLAG_PATTERN.test(preceding);
     values.push(...(flagged ? variants : variants.slice(1)));
   }

--- a/src/process/doctor/checks/mcpChecks.ts
+++ b/src/process/doctor/checks/mcpChecks.ts
@@ -120,8 +120,9 @@ function unwrapVariants(value: string): string[] {
  *    `--api-key=<v>` but also masked `@modelcontextprotocol/server-filesystem`
  *    and `/Users/alice/Documents`, which are exactly the strings the two
  *    commonest failures (wrong package, missing directory) need to stay readable.
- *    The ONE exception is an argument whose PRECEDING token names a credential
- *    ({@link CREDENTIAL_FLAG_PATTERN}), because `--api-key <value>` is a
+ *    The ONE exception is an argument preceded by a token that names a
+ *    credential and does not already carry its own value
+ *    ({@link namesFollowingCredential}), because `--api-key <value>` is a
  *    separator-free argument that IS the credential in full. That shape leaked
  *    [executed], and it is the documented CLI spelling for most servers.
  *
@@ -147,11 +148,61 @@ function asStrings(values: unknown[]): string[] {
 }
 
 /**
- * A token that names a credential, so whatever comes NEXT on the command line is
- * one. Matches `--api-key`, `--token`, `-secret`, `--password`, `--auth`, and the
- * same words inside a longer flag.
+ * A credential-naming word, anchored so it cannot match the tail of a longer
+ * lowercase word.
+ *
+ * The first version was `/(key|token|secret|password|auth)/i` with no boundary at
+ * all, and it was wrong in BOTH directions - every case below executed:
+ *
+ *  - `@acme/oauthy-mcp` matched on `auth` INSIDE `oauthy`, so the argument after
+ *    the package name - the served directory - came back `scandir '[redacted]'`.
+ *  - `command: 'keyring-mcp'` matched on `key`, and `command` is the token before
+ *    `args[0]`, so `npm ERR! 404 '@modelcontextprotocol/server-filesystem' is not
+ *    in the registry` came back `404 '[redacted]'`. That is one of the two
+ *    commonest failures {@link declaredSecretValues} exists to keep readable, i.e.
+ *    an FF-6 regression reached by a second route.
+ *  - and it MISSED `--bearer`, `--credential`, `--pat`, `--session-id`,
+ *    `--passphrase` and `--pwd`, each of which leaked its full bare value.
+ *
+ * The trailing `(?![a-z])` is what rejects `oauthy`; a leading boundary is NOT
+ * wanted, because `--api-key` and `-X-Auth-Token` are exactly the shapes to catch.
+ * `passphrase` is listed separately from `password` because it shares no prefix
+ * with it, and because `secretRedaction` is growing a `pass[_-]?phrase` label - two
+ * defences disagreeing about the same word is its own defect. `session` is here
+ * because a session id is bearer-equivalent (`--session-id <v>` leaked whole).
+ *
+ * `pat` earns the anchor twice over: without it `--path` and `--patch` would both
+ * flag their argument, which is the FF-6 direction again. `--compat` still would,
+ * and that over-masks one path rather than printing one credential, which is the
+ * direction this whole file trades in.
  */
-const CREDENTIAL_FLAG_PATTERN = /(key|token|secret|password|auth)/i;
+const CREDENTIAL_WORD_PATTERN =
+  /(?:key|token|secret|password|passphrase|auth|bearer|credential|session|pat|pwd)(?![a-z])/i;
+
+/**
+ * True when `preceding` names a credential AND makes a claim about what comes
+ * next, so the following argument is the value in full.
+ *
+ * One condition beyond the anchored word, and it was reached by execution: the
+ * token must not ALREADY carry its own value. `--api-key=<v>` yields `<v>` through
+ * `unwrapVariants` on its own, so treating the NEXT argument as a credential too
+ * buys nothing and cost a real path - `['-y', '--api-key=<v>', '/Users/alice/
+ * Documents']` reported `scandir '[redacted]'`. `unwrapVariants(...).length === 1`
+ * is the test: one variant means no `=`, `:` or whitespace inside.
+ *
+ * DELIBERATELY NOT `startsWith('-')`, and this was measured rather than assumed. A
+ * flag-only rule looks tighter and is wrong: `command` counts as the token before
+ * `args[0]`, and `command: 'x-auth-helper', args: ['<secret>']` is a real masked
+ * shape with an oracle of its own. Requiring a leading `-` reopened it. The anchor
+ * on {@link CREDENTIAL_WORD_PATTERN} is what actually separates the cases -
+ * `keyring-mcp` and `oauthy-mcp` fail it because `key` and `auth` are followed by a
+ * lowercase letter, while `x-auth-helper` and `--api-key` pass.
+ */
+function namesFollowingCredential(preceding: unknown): boolean {
+  if (typeof preceding !== 'string') return false;
+  if (unwrapVariants(preceding).length !== 1) return false;
+  return CREDENTIAL_WORD_PATTERN.test(preceding);
+}
 
 /** Shortest URL path or query segment worth treating as a possible token. */
 const MIN_URL_SEGMENT_LENGTH = 8;
@@ -235,15 +286,15 @@ function declaredSecretValues(server: IMcpServer): string[] {
   // strength of its own quotes.
   if (server.name.length >= MIN_DECLARED_SECRET_LENGTH) values.push(`"${server.name}"`);
   // Arguments: the remainder past a separator only, so paths and package names
-  // survive intact - UNLESS the preceding token names a credential, in which case
-  // this whole argument is the value. `command` counts as the token before
-  // `args[0]`, so `command: 'x-auth-helper'` covers its first argument too.
+  // survive intact - UNLESS the preceding token names a credential and carries no
+  // value of its own, in which case this whole argument is the value. `command`
+  // counts as the token before `args[0]`, so `command: 'x-auth-helper'` still
+  // covers its first argument. See {@link namesFollowingCredential}.
   const args = asStrings(transport?.args ?? []);
   for (let index = 0; index < args.length; index += 1) {
     const variants = unwrapVariants(args[index]);
     const preceding = index === 0 ? transport?.command : args[index - 1];
-    const flagged = typeof preceding === 'string' && CREDENTIAL_FLAG_PATTERN.test(preceding);
-    values.push(...(flagged ? variants : variants.slice(1)));
+    values.push(...(namesFollowingCredential(preceding) ? variants : variants.slice(1)));
   }
 
   return values.filter((value) => value.length >= MIN_DECLARED_SECRET_LENGTH).toSorted((a, b) => b.length - a.length);

--- a/src/process/doctor/checks/mcpChecks.ts
+++ b/src/process/doctor/checks/mcpChecks.ts
@@ -132,7 +132,10 @@ export async function checkMcpServers(deps: McpCheckDeps): Promise<DoctorCheckOu
       // the OAuth bearer `McpService.attachOAuthToken` adds), so a 401 body or an
       // stderr echo can hand a credential straight into a Doctor report that
       // exists to be copied to support - the same class of exposure as
-      // GHSA-2g2m-r86j-jg6h. Scrub before it reaches the detail.
+      // GHSA-2g2m-r86j-jg6h. Scrub before it reaches the detail. Best-effort
+      // only - `redactSecrets` matches known value prefixes and a labelled
+      // assignment, and misses the prefixed label form (#1026); there is no
+      // structure in free-form probe output to strip instead.
       errored.push(`${server.name}${result.error ? ` (${redactSecrets(result.error)})` : ''}`);
     }
   }

--- a/src/process/doctor/checks/mcpChecks.ts
+++ b/src/process/doctor/checks/mcpChecks.ts
@@ -166,10 +166,10 @@ function asStrings(values: unknown[]): string[] {
  *
  * The trailing `(?![a-z])` is what rejects `oauthy`; a leading boundary is NOT
  * wanted, because `--api-key` and `-X-Auth-Token` are exactly the shapes to catch.
+ *
  * `passphrase` is listed separately from `password` because it shares no prefix
- * with it, and because `secretRedaction` is growing a `pass[_-]?phrase` label - two
- * defences disagreeing about the same word is its own defect. `session` is here
- * because a session id is bearer-equivalent (`--session-id <v>` leaked whole).
+ * with it. `session` is here because a session id is bearer-equivalent
+ * (`--session-id <v>` leaked whole).
  *
  * `pat` earns the anchor twice over: without it `--path` and `--patch` would both
  * flag their argument, which is the FF-6 direction again. `--compat` still would,
@@ -180,15 +180,32 @@ const CREDENTIAL_WORD_PATTERN =
   /(?:key|token|secret|password|passphrase|auth|bearer|credential|session|pat|pwd)(?![a-z])/i;
 
 /**
- * True when `preceding` names a credential AND makes a claim about what comes
- * next, so the following argument is the value in full.
+ * A credential-naming word with NO separator anywhere after it, i.e. a token that
+ * names a credential and does not already carry the value itself.
  *
- * One condition beyond the anchored word, and it was reached by execution: the
- * token must not ALREADY carry its own value. `--api-key=<v>` yields `<v>` through
- * `unwrapVariants` on its own, so treating the NEXT argument as a credential too
- * buys nothing and cost a real path - `['-y', '--api-key=<v>', '/Users/alice/
- * Documents']` reported `scandir '[redacted]'`. `unwrapVariants(...).length === 1`
- * is the test: one variant means no `=`, `:` or whitespace inside.
+ * The separator test is scoped to the text AFTER the word, and that scoping is the
+ * whole point. The first version asked whether the token contained a separator
+ * ANYWHERE (`unwrapVariants(preceding).length !== 1`), using "contains `=`, `:` or
+ * whitespace" as a proxy for "already carries its own value". The proxy is wrong,
+ * and the ordinary Windows spelling of the pinned Unix oracle is enough to defeat
+ * it - all of these executed, masking before the proxy landed and leaking the full
+ * bare argument after it:
+ *
+ *  - `C:\tools\x-auth-helper.exe` - a drive letter is a `:`.
+ *  - `/App Support/x-auth-helper` - any path with a space in it.
+ *  - `Authorization: Bearer` as the preceding argument - header-shaped, and it
+ *    carries no value at all.
+ *
+ * Asking instead whether a separator follows the word keeps the case the proxy
+ * existed for: `--api-key=<v>` yields `<v>` through `unwrapVariants` on its own, so
+ * treating the NEXT argument as a credential too buys nothing and cost a real path
+ * (`['-y', '--api-key=<v>', '/Users/alice/Documents']` reported
+ * `scandir '[redacted]'`). `=<v>` follows `key`, so that token is still refused,
+ * and so is `X-Api-Key: <v>` and `Authorization: Bearer <v>`.
+ *
+ * `[^=:\s]*$` rather than a search for the LAST match: they are the same test, and
+ * this one is one regex. It succeeds only where some anchored credential word is
+ * followed by separator-free text to the end of the token.
  *
  * DELIBERATELY NOT `startsWith('-')`, and this was measured rather than assumed. A
  * flag-only rule looks tighter and is wrong: `command` counts as the token before
@@ -198,10 +215,15 @@ const CREDENTIAL_WORD_PATTERN =
  * `keyring-mcp` and `oauthy-mcp` fail it because `key` and `auth` are followed by a
  * lowercase letter, while `x-auth-helper` and `--api-key` pass.
  */
+const CREDENTIAL_WORD_CARRYING_NO_VALUE = new RegExp(`${CREDENTIAL_WORD_PATTERN.source}[^=:\\s]*$`, 'i');
+
+/**
+ * True when `preceding` names a credential AND makes a claim about what comes
+ * next, so the following argument is the value in full.
+ */
 function namesFollowingCredential(preceding: unknown): boolean {
   if (typeof preceding !== 'string') return false;
-  if (unwrapVariants(preceding).length !== 1) return false;
-  return CREDENTIAL_WORD_PATTERN.test(preceding);
+  return CREDENTIAL_WORD_CARRYING_NO_VALUE.test(preceding);
 }
 
 /**

--- a/src/process/doctor/checks/mcpChecks.ts
+++ b/src/process/doctor/checks/mcpChecks.ts
@@ -52,6 +52,79 @@ export type McpCheckDeps = {
 /** Default per-server probe budget. Three servers at 10s each stay under the runner's 30s. */
 const DEFAULT_PER_SERVER_TIMEOUT_MS = 10_000;
 
+/**
+ * Shortest declared value worth masking. Below this a value is not a credential
+ * and blanket-replacing it would shred the diagnostic - an `env` of
+ * `NODE_ENV=production` or `PORT=3000` would blank the words "production" and
+ * "3000" out of the probe's own error text. Matches the `{8,}` floors
+ * `redactSecrets` already uses.
+ */
+const MIN_DECLARED_SECRET_LENGTH = 8;
+
+/**
+ * The user-supplied configuration values in `server`'s own declaration that can
+ * BE a credential: a stdio server's `env` values and `args`, and an
+ * http/sse/streamable_http server's `headers` values - each both whole and
+ * unwrapped past a leading `--flag=` / `Bearer ` style prefix.
+ *
+ * Longest first, so a value that happens to contain another is replaced whole
+ * rather than being half-substituted from the inside out.
+ */
+function declaredSecretValues(server: IMcpServer): string[] {
+  const transport = server.transport as
+    | { env?: Record<string, string>; headers?: Record<string, string>; args?: string[] }
+    | undefined;
+  if (!transport) return [];
+  const declared = [
+    ...Object.values(transport.env ?? {}),
+    ...Object.values(transport.headers ?? {}),
+    ...(transport.args ?? []),
+  ].filter((value): value is string => typeof value === 'string');
+
+  const values: string[] = [];
+  for (const value of declared) {
+    values.push(value);
+    // Also the right-hand side of a `--flag=value` / `Key: value` style token.
+    // A credential is routinely declared WRAPPED - `--api-key=<secret>` in `args`,
+    // `Bearer <secret>` in a header - and the server then echoes the bare secret
+    // on its own ("invalid key: <secret>"). Matching only the whole declared
+    // token would miss that, which a canary caught here rather than in
+    // production. Longest-first ordering below still replaces the wrapped form
+    // whole when the wrapped form is what was echoed.
+    const separator = value.search(/[=:\s]/);
+    if (separator !== -1) values.push(value.slice(separator + 1).trim());
+  }
+
+  return values.filter((value) => value.length >= MIN_DECLARED_SECRET_LENGTH).toSorted((a, b) => b.length - a.length);
+}
+
+/**
+ * Mask any value the user themselves put in this server's declaration wherever
+ * it appears in the probe's output.
+ *
+ * This is the STRUCTURAL half of the mcp fix, and it is why this sink is not
+ * left waiting on #1026: a literal string replacement pattern-matches nothing,
+ * so it is immune to every shape a credential can take. A stdio server that dies
+ * with `AZURE_OPENAI_API_KEY=<value>` on stderr has that stderr appended to the
+ * user-facing error as `Server output: ...` (`McpProtocol.ts`), and the value is
+ * masked here because it came out of `transport.env`, not because it looked like
+ * anything.
+ *
+ * `split`/`join` rather than a built regex: the values are arbitrary user text
+ * and a missed escape would be a silent no-match, i.e. a silent leak.
+ *
+ * It does NOT cover the OAuth bearer `McpService.attachOAuthToken` injects at
+ * probe time - that token is never in the stored declaration this check reads.
+ * `redactSecrets`' `Bearer` rule is what covers that one, which is why both run.
+ */
+function redactDeclaredValues(text: string, server: IMcpServer): string {
+  let out = text;
+  for (const value of declaredSecretValues(server)) {
+    out = out.split(value).join('[redacted]');
+  }
+  return out;
+}
+
 /** Sentinel a per-server timeout resolves to, distinct from a real probe error. */
 const TIMED_OUT = Symbol('mcp-probe-timeout');
 
@@ -132,11 +205,17 @@ export async function checkMcpServers(deps: McpCheckDeps): Promise<DoctorCheckOu
       // the OAuth bearer `McpService.attachOAuthToken` adds), so a 401 body or an
       // stderr echo can hand a credential straight into a Doctor report that
       // exists to be copied to support - the same class of exposure as
-      // GHSA-2g2m-r86j-jg6h. Scrub before it reaches the detail. Best-effort
-      // only - `redactSecrets` matches known value prefixes and a labelled
-      // assignment, and misses the prefixed label form (#1026); there is no
-      // structure in free-form probe output to strip instead.
-      errored.push(`${server.name}${result.error ? ` (${redactSecrets(result.error)})` : ''}`);
+      // GHSA-2g2m-r86j-jg6h.
+      //
+      // TWO layers, because the probe TEXT has no structure but the DECLARATION
+      // does. `redactDeclaredValues` masks the user's own configured values by
+      // literal match, which needs no pattern and so is immune to #1026;
+      // `redactSecrets` then catches credentials that were never in the
+      // declaration - notably the injected OAuth bearer, and anything the server
+      // volunteers about a third party.
+      errored.push(
+        `${server.name}${result.error ? ` (${redactSecrets(redactDeclaredValues(result.error, server))})` : ''}`
+      );
     }
   }
 

--- a/src/process/doctor/checks/mcpChecks.ts
+++ b/src/process/doctor/checks/mcpChecks.ts
@@ -116,19 +116,72 @@ function unwrapVariants(value: string): string[] {
  *    `--api-key=<v>` but also masked `@modelcontextprotocol/server-filesystem`
  *    and `/Users/alice/Documents`, which are exactly the strings the two
  *    commonest failures (wrong package, missing directory) need to stay readable.
+ *    The ONE exception is an argument whose PRECEDING token names a credential
+ *    ({@link CREDENTIAL_FLAG_PATTERN}), because `--api-key <value>` is a
+ *    separator-free argument that IS the credential in full. That shape leaked
+ *    [executed], and it is the documented CLI spelling for most servers.
  *
  * ACCEPTED LIMITS of literal matching, not oversights: a case-folded echo, a
  * URL-encoded echo, or a value glued to a short flag with no separator
  * (`-k<secret>`) will not match. Chasing those means pattern-matching, which is
  * the fragility this exists to avoid.
+ *
+ * ONE MORE ACCEPTED LIMIT, and it is a leak rather than a miss, so it is named
+ * plainly. A single separator-free argument with NO credential-naming token before
+ * it - `args: ['<secret>']` behind `command: 'node'` - is not masked. It cannot be:
+ * it is indistinguishable from `args: ['@modelcontextprotocol/server-filesystem']`,
+ * and masking it whole is precisely the FF-6 regression that made the tool unable
+ * to name the package or directory in the two commonest failures. It is a trade,
+ * not an oversight.
+ *
+ * The over-masking direction of the flag rule is accepted too: `--auth-file
+ * /Users/alice/creds.json` masks the path, so an ENOENT on it reads
+ * `[redacted]`. A flag that names a credential is worth that.
  */
 function asStrings(values: unknown[]): string[] {
   return values.filter((value): value is string => typeof value === 'string');
 }
 
+/**
+ * A token that names a credential, so whatever comes NEXT on the command line is
+ * one. Matches `--api-key`, `--token`, `-secret`, `--password`, `--auth`, and the
+ * same words inside a longer flag.
+ */
+const CREDENTIAL_FLAG_PATTERN = /(key|token|secret|password|auth)/i;
+
+/** Shortest URL path or query segment worth treating as a possible token. */
+const MIN_URL_SEGMENT_LENGTH = 8;
+
+/**
+ * The `/`-delimited path segments and query values of a hosted endpoint URL.
+ *
+ * The whole URL is already contributed as one value, but that only helps when the
+ * probe echoes the whole URL. A server that rejects a path-embedded token and
+ * echoes only the TOKEN - the standard Zapier / Smithery / Composio shape - was not
+ * covered, because `unwrapVariants` splits on `=`, `:` and whitespace and never on
+ * `/` [executed: `url: 'https://host/<secret>/sse'` leaked when the probe echoed
+ * only the token].
+ *
+ * The scheme and authority are dropped FIRST so a hostname can never be masked.
+ * Masking it would turn `getaddrinfo ENOTFOUND mcp.example.com` into `[redacted]`
+ * and destroy the commonest hosted-server diagnostic. The 8-character floor is
+ * higher than the general one for the same reason: short path segments (`v1`,
+ * `sse`, `api`) are structure, not secrets.
+ */
+function urlTokenSegments(url: string): string[] {
+  const afterAuthority = url.replace(/^[a-z][a-z0-9+.-]*:\/\/[^/?#]*/i, '');
+  return afterAuthority.split(/[/?#&]/).filter((segment) => segment.length >= MIN_URL_SEGMENT_LENGTH);
+}
+
 function declaredSecretValues(server: IMcpServer): string[] {
   const transport = server.transport as
-    | { env?: Record<string, string>; headers?: Record<string, string>; args?: string[]; url?: string }
+    | {
+        env?: Record<string, string>;
+        headers?: Record<string, string>;
+        args?: string[];
+        url?: string;
+        command?: string;
+      }
     | undefined;
   if (!transport) return [];
 
@@ -141,10 +194,22 @@ function declaredSecretValues(server: IMcpServer): string[] {
   ]) {
     values.push(...unwrapVariants(value));
   }
+  // A path-embedded or query-embedded token, reachable only by splitting on `/`.
+  for (const url of asStrings([transport.url])) {
+    for (const segment of urlTokenSegments(url)) {
+      values.push(...unwrapVariants(segment));
+    }
+  }
   // Arguments: the remainder past a separator only, so paths and package names
-  // survive intact.
-  for (const arg of asStrings(transport.args ?? [])) {
-    values.push(...unwrapVariants(arg).slice(1));
+  // survive intact - UNLESS the preceding token names a credential, in which case
+  // this whole argument is the value. `command` counts as the token before
+  // `args[0]`, so `command: 'x-auth-helper'` covers its first argument too.
+  const args = asStrings(transport.args ?? []);
+  for (let index = 0; index < args.length; index += 1) {
+    const variants = unwrapVariants(args[index]);
+    const preceding = index === 0 ? transport.command : args[index - 1];
+    const flagged = typeof preceding === 'string' && CREDENTIAL_FLAG_PATTERN.test(preceding);
+    values.push(...(flagged ? variants : variants.slice(1)));
   }
 
   return values.filter((value) => value.length >= MIN_DECLARED_SECRET_LENGTH).toSorted((a, b) => b.length - a.length);
@@ -155,12 +220,21 @@ function declaredSecretValues(server: IMcpServer): string[] {
  * it appears in the probe's output.
  *
  * This is the STRUCTURAL half of the mcp fix, and it is why this sink does not
- * wait on #1026: a literal string replacement pattern-matches nothing, so no
- * credential SHAPE can slip past it. A stdio server that dies with
- * `AZURE_OPENAI_API_KEY=<value>` on stderr has that stderr appended to the
- * user-facing error as `Server output: ...` (`McpProtocol.ts`), and the value is
- * masked because it came out of `transport.env`, not because it looked like
+ * wait on #1026: a literal string replacement pattern-matches nothing, so a
+ * credential's SHAPE is irrelevant to whether it is masked. A stdio server that
+ * dies with `AZURE_OPENAI_API_KEY=<value>` on stderr has that stderr appended to
+ * the user-facing error as `Server output: ...` (`McpProtocol.ts`), and the value
+ * is masked because it came out of `transport.env`, not because it looked like
  * anything.
+ *
+ * CORRECTION. An earlier version of this comment said "no credential SHAPE can
+ * slip past it", and that overclaimed in a way execution refuted. Shape-blindness
+ * is not coverage: what is masked is whatever {@link declaredSecretValues} extracts
+ * from the declaration, and three shapes were escaping that extraction entirely -
+ * `--api-key <value>` as two separate args, a lone separator-free arg, and a
+ * `/`-delimited URL path segment. Two are fixed below and the third is a stated
+ * trade. Read the accepted-limits list on `declaredSecretValues` as the actual
+ * coverage claim; this paragraph is only about WHY the mechanism needs no pattern.
  *
  * `split`/`join` rather than a built regex: the values are arbitrary user text
  * and a missed escape would be a silent no-match, i.e. a silent leak.

--- a/src/process/doctor/checks/mcpChecks.ts
+++ b/src/process/doctor/checks/mcpChecks.ts
@@ -149,7 +149,7 @@ function asStrings(values: unknown[]): string[] {
 
 /**
  * A credential-naming word, anchored so it cannot match the tail of a longer
- * lowercase word.
+ * lowercase word, and tolerant of a plural.
  *
  * The first version was `/(key|token|secret|password|auth)/i` with no boundary at
  * all, and it was wrong in BOTH directions - every case below executed:
@@ -167,6 +167,19 @@ function asStrings(values: unknown[]): string[] {
  * The trailing `(?![a-z])` is what rejects `oauthy`; a leading boundary is NOT
  * wanted, because `--api-key` and `-X-Auth-Token` are exactly the shapes to catch.
  *
+ * The `s?` and the extra spellings are a REGRESSION FIX, and each one was measured
+ * rather than reasoned about. Adding the anchor without them silently narrowed the
+ * rule: `--tokens`, `--secrets`, `--keys`, `--apikeys`, `--passwords`,
+ * `--credentials`, `--pats` and `--sessions` all masked their bare argument before
+ * the anchor landed and leaked it whole afterwards, because a plural `s` is a
+ * lowercase letter. `--authorization` is the reachable one of those - it is an
+ * ordinary option spelling, not a contrived one - and it needs its own alternative
+ * rather than an `s`, so it is listed. `passwd` and `sessionid`/`sessionId` never
+ * matched in either version, and `passwd` is ALREADY a label in
+ * `secretRedaction`'s `LABELLED_SECRET_ASSIGNMENT` [read: it carries
+ * `password|passwd`], so leaving it out left two defences disagreeing about one
+ * word - the exact defect that put `passphrase` on this list.
+ *
  * `passphrase` is listed separately from `password` because it shares no prefix
  * with it. `session` is here because a session id is bearer-equivalent
  * (`--session-id <v>` leaked whole).
@@ -174,10 +187,12 @@ function asStrings(values: unknown[]): string[] {
  * `pat` earns the anchor twice over: without it `--path` and `--patch` would both
  * flag their argument, which is the FF-6 direction again. `--compat` still would,
  * and that over-masks one path rather than printing one credential, which is the
- * direction this whole file trades in.
+ * direction this whole file trades in. The `s?` widens that accepted over-mask
+ * slightly (a command under a literal `/etc/keys/` directory now flags its first
+ * argument); one masked path is the cheaper side of the trade every time.
  */
 const CREDENTIAL_WORD_PATTERN =
-  /(?:key|token|secret|password|passphrase|auth|bearer|credential|session|pat|pwd)(?![a-z])/i;
+  /(?:key|token|secret|password|passwd|passphrase|auth|authorization|bearer|credential|session(?:[_-]?id)?|pat|pwd)s?(?![a-z])/i;
 
 /**
  * A credential-naming word with NO separator anywhere after it, i.e. a token that

--- a/src/process/doctor/checks/mcpChecks.ts
+++ b/src/process/doctor/checks/mcpChecks.ts
@@ -22,6 +22,7 @@
  * total tool count on the way through.
  */
 
+import { redactSecrets } from '@process/utils/secretRedaction';
 import type { IMcpServer } from '@/common/config/storage';
 import type { DoctorCheckOutcome } from '../types';
 
@@ -125,7 +126,14 @@ export async function checkMcpServers(deps: McpCheckDeps): Promise<DoctorCheckOu
     } else if (result.needsAuth) {
       needAuth.push(server.name);
     } else {
-      errored.push(`${server.name}${result.error ? ` (${result.error})` : ''}`);
+      // `result.error` is FREE-FORM text from the probe: an HTTP response body,
+      // or a spawned server's stderr. The declaration being probed carries the
+      // server's `env` (API keys) and `headers` (an `Authorization:` value, plus
+      // the OAuth bearer `McpService.attachOAuthToken` adds), so a 401 body or an
+      // stderr echo can hand a credential straight into a Doctor report that
+      // exists to be copied to support - the same class of exposure as
+      // GHSA-2g2m-r86j-jg6h. Scrub before it reaches the detail.
+      errored.push(`${server.name}${result.error ? ` (${redactSecrets(result.error)})` : ''}`);
     }
   }
 

--- a/src/process/doctor/checks/mcpChecks.ts
+++ b/src/process/doctor/checks/mcpChecks.ts
@@ -204,7 +204,21 @@ function namesFollowingCredential(preceding: unknown): boolean {
   return CREDENTIAL_WORD_PATTERN.test(preceding);
 }
 
-/** Shortest URL path or query segment worth treating as a possible token. */
+/**
+ * Shortest URL path or query segment worth treating as a possible token.
+ *
+ * 8, and the cost is real rather than theoretical: measured, a 7-character segment
+ * survives and an 8-character one is masked, so ordinary route names are masked too
+ * - `messages` (the Streamable HTTP spec's own path), `endpoint`, `connectors`,
+ * `streamable`, `healthcheck` all read `[redacted]` in an echoed 404.
+ *
+ * KEPT ANYWAY, because the trade is asymmetric. A masked route name costs a reader
+ * one word they can recover from their own settings, and the status code, the
+ * hostname and the rest of the path all survive. An UNMASKED short path token is a
+ * credential in a report with a "Copy report" button, and nothing recovers that.
+ * Raising the floor to clear `messages` would un-mask every 8-to-11-character path
+ * token to buy prettier 404s. Both sides of the boundary are pinned.
+ */
 const MIN_URL_SEGMENT_LENGTH = 8;
 
 /**

--- a/src/process/doctor/checks/mcpChecks.ts
+++ b/src/process/doctor/checks/mcpChecks.ts
@@ -335,7 +335,22 @@ function declaredSecretValues(server: IMcpServer): string[] {
   // of the declaration from an incidental word. The floor is applied to the NAME
   // rather than the quoted string so a 2-character name is not masked on the
   // strength of its own quotes.
-  if (server.name.length >= MIN_DECLARED_SECRET_LENGTH) values.push(`"${server.name}"`);
+  //
+  // `typeof` guarded, and the guard is not defensive padding. `IMcpServer.name` is
+  // declared non-optional, so reading `.length` off it type-checks - but a stored
+  // declaration is not a type. The config migration copies `mcp.config` entries
+  // VERBATIM out of an external `wayland-config.txt`, so a nameless entry reaches
+  // here [executed: `{ id: 'mcp_abc', enabled: true, transport: {...} }` threw
+  // `Cannot read properties of undefined (reading 'length')` straight out of
+  // `checkMcpServers`]. That throw is not a leak, it is a diagnostic fail-closed:
+  // it escapes into `runOne`'s per-check catch and collapses the whole MCP row to
+  // `Check threw an error: ...`, destroying every other enabled server's per-server
+  // detail - the exact #273 mode `probeWithTimeout`'s catch exists to prevent. Same
+  // class as the three throw sites this branch already fixed elsewhere; the commit
+  // that added this line optional-chained every `transport` read and left the name.
+  if (typeof server.name === 'string' && server.name.length >= MIN_DECLARED_SECRET_LENGTH) {
+    values.push(`"${server.name}"`);
+  }
   // Arguments: the remainder past a separator only, so paths and package names
   // survive intact - UNLESS the preceding token names a credential and carries no
   // value of its own, in which case this whole argument is the value. `command`

--- a/src/process/doctor/checks/mcpChecks.ts
+++ b/src/process/doctor/checks/mcpChecks.ts
@@ -354,10 +354,23 @@ function redactDeclaredValues(text: string, server: IMcpServer): string {
  * Three of them previously rendered `name` raw, which meant the fix on one branch
  * would have been worth nothing.
  *
- * `id` is app-generated at every creation path: both `handleAddMcpServer` and the
- * library install in `useMcpServerCRUD` mint `mcp_<randomUUID>`, and the type they
- * accept is `Omit<IMcpServer, 'id' | ...>` so an imported declaration cannot carry
- * its own [verified: `newMcpServerId` is the only assignment of this field].
+ * `id` is app-generated on every path that reaches THIS check, which is a narrower
+ * claim than an earlier version of this comment made, and the difference matters.
+ *
+ * `handleAddMcpServer` and the library install in `useMcpServerCRUD` both mint
+ * `mcp_<randomUUID>` and accept `Omit<IMcpServer, 'id' | ...>`. But
+ * `newMcpServerId` is NOT the only assignment of the field: `initStorage` mints
+ * `mcp_default_<ts>_<i>`, and `WCoreMcpAgent` and `CodexMcpAgent` mint
+ * `wcore_${name}` and `codex_${entry.name}` - which DERIVE THE ID FROM THE NAME.
+ * Nor is it true that an imported declaration "cannot carry its own": the config
+ * migration copies `mcp.config` entries verbatim from an external
+ * `wayland-config.txt`, ids included (`filterMcpConfig` only drops builtins).
+ *
+ * The conclusion survives because the Doctor reads ONE source -
+ * `ProcessConfig.get('mcp.config')` (`registry.ts`) - and neither agent projection
+ * is written there. So `doctorServerLabel` is safe today and is ONE PRODUCER away
+ * from being a name-carrying label. If a `wcore_`/`codex_` projection ever reaches
+ * `mcp.config`, this function is where it has to be caught.
  */
 function doctorServerLabel(server: IMcpServer): string {
   return server.id;

--- a/src/process/doctor/checks/mcpChecks.ts
+++ b/src/process/doctor/checks/mcpChecks.ts
@@ -178,6 +178,32 @@ function redactDeclaredValues(text: string, server: IMcpServer): string {
   return out;
 }
 
+/**
+ * Identify a server in a Doctor detail by its APP-GENERATED id, never by the
+ * user-authored `server.name`.
+ *
+ * `name` is free-form user text: the MCP Library's Add Custom flow takes it
+ * verbatim, and a JSON import takes whatever the file says. So a credential
+ * pasted into that field becomes a line in a report the Doctor panel offers to
+ * copy (GHSA-2g2m-r86j-jg6h). No scrubber closes that - a bare credential in a
+ * name carries no label, no assignment and no recognisable prefix, so it matches
+ * no rule at all [verified by execution: `redactSecrets` returns a bare 32-hex
+ * name untouched]. It is the same defect, and the same fix, as the conversation
+ * name in `doctor/workspaceInventory.ts`.
+ *
+ * All FOUR branches label through here (errored, needsAuth, toolless, timedOut).
+ * Three of them previously rendered `name` raw, which meant the fix on one branch
+ * would have been worth nothing.
+ *
+ * `id` is app-generated at every creation path: both `handleAddMcpServer` and the
+ * library install in `useMcpServerCRUD` mint `mcp_<randomUUID>`, and the type they
+ * accept is `Omit<IMcpServer, 'id' | ...>` so an imported declaration cannot carry
+ * its own [verified: `newMcpServerId` is the only assignment of this field].
+ */
+function doctorServerLabel(server: IMcpServer): string {
+  return server.id;
+}
+
 /** Sentinel a per-server timeout resolves to, distinct from a real probe error. */
 const TIMED_OUT = Symbol('mcp-probe-timeout');
 
@@ -256,7 +282,7 @@ export async function checkMcpServers(deps: McpCheckDeps): Promise<DoctorCheckOu
     const server = enabled[i];
     const result = results[i];
     if (result === TIMED_OUT) {
-      timedOut.push(server.name);
+      timedOut.push(doctorServerLabel(server));
     } else if (result.success) {
       okCount += 1;
       // `tools` absent and `tools: []` are NOT the same thing, and conflating
@@ -264,11 +290,11 @@ export async function checkMcpServers(deps: McpCheckDeps): Promise<DoctorCheckOu
       // tool list at all; only an explicitly empty list means "connected and
       // published nothing".
       if (Array.isArray(result.tools)) {
-        if (result.tools.length === 0) toolless.push(server.name);
+        if (result.tools.length === 0) toolless.push(doctorServerLabel(server));
         else toolCount += result.tools.length;
       }
     } else if (result.needsAuth) {
-      needAuth.push(server.name);
+      needAuth.push(doctorServerLabel(server));
     } else {
       // `result.error` is FREE-FORM text from the probe: an HTTP response body,
       // or a spawned server's stderr. The declaration being probed carries the
@@ -293,7 +319,9 @@ export async function checkMcpServers(deps: McpCheckDeps): Promise<DoctorCheckOu
       // authed server threaded back to here, which is a change to the
       // `testConnection` contract rather than to this check.
       errored.push(
-        `${server.name}${result.error ? ` (${redactSecrets(redactDeclaredValues(result.error, server))})` : ''}`
+        `${doctorServerLabel(server)}${
+          result.error ? ` (${redactSecrets(redactDeclaredValues(result.error, server))})` : ''
+        }`
       );
     }
   }

--- a/src/process/doctor/checks/mcpChecks.ts
+++ b/src/process/doctor/checks/mcpChecks.ts
@@ -53,46 +53,98 @@ export type McpCheckDeps = {
 const DEFAULT_PER_SERVER_TIMEOUT_MS = 10_000;
 
 /**
- * Shortest declared value worth masking. Below this a value is not a credential
- * and blanket-replacing it would shred the diagnostic - an `env` of
- * `NODE_ENV=production` or `PORT=3000` would blank the words "production" and
- * "3000" out of the probe's own error text. Matches the `{8,}` floors
- * `redactSecrets` already uses.
+ * Shortest `env`/`headers` value worth masking.
+ *
+ * A floor is needed at all because a literal replacement is blind: an `env` of
+ * `DEBUG=1` would otherwise blank every "1" in the probe's own error text, which
+ * destroys the diagnostic rather than protecting anything. But the first attempt
+ * set it to 8 and that was wrong in BOTH directions, proved by execution in a
+ * cross-audit: `DB_PASSWORD=hunter7` and `PIN=9182` sailed straight through
+ * (`redactSecrets` shares the same `{8,}` floor, so nothing caught them), while
+ * whole `args` were being masked and turned the two commonest MCP failures into
+ * `GET https://registry.npmjs.org/[redacted]` and `scandir '[redacted]'`.
+ *
+ * 4 is the compromise, and it only applies to `env` and `headers`, where a short
+ * value is far likelier to be a credential than a word the diagnostic needs.
+ * `args` are handled separately below and never masked whole.
  */
-const MIN_DECLARED_SECRET_LENGTH = 8;
+const MIN_DECLARED_SECRET_LENGTH = 4;
 
 /**
- * The user-supplied configuration values in `server`'s own declaration that can
- * BE a credential: a stdio server's `env` values and `args`, and an
- * http/sse/streamable_http server's `headers` values - each both whole and
- * unwrapped past a leading `--flag=` / `Bearer ` style prefix.
+ * Split a declared value at EVERY `=`, `:` or whitespace run and return each
+ * suffix, longest first, plus the trimmed original.
  *
- * Longest first, so a value that happens to contain another is replaced whole
- * rather than being half-substituted from the inside out.
+ * A credential is routinely declared WRAPPED, and one unwrap is not enough:
+ * `--header` `Authorization: Bearer <secret>` is the documented `mcp-remote`
+ * shape, and reaching `<secret>` from it takes two hops (past `:`, then past the
+ * space after `Bearer`). A single-pass unwrap stopped at `Bearer <secret>` and
+ * left the bare token unmasked whenever the server echoed only that - found by
+ * execution, not review. The trim matters for the same reason: an `env` value
+ * with a trailing space is legal (`validateMcpEnvEntry` only rejects <= 0x1f), and
+ * the untrimmed original never matches the echoed token.
  */
+function unwrapVariants(value: string): string[] {
+  const variants: string[] = [];
+  let rest = value.trim();
+  variants.push(rest);
+  // Bounded by the number of separators, so this cannot loop unexpectedly.
+  for (;;) {
+    const separator = rest.search(/[=:\s]/);
+    if (separator === -1) break;
+    rest = rest.slice(separator + 1).trim();
+    if (rest.length === 0) break;
+    variants.push(rest);
+  }
+  return variants;
+}
+
+/**
+ * Every user-supplied string in `server`'s own declaration that can BE a
+ * credential, longest first so an overlapping value is replaced whole rather
+ * than half-substituted from the inside out.
+ *
+ * The three sources are deliberately NOT treated alike:
+ *
+ *  - `env` values and `headers` values are masked WHOLE (and unwrapped), subject
+ *    only to {@link MIN_DECLARED_SECRET_LENGTH}. These are the credential slots.
+ *  - `url` is included because a hosted MCP endpoint routinely carries its token
+ *    IN THE URL - path-embedded is the standard shape for Zapier, Smithery and
+ *    Composio - and undici's own error text echoes the URL, as does a DNS
+ *    failure's `getaddrinfo`. Missing this was a live leak.
+ *  - `args` contribute ONLY their unwrapped remainder past a separator, never the
+ *    whole argument. This is the FF-6 line: masking whole args covered
+ *    `--api-key=<v>` but also masked `@modelcontextprotocol/server-filesystem`
+ *    and `/Users/alice/Documents`, which are exactly the strings the two
+ *    commonest failures (wrong package, missing directory) need to stay readable.
+ *
+ * ACCEPTED LIMITS of literal matching, not oversights: a case-folded echo, a
+ * URL-encoded echo, or a value glued to a short flag with no separator
+ * (`-k<secret>`) will not match. Chasing those means pattern-matching, which is
+ * the fragility this exists to avoid.
+ */
+function asStrings(values: unknown[]): string[] {
+  return values.filter((value): value is string => typeof value === 'string');
+}
+
 function declaredSecretValues(server: IMcpServer): string[] {
   const transport = server.transport as
-    | { env?: Record<string, string>; headers?: Record<string, string>; args?: string[] }
+    | { env?: Record<string, string>; headers?: Record<string, string>; args?: string[]; url?: string }
     | undefined;
   if (!transport) return [];
-  const declared = [
-    ...Object.values(transport.env ?? {}),
-    ...Object.values(transport.headers ?? {}),
-    ...(transport.args ?? []),
-  ].filter((value): value is string => typeof value === 'string');
 
   const values: string[] = [];
-  for (const value of declared) {
-    values.push(value);
-    // Also the right-hand side of a `--flag=value` / `Key: value` style token.
-    // A credential is routinely declared WRAPPED - `--api-key=<secret>` in `args`,
-    // `Bearer <secret>` in a header - and the server then echoes the bare secret
-    // on its own ("invalid key: <secret>"). Matching only the whole declared
-    // token would miss that, which a canary caught here rather than in
-    // production. Longest-first ordering below still replaces the wrapped form
-    // whole when the wrapped form is what was echoed.
-    const separator = value.search(/[=:\s]/);
-    if (separator !== -1) values.push(value.slice(separator + 1).trim());
+  // Credential slots: whole value, plus every unwrapped suffix.
+  for (const value of [
+    ...asStrings(Object.values(transport.env ?? {})),
+    ...asStrings(Object.values(transport.headers ?? {})),
+    ...asStrings([transport.url]),
+  ]) {
+    values.push(...unwrapVariants(value));
+  }
+  // Arguments: the remainder past a separator only, so paths and package names
+  // survive intact.
+  for (const arg of asStrings(transport.args ?? [])) {
+    values.push(...unwrapVariants(arg).slice(1));
   }
 
   return values.filter((value) => value.length >= MIN_DECLARED_SECRET_LENGTH).toSorted((a, b) => b.length - a.length);
@@ -102,20 +154,21 @@ function declaredSecretValues(server: IMcpServer): string[] {
  * Mask any value the user themselves put in this server's declaration wherever
  * it appears in the probe's output.
  *
- * This is the STRUCTURAL half of the mcp fix, and it is why this sink is not
- * left waiting on #1026: a literal string replacement pattern-matches nothing,
- * so it is immune to every shape a credential can take. A stdio server that dies
- * with `AZURE_OPENAI_API_KEY=<value>` on stderr has that stderr appended to the
+ * This is the STRUCTURAL half of the mcp fix, and it is why this sink does not
+ * wait on #1026: a literal string replacement pattern-matches nothing, so no
+ * credential SHAPE can slip past it. A stdio server that dies with
+ * `AZURE_OPENAI_API_KEY=<value>` on stderr has that stderr appended to the
  * user-facing error as `Server output: ...` (`McpProtocol.ts`), and the value is
- * masked here because it came out of `transport.env`, not because it looked like
+ * masked because it came out of `transport.env`, not because it looked like
  * anything.
  *
  * `split`/`join` rather than a built regex: the values are arbitrary user text
  * and a missed escape would be a silent no-match, i.e. a silent leak.
  *
- * It does NOT cover the OAuth bearer `McpService.attachOAuthToken` injects at
- * probe time - that token is never in the stored declaration this check reads.
- * `redactSecrets`' `Bearer` rule is what covers that one, which is why both run.
+ * Sound only because the STORED declaration is what actually gets spawned for
+ * these fields: `normalizeMcpServerForSpawn` rewrites the filesystem server's
+ * directory arguments and nothing else, and in particular does not expand
+ * `${TOKEN}` in a url or header.
  */
 function redactDeclaredValues(text: string, server: IMcpServer): string {
   let out = text;
@@ -128,7 +181,23 @@ function redactDeclaredValues(text: string, server: IMcpServer): string {
 /** Sentinel a per-server timeout resolves to, distinct from a real probe error. */
 const TIMED_OUT = Symbol('mcp-probe-timeout');
 
-/** Run one server's probe bounded by `timeoutMs`; resolves the timeout sentinel if it hangs. */
+/**
+ * Run one server's probe bounded by `timeoutMs`; resolves the timeout sentinel if
+ * it hangs, and converts a THROWN probe into an ordinary failed result.
+ *
+ * That catch is security-load-bearing, not tidiness. `testMcpConnection` calls
+ * `validateMcpServer` synchronously before it ever spawns anything, and that
+ * validator throws `Invalid MCP server URL for "<name>": <url>` carrying the RAW
+ * url. Without a catch the rejection escaped `Promise.all`, escaped
+ * `checkMcpServers` entirely, and surfaced through the runner's catch-all - which
+ * runs `redactSecrets` but knows nothing about this server's declaration. So the
+ * whole declaration-masking fix was BYPASSED for exactly the servers most likely
+ * to be malformed: stored declarations from older installs and JSON imports that
+ * predate validation. Proved end to end through `runDoctor`.
+ *
+ * It also stops one malformed server collapsing every other server's detail into
+ * a single thrown-error line.
+ */
 async function probeWithTimeout(
   testConnection: (server: IMcpServer) => Promise<McpTestResult>,
   server: IMcpServer,
@@ -140,6 +209,8 @@ async function probeWithTimeout(
   });
   try {
     return await Promise.race([testConnection(server), timeout]);
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : String(error) };
   } finally {
     if (timer) clearTimeout(timer);
   }
@@ -211,8 +282,16 @@ export async function checkMcpServers(deps: McpCheckDeps): Promise<DoctorCheckOu
       // does. `redactDeclaredValues` masks the user's own configured values by
       // literal match, which needs no pattern and so is immune to #1026;
       // `redactSecrets` then catches credentials that were never in the
-      // declaration - notably the injected OAuth bearer, and anything the server
-      // volunteers about a third party.
+      // declaration.
+      //
+      // RESIDUAL, stated rather than papered over: the OAuth bearer
+      // `McpService.attachOAuthToken` injects at probe time is NOT in the stored
+      // declaration this check reads [verified], so literal masking cannot see
+      // it, and `redactSecrets` only catches it when the echo carries the literal
+      // `Bearer ` prefix. `"invalid token: Bearer <opaque>"` is masked;
+      // `"invalid token: <opaque>"` is NOT. Closing that needs the probe-time
+      // authed server threaded back to here, which is a change to the
+      // `testConnection` contract rather than to this check.
       errored.push(
         `${server.name}${result.error ? ` (${redactSecrets(redactDeclaredValues(result.error, server))})` : ''}`
       );

--- a/src/process/doctor/checks/workspaceChecks.ts
+++ b/src/process/doctor/checks/workspaceChecks.ts
@@ -14,6 +14,7 @@
  * that are missing.
  */
 
+import { redactSecrets } from '@process/utils/secretRedaction';
 import type { DoctorCheckOutcome } from '../types';
 
 /** A configured workspace path with a label for the diagnostic copy. */
@@ -43,9 +44,17 @@ export async function checkWorkspaceDrift(deps: WorkspaceCheckDeps): Promise<Doc
   const checked = await Promise.all(
     workspaces.map(async (entry) => ({ entry, exists: await deps.pathExists(entry.path) }))
   );
+  // `label` is `Chat "<name>"` / `Project "<name>"` (`doctor/registry.ts`), and a
+  // conversation's name is AUTO-GENERATED FROM THE USER'S FIRST MESSAGE — so a
+  // user who pastes a credential into chat gets it as the chat title, and from
+  // there into a report the Doctor panel offers to copy (the
+  // GHSA-2g2m-r86j-jg6h class). Scrub-only: the label IS user prose, so there is
+  // no structure to strip the way there is for a TOML parse error or an MCP
+  // declaration. That leaves the prefixed-label form (`FOO_API_KEY=<value>`)
+  // exposed until #1026 lands — tracked there, alongside backendChecks.
   const missing = checked
     .filter((result) => !result.exists)
-    .map((result) => `${result.entry.label} → ${result.entry.path}`);
+    .map((result) => `${redactSecrets(result.entry.label)} → ${result.entry.path}`);
 
   if (missing.length > 0) {
     return {
@@ -115,7 +124,11 @@ export async function checkWorkspaceConfigured(deps: WorkspaceConfiguredDeps): P
   );
 
   if (temp.length > 0) {
-    const shown = temp.slice(0, MAX_LISTED_TEMP).map((entry) => `${entry.label} → ${entry.path ?? '(no folder)'}`);
+    // Same user-authored label as in `checkWorkspaceDrift` above, same scrub,
+    // same #1026 caveat.
+    const shown = temp
+      .slice(0, MAX_LISTED_TEMP)
+      .map((entry) => `${redactSecrets(entry.label)} → ${entry.path ?? '(no folder)'}`);
     const suffix = temp.length > MAX_LISTED_TEMP ? `; and ${temp.length - MAX_LISTED_TEMP} more` : '';
     return {
       status: 'warn',

--- a/src/process/doctor/checks/workspaceChecks.ts
+++ b/src/process/doctor/checks/workspaceChecks.ts
@@ -17,8 +17,17 @@
 import { redactSecrets } from '@process/utils/secretRedaction';
 import type { DoctorCheckOutcome } from '../types';
 
-/** A configured workspace path with a label for the diagnostic copy. */
-export type WorkspaceEntry = { label: string; path: string };
+/**
+ * A configured workspace path with a label for the diagnostic copy.
+ *
+ * `path` is the REAL path and is what gets stat'd. `displayPath`, when the
+ * producer sets it, is what gets RENDERED - see `doctorWorkspaceDisplayPath`: for
+ * an app-derived workspace the folder name is the user-authored entity name, so
+ * the leaf has to be withheld while the path itself is still probed. Rendering
+ * `path` when a `displayPath` exists puts the name straight back in the report;
+ * probing `displayPath` would stat a folder that does not exist.
+ */
+export type WorkspaceEntry = { label: string; path: string; displayPath?: string };
 
 /** Dependencies — the configured paths, plus an injectable existence probe. */
 export type WorkspaceCheckDeps = {
@@ -44,24 +53,34 @@ export async function checkWorkspaceDrift(deps: WorkspaceCheckDeps): Promise<Doc
   const checked = await Promise.all(
     workspaces.map(async (entry) => ({ entry, exists: await deps.pathExists(entry.path) }))
   );
-  // BOTH halves are scrubbed, and neither is the real defence.
+  // BOTH halves are scrubbed, and neither scrub is the real defence.
   //
   // `label` used to be `Chat "<name>"`, and a conversation's name is generated
   // from the user's FIRST MESSAGE - so a credential pasted into chat became the
   // chat title and then a line in a report the Doctor panel offers to copy
   // (GHSA-2g2m-r86j-jg6h). A scrub cannot close that: a bare secret typed as a
   // first message carries no label and no assignment, so no rule matches it. The
-  // fix is at the PRODUCER, which now emits the app-generated id instead of the
-  // name (`doctorEntityLabel` in `doctor/registry.ts`), making it unreachable.
+  // fix is at the PRODUCER, which emits the app-generated id instead of the name
+  // (`doctorEntityLabel` in `doctor/workspaceInventory.ts`).
+  //
+  // The id alone was NOT enough, and the earlier claim that it made the leak
+  // unreachable was wrong. A project's default workspace is
+  // `~/Documents/Wayland/<project-name>`, so for a project the name IS the path
+  // and it walked straight back in through this second half of the line
+  // [measured]. The producer now also supplies a `displayPath` with the
+  // app-derived leaf withheld, and it is `displayPath` that is rendered while
+  // `path` above is what got stat'd.
   //
   // The scrub stays because this check is dependency-injected and any caller can
-  // pass any label. `path` is scrubbed for the same reason - a workspace folder
-  // can itself be named after a credential - but a path must stay readable to be
-  // actionable, so there is no structural option there and the prefixed-label
-  // form in a path remains exposed until #1026.
+  // pass any label or path. A path the user chose OUTSIDE the app's base dir is
+  // still rendered verbatim - it has to be, to be actionable - so the
+  // prefixed-label form inside such a path remains exposed until #1026.
   const missing = checked
     .filter((result) => !result.exists)
-    .map((result) => `${redactSecrets(result.entry.label)} → ${redactSecrets(result.entry.path)}`);
+    .map(
+      (result) =>
+        `${redactSecrets(result.entry.label)} → ${redactSecrets(result.entry.displayPath ?? result.entry.path)}`
+    );
 
   if (missing.length > 0) {
     return {
@@ -81,6 +100,8 @@ export type WorkspaceConfigEntry = {
   label: string;
   /** Resolved workspace path, or `null` when the binding carries none (itself a temp fallback). */
   path: string | null;
+  /** Rendered instead of `path` when set. Same split, same reason, as {@link WorkspaceEntry}. */
+  displayPath?: string;
   /**
    * The app's authoritative "this is a user-chosen persistent workspace" flag
    * (a conversation's `extra.customWorkspace`). `false` means a temp/default
@@ -131,10 +152,13 @@ export async function checkWorkspaceConfigured(deps: WorkspaceConfiguredDeps): P
   );
 
   if (temp.length > 0) {
-    // Same two halves, same scrub, same reasoning as `checkWorkspaceDrift` above.
-    const shown = temp
-      .slice(0, MAX_LISTED_TEMP)
-      .map((entry) => `${redactSecrets(entry.label)} → ${entry.path ? redactSecrets(entry.path) : '(no folder)'}`);
+    // Same two halves, same scrub, same display/probe split and same reasoning as
+    // `checkWorkspaceDrift` above. `isTempWorkspacePath` above classified the REAL
+    // `path`; only the rendering below prefers `displayPath`.
+    const shown = temp.slice(0, MAX_LISTED_TEMP).map((entry) => {
+      const rendered = entry.displayPath ?? entry.path;
+      return `${redactSecrets(entry.label)} → ${rendered ? redactSecrets(rendered) : '(no folder)'}`;
+    });
     const suffix = temp.length > MAX_LISTED_TEMP ? `; and ${temp.length - MAX_LISTED_TEMP} more` : '';
     return {
       status: 'warn',

--- a/src/process/doctor/checks/workspaceChecks.ts
+++ b/src/process/doctor/checks/workspaceChecks.ts
@@ -44,17 +44,24 @@ export async function checkWorkspaceDrift(deps: WorkspaceCheckDeps): Promise<Doc
   const checked = await Promise.all(
     workspaces.map(async (entry) => ({ entry, exists: await deps.pathExists(entry.path) }))
   );
-  // `label` is `Chat "<name>"` / `Project "<name>"` (`doctor/registry.ts`), and a
-  // conversation's name is AUTO-GENERATED FROM THE USER'S FIRST MESSAGE — so a
-  // user who pastes a credential into chat gets it as the chat title, and from
-  // there into a report the Doctor panel offers to copy (the
-  // GHSA-2g2m-r86j-jg6h class). Scrub-only: the label IS user prose, so there is
-  // no structure to strip the way there is for a TOML parse error or an MCP
-  // declaration. That leaves the prefixed-label form (`FOO_API_KEY=<value>`)
-  // exposed until #1026 lands — tracked there, alongside backendChecks.
+  // BOTH halves are scrubbed, and neither is the real defence.
+  //
+  // `label` used to be `Chat "<name>"`, and a conversation's name is generated
+  // from the user's FIRST MESSAGE - so a credential pasted into chat became the
+  // chat title and then a line in a report the Doctor panel offers to copy
+  // (GHSA-2g2m-r86j-jg6h). A scrub cannot close that: a bare secret typed as a
+  // first message carries no label and no assignment, so no rule matches it. The
+  // fix is at the PRODUCER, which now emits the app-generated id instead of the
+  // name (`doctorEntityLabel` in `doctor/registry.ts`), making it unreachable.
+  //
+  // The scrub stays because this check is dependency-injected and any caller can
+  // pass any label. `path` is scrubbed for the same reason - a workspace folder
+  // can itself be named after a credential - but a path must stay readable to be
+  // actionable, so there is no structural option there and the prefixed-label
+  // form in a path remains exposed until #1026.
   const missing = checked
     .filter((result) => !result.exists)
-    .map((result) => `${redactSecrets(result.entry.label)} → ${result.entry.path}`);
+    .map((result) => `${redactSecrets(result.entry.label)} → ${redactSecrets(result.entry.path)}`);
 
   if (missing.length > 0) {
     return {
@@ -124,11 +131,10 @@ export async function checkWorkspaceConfigured(deps: WorkspaceConfiguredDeps): P
   );
 
   if (temp.length > 0) {
-    // Same user-authored label as in `checkWorkspaceDrift` above, same scrub,
-    // same #1026 caveat.
+    // Same two halves, same scrub, same reasoning as `checkWorkspaceDrift` above.
     const shown = temp
       .slice(0, MAX_LISTED_TEMP)
-      .map((entry) => `${redactSecrets(entry.label)} → ${entry.path ?? '(no folder)'}`);
+      .map((entry) => `${redactSecrets(entry.label)} → ${entry.path ? redactSecrets(entry.path) : '(no folder)'}`);
     const suffix = temp.length > MAX_LISTED_TEMP ? `; and ${temp.length - MAX_LISTED_TEMP} more` : '';
     return {
       status: 'warn',

--- a/src/process/doctor/engineConfigProbe.ts
+++ b/src/process/doctor/engineConfigProbe.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * The engine-`config.toml` read the Doctor's config-integrity check consumes.
+ *
+ * Extracted out of `registry.ts` for one reason: this is the SANITISATION point
+ * for GHSA-2g2m-r86j-jg6h, and a security boundary that can only be exercised
+ * through Electron singletons is a boundary nobody can test. It has no Electron
+ * dependency, so `tests/unit/process/doctor/engineConfigParseErrorRedaction.test.ts`
+ * drives it against a real corrupt file on disk.
+ *
+ * The sanitisation lives HERE, at the producer, not at the consumer: the raw
+ * `smol-toml` message echoes the user's own config lines (their `api_key`s
+ * among them), so stripping it inside one check would still leave it available
+ * to the next consumer of this result. See `@process/utils/tomlErrorSummary`.
+ */
+
+import { access } from 'node:fs/promises';
+import { readConfig, resolveUserConfigPath } from '@process/agent/wcore/configBridge';
+import { summarizeTomlError, tomlErrorPosition } from '@process/utils/tomlErrorSummary';
+
+/**
+ * `'ok'` when the config parsed or is simply absent (a fresh install has none);
+ * `'corrupt'` with a SANITISED reason plus the failure's position as numbers.
+ */
+export type EngineConfigProbeResult =
+  | { status: 'ok'; existed: boolean }
+  | { status: 'corrupt'; message: string; line?: number; column?: number };
+
+/**
+ * Read + parse the engine's user `config.toml`. Never throws, and never carries
+ * any of the file's own bytes out - only the parser's one-line reason (scrubbed)
+ * and the line/column numbers.
+ *
+ * @param path Optional override; defaults to the default profile's config.
+ */
+export async function probeEngineConfig(path: string = resolveUserConfigPath()): Promise<EngineConfigProbeResult> {
+  let existed = true;
+  try {
+    await access(path);
+  } catch {
+    existed = false;
+  }
+
+  try {
+    await readConfig(path);
+    return { status: 'ok', existed };
+  } catch (error) {
+    const position = tomlErrorPosition(error);
+    return {
+      status: 'corrupt',
+      message: summarizeTomlError(error),
+      ...(position ? { line: position.line, column: position.column } : {}),
+    };
+  }
+}

--- a/src/process/doctor/engineConfigProbe.ts
+++ b/src/process/doctor/engineConfigProbe.ts
@@ -20,40 +20,80 @@
  */
 
 import { access } from 'node:fs/promises';
-import { readConfig, resolveUserConfigPath } from '@process/agent/wcore/configBridge';
+import { readConfig } from '@process/agent/wcore/configBridge';
+import { resolveActiveConfigPath } from '@process/agent/wcore/profilePaths';
+import { redactSecrets } from '@process/utils/secretRedaction';
 import { summarizeTomlError, tomlErrorPosition } from '@process/utils/tomlErrorSummary';
 
 /**
  * `'ok'` when the config parsed or is simply absent (a fresh install has none);
- * `'corrupt'` with a SANITISED reason plus the failure's position as numbers.
+ * `'corrupt'` with a SANITISED reason plus the failure's position as numbers;
+ * `'unresolved'` when the ACTIVE PROFILE itself could not be resolved, which is
+ * a different fault and must not be reported as a parse failure.
+ *
+ * `path` is the file actually inspected, so the check can name the same target
+ * the recovery panel does instead of leaving the user to guess.
  */
 export type EngineConfigProbeResult =
-  | { status: 'ok'; existed: boolean }
-  | { status: 'corrupt'; message: string; line?: number; column?: number };
+  | { status: 'ok'; existed: boolean; path: string }
+  | { status: 'corrupt'; message: string; path: string; line?: number; column?: number }
+  | { status: 'unresolved'; message: string };
 
 /**
  * Read + parse the engine's user `config.toml`. Never throws, and never carries
  * any of the file's own bytes out - only the parser's one-line reason (scrubbed)
  * and the line/column numbers.
  *
- * @param path Optional override; defaults to the default profile's config.
+ * TARGET: `resolveActiveConfigPath()`, i.e. the ACTIVE PROFILE's config - NOT
+ * `resolveUserConfigPath()` (the native one). This was wrong on the first pass
+ * and it was reachable today, because profile activation is shipped UI. With a
+ * named profile active the two paths differ [verified by execution], so the check
+ * inspected a file the engine would never load: the Doctor row failed forever
+ * over a corrupt native config while the recovery panel mounted beneath it - which
+ * reads the active path - reported `ok`, and Reveal opened neither.
+ *
+ * The active path is the correct side, established rather than assumed: the
+ * engine spawn sets `WAYLAND_HOME` from `resolveActiveConfigDir()`
+ * (`WCoreAgent.resolveWaylandHomeForLaunch`), and Core treats `$WAYLAND_HOME` as
+ * the literal config dir. So the active profile's `config.toml` IS the file the
+ * engine launches against. `readConfig()` already defaults to the same path; only
+ * this caller was overriding it with the native one.
+ *
+ * @param path Optional override (tests / non-default homes).
  */
-export async function probeEngineConfig(path: string = resolveUserConfigPath()): Promise<EngineConfigProbeResult> {
+export async function probeEngineConfig(path?: string): Promise<EngineConfigProbeResult> {
+  let target: string;
+  if (path === undefined) {
+    try {
+      target = await resolveActiveConfigPath();
+    } catch (error) {
+      // A named profile that cannot be resolved is fail-closed by contract
+      // (#278) and is NOT a parse failure. Reporting it as "config.toml could
+      // not be parsed" would misdiagnose it exactly the way the wrong-target bug
+      // above did. Scrubbed like every other message that reaches a report the
+      // Doctor panel offers to copy.
+      return { status: 'unresolved', message: redactSecrets(summarizeTomlError(error)) };
+    }
+  } else {
+    target = path;
+  }
+
   let existed = true;
   try {
-    await access(path);
+    await access(target);
   } catch {
     existed = false;
   }
 
   try {
-    await readConfig(path);
-    return { status: 'ok', existed };
+    await readConfig(target);
+    return { status: 'ok', existed, path: target };
   } catch (error) {
     const position = tomlErrorPosition(error);
     return {
       status: 'corrupt',
       message: summarizeTomlError(error),
+      path: target,
       ...(position ? { line: position.line, column: position.column } : {}),
     };
   }

--- a/src/process/doctor/engineConfigProbe.ts
+++ b/src/process/doctor/engineConfigProbe.ts
@@ -21,8 +21,7 @@
 
 import { access } from 'node:fs/promises';
 import { readConfig } from '@process/agent/wcore/configBridge';
-import { resolveActiveConfigPath } from '@process/agent/wcore/profilePaths';
-import { redactSecrets } from '@process/utils/secretRedaction';
+import { ProfileIsolationError, resolveActiveConfigPath } from '@process/agent/wcore/profilePaths';
 import { summarizeTomlError, tomlErrorPosition } from '@process/utils/tomlErrorSummary';
 
 /**
@@ -38,6 +37,34 @@ export type EngineConfigProbeResult =
   | { status: 'ok'; existed: boolean; path: string }
   | { status: 'corrupt'; message: string; path: string; line?: number; column?: number }
   | { status: 'unresolved'; message: string };
+
+/**
+ * The two reasons an active profile can fail to resolve, as CONSTANTS.
+ *
+ * This branch used to route the thrown error through `summarizeTomlError`, and
+ * that failed open. `ProfileIsolationError` interpolates the profile name into
+ * the FIRST line of its own message (`Cannot resolve the config directory for the
+ * active profile "<name>" ...`), so keeping only the first line kept the name, and
+ * the scrub cannot see a bare value. Executed, the Doctor detail read
+ * `... active profile "f0e9d8c7b6a5948372615041302f1e0d"`.
+ *
+ * A profile name is user-authored: `PROFILE_NAME_RE` allows 64 characters of
+ * `[A-Za-z0-9._-]`, which fits a 32-hex key and an `sk-ant-` token alike, and the
+ * invalid-marker branch passes whatever the marker file contained. So the name is
+ * withheld outright rather than surfaced or truncated.
+ *
+ * The two constants preserve the distinction the #278 contract actually turns on -
+ * a named profile whose directory is broken (fail closed) versus a fault reading
+ * the selection itself - and the remediation covers both. The error's own `detail`
+ * argument is dropped with them, because on two of its three call sites it is an
+ * fs message carrying the profile path, and therefore the name again.
+ */
+const PROFILE_ISOLATION_REASON = 'a named profile is active and its config directory could not be resolved';
+const PROFILE_SELECTION_REASON = 'the active-profile selection could not be read';
+
+function profileUnresolvedReason(error: unknown): string {
+  return error instanceof ProfileIsolationError ? PROFILE_ISOLATION_REASON : PROFILE_SELECTION_REASON;
+}
 
 /**
  * Read + parse the engine's user `config.toml`. Never throws, and never carries
@@ -70,9 +97,8 @@ export async function probeEngineConfig(path?: string): Promise<EngineConfigProb
       // A named profile that cannot be resolved is fail-closed by contract
       // (#278) and is NOT a parse failure. Reporting it as "config.toml could
       // not be parsed" would misdiagnose it exactly the way the wrong-target bug
-      // above did. Scrubbed like every other message that reaches a report the
-      // Doctor panel offers to copy.
-      return { status: 'unresolved', message: redactSecrets(summarizeTomlError(error)) };
+      // above did.
+      return { status: 'unresolved', message: profileUnresolvedReason(error) };
     }
   } else {
     target = path;

--- a/src/process/doctor/engineConfigProbe.ts
+++ b/src/process/doctor/engineConfigProbe.ts
@@ -20,8 +20,9 @@
  */
 
 import { access } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 import { readConfig } from '@process/agent/wcore/configBridge';
-import { ProfileIsolationError, resolveActiveConfigPath } from '@process/agent/wcore/profilePaths';
+import { DEFAULT_PROFILE, ProfileIsolationError, resolveActiveConfigIdentity } from '@process/agent/wcore/profilePaths';
 import { summarizeTomlError, tomlErrorPosition } from '@process/utils/tomlErrorSummary';
 
 /**
@@ -32,10 +33,16 @@ import { summarizeTomlError, tomlErrorPosition } from '@process/utils/tomlErrorS
  *
  * `path` is the file actually inspected, so the check can name the same target
  * the recovery panel does instead of leaving the user to guess.
+ *
+ * `displayPath` is what a SURFACE must render instead, when it is set. Same split,
+ * and for the same reason, as `WorkspaceEntry.displayPath`: `path` is the real
+ * file - Reveal-in-Finder opens it and the recovery panel edits it - while under a
+ * named profile the path's second-to-last segment IS the user-authored profile
+ * name and printing the path prints the name. See {@link withheldProfilePath}.
  */
 export type EngineConfigProbeResult =
-  | { status: 'ok'; existed: boolean; path: string }
-  | { status: 'corrupt'; message: string; path: string; line?: number; column?: number }
+  | { status: 'ok'; existed: boolean; path: string; displayPath?: string }
+  | { status: 'corrupt'; message: string; path: string; displayPath?: string; line?: number; column?: number }
   | { status: 'unresolved'; message: string };
 
 /**
@@ -53,6 +60,16 @@ export type EngineConfigProbeResult =
  * invalid-marker branch passes whatever the marker file contained. So the name is
  * withheld outright rather than surfaced or truncated.
  *
+ * CORRECTION. An earlier version of this paragraph read as though withholding the
+ * name were a property of this module. It was true of THIS branch only, and false
+ * of the two beside it: the `ok` and `corrupt` branches returned the resolved
+ * `path`, whose second-to-last segment is the lowercased profile name, and the
+ * config check interpolated it into a detail AND a remediation on EVERY Doctor run
+ * - not only on a fault. Executed, a healthy config read `Engine config.toml
+ * (.../f0e9d8c7b6a5948372615041302f1e0d/config.toml) parses cleanly.` The name is
+ * withheld on all three branches now; {@link withheldProfilePath} does the other
+ * two.
+ *
  * The two constants preserve the distinction the #278 contract actually turns on -
  * a named profile whose directory is broken (fail closed) versus a fault reading
  * the selection itself - and the remediation covers both. The error's own `detail`
@@ -64,6 +81,27 @@ const PROFILE_SELECTION_REASON = 'the active-profile selection could not be read
 
 function profileUnresolvedReason(error: unknown): string {
   return error instanceof ProfileIsolationError ? PROFILE_ISOLATION_REASON : PROFILE_SELECTION_REASON;
+}
+
+/** Stands in for a withheld profile-directory name in a Doctor detail. */
+const WITHHELD_PROFILE = '(profile name withheld)';
+
+/**
+ * The config path to RENDER for a named profile: the same path with the profile
+ * directory replaced by {@link WITHHELD_PROFILE}.
+ *
+ * The profiles ROOT is kept because it is the actionable half - it is where the
+ * user looks in Finder - and dropping only the leaf directory drops the part that
+ * carries the name. This mirrors `doctorWorkspaceDisplayPath`, which made the same
+ * trade for the same reason on the workspace paths.
+ *
+ * `dirname` of the profile dir rather than `profilesRoot()`: the dir handed in has
+ * been through `realpath` (`resolveProfileDir`), and the root may itself be
+ * Desktop's intentional macOS CLI-compatibility symlink, so recomputing the root
+ * could print a path that does not prefix the real one.
+ */
+function withheldProfilePath(profileDir: string): string {
+  return join(dirname(profileDir), WITHHELD_PROFILE, 'config.toml');
 }
 
 /**
@@ -90,9 +128,17 @@ function profileUnresolvedReason(error: unknown): string {
  */
 export async function probeEngineConfig(path?: string): Promise<EngineConfigProbeResult> {
   let target: string;
+  /** Set only under a named profile; `undefined` means `target` is safe to render. */
+  let displayTarget: string | undefined;
   if (path === undefined) {
     try {
-      target = await resolveActiveConfigPath();
+      // `resolveActiveConfigIdentity`, not `resolveActiveConfigPath`: the same one
+      // marker read, but it also returns WHICH profile resolved, and that is what
+      // decides whether the path carries a user-authored name at all. The native
+      // selector's dir is `<config-base>/wayland-core` and carries none.
+      const identity = await resolveActiveConfigIdentity();
+      target = join(identity.dir, 'config.toml');
+      if (identity.profile !== DEFAULT_PROFILE) displayTarget = withheldProfilePath(identity.dir);
     } catch (error) {
       // A named profile that cannot be resolved is fail-closed by contract
       // (#278) and is NOT a parse failure. Reporting it as "config.toml could
@@ -111,15 +157,17 @@ export async function probeEngineConfig(path?: string): Promise<EngineConfigProb
     existed = false;
   }
 
+  const shown = displayTarget ? { displayPath: displayTarget } : {};
   try {
     await readConfig(target);
-    return { status: 'ok', existed, path: target };
+    return { status: 'ok', existed, path: target, ...shown };
   } catch (error) {
     const position = tomlErrorPosition(error);
     return {
       status: 'corrupt',
       message: summarizeTomlError(error),
       path: target,
+      ...shown,
       ...(position ? { line: position.line, column: position.column } : {}),
     };
   }

--- a/src/process/doctor/registry.ts
+++ b/src/process/doctor/registry.ts
@@ -28,7 +28,6 @@ import { Curator } from '@process/providers/catalog/Curator';
 import type { ProviderId } from '@process/providers/types';
 import { detectWCore, resolveWCoreBinary } from '@process/agent/wcore/binaryResolver';
 import { DESKTOP_CORE_V1_PIN } from '@process/agent/wcore/desktopContractV1';
-import { readConfig, resolveUserConfigPath } from '@process/agent/wcore/configBridge';
 import { nativeConfigDir } from '@process/agent/wcore/profilePaths';
 import { getConfigPath } from '@process/utils/utils';
 import { isEncryptionAvailable } from '@process/secrets/safeStorage';
@@ -65,6 +64,7 @@ import {
 } from './checks/workspaceChecks';
 import { checkSecretStorage, checkEngineConfigIntegrity, checkConfigPaths } from './checks/configChecks';
 import { checkAppArchitecture } from './checks/platformChecks';
+import { probeEngineConfig } from './engineConfigProbe';
 
 /** Build a `ProviderRepository` bound to the live UI database. */
 async function providerRepo(): Promise<ProviderRepository> {
@@ -322,17 +322,12 @@ export function buildDoctorChecks(): DoctorCheck[] {
       id: 'config.engineConfig',
       titleKey: 'settings.doctor.checks.engineConfig',
       category: 'config',
-      run: () =>
-        checkEngineConfigIntegrity(async () => {
-          const path = resolveUserConfigPath();
-          const existed = await pathExists(path);
-          try {
-            await readConfig(path);
-            return { status: 'ok', existed };
-          } catch (error) {
-            return { status: 'corrupt', message: error instanceof Error ? error.message : String(error) };
-          }
-        }),
+      // `probeEngineConfig`, not an inline read: it is the sanitisation point
+      // for GHSA-2g2m-r86j-jg6h (the raw `smol-toml` message echoes the user's
+      // own config lines, `api_key`s included, and Doctor reports get copied
+      // into support threads), and it lives in its own Electron-free module so
+      // that boundary is reachable from a unit test.
+      run: () => checkEngineConfigIntegrity(() => probeEngineConfig()),
     },
   ];
 }

--- a/src/process/doctor/registry.ts
+++ b/src/process/doctor/registry.ts
@@ -33,8 +33,7 @@ import { getConfigPath } from '@process/utils/utils';
 import { isEncryptionAvailable } from '@process/secrets/safeStorage';
 import { mcpService } from '@process/services/mcpServices/McpService';
 import { ProcessConfig } from '@process/utils/initStorage';
-import type { IMcpServer, TChatConversation } from '@/common/config/storage';
-import type { IProject } from '@/common/types/project';
+import type { IMcpServer } from '@/common/config/storage';
 import { projectServiceSingleton } from '@process/services/projectServiceSingleton';
 import { conversationServiceSingleton } from '@process/services/conversationServiceSingleton';
 import type { DoctorCheck } from './types';
@@ -56,15 +55,11 @@ import { checkProviderConnectivity, checkModelRegistrySanity } from './checks/pr
 import { checkEngineReachable, checkEngineRouting, checkEngineContractPin } from './checks/engineChecks';
 import { checkMcpServers } from './checks/mcpChecks';
 import { checkBackends } from './checks/backendChecks';
-import {
-  checkWorkspaceDrift,
-  checkWorkspaceConfigured,
-  type WorkspaceEntry,
-  type WorkspaceConfigEntry,
-} from './checks/workspaceChecks';
+import { checkWorkspaceDrift, checkWorkspaceConfigured } from './checks/workspaceChecks';
 import { checkSecretStorage, checkEngineConfigIntegrity, checkConfigPaths } from './checks/configChecks';
 import { checkAppArchitecture } from './checks/platformChecks';
 import { probeEngineConfig } from './engineConfigProbe';
+import { collectConfiguredWorkspaces, collectWorkspaceConfigEntries } from './workspaceInventory';
 
 /** Build a `ProviderRepository` bound to the live UI database. */
 async function providerRepo(): Promise<ProviderRepository> {
@@ -117,67 +112,6 @@ async function listMcpServers(): Promise<IMcpServer[]> {
 }
 
 /**
- * Collect every configured workspace path: project workspaces plus
- * conversation `extra.workspace` directories. Deduplicated by path so a project
- * and its conversations sharing a folder are reported once.
- */
-async function listConfiguredWorkspaces(): Promise<WorkspaceEntry[]> {
-  const entries: WorkspaceEntry[] = [];
-  const seen = new Set<string>();
-
-  const add = (label: string, path: unknown): void => {
-    if (typeof path !== 'string' || path.trim().length === 0) return;
-    if (seen.has(path)) return;
-    seen.add(path);
-    entries.push({ label, path });
-  };
-
-  const projects = await projectServiceSingleton.listProjects().catch((): IProject[] => []);
-  for (const project of projects) {
-    add(`Project "${project.name}"`, project.workspace);
-  }
-
-  const conversations = await conversationServiceSingleton.listAllConversations().catch((): TChatConversation[] => []);
-  for (const conversation of conversations) {
-    // `extra.workspace` exists on gemini/acp conversations; read defensively
-    // since the union is wide and some kinds carry no workspace.
-    const extra = conversation.extra as { workspace?: unknown } | undefined;
-    add(`Chat "${conversation.name ?? conversation.id}"`, extra?.workspace);
-  }
-
-  return entries;
-}
-
-/**
- * Collect every configured workspace with its persistent-vs-temp classification
- * inputs: project workspaces (no `customWorkspace` flag → `null`) plus
- * conversation `extra.workspace` / `extra.customWorkspace`. Conversations that
- * carry no workspace binding at all are skipped (nothing to assess).
- */
-async function listWorkspaceConfigEntries(): Promise<WorkspaceConfigEntry[]> {
-  const entries: WorkspaceConfigEntry[] = [];
-
-  const asPath = (value: unknown): string | null =>
-    typeof value === 'string' && value.trim().length > 0 ? value : null;
-
-  const projects = await projectServiceSingleton.listProjects().catch((): IProject[] => []);
-  for (const project of projects) {
-    entries.push({ label: `Project "${project.name}"`, path: asPath(project.workspace), customWorkspace: null });
-  }
-
-  const conversations = await conversationServiceSingleton.listAllConversations().catch((): TChatConversation[] => []);
-  for (const conversation of conversations) {
-    const extra = conversation.extra as { workspace?: unknown; customWorkspace?: unknown } | undefined;
-    const path = asPath(extra?.workspace);
-    const customWorkspace = typeof extra?.customWorkspace === 'boolean' ? extra.customWorkspace : null;
-    if (path === null && customWorkspace === null) continue;
-    entries.push({ label: `Chat "${conversation.name ?? conversation.id}"`, path, customWorkspace });
-  }
-
-  return entries;
-}
-
-/**
  * Build the ordered list of Doctor checks with live dependencies bound.
  *
  * The order here is the display order in the UI. Each entry binds its pure
@@ -185,6 +119,10 @@ async function listWorkspaceConfigEntries(): Promise<WorkspaceConfigEntry[]> {
  */
 export function buildDoctorChecks(): DoctorCheck[] {
   const connectionTester = new ConnectionTester();
+  const workspaceServices = {
+    listProjects: () => projectServiceSingleton.listProjects(),
+    listConversations: () => conversationServiceSingleton.listAllConversations(),
+  };
 
   return [
     {
@@ -283,13 +221,18 @@ export function buildDoctorChecks(): DoctorCheck[] {
       id: 'workspace.drift',
       titleKey: 'settings.doctor.checks.workspaceDrift',
       category: 'workspace',
-      run: () => checkWorkspaceDrift({ listWorkspaces: listConfiguredWorkspaces, pathExists }),
+      run: () =>
+        checkWorkspaceDrift({ listWorkspaces: () => collectConfiguredWorkspaces(workspaceServices), pathExists }),
     },
     {
       id: 'workspace.configured',
       titleKey: 'settings.doctor.checks.workspaceConfigured',
       category: 'workspace',
-      run: () => checkWorkspaceConfigured({ listWorkspaces: listWorkspaceConfigEntries, tmpDir: tmpdir() }),
+      run: () =>
+        checkWorkspaceConfigured({
+          listWorkspaces: () => collectWorkspaceConfigEntries(workspaceServices),
+          tmpDir: tmpdir(),
+        }),
     },
     {
       id: 'config.paths',

--- a/src/process/doctor/registry.ts
+++ b/src/process/doctor/registry.ts
@@ -36,6 +36,7 @@ import { ProcessConfig } from '@process/utils/initStorage';
 import type { IMcpServer } from '@/common/config/storage';
 import { projectServiceSingleton } from '@process/services/projectServiceSingleton';
 import { conversationServiceSingleton } from '@process/services/conversationServiceSingleton';
+import { defaultWorkspaceBaseDir } from '@process/services/projectWorkspace';
 import type { DoctorCheck } from './types';
 import { extractFromFile } from './fileMarker';
 
@@ -60,6 +61,7 @@ import { checkSecretStorage, checkEngineConfigIntegrity, checkConfigPaths } from
 import { checkAppArchitecture } from './checks/platformChecks';
 import { probeEngineConfig } from './engineConfigProbe';
 import { collectConfiguredWorkspaces, collectWorkspaceConfigEntries } from './workspaceInventory';
+import type { WorkspaceInventoryDeps } from './workspaceInventory';
 
 /** Build a `ProviderRepository` bound to the live UI database. */
 async function providerRepo(): Promise<ProviderRepository> {
@@ -119,10 +121,23 @@ async function listMcpServers(): Promise<IMcpServer[]> {
  */
 export function buildDoctorChecks(): DoctorCheck[] {
   const connectionTester = new ConnectionTester();
-  const workspaceServices = {
+  const listingServices = {
     listProjects: () => projectServiceSingleton.listProjects(),
     listConversations: () => conversationServiceSingleton.listAllConversations(),
   };
+  /**
+   * The listing services PLUS the app's own workspace base dir, which the
+   * inventory needs to know which paths are app-derived and must have their leaf
+   * withheld (a project's default workspace is `<base>/<project-name>`, so the
+   * name IS the path). Read through `defaultWorkspaceBaseDir` rather than
+   * rebuilding the literal here - a second copy would fail open silently if the
+   * allocator's base ever moves. A failure to resolve it yields `null`, which the
+   * inventory treats as "withhold nothing" rather than crashing the check.
+   */
+  const workspaceServices = async (): Promise<WorkspaceInventoryDeps> => ({
+    ...listingServices,
+    appManagedWorkspaceBase: await defaultWorkspaceBaseDir().catch((): string | null => null),
+  });
 
   return [
     {
@@ -221,18 +236,22 @@ export function buildDoctorChecks(): DoctorCheck[] {
       id: 'workspace.drift',
       titleKey: 'settings.doctor.checks.workspaceDrift',
       category: 'workspace',
-      run: () =>
-        checkWorkspaceDrift({ listWorkspaces: () => collectConfiguredWorkspaces(workspaceServices), pathExists }),
+      run: async () => {
+        const services = await workspaceServices();
+        return checkWorkspaceDrift({ listWorkspaces: () => collectConfiguredWorkspaces(services), pathExists });
+      },
     },
     {
       id: 'workspace.configured',
       titleKey: 'settings.doctor.checks.workspaceConfigured',
       category: 'workspace',
-      run: () =>
-        checkWorkspaceConfigured({
-          listWorkspaces: () => collectWorkspaceConfigEntries(workspaceServices),
+      run: async () => {
+        const services = await workspaceServices();
+        return checkWorkspaceConfigured({
+          listWorkspaces: () => collectWorkspaceConfigEntries(services),
           tmpDir: tmpdir(),
-        }),
+        });
+      },
     },
     {
       id: 'config.paths',

--- a/src/process/doctor/runner.ts
+++ b/src/process/doctor/runner.ts
@@ -14,6 +14,7 @@
  * would needlessly multiply the wall-clock time.
  */
 
+import { redactSecrets } from '@process/utils/secretRedaction';
 import type { DoctorCheck, DoctorCheckResult, DoctorReport, DoctorStatus } from './types';
 
 /** Per-check wall-clock budget. A check that exceeds this resolves to `fail`. */
@@ -54,7 +55,12 @@ async function runOne(check: DoctorCheck, timeoutMs: number): Promise<DoctorChec
       const outcome = await check.run();
       return { ...base, ...outcome, durationMs: Date.now() - started };
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      // The catch-all for EVERY check, so it is also the last place an
+      // unanticipated credential-bearing error message could reach a Doctor
+      // report (which has a "Copy report" button). Scrub unconditionally -
+      // nothing here knows which check threw or what it was reading
+      // (GHSA-2g2m-r86j-jg6h).
+      const message = redactSecrets(error instanceof Error ? error.message : String(error));
       return {
         ...base,
         status: 'fail',

--- a/src/process/doctor/runner.ts
+++ b/src/process/doctor/runner.ts
@@ -59,7 +59,9 @@ async function runOne(check: DoctorCheck, timeoutMs: number): Promise<DoctorChec
       // unanticipated credential-bearing error message could reach a Doctor
       // report (which has a "Copy report" button). Scrub unconditionally -
       // nothing here knows which check threw or what it was reading
-      // (GHSA-2g2m-r86j-jg6h).
+      // (GHSA-2g2m-r86j-jg6h). A backstop, not a guarantee: `redactSecrets`
+      // misses the prefixed label form (#1026), so a check that can name a
+      // credential-bearing source must still sanitise at its own producer.
       const message = redactSecrets(error instanceof Error ? error.message : String(error));
       return {
         ...base,

--- a/src/process/doctor/runner.ts
+++ b/src/process/doctor/runner.ts
@@ -12,6 +12,10 @@
  * check is bounded by a per-check timeout. Checks run concurrently — they are
  * independent and mostly I/O-bound (network probes, fs stats), so a serial run
  * would needlessly multiply the wall-clock time.
+ *
+ * This is also the only funnel EVERY result passes through, so it is where the two
+ * whole-surface guarantees live: nothing here can throw (see `safeErrorMessage`),
+ * and no user-facing field leaves unbounded (see `bounded`).
  */
 
 import { redactSecrets } from '@process/utils/secretRedaction';
@@ -26,6 +30,58 @@ const STATUS_RANK: Record<DoctorStatus, number> = { pass: 0, warn: 1, fail: 2 };
 /** Resolve `'pass' | 'warn' | 'fail'` for the worst of two statuses. */
 function worse(a: DoctorStatus, b: DoctorStatus): DoctorStatus {
   return STATUS_RANK[a] >= STATUS_RANK[b] ? a : b;
+}
+
+/**
+ * Cap on any single user-facing field in a result.
+ *
+ * Every check's `detail` used to be unbounded, and one of them provably is: a
+ * 2,000,000-character probe error came back as a 2,000,052-character detail
+ * [executed], which the UI then renders and offers to copy. Bounding it HERE
+ * rather than per check is the point - this is the one funnel every result passes
+ * through, so no future check has to remember.
+ *
+ * 4,000 is chosen against the largest legitimate detail this surface produces: the
+ * MCP check enumerates one line per failing server, and a twenty-server failure at
+ * roughly 150 characters each is about 3,000. Nothing that fits inside real
+ * diagnostics is trimmed.
+ */
+const MAX_FIELD_LENGTH = 4_000;
+
+/** Appended when a field is trimmed, so the user is not misled by a clean cut. */
+const TRUNCATION_NOTE = ' [truncated]';
+
+function boundedField(text: string): string {
+  if (text.length <= MAX_FIELD_LENGTH) return text;
+  return `${text.slice(0, MAX_FIELD_LENGTH - TRUNCATION_NOTE.length)}${TRUNCATION_NOTE}`;
+}
+
+/** Bound both user-facing fields of a result. Applied to EVERY outcome, uniformly. */
+function bounded(result: DoctorCheckResult): DoctorCheckResult {
+  return {
+    ...result,
+    detail: boundedField(result.detail),
+    ...(result.remediation === undefined ? {} : { remediation: boundedField(result.remediation) }),
+  };
+}
+
+/**
+ * A thrown value's message, scrubbed, without ever throwing itself.
+ *
+ * `runDoctor` documents that it never throws, and reading `error.message` was the
+ * hole in that: an `Error` subclass whose `message` getter throws makes the
+ * extraction throw, the rejection escapes `runOne` and `Promise.all`, `runDoctor`
+ * rejects, and the SECONDARY error's text reaches `doctorBridge` having passed
+ * through no scrubber at all [executed]. Reachability is exotic - it takes a
+ * hostile or badly-built Error - but the cost of closing it is one catch, and the
+ * contract is either true or it is not.
+ */
+function safeErrorMessage(error: unknown): string {
+  try {
+    return redactSecrets(error instanceof Error ? error.message : String(error));
+  } catch {
+    return '(the error could not be read)';
+  }
 }
 
 /**
@@ -62,7 +118,7 @@ async function runOne(check: DoctorCheck, timeoutMs: number): Promise<DoctorChec
       // (GHSA-2g2m-r86j-jg6h). A backstop, not a guarantee: `redactSecrets`
       // misses the prefixed label form (#1026), so a check that can name a
       // credential-bearing source must still sanitise at its own producer.
-      const message = redactSecrets(error instanceof Error ? error.message : String(error));
+      const message = safeErrorMessage(error);
       return {
         ...base,
         status: 'fail',
@@ -74,7 +130,7 @@ async function runOne(check: DoctorCheck, timeoutMs: number): Promise<DoctorChec
   })();
 
   try {
-    return await Promise.race([run, timeout]);
+    return bounded(await Promise.race([run, timeout]));
   } finally {
     if (timer) clearTimeout(timer);
   }

--- a/src/process/doctor/runner.ts
+++ b/src/process/doctor/runner.ts
@@ -51,7 +51,20 @@ const MAX_FIELD_LENGTH = 4_000;
 /** Appended when a field is trimmed, so the user is not misled by a clean cut. */
 const TRUNCATION_NOTE = ' [truncated]';
 
-function boundedField(text: string): string {
+/**
+ * Bound one field, tolerating a non-string.
+ *
+ * TypeScript forbids an outcome without a `detail`, and so did it forbid the
+ * hostile-getter case `safeErrorMessage` guards five lines below - the contract is
+ * either true at runtime or it is not. An outcome missing `detail` made this read
+ * `undefined.length`, the TypeError escaped `runOne` (its `try` at the bottom has a
+ * `finally` and no `catch`, so `bounded` runs OUTSIDE the per-check guard) and
+ * `runDoctor` REJECTED with `Cannot read properties of undefined (reading
+ * 'length')` [executed]. Pre-delta the same input was harmless, so bounding every
+ * field is what introduced the exposure and this is where it belongs.
+ */
+function boundedField(text: unknown): string {
+  if (typeof text !== 'string') return '';
   if (text.length <= MAX_FIELD_LENGTH) return text;
   return `${text.slice(0, MAX_FIELD_LENGTH - TRUNCATION_NOTE.length)}${TRUNCATION_NOTE}`;
 }

--- a/src/process/doctor/workspaceInventory.ts
+++ b/src/process/doctor/workspaceInventory.ts
@@ -14,6 +14,7 @@
  * test. Nothing here touches Electron; `registry.ts` binds the live services.
  */
 
+import { relative, sep } from 'node:path';
 import type { TChatConversation } from '@/common/config/storage';
 import type { IProject } from '@/common/types/project';
 import type { WorkspaceEntry, WorkspaceConfigEntry } from './checks/workspaceChecks';
@@ -22,6 +23,17 @@ import type { WorkspaceEntry, WorkspaceConfigEntry } from './checks/workspaceChe
 export type WorkspaceInventoryDeps = {
   listProjects: () => Promise<IProject[]>;
   listConversations: () => Promise<TChatConversation[]>;
+  /**
+   * Absolute path of the app's OWN default workspace base dir
+   * (`defaultWorkspaceBaseDir()`, i.e. `~/Documents/Wayland`), or `null` when it
+   * could not be resolved.
+   *
+   * REQUIRED rather than optional on purpose. Its whole job is to decide which
+   * paths are app-derived and must have their leaf withheld, so a caller that
+   * forgets it re-opens the leak silently. `null` is the honest "could not
+   * resolve" answer and is handled, but it has to be passed deliberately.
+   */
+  appManagedWorkspaceBase: string | null;
 };
 
 /**
@@ -36,13 +48,74 @@ export type WorkspaceInventoryDeps = {
  * the earlier "wait for #1026" plan for this sink was wrong. Truncating the name
  * would not close it either, since a short credential survives any truncation.
  *
- * Emitting the id makes the leak UNREACHABLE rather than unlikely - the same
- * producer-side correction this advisory already applied to the engine config
- * parse error and to the MCP declaration. Nothing actionable is lost: the
- * workspace PATH is the half the user acts on, and it is still reported.
+ * CORRECTION. An earlier version of this comment claimed emitting the id made
+ * the leak "UNREACHABLE rather than unlikely". That was FALSE for projects, and
+ * measured to be false: a project's default workspace is
+ * `~/Documents/Wayland/<project-name>` (`allocateProjectWorkspace`) and the leaf
+ * is the sanitised name verbatim, so the name simply re-entered through the PATH
+ * half of the same line. Executed, the drift detail read
+ * `Project proj-1 -> /Users/x/Documents/Wayland/<the name>`. The id fixes the
+ * LABEL only; {@link doctorWorkspaceDisplayPath} is what closes the path.
  */
 export function doctorEntityLabel(kind: 'Project' | 'Chat', id: string): string {
   return `${kind} ${id}`;
+}
+
+/** Stands in for a withheld app-derived folder name in a Doctor detail. */
+const WITHHELD_LEAF = '(folder name withheld)';
+
+/**
+ * True when `candidate` sits at or below `base`.
+ *
+ * A bare `relative().startsWith('..')` is UNSOUND, and the trap that matters here
+ * is the one that fails OPEN: `base/..foo` is inside `base` and its relative form
+ * is `..foo`, which starts with `..`, so a naive test calls it outside and the
+ * folder name goes into the report. The walk test therefore needs the separator
+ * (or an exact `..`).
+ *
+ * The other classic trap - a win32 cross-drive path, where `relative` returns an
+ * ABSOLUTE result rather than a `..` walk - is deliberately NOT guarded, and the
+ * direction of the error is why. This is a REDACTION decision, not an access
+ * decision: a false "contained" withholds a folder name that did not need
+ * withholding, while a false "outside" prints one that did. So a cross-drive path
+ * reads as contained and is over-withheld, which costs a user on another Windows
+ * drive the name of their own folder and leaks nothing. Do not "fix" this by
+ * adding an `isAbsolute` early return without also pinning it with a test - that
+ * flips the one case this file cannot exercise back to fail-open.
+ */
+function isAtOrUnder(candidate: string, base: string): boolean {
+  // `candidate === base` relativises to the empty string, which passes both tests
+  // below, so the "at" half needs no arm of its own.
+  const rel = relative(base, candidate);
+  return rel !== '..' && !rel.startsWith(`..${sep}`);
+}
+
+/**
+ * The path to RENDER for a workspace, or `undefined` when the real path is safe
+ * to render as-is.
+ *
+ * For an app-derived workspace the folder name is the user-authored entity name,
+ * so printing the path prints the name. Everything below the app's own base dir
+ * is therefore replaced by {@link WITHHELD_LEAF}, keeping the base (which is the
+ * actionable half - it is where the user looks in Finder) and dropping the part
+ * that carries the name.
+ *
+ * DECIDED, and the trade is deliberate: a path OUTSIDE the base is one the user
+ * typed or picked themselves, it is not derived from an entity name, and a
+ * workspace the user chose is the one they most need named to act on it. Those
+ * stay verbatim, scrubbed only. A path the user picked that happens to sit inside
+ * the base is over-withheld; that direction of error is harmless and not worth a
+ * second signal to distinguish.
+ *
+ * The comparison is also run on lowercased copies because macOS and Windows
+ * filesystems are case-insensitive by default, so a stored path differing only in
+ * case names the same directory. Over-withholding is again the safe direction.
+ */
+export function doctorWorkspaceDisplayPath(path: string, appManagedBase: string | null): string | undefined {
+  if (!appManagedBase) return undefined;
+  const under = isAtOrUnder(path, appManagedBase) || isAtOrUnder(path.toLowerCase(), appManagedBase.toLowerCase());
+  if (!under) return undefined;
+  return `${appManagedBase}${sep}${WITHHELD_LEAF}`;
 }
 
 /**
@@ -58,7 +131,11 @@ export async function collectConfiguredWorkspaces(deps: WorkspaceInventoryDeps):
     if (typeof path !== 'string' || path.trim().length === 0) return;
     if (seen.has(path)) return;
     seen.add(path);
-    entries.push({ label, path });
+    // `path` stays the REAL path - the check stats it - and `displayPath` is what
+    // gets rendered. Collapsing the two would make an app-derived workspace stat
+    // the base dir, which exists, and the drift check would silently stop failing.
+    const displayPath = doctorWorkspaceDisplayPath(path, deps.appManagedWorkspaceBase);
+    entries.push({ label, path, ...(displayPath ? { displayPath } : {}) });
   };
 
   const projects = await deps.listProjects().catch((): IProject[] => []);
@@ -89,12 +166,20 @@ export async function collectWorkspaceConfigEntries(deps: WorkspaceInventoryDeps
   const asPath = (value: unknown): string | null =>
     typeof value === 'string' && value.trim().length > 0 ? value : null;
 
+  /** Same split as the drift inventory: real `path` classified, `displayPath` rendered. */
+  const withDisplay = (path: string | null): { displayPath?: string } => {
+    const displayPath = path === null ? undefined : doctorWorkspaceDisplayPath(path, deps.appManagedWorkspaceBase);
+    return displayPath ? { displayPath } : {};
+  };
+
   const projects = await deps.listProjects().catch((): IProject[] => []);
   for (const project of projects) {
+    const path = asPath(project.workspace);
     entries.push({
       label: doctorEntityLabel('Project', project.id),
-      path: asPath(project.workspace),
+      path,
       customWorkspace: null,
+      ...withDisplay(path),
     });
   }
 
@@ -104,7 +189,7 @@ export async function collectWorkspaceConfigEntries(deps: WorkspaceInventoryDeps
     const path = asPath(extra?.workspace);
     const customWorkspace = typeof extra?.customWorkspace === 'boolean' ? extra.customWorkspace : null;
     if (path === null && customWorkspace === null) continue;
-    entries.push({ label: doctorEntityLabel('Chat', conversation.id), path, customWorkspace });
+    entries.push({ label: doctorEntityLabel('Chat', conversation.id), path, customWorkspace, ...withDisplay(path) });
   }
 
   return entries;

--- a/src/process/doctor/workspaceInventory.ts
+++ b/src/process/doctor/workspaceInventory.ts
@@ -1,0 +1,111 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * The workspace inventory the two workspace Doctor checks consume.
+ *
+ * Extracted out of `registry.ts` for the same reason `engineConfigProbe` was:
+ * this is where an entry's LABEL is chosen, that choice is the fix for a
+ * credential-disclosure defect (GHSA-2g2m-r86j-jg6h), and a security boundary
+ * that can only be reached through Electron singletons is a boundary nobody can
+ * test. Nothing here touches Electron; `registry.ts` binds the live services.
+ */
+
+import type { TChatConversation } from '@/common/config/storage';
+import type { IProject } from '@/common/types/project';
+import type { WorkspaceEntry, WorkspaceConfigEntry } from './checks/workspaceChecks';
+
+/** The two listing services the inventory reads, injected so it is testable. */
+export type WorkspaceInventoryDeps = {
+  listProjects: () => Promise<IProject[]>;
+  listConversations: () => Promise<TChatConversation[]>;
+};
+
+/**
+ * Identify a project or conversation in a Doctor label by its APP-GENERATED id,
+ * never by its user-authored name.
+ *
+ * A conversation's name is generated from the user's FIRST MESSAGE, so a
+ * credential pasted into a chat becomes the chat title and from there a line in a
+ * report the Doctor panel offers to copy. No scrubber closes that: a bare secret
+ * typed as a first message carries no label, no assignment and no recognisable
+ * prefix, so it matches no rule at all - verified by execution, and the reason
+ * the earlier "wait for #1026" plan for this sink was wrong. Truncating the name
+ * would not close it either, since a short credential survives any truncation.
+ *
+ * Emitting the id makes the leak UNREACHABLE rather than unlikely - the same
+ * producer-side correction this advisory already applied to the engine config
+ * parse error and to the MCP declaration. Nothing actionable is lost: the
+ * workspace PATH is the half the user acts on, and it is still reported.
+ */
+export function doctorEntityLabel(kind: 'Project' | 'Chat', id: string): string {
+  return `${kind} ${id}`;
+}
+
+/**
+ * Every configured workspace path: project workspaces plus conversation
+ * `extra.workspace` directories. Deduplicated by path so a project and its
+ * conversations sharing a folder are reported once.
+ */
+export async function collectConfiguredWorkspaces(deps: WorkspaceInventoryDeps): Promise<WorkspaceEntry[]> {
+  const entries: WorkspaceEntry[] = [];
+  const seen = new Set<string>();
+
+  const add = (label: string, path: unknown): void => {
+    if (typeof path !== 'string' || path.trim().length === 0) return;
+    if (seen.has(path)) return;
+    seen.add(path);
+    entries.push({ label, path });
+  };
+
+  const projects = await deps.listProjects().catch((): IProject[] => []);
+  for (const project of projects) {
+    add(doctorEntityLabel('Project', project.id), project.workspace);
+  }
+
+  const conversations = await deps.listConversations().catch((): TChatConversation[] => []);
+  for (const conversation of conversations) {
+    // `extra.workspace` exists on gemini/acp conversations; read defensively
+    // since the union is wide and some kinds carry no workspace.
+    const extra = conversation.extra as { workspace?: unknown } | undefined;
+    add(doctorEntityLabel('Chat', conversation.id), extra?.workspace);
+  }
+
+  return entries;
+}
+
+/**
+ * Every configured workspace with its persistent-vs-temp classification inputs:
+ * project workspaces (no `customWorkspace` flag → `null`) plus conversation
+ * `extra.workspace` / `extra.customWorkspace`. Conversations that carry no
+ * workspace binding at all are skipped (nothing to assess).
+ */
+export async function collectWorkspaceConfigEntries(deps: WorkspaceInventoryDeps): Promise<WorkspaceConfigEntry[]> {
+  const entries: WorkspaceConfigEntry[] = [];
+
+  const asPath = (value: unknown): string | null =>
+    typeof value === 'string' && value.trim().length > 0 ? value : null;
+
+  const projects = await deps.listProjects().catch((): IProject[] => []);
+  for (const project of projects) {
+    entries.push({
+      label: doctorEntityLabel('Project', project.id),
+      path: asPath(project.workspace),
+      customWorkspace: null,
+    });
+  }
+
+  const conversations = await deps.listConversations().catch((): TChatConversation[] => []);
+  for (const conversation of conversations) {
+    const extra = conversation.extra as { workspace?: unknown; customWorkspace?: unknown } | undefined;
+    const path = asPath(extra?.workspace);
+    const customWorkspace = typeof extra?.customWorkspace === 'boolean' ? extra.customWorkspace : null;
+    if (path === null && customWorkspace === null) continue;
+    entries.push({ label: doctorEntityLabel('Chat', conversation.id), path, customWorkspace });
+  }
+
+  return entries;
+}

--- a/src/process/services/projectWorkspace.ts
+++ b/src/process/services/projectWorkspace.ts
@@ -52,9 +52,16 @@ export async function enforceProjectWorkspace(extra: Record<string, unknown> | u
  * files an agent writes "to the local workspace" are not lost in a hidden temp
  * dir. Electron is imported lazily so this module stays loadable in unit tests
  * that don't exercise allocation.
+ *
+ * Exported because the Doctor has to withhold the LEAF of any path under this
+ * base: the leaf is the sanitised project name, so for a managed workspace the
+ * name IS the path (`doctorWorkspaceDisplayPath` in `doctor/workspaceInventory`).
+ * Read through this function rather than rebuilding `<documents>/Wayland` at the
+ * call site - a second copy of the literal is a silent fail-open the moment this
+ * one moves.
  */
 let _baseDirPromise: Promise<string> | null = null;
-async function defaultWorkspaceBaseDir(): Promise<string> {
+export async function defaultWorkspaceBaseDir(): Promise<string> {
   // Memoized: the documents dir doesn't change at runtime, and sharing a single
   // import keeps concurrent allocations from each re-importing electron.
   if (!_baseDirPromise) {

--- a/src/process/services/projectWorkspace.ts
+++ b/src/process/services/projectWorkspace.ts
@@ -65,7 +65,18 @@ export async function defaultWorkspaceBaseDir(): Promise<string> {
   // Memoized: the documents dir doesn't change at runtime, and sharing a single
   // import keeps concurrent allocations from each re-importing electron.
   if (!_baseDirPromise) {
-    _baseDirPromise = import('electron').then(({ app }) => path.join(app.getPath('documents'), 'Wayland'));
+    const pending = import('electron').then(({ app }) => path.join(app.getPath('documents'), 'Wayland'));
+    _baseDirPromise = pending;
+    // Cache the SUCCESS, not the attempt. Caching the promise unconditionally meant
+    // ONE rejected read was replayed for the whole process lifetime - and
+    // `app.getPath` is not throw-free - so the Doctor's `.catch(() => null)` turned
+    // a transient fault into `appManagedWorkspaceBase: null` permanently, which
+    // disables the workspace-name withholding rather than degrading it. Clearing the
+    // slot on rejection keeps the concurrent-dedup property (in-flight callers still
+    // share `pending`) while letting the next call retry.
+    pending.catch(() => {
+      if (_baseDirPromise === pending) _baseDirPromise = null;
+    });
   }
   return _baseDirPromise;
 }

--- a/src/process/utils/tomlErrorSummary.ts
+++ b/src/process/utils/tomlErrorSummary.ts
@@ -35,6 +35,15 @@
  *     line carrying no file content is a property of the current parser, not a
  *     contract, and the scrub costs nothing on a one-line string.
  *
+ * Layer 1 is the defence. Layer 2 is a BACKSTOP and it is known to be
+ * incomplete: `redactSecrets` masks recognisable value prefixes plus a labelled
+ * assignment, and its label rule anchors a word boundary before the label, so
+ * the prefixed spelling that is actually common in the wild
+ * (`ANTHROPIC_API_KEY=<value>`, `my_api_key = "<value>"`) survives whenever the
+ * VALUE itself carries no recognisable prefix - issue #1026, confirmed by
+ * execution. Do not weaken layer 1 on the strength of layer 2, and do not read
+ * a passing scrubber assertion as proof a path is safe.
+ *
  * Discovered originally by the K-01 4-leg cross-audit (Gemini 3.1 Pro leg) and
  * confirmed by executing the parser against a key-bearing malformed line.
  */

--- a/src/process/utils/tomlErrorSummary.ts
+++ b/src/process/utils/tomlErrorSummary.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Shared summarizer for `smol-toml` parse errors (GHSA-2g2m-r86j-jg6h).
+ *
+ * A `smol-toml` parse error message echoes the OFFENDING SOURCE LINE and its
+ * neighbours verbatim after a blank line, e.g.:
+ *
+ *   Invalid TOML document: each key-value declaration must be followed by ...
+ *
+ *   2:  api_key = "sk-ant-REDACTED-EXAMPLE"
+ *   3:  base_url = "https://api.anthropic.com" oops
+ *                                             ^
+ *
+ * The TOML files this app parses on the user's behalf - above all the engine's
+ * global `config.toml` - hold real `api_key` values, so the raw message IS a
+ * live credential inside an Error that gets logged, surfaced in the UI, and (on
+ * the Doctor panel, which has a "Copy report" button and exists to be shared
+ * with support) copied out by the user.
+ *
+ * This logic lived as a private `summarizeTomlError` inside
+ * `@process/agent/wcore/desktopProfileSplice`, while `doctor/registry.ts`
+ * passed `error.message` through untouched: two components reaching opposite
+ * conclusions about the same data, and the one on the copy-to-support surface
+ * was the one that leaked. It is one helper now, and both call it.
+ *
+ * Two layers:
+ *  1. keep only the FIRST line - the human-readable reason - and drop the echoed
+ *     source block entirely;
+ *  2. run the survivor through the shared `redactSecrets` scrubber. The first
+ *     line carrying no file content is a property of the current parser, not a
+ *     contract, and the scrub costs nothing on a one-line string.
+ *
+ * Discovered originally by the K-01 4-leg cross-audit (Gemini 3.1 Pro leg) and
+ * confirmed by executing the parser against a key-bearing malformed line.
+ */
+
+import { redactSecrets } from './secretRedaction';
+
+/** A 1-based position inside the offending TOML document. */
+export type TomlErrorPosition = { line: number; column: number };
+
+/**
+ * The human-readable reason for a TOML parse failure, with the echoed source
+ * block stripped and the survivor scrubbed. Safe to surface, log, and copy.
+ */
+export function summarizeTomlError(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  return redactSecrets(raw.split('\n', 1)[0].trim());
+}
+
+/**
+ * The failure's position as NUMBERS, so a caller can stay actionable ("fix line
+ * 3, column 40") without echoing the line's text.
+ *
+ * `smol-toml`'s `TomlError` carries `line`, `column` and `codeblock` as own
+ * properties [verified by execution against the installed smol-toml]. Only the
+ * two numbers are read here; `codeblock` is the echoed source itself and must
+ * never be surfaced. Read structurally rather than via an `instanceof
+ * TomlError` check so this module stays free of a `smol-toml` import - it is
+ * pulled in by error paths that must not drag the parser along.
+ */
+export function tomlErrorPosition(error: unknown): TomlErrorPosition | null {
+  if (typeof error !== 'object' || error === null) return null;
+  const { line, column } = error as { line?: unknown; column?: unknown };
+  if (typeof line !== 'number' || !Number.isFinite(line)) return null;
+  if (typeof column !== 'number' || !Number.isFinite(column)) return null;
+  return { line, column };
+}

--- a/src/process/utils/tomlErrorSummary.ts
+++ b/src/process/utils/tomlErrorSummary.ts
@@ -100,9 +100,20 @@ const MAX_SUMMARY_LENGTH = 200;
  * mask. Scrubbing the whole line first means the pattern sees the value intact.
  */
 export function summarizeTomlError(error: unknown): string {
-  const raw = error instanceof Error ? error.message : String(error);
-  const firstLine = raw.split(LINE_TERMINATOR, 1)[0].trim();
-  return redactSecrets(firstLine).slice(0, MAX_SUMMARY_LENGTH);
+  try {
+    const raw = error instanceof Error ? error.message : String(error);
+    const firstLine = raw.split(LINE_TERMINATOR, 1)[0].trim();
+    return redactSecrets(firstLine).slice(0, MAX_SUMMARY_LENGTH);
+  } catch {
+    // `error.message` is a GETTER, and `String(error)` runs `toString`; either can
+    // throw on a hostile or badly-built Error. Unguarded, that throw propagated out
+    // of `probeEngineConfig`'s own catch and falsified its documented "Never throws"
+    // contract [executed]. Nothing leaked today only because the runner's
+    // `safeErrorMessage` happened to be downstream - i.e. the contract was held up
+    // by a coincidence rather than by this function. Same guard, and the same
+    // reasoning, as `safeErrorMessage` in `doctor/runner.ts`.
+    return '(the parse error could not be read)';
+  }
 }
 
 /**
@@ -118,8 +129,16 @@ export function summarizeTomlError(error: unknown): string {
  */
 export function tomlErrorPosition(error: unknown): TomlErrorPosition | null {
   if (typeof error !== 'object' || error === null) return null;
-  const { line, column } = error as { line?: unknown; column?: unknown };
-  if (typeof line !== 'number' || !Number.isFinite(line)) return null;
-  if (typeof column !== 'number' || !Number.isFinite(column)) return null;
-  return { line, column };
+  try {
+    // The DESTRUCTURE is the exposure, not the type tests below it: `line` and
+    // `column` are read as properties, so a throwing getter throws here [executed].
+    // Position is a nice-to-have - the caller drops it when it is absent - so
+    // failing to `null` is strictly better than propagating.
+    const { line, column } = error as { line?: unknown; column?: unknown };
+    if (typeof line !== 'number' || !Number.isFinite(line)) return null;
+    if (typeof column !== 'number' || !Number.isFinite(column)) return null;
+    return { line, column };
+  } catch {
+    return null;
+  }
 }

--- a/src/process/utils/tomlErrorSummary.ts
+++ b/src/process/utils/tomlErrorSummary.ts
@@ -28,21 +28,32 @@
  * conclusions about the same data, and the one on the copy-to-support surface
  * was the one that leaked. It is one helper now, and both call it.
  *
- * Two layers:
+ * Three layers:
  *  1. keep only the FIRST line - the human-readable reason - and drop the echoed
  *     source block entirely;
- *  2. run the survivor through the shared `redactSecrets` scrubber. The first
- *     line carrying no file content is a property of the current parser, not a
- *     contract, and the scrub costs nothing on a one-line string.
+ *  2. cap the survivor's LENGTH, because a first line is not a short line;
+ *  3. run it through the shared `redactSecrets` scrubber. The first line carrying
+ *     no file content is a property of the current parser, not a contract, and
+ *     the scrub costs nothing on a bounded string.
  *
- * Layer 1 is the defence. Layer 2 is a BACKSTOP and it is known to be
+ * Layer 1 is the defence. Layer 3 is a BACKSTOP and it is known to be
  * incomplete: `redactSecrets` masks recognisable value prefixes plus a labelled
  * assignment, and its label rule anchors a word boundary before the label, so
  * the prefixed spelling that is actually common in the wild
  * (`ANTHROPIC_API_KEY=<value>`, `my_api_key = "<value>"`) survives whenever the
  * VALUE itself carries no recognisable prefix - issue #1026, confirmed by
- * execution. Do not weaken layer 1 on the strength of layer 2, and do not read
+ * execution. Do not weaken layer 1 on the strength of layer 3, and do not read
  * a passing scrubber assertion as proof a path is safe.
+ *
+ * WHAT THIS HELPER IS FOR, and what it is not. It is for `smol-toml` parse
+ * errors, whose first line is a fixed English reason [verified across ten real
+ * corrupt files: the reason ran 36 to 87 characters and the file's own content
+ * never reached line 1]. It is NOT a general-purpose sanitiser, and routing an
+ * arbitrary error through it fails open. `probeEngineConfig` used to route a
+ * `ProfileIsolationError` here, and that error interpolates the profile name on
+ * its FIRST line, so layer 1 was inert and layer 2 could not see a bare value -
+ * the profile name went straight into the report. That branch returns a constant
+ * now. Before adding a caller, check that its first line cannot carry user text.
  *
  * Discovered originally by the K-01 4-leg cross-audit (Gemini 3.1 Pro leg) and
  * confirmed by executing the parser against a key-bearing malformed line.
@@ -54,12 +65,44 @@ import { redactSecrets } from './secretRedaction';
 export type TomlErrorPosition = { line: number; column: number };
 
 /**
+ * Every character a line can END on, not just `\n`.
+ *
+ * `split('\n', 1)` was not enough, and both gaps were reached by execution. A
+ * message whose lines end in a bare `\r` (classic-Mac line endings still occur in
+ * hand-edited files, and any producer can emit one) kept its whole body in
+ * "line 1", and so did one separated by U+2028 LINE SEPARATOR or U+2029 PARAGRAPH
+ * SEPARATOR - both of which JavaScript treats as line terminators, so text
+ * downstream renders them as breaks while `split('\n')` never saw them.
+ */
+const LINE_TERMINATOR = /\r\n|\r|\n|\u2028|\u2029/;
+
+/**
+ * Hard cap on the surfaced reason.
+ *
+ * Layer 1 keeps only the first line, but a first line is not a SHORT line: a
+ * single-line 500,000-character message returned all 500,032 characters, straight
+ * into a report the UI renders and offers to copy [executed]. 200 is a measured
+ * bound, not a guess: across ten real corrupt TOML files the smol-toml reason line
+ * ran 36 to 87 characters, the longest being "only letter, numbers, dashes and
+ * underscores are allowed in keys" at 87, so this leaves better than twice the
+ * headroom of anything the parser actually produces.
+ */
+const MAX_SUMMARY_LENGTH = 200;
+
+/**
  * The human-readable reason for a TOML parse failure, with the echoed source
- * block stripped and the survivor scrubbed. Safe to surface, log, and copy.
+ * block stripped, the survivor scrubbed, and the result length-capped. Safe to
+ * surface, log, and copy.
+ *
+ * ORDER IS LOAD-BEARING: scrub, THEN cap. Capping first truncates a credential
+ * that straddles the boundary, and a truncated credential can fail to match its
+ * own pattern - so the cap would hand out the surviving fragment instead of a
+ * mask. Scrubbing the whole line first means the pattern sees the value intact.
  */
 export function summarizeTomlError(error: unknown): string {
   const raw = error instanceof Error ? error.message : String(error);
-  return redactSecrets(raw.split('\n', 1)[0].trim());
+  const firstLine = raw.split(LINE_TERMINATOR, 1)[0].trim();
+  return redactSecrets(firstLine).slice(0, MAX_SUMMARY_LENGTH);
 }
 
 /**

--- a/tests/unit/process/doctor/checks.test.ts
+++ b/tests/unit/process/doctor/checks.test.ts
@@ -327,20 +327,20 @@ describe('checkMcpServers', () => {
 
   it('fails when an enabled server errors', async () => {
     const result = await checkMcpServers({
-      listServers: async () => [mcpServer({ name: 'broken' })],
+      listServers: async () => [mcpServer({ id: 'mcp_broken', name: 'broken' })],
       testConnection: async () => ({ success: false, error: 'spawn failed' }),
     });
     expect(result.status).toBe('fail');
-    expect(result.detail).toContain('broken');
+    expect(result.detail).toContain('mcp_broken');
   });
 
   it('warns when an enabled server needs auth', async () => {
     const result = await checkMcpServers({
-      listServers: async () => [mcpServer({ name: 'needs-login' })],
+      listServers: async () => [mcpServer({ id: 'mcp_needs-login', name: 'needs-login' })],
       testConnection: async () => ({ success: false, needsAuth: true }),
     });
     expect(result.status).toBe('warn');
-    expect(result.detail).toContain('needs-login');
+    expect(result.detail).toContain('mcp_needs-login');
   });
 
   /**
@@ -351,11 +351,11 @@ describe('checkMcpServers', () => {
    */
   it('names a server that connects but publishes no tools', async () => {
     const result = await checkMcpServers({
-      listServers: async () => [mcpServer({ name: 'tvcontrol' })],
+      listServers: async () => [mcpServer({ id: 'mcp_tvcontrol', name: 'tvcontrol' })],
       testConnection: async () => ({ success: true, tools: [] }),
     });
     expect(result.status).toBe('warn');
-    expect(result.detail).toContain('tvcontrol');
+    expect(result.detail).toContain('mcp_tvcontrol');
     expect(result.detail).toContain('no tools');
   });
 
@@ -388,13 +388,16 @@ describe('checkMcpServers', () => {
    */
   it('reports a toolless server and an unauthenticated one together', async () => {
     const result = await checkMcpServers({
-      listServers: async () => [mcpServer({ name: 'empty' }), mcpServer({ name: 'locked', id: 'b' })],
+      listServers: async () => [
+        mcpServer({ id: 'mcp_empty', name: 'empty' }),
+        mcpServer({ id: 'mcp_locked', name: 'locked' }),
+      ],
       testConnection: async (server) =>
         server.name === 'empty' ? { success: true, tools: [] } : { success: false, needsAuth: true },
     });
     expect(result.status).toBe('warn');
-    expect(result.detail).toContain('empty');
-    expect(result.detail).toContain('locked');
+    expect(result.detail).toContain('mcp_empty');
+    expect(result.detail).toContain('mcp_locked');
     expect(result.detail).toContain('no tools');
     expect(result.detail).toContain('authentication');
     expect(result.remediation).toContain('Log in');

--- a/tests/unit/process/doctor/doctorRegistryComposition.test.ts
+++ b/tests/unit/process/doctor/doctorRegistryComposition.test.ts
@@ -1,0 +1,145 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * The COMPOSITION ROOT, tested rather than assumed.
+ *
+ * Every other Doctor test injects its dependencies, which is what makes the checks
+ * testable and is also a blind spot: `appManagedWorkspaceBase` could be bound to
+ * `null` in `registry.ts` and the whole 169-test battery stayed green [executed].
+ * `null` is a legal, handled value that means "withhold nothing", so that mutant is
+ * a silent fail-open on the ONLY production wiring of the withholding fix -
+ * `workspaceInventory` makes the field required precisely because "a caller that
+ * forgets it re-opens the leak silently", and the type enforces presence while
+ * nothing enforced the value.
+ *
+ * So this file imports the real `buildDoctorChecks` and runs the real
+ * `defaultWorkspaceBaseDir` behind a mocked Electron `app`. It is the only Doctor
+ * test that pulls the live singleton graph in, and that is the point.
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import type { DoctorCheck } from '@process/doctor/types';
+
+/** Base the mocked `app.getPath('documents')` reports. Assigned in `beforeAll`. */
+let documentsDir = '';
+/** Flipped by the memoization test to make the FIRST electron read fail. */
+let failNextGetPath = false;
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (): string => {
+      if (failNextGetPath) {
+        failNextGetPath = false;
+        throw new Error('uv_os_get_documents failed');
+      }
+      return documentsDir;
+    },
+    runningUnderARM64Translation: false,
+  },
+}));
+
+/**
+ * A BARE credential used as a project NAME. A project's default workspace is
+ * `<base>/<sanitised name>` (`allocateProjectWorkspace`), so the name IS the path's
+ * leaf, and `redactSecrets` returns a value of this shape untouched.
+ */
+const BARE_SECRET = 'f0e9d8c7b6a5948372615041302f1e0d';
+
+vi.mock('@process/services/projectServiceSingleton', () => ({
+  projectServiceSingleton: {
+    listProjects: async () => [
+      // Under the app's own base dir, and deliberately NOT created on disk so the
+      // drift check reports it and renders the path.
+      { id: 'proj-1', name: BARE_SECRET, workspace: join(documentsDir, 'Wayland', BARE_SECRET) },
+    ],
+  },
+}));
+
+vi.mock('@process/services/conversationServiceSingleton', () => ({
+  conversationServiceSingleton: { listAllConversations: async () => [] },
+}));
+
+describe('buildDoctorChecks — the composition root really supplies the workspace base', () => {
+  let root: string;
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), 'doctor-registry-'));
+    documentsDir = root;
+  });
+
+  afterAll(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  const drift = async (): Promise<DoctorCheck> => {
+    const { buildDoctorChecks } = await import('@process/doctor/registry');
+    const check = buildDoctorChecks().find((entry) => entry.id === 'workspace.drift');
+    expect(check, 'workspace.drift must exist in the registry').toBeDefined();
+    return check as DoctorCheck;
+  };
+
+  it('KNOWN POSITIVE: the real base resolver returns the mocked documents dir', async () => {
+    // Without this the assertions below could pass because the base failed to
+    // resolve to anything, which is the very fail-open they are guarding.
+    const { defaultWorkspaceBaseDir } = await import('@process/services/projectWorkspace');
+    expect(await defaultWorkspaceBaseDir()).toBe(join(root, 'Wayland'));
+  });
+
+  it('withholds the app-derived folder name in the wired workspace.drift check', async () => {
+    const outcome = await (await drift()).run();
+
+    expect(outcome.status).toBe('fail');
+    // THE MUTANT KILLER: with `appManagedWorkspaceBase: null` this line is the
+    // project name verbatim.
+    expect(outcome.detail).not.toContain(BARE_SECRET);
+    expect(outcome.detail).toContain('(folder name withheld)');
+    // NOT VACUOUS: the base dir - the actionable half - still reaches the user, and
+    // the row still names which project by its app-generated id.
+    expect(outcome.detail).toContain(join(root, 'Wayland'));
+    expect(outcome.detail).toContain('Project proj-1');
+  });
+
+  it('KNOWN POSITIVE: nothing masks a bare 32-hex path leaf, so the fix is structural', async () => {
+    const { redactSecrets } = await import('@process/utils/secretRedaction');
+    expect(redactSecrets(join(root, 'Wayland', BARE_SECRET))).toContain(BARE_SECRET);
+  });
+});
+
+describe('defaultWorkspaceBaseDir — a transient failure must not be cached forever', () => {
+  let root: string;
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), 'doctor-memo-'));
+  });
+
+  afterAll(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  /**
+   * The memo used to cache the PROMISE unconditionally, so a single rejected
+   * electron read was cached for the process lifetime: every later call rejected,
+   * `registry.ts` mapped that to `null`, and the withholding above was disabled
+   * permanently rather than for one run. `app.getPath` is not throw-free, so this
+   * is a real degradation path and not merely a hostile one.
+   */
+  it('retries after a rejected resolve instead of failing open for the process lifetime', async () => {
+    vi.resetModules();
+    documentsDir = root;
+    failNextGetPath = true;
+
+    const { defaultWorkspaceBaseDir } = await import('@process/services/projectWorkspace');
+    // KNOWN POSITIVE: the first call really does reject, so the retry below is a
+    // retry and not a first attempt.
+    await expect(defaultWorkspaceBaseDir()).rejects.toThrow('uv_os_get_documents failed');
+    // And the very next call succeeds.
+    expect(await defaultWorkspaceBaseDir()).toBe(join(root, 'Wayland'));
+  });
+});

--- a/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
+++ b/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
@@ -31,7 +31,9 @@ import { checkMcpServers } from '@process/doctor/checks/mcpChecks';
 import { checkBackends } from '@process/doctor/checks/backendChecks';
 import { checkEngineContractPin, checkEngineReachable } from '@process/doctor/checks/engineChecks';
 import { checkWorkspaceDrift, checkWorkspaceConfigured } from '@process/doctor/checks/workspaceChecks';
+import { collectConfiguredWorkspaces, collectWorkspaceConfigEntries } from '@process/doctor/workspaceInventory';
 import { runDoctor } from '@process/doctor/runner';
+import { redactSecrets } from '@process/utils/secretRedaction';
 import type { IMcpServer } from '@/common/config/storage';
 import type { DetectedAgent } from '@/common/types/detectedAgent';
 
@@ -49,6 +51,23 @@ const BEARER = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ3YXlsYW5kLXRlc3QifQ.s3cr3tS1gnat
  */
 const PREFIXLESS_KEY = 'a1b2c3d4e5f60718293a4b5c6d7e8f90';
 const PREFIXLESS_ASSIGNMENT = `AZURE_OPENAI_API_KEY=${PREFIXLESS_KEY}`;
+
+/**
+ * A SHORT credential. `redactSecrets` floors every rule at 8 characters, so a
+ * 7-character password is invisible to it no matter how it is labelled - and a
+ * database password of this length is entirely ordinary.
+ */
+const SHORT_SECRET = 'hunter7';
+
+/** A 4-character one, the shortest this check masks at all. */
+const TINY_SECRET = '9182';
+
+/**
+ * A BARE credential: no label, no assignment, no recognisable prefix. Nothing in
+ * any scrubber can match this, which is why the only fixes that close it are
+ * structural ones.
+ */
+const BARE_SECRET = 'f0e9d8c7b6a5948372615041302f1e0d';
 
 /** Distinctive prefixes as well as whole values, so a partial leak still counts. */
 const findsSecret = (text: string): boolean =>
@@ -164,21 +183,152 @@ describe('MCP check — the probe error is free-form text from a credential-carr
     }
   });
 
-  it('leaves a short non-secret env value alone so the diagnostic survives', async () => {
-    // A blanket literal replacement with no length floor would blank the word
-    // "production" out of the probe's own error text.
-    const server2 = {
-      id: 'plain',
-      name: 'plain',
+  it('SHORT CANARY: masks a 7-char password and a 4-char pin from env', async () => {
+    // `redactSecrets` floors every rule at 8 characters, so neither of these is
+    // visible to it. They are masked here only because they are declared values.
+    const server3 = {
+      id: 'db',
+      name: 'db',
       enabled: true,
-      transport: { type: 'stdio', command: 'node', env: { NODE_ENV: 'prod', PORT: '3000' } },
+      transport: { type: 'stdio', command: 'node', env: { DB_PASSWORD: SHORT_SECRET, PIN: TINY_SECRET } },
     } as unknown as IMcpServer;
     const result = await checkMcpServers({
-      listServers: async () => [server2],
-      testConnection: async () => ({ success: false, error: 'listen EADDRINUSE on port 3000 in prod mode' }),
+      listServers: async () => [server3],
+      testConnection: async () => ({
+        success: false,
+        error: `auth failed: password ${SHORT_SECRET} pin ${TINY_SECRET}`,
+      }),
     });
-    expect(result.detail).toContain('3000');
-    expect(result.detail).toContain('prod');
+    expect(result.detail).not.toContain(SHORT_SECRET);
+    expect(result.detail).not.toContain(TINY_SECRET);
+    expect(result.detail).toContain('db');
+  });
+
+  it('does NOT mask a 1-3 char env value, which would shred the whole detail', async () => {
+    // `DEBUG=1` is an ordinary declaration. Masking it would blank every "1" in
+    // the error text, destroying the diagnostic instead of protecting anything.
+    const server4 = {
+      id: 'dbg',
+      name: 'dbg',
+      enabled: true,
+      transport: { type: 'stdio', command: 'node', env: { DEBUG: '1', TZ: 'UTC' } },
+    } as unknown as IMcpServer;
+    const result = await checkMcpServers({
+      listServers: async () => [server4],
+      testConnection: async () => ({ success: false, error: 'MCP error -32000: exited with code 1 at 10:31 UTC' }),
+    });
+    expect(result.detail).toContain('-32000');
+    expect(result.detail).toContain('code 1');
+    expect(result.detail).toContain('UTC');
+  });
+
+  it('ACCEPTANCE: the two commonest MCP failures stay readable', async () => {
+    // A stock filesystem-server declaration. Masking whole `args` turned these
+    // into `registry.npmjs.org/[redacted]` and `scandir '[redacted]'` - i.e. the
+    // tool whose only job is to diagnose these two failures could no longer say
+    // which package or which directory. Both strings must survive verbatim.
+    const filesystem = {
+      id: 'fs',
+      name: 'filesystem',
+      enabled: true,
+      transport: {
+        type: 'stdio',
+        command: 'npx',
+        args: ['-y', '@modelcontextprotocol/server-filesystem', '/Users/alice/Documents'],
+        env: { NODE_ENV: 'production' },
+      },
+    } as unknown as IMcpServer;
+
+    const wrongPackage = await checkMcpServers({
+      listServers: async () => [filesystem],
+      testConnection: async () => ({
+        success: false,
+        error:
+          'MCP error -32000: Connection closed. Server output: npm ERR! 404 Not Found - GET https://registry.npmjs.org/@modelcontextprotocol/server-filesystem - Not found.',
+      }),
+    });
+    expect(wrongPackage.detail).toContain('npm ERR! 404');
+    expect(wrongPackage.detail).toContain('https://registry.npmjs.org/@modelcontextprotocol/server-filesystem');
+
+    const missingDir = await checkMcpServers({
+      listServers: async () => [filesystem],
+      testConnection: async () => ({
+        success: false,
+        error: "ENOENT: no such file or directory, scandir '/Users/alice/Documents'",
+      }),
+    });
+    expect(missingDir.detail).toContain('ENOENT: no such file or directory');
+    expect(missingDir.detail).toContain("scandir '/Users/alice/Documents'");
+  });
+
+  it('PREFIXLESS CANARY: masks a token embedded in a hosted endpoint URL', async () => {
+    // Path-embedded is the standard shape for Zapier / Smithery / Composio, and
+    // undici echoes the URL in its own error text.
+    const urls = [
+      `https://mcp.example.com/v1/${PREFIXLESS_KEY}/sse`,
+      `https://mcp.example.com/sse?t=${PREFIXLESS_KEY}`,
+      `https://mcp.example.com/sse?azure_openai_api_key=${PREFIXLESS_KEY}`,
+    ];
+    const results = await Promise.all(
+      urls.map((url) =>
+        checkMcpServers({
+          listServers: async () => [
+            { id: 'hosted', name: 'hosted', enabled: true, transport: { type: 'sse', url } } as unknown as IMcpServer,
+          ],
+          testConnection: async () => ({ success: false, error: `getaddrinfo ENOTFOUND for ${url}` }),
+        })
+      )
+    );
+    for (const result of results) {
+      expect(findsPrefixlessKey(surfaced(result))).toBe(false);
+      expect(result.detail).toContain('hosted');
+    }
+  });
+
+  it('PREFIXLESS CANARY: masks the mcp-remote --header Authorization shape', async () => {
+    // The documented `mcp-remote` spelling. Reaching the bare token needs TWO
+    // unwraps: past the `:`, then past the space after `Bearer`.
+    const shapes = [
+      ['mcp-remote', 'https://x/sse', '--header', `Authorization: Bearer ${PREFIXLESS_KEY}`],
+      ['mcp-remote', 'https://x/sse', `--header=Authorization: Bearer ${PREFIXLESS_KEY}`],
+    ];
+    const echoes = [`rejected: ${PREFIXLESS_KEY}`, `sent Bearer ${PREFIXLESS_KEY}`];
+    const combos = shapes.flatMap((args) => echoes.map((echo) => ({ args, echo })));
+    const results = await Promise.all(
+      combos.map(({ args, echo }) =>
+        checkMcpServers({
+          listServers: async () => [
+            {
+              id: 'remote',
+              name: 'remote',
+              enabled: true,
+              transport: { type: 'stdio', command: 'npx', args },
+            } as unknown as IMcpServer,
+          ],
+          testConnection: async () => ({ success: false, error: echo }),
+        })
+      )
+    );
+    for (const result of results) {
+      expect(findsPrefixlessKey(surfaced(result))).toBe(false);
+    }
+  });
+
+  it('PREFIXLESS CANARY: masks an env value declared with a trailing space', async () => {
+    // A trailing space is legal in an env value (`validateMcpEnvEntry` rejects
+    // only <= 0x1f), and the untrimmed original never matches the echoed token.
+    const result = await checkMcpServers({
+      listServers: async () => [
+        {
+          id: 'sloppy',
+          name: 'sloppy',
+          enabled: true,
+          transport: { type: 'stdio', command: 'node', env: { TOK: `${PREFIXLESS_KEY} ` } },
+        } as unknown as IMcpServer,
+      ],
+      testConnection: async () => ({ success: false, error: `bad token ${PREFIXLESS_KEY}` }),
+    });
+    expect(findsPrefixlessKey(surfaced(result))).toBe(false);
   });
 
   it('scrubs an api_key echoed from a stdio server env', async () => {
@@ -230,6 +380,58 @@ describe('engine reachability check — unbounded `--version` stdout', () => {
     expect(result.detail).toContain('0.13.0');
   });
 
+  it('PREFIXLESS CANARY: none of the six adversarial banners leaks', async () => {
+    // Every one of these returned `pass` with the credential in the detail under
+    // the first, unanchored/unbounded pattern. The last needs no version banner
+    // at all: the search simply started INSIDE the token.
+    const long = 'x'.repeat(200_000);
+    const banners = [
+      `1.0.0-sk-ant-api03-${'A'.repeat(40)}`,
+      `0.13.0_${PREFIXLESS_KEY}`,
+      `0.13.0+build.${'eyJhbGciOiJIUzI1NiJ9'}.${'b'.repeat(46)}`,
+      `token=sk-ant-1.2.3-${'c'.repeat(58)}`,
+      `9.9.9-${long}`,
+      `wayland-core 0.13.0 (env ${PREFIXLESS_ASSIGNMENT})`,
+    ];
+
+    const results = await Promise.all(
+      banners.map((version) => checkEngineReachable(() => ({ available: true, path: '/opt/e', version })))
+    );
+
+    for (const result of results) {
+      const text = surfaced(result);
+      expect(findsPrefixlessKey(text)).toBe(false);
+      expect(findsSecret(text)).toBe(false);
+      expect(text).not.toContain('A'.repeat(40));
+      expect(text).not.toContain('b'.repeat(46));
+      expect(text).not.toContain('c'.repeat(58));
+      expect(text).not.toContain(long);
+      // Belt-and-braces cap: nothing version-shaped can be long.
+      expect(text.length).toBeLessThan(200);
+    }
+  });
+
+  it('still accepts the three legitimate banner spellings', async () => {
+    const cases: Array<[string, string]> = [
+      ['v0.10.0', 'v0.10.0'],
+      ['wayland-core 0.13.0 (env X)', '0.13.0'],
+      ['banner v0.10.0 extra', 'v0.10.0'],
+    ];
+    const results = await Promise.all(
+      cases.map(([version]) => checkEngineReachable(() => ({ available: true, path: '/opt/e', version })))
+    );
+    results.forEach((result, index) => {
+      expect(result.status).toBe('pass');
+      expect(result.detail).toContain(`engine ${cases[index][1]} is reachable`);
+    });
+  });
+
+  it('accepts a normal prerelease/build tail but not an unbounded one', async () => {
+    const ok = await checkEngineReachable(() => ({ available: true, path: '/opt/e', version: '0.13.0-rc.1' }));
+    expect(ok.status).toBe('pass');
+    expect(ok.detail).toContain('0.13.0-rc.1');
+  });
+
   it('warns without echoing stdout when it carries no version number', async () => {
     const result = await checkEngineReachable(() => ({
       available: true,
@@ -269,6 +471,15 @@ describe('workspace checks — labels built from auto-generated chat titles', ()
     expect(result.detail).toContain('/gone/workspace');
   });
 
+  it('scrubs the workspace PATH, not just the label', async () => {
+    // A workspace folder can itself be named after a credential.
+    const result = await checkWorkspaceDrift({
+      listWorkspaces: async () => [{ label: 'Chat conv-1', path: `/Users/a/ws/${API_KEY}` }],
+      pathExists: async () => false,
+    });
+    expect(findsSecret(surfaced(result))).toBe(false);
+  });
+
   it('scrubs the label in the configured check', async () => {
     const result = await checkWorkspaceConfigured({
       listWorkspaces: async () => [{ label: leakyLabel, path: '/tmp/throwaway', customWorkspace: false }],
@@ -294,6 +505,119 @@ describe('engine contract-pin check — raw fs error text', () => {
     expect(result.status).toBe('warn');
     expect(findsSecret(surfaced(result))).toBe(false);
     expect(result.detail).toContain('EACCES');
+  });
+});
+
+describe('MCP check — a THROWN probe must not bypass the declaration masking', () => {
+  // `testMcpConnection` runs `validateMcpServer` synchronously before it spawns
+  // anything, and that validator throws with the RAW url. Before the catch in
+  // `probeWithTimeout`, the rejection escaped `checkMcpServers` altogether and
+  // surfaced through the runner's catch-all, which knows nothing about this
+  // server's declaration - so the whole masking fix was bypassed for exactly the
+  // servers most likely to be malformed. Stored declarations CAN be invalid:
+  // older installs and JSON imports predate validation.
+  const badUrl = `https://mcp.example.com/v1/${PREFIXLESS_KEY}/sse`;
+  const invalid = {
+    id: 'invalid',
+    name: 'invalid',
+    enabled: true,
+    transport: { type: 'sse', url: badUrl },
+  } as unknown as IMcpServer;
+  const thrower = async (): Promise<never> => {
+    throw new Error(`Invalid MCP server URL for "invalid": ${badUrl}`);
+  };
+
+  it('PREFIXLESS CANARY: converts the throw into a masked per-server failure', async () => {
+    const result = await checkMcpServers({ listServers: async () => [invalid], testConnection: thrower });
+    expect(result.status).toBe('fail');
+    expect(findsPrefixlessKey(surfaced(result))).toBe(false);
+    expect(result.detail).toContain('invalid');
+  });
+
+  it('PREFIXLESS CANARY: stays masked end to end through runDoctor', async () => {
+    const report = await runDoctor([
+      {
+        id: 'mcp.servers',
+        titleKey: 'mcp.servers',
+        category: 'mcp',
+        run: () => checkMcpServers({ listServers: async () => [invalid], testConnection: thrower }),
+      },
+    ]);
+    const [result] = report.results;
+    expect(findsPrefixlessKey(surfaced(result))).toBe(false);
+    // Not the runner's generic "Check threw an error" line - the per-server
+    // detail survived, which is the point of catching it in the check.
+    expect(result.detail).not.toContain('Check threw an error');
+  });
+
+  it("one malformed server does not destroy the other servers' detail", async () => {
+    const healthy = {
+      id: 'ok',
+      name: 'ok',
+      enabled: true,
+      transport: { type: 'stdio', command: 'node' },
+    } as unknown as IMcpServer;
+    const result = await checkMcpServers({
+      listServers: async () => [invalid, healthy],
+      testConnection: async (server) => {
+        if (server.name === 'invalid') return thrower();
+        return { success: false, error: 'plain failure' };
+      },
+    });
+    expect(result.detail).toContain('ok');
+    expect(result.detail).toContain('plain failure');
+    expect(findsPrefixlessKey(surfaced(result))).toBe(false);
+  });
+});
+
+describe('workspace inventory — the producer chooses the label', () => {
+  // A conversation name is generated from the user's FIRST MESSAGE. A BARE
+  // credential as that message has no label, no assignment and no recognisable
+  // prefix, so NO scrubber can ever match it - which is why the fix has to be
+  // here, at the producer, and not a scrub downstream.
+  const services = {
+    listProjects: async () => [
+      { id: 'proj-1', name: BARE_SECRET, workspace: '/gone/ws', pinned: false, createTime: 0, modifyTime: 0 },
+    ],
+    listConversations: async () => [
+      { id: 'conv-1', name: BARE_SECRET, extra: { workspace: '/gone/chat-ws', customWorkspace: false } },
+    ],
+  } as unknown as Parameters<typeof collectConfiguredWorkspaces>[0];
+
+  it('KNOWN POSITIVE: no scrubber can mask a bare credential used as a chat title', () => {
+    // Proves the matcher works AND that the scrub-only plan for this sink was
+    // never going to close it.
+    expect(redactSecrets(`Chat "${BARE_SECRET}"`)).toContain(BARE_SECRET);
+  });
+
+  it('BARE CANARY: emits the app-generated id, never the name (drift inventory)', async () => {
+    const entries = await collectConfiguredWorkspaces(services);
+    expect(entries).toHaveLength(2);
+    for (const entry of entries) {
+      expect(entry.label).not.toContain(BARE_SECRET);
+    }
+    expect(entries.map((entry) => entry.label)).toEqual(['Project proj-1', 'Chat conv-1']);
+    // The actionable half is untouched.
+    expect(entries.map((entry) => entry.path)).toEqual(['/gone/ws', '/gone/chat-ws']);
+  });
+
+  it('BARE CANARY: emits the app-generated id, never the name (configured inventory)', async () => {
+    const entries = await collectWorkspaceConfigEntries(services);
+    expect(entries).toHaveLength(2);
+    for (const entry of entries) {
+      expect(entry.label).not.toContain(BARE_SECRET);
+    }
+    expect(entries.map((entry) => entry.label)).toEqual(['Project proj-1', 'Chat conv-1']);
+  });
+
+  it('BARE CANARY: the rendered Doctor detail carries no trace of the name', async () => {
+    const result = await checkWorkspaceDrift({
+      listWorkspaces: () => collectConfiguredWorkspaces(services),
+      pathExists: async () => false,
+    });
+    expect(result.status).toBe('fail');
+    expect(result.detail).not.toContain(BARE_SECRET);
+    expect(result.detail).toContain('/gone/ws');
   });
 });
 

--- a/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
+++ b/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * The Doctor-surface sweep for GHSA-2g2m-r86j-jg6h.
+ *
+ * The advisory's own remediation says to audit the REST of the Doctor surface
+ * for the same pattern: any check that interpolates free-form error text from a
+ * credential-bearing source hands that credential to a report with a "Copy
+ * report" button. These are the sinks that audit found, each proved by feeding a
+ * realistic credential through the real check.
+ *
+ * The engine-`config.toml` sink - the advisory's primary defect - is covered
+ * separately and in more depth by `engineConfigParseErrorRedaction.test.ts`.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { checkMcpServers } from '@process/doctor/checks/mcpChecks';
+import { checkBackends } from '@process/doctor/checks/backendChecks';
+import { checkEngineContractPin } from '@process/doctor/checks/engineChecks';
+import { runDoctor } from '@process/doctor/runner';
+import type { IMcpServer } from '@/common/config/storage';
+import type { DetectedAgent } from '@/common/types/detectedAgent';
+
+const API_KEY = 'sk-ant-api03-Zx91QmT4LpVn7BdKe0RsYcHu2WjAgF6oXlP3NtEbQvMk8ZaSdCyRfGhJ';
+const BEARER = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ3YXlsYW5kLXRlc3QifQ.s3cr3tS1gnatureV4lu3';
+
+/** Distinctive prefixes as well as whole values, so a partial leak still counts. */
+const findsSecret = (text: string): boolean =>
+  text.includes(API_KEY) ||
+  text.includes('sk-ant-api03-Zx91') ||
+  text.includes(BEARER) ||
+  text.includes('s3cr3tS1gnatureV4lu3');
+
+/** Every string a Doctor result can put in front of the user. */
+const surfaced = (result: { detail: string; remediation?: string }): string =>
+  `${result.detail}\n${result.remediation ?? ''}`;
+
+describe('MCP check — the probe error is free-form text from a credential-carrying declaration', () => {
+  const server = (name: string): IMcpServer =>
+    ({
+      id: name,
+      name,
+      enabled: true,
+      transport: { type: 'http', url: 'https://mcp.example.com', headers: { Authorization: `Bearer ${BEARER}` } },
+    }) as unknown as IMcpServer;
+
+  it('KNOWN POSITIVE: the matcher finds the secret in the unscrubbed probe text', () => {
+    expect(findsSecret(`401 Unauthorized (sent Authorization: Bearer ${BEARER})`)).toBe(true);
+  });
+
+  it('scrubs a bearer echoed back by a failing server', async () => {
+    const result = await checkMcpServers({
+      listServers: async () => [server('notion')],
+      testConnection: async () => ({
+        success: false,
+        error: `401 Unauthorized (sent Authorization: Bearer ${BEARER})`,
+      }),
+    });
+    expect(result.status).toBe('fail');
+    expect(findsSecret(surfaced(result))).toBe(false);
+    // Still names the server so the user knows what to fix.
+    expect(result.detail).toContain('notion');
+  });
+
+  it('scrubs an api_key echoed from a stdio server env', async () => {
+    const result = await checkMcpServers({
+      listServers: async () => [server('custom')],
+      testConnection: async () => ({
+        success: false,
+        error: `spawn failed: ANTHROPIC_API_KEY=${API_KEY} node ./server.js`,
+      }),
+    });
+    expect(findsSecret(surfaced(result))).toBe(false);
+    expect(result.detail).toContain('custom');
+  });
+});
+
+describe('backends check — loader errors come from credential-bearing config stores', () => {
+  const agents: DetectedAgent[] = [
+    { id: 'claude', name: 'Claude Code', kind: 'acp', available: true, backend: 'claude' } as unknown as DetectedAgent,
+  ];
+
+  it('scrubs a credential carried in a remote-agent loader error', async () => {
+    const result = await checkBackends({
+      getDetectedAgents: () => agents,
+      getLoadErrors: () => [`[remote] request rejected for token ${API_KEY}`],
+    });
+    expect(result.status).toBe('warn');
+    expect(findsSecret(surfaced(result))).toBe(false);
+    // Still reports that a loader failed, and how many.
+    expect(result.detail).toContain('1 loader error(s)');
+  });
+});
+
+describe('engine contract-pin check — raw fs error text', () => {
+  it('scrubs the binary-read failure message', async () => {
+    const result = await checkEngineContractPin(
+      {
+        binaryPath: () => '/opt/wayland/engine',
+        advertisedSchemaDigest: async () => {
+          throw new Error(`EACCES: /opt/wayland/engine (token ${API_KEY})`);
+        },
+      },
+      'sha256:0000'
+    );
+    expect(result.status).toBe('warn');
+    expect(findsSecret(surfaced(result))).toBe(false);
+    expect(result.detail).toContain('EACCES');
+  });
+});
+
+describe('runner — the catch-all for every check', () => {
+  it('scrubs a credential carried by a thrown check error', async () => {
+    const report = await runDoctor([
+      {
+        id: 'test.throws',
+        titleKey: 'test.throws',
+        category: 'config',
+        run: async () => {
+          throw new Error(`failed reading config: api_key = "${API_KEY}"`);
+        },
+      },
+    ]);
+    expect(report.results).toHaveLength(1);
+    const [result] = report.results;
+    expect(result.status).toBe('fail');
+    expect(findsSecret(surfaced(result))).toBe(false);
+    // Still says a check threw, so the failure is not silent.
+    expect(result.detail).toContain('Check threw an error');
+  });
+});

--- a/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
+++ b/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
@@ -386,6 +386,103 @@ describe('MCP check — the probe error is free-form text from a credential-carr
     expect(report.results[0].detail).toContain('mcp_11112222');
   });
 
+  /**
+   * THE FLAG RULE, pinned in BOTH directions.
+   *
+   * The rule started as an unanchored `/(key|token|secret|password|auth)/i` tested
+   * against the preceding arg OR the command, and every row below executed against
+   * it. It over-masked three diagnostics and missed six credential flags, so
+   * asserting only one side would have left the other free to move.
+   */
+  it('FLAG RULE — the diagnostics that must stay readable', async () => {
+    const readable: Array<[string, unknown, string, string]> = [
+      // An INLINE flag already yields its value through `unwrapVariants`, so
+      // flagging the NEXT argument bought nothing and cost the served directory.
+      [
+        'inline --api-key= then a path',
+        { type: 'stdio', command: 'npx', args: ['-y', `--api-key=${PREFIXLESS_KEY}`, '/Users/alice/Documents'] },
+        "ENOENT: no such file or directory, scandir '/Users/alice/Documents'",
+        '/Users/alice/Documents',
+      ],
+      // `auth` INSIDE `oauthy`: a package-name substring, not a credential flag.
+      [
+        'package name containing "oauth"',
+        { type: 'stdio', command: 'npx', args: ['-y', '@acme/oauthy-mcp', '/Users/alice/Documents'] },
+        "ENOENT: no such file or directory, scandir '/Users/alice/Documents'",
+        '/Users/alice/Documents',
+      ],
+      // `key` inside the COMMAND, which counts as the token before `args[0]` - so
+      // this masked the package name in the wrong-package failure. FF-6 again.
+      [
+        'command containing "key"',
+        { type: 'stdio', command: 'keyring-mcp', args: ['@modelcontextprotocol/server-filesystem'] },
+        "npm ERR! 404 '@modelcontextprotocol/server-filesystem' is not in the registry",
+        '@modelcontextprotocol/server-filesystem',
+      ],
+    ];
+
+    const results = await Promise.all(
+      readable.map(async ([why, transport, error, mustSurvive]) => ({
+        why,
+        mustSurvive,
+        detail: (
+          await checkMcpServers({
+            listServers: async () => [{ id: 'mcp_x', name: 'srv', enabled: true, transport } as unknown as IMcpServer],
+            testConnection: async () => ({ success: false, error }),
+          })
+        ).detail,
+      }))
+    );
+
+    for (const { why, mustSurvive, detail } of results) {
+      expect(detail, why).toContain(mustSurvive);
+      expect(detail, why).not.toContain('[redacted]');
+    }
+  });
+
+  it('FLAG RULE — every credential flag masks its separate value', async () => {
+    // All six of these leaked the full bare value. `PREFIXLESS_KEY` is the canary
+    // precisely because no scrubber sees it, so a mask here is the flag rule and
+    // nothing else - `--api-key` and `--token` ride along as known positives.
+    const flags = [
+      '--api-key',
+      '--token',
+      '--bearer',
+      '--credential',
+      '--pat',
+      '--session-id',
+      '--passphrase',
+      '--pwd',
+      '-X-Auth-Token',
+    ];
+    // KNOWN POSITIVE for the canary itself: unmasked, this text keeps the value.
+    expect(redactSecrets(`auth rejected for ${PREFIXLESS_KEY}`)).toContain(PREFIXLESS_KEY);
+
+    const results = await Promise.all(
+      flags.map(async (flag) => ({
+        flag,
+        detail: (
+          await checkMcpServers({
+            listServers: async () => [
+              {
+                id: 'mcp_x',
+                name: 'srv',
+                enabled: true,
+                transport: { type: 'stdio', command: 'npx', args: ['-y', 'pkg', flag, PREFIXLESS_KEY] },
+              } as unknown as IMcpServer,
+            ],
+            testConnection: async () => ({ success: false, error: `auth rejected for ${PREFIXLESS_KEY}` }),
+          })
+        ).detail,
+      }))
+    );
+
+    for (const { flag, detail } of results) {
+      expect(detail, flag).not.toContain(PREFIXLESS_KEY);
+      expect(detail, flag).toContain('[redacted]');
+    }
+  });
+
   it('PREFIXLESS CANARY: masks a token embedded in a hosted endpoint URL', async () => {
     // Path-embedded is the standard shape for Zapier / Smithery / Composio, and
     // undici echoes the URL in its own error text.

--- a/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
+++ b/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
@@ -696,6 +696,120 @@ describe('MCP check — a THROWN probe must not bypass the declaration masking',
   });
 });
 
+describe('MCP check — declaration masking across every credential SHAPE', () => {
+  // Executed against a PREFIXLESS secret, which is the only honest way to test
+  // this: a value with a recognisable prefix is masked by `redactSecrets` whatever
+  // the declaration does, so a passing assertion would prove nothing about the
+  // declaration masking at all.
+  const probe = async (transport: unknown, echo: string): Promise<string> => {
+    const result = await checkMcpServers({
+      listServers: async () => [{ id: 'srv', name: 'srv', enabled: true, transport } as unknown as IMcpServer],
+      testConnection: async () => ({ success: false, error: echo }),
+    });
+    return surfaced(result);
+  };
+
+  it('KNOWN POSITIVE: an UNDECLARED prefixless value is not masked, so these are real', async () => {
+    // The control this whole block depends on. If a bare 32-hex value were masked
+    // by the scrubber alone, every assertion below would hold vacuously.
+    const text = await probe(
+      { type: 'stdio', command: 'node', args: ['./server.js'] },
+      `rejected token ${PREFIXLESS_KEY}`
+    );
+    expect(text).toContain(PREFIXLESS_KEY);
+  });
+
+  const masked: Array<[string, unknown, string]> = [
+    // The two shapes this fix adds.
+    [
+      'space-separated flag: --api-key <value>',
+      { type: 'stdio', command: 'node', args: ['--api-key', PREFIXLESS_KEY] },
+      `rejected ${PREFIXLESS_KEY}`,
+    ],
+    [
+      'space-separated flag: --token <value>',
+      { type: 'stdio', command: 'node', args: ['server.js', '--token', PREFIXLESS_KEY] },
+      `bad token: ${PREFIXLESS_KEY}`,
+    ],
+    [
+      'command itself names the credential',
+      { type: 'stdio', command: 'x-auth-helper', args: [PREFIXLESS_KEY] },
+      `refused ${PREFIXLESS_KEY}`,
+    ],
+    [
+      'url path segment echoed alone',
+      { type: 'sse', url: `https://mcp.example.com/v1/${PREFIXLESS_KEY}/sse` },
+      `token ${PREFIXLESS_KEY} refused`,
+    ],
+    [
+      'url query value echoed alone',
+      { type: 'sse', url: `https://mcp.example.com/sse?t=${PREFIXLESS_KEY}&x=1` },
+      `token ${PREFIXLESS_KEY} refused`,
+    ],
+    // The shapes that already worked, kept here so a change to the extraction
+    // cannot quietly drop one of them.
+    ['env whole', { type: 'stdio', command: 'node', env: { K: PREFIXLESS_KEY } }, `rejected ${PREFIXLESS_KEY}`],
+    [
+      'header whole',
+      { type: 'http', url: 'https://mcp.example.com', headers: { 'X-Api-Key': PREFIXLESS_KEY } },
+      `rejected ${PREFIXLESS_KEY}`,
+    ],
+    [
+      'glued flag: --api-key=<value>',
+      { type: 'stdio', command: 'node', args: [`--api-key=${PREFIXLESS_KEY}`] },
+      `rejected ${PREFIXLESS_KEY}`,
+    ],
+  ];
+
+  it.each(masked)('masks %s', async (_label, transport, echo) => {
+    expect(await probe(transport, echo)).not.toContain(PREFIXLESS_KEY);
+  });
+
+  it('does NOT mask the hostname out of a URL declaration', async () => {
+    // The reason URL segments skip the scheme and authority. Masking the host turns
+    // the commonest hosted-server failure into `[redacted]`.
+    const text = await probe(
+      { type: 'sse', url: `https://mcp.example.com/v1/${PREFIXLESS_KEY}/sse` },
+      'getaddrinfo ENOTFOUND mcp.example.com'
+    );
+    expect(text).toContain('mcp.example.com');
+  });
+
+  it('does NOT mask a short structural path segment out of a URL', async () => {
+    // The reason the URL segment floor is 8 rather than the general 4. `proxy` and
+    // `stream` are route structure, and a 404 that names the route is the diagnostic.
+    const text = await probe(
+      { type: 'sse', url: `https://mcp.example.com/proxy/${PREFIXLESS_KEY}/stream` },
+      '404 Not Found for /proxy/<id>/stream on mcp.example.com'
+    );
+    expect(text).toContain('/proxy/');
+    expect(text).toContain('/stream');
+  });
+
+  it('does NOT mask a package name or a directory behind an ordinary flag', async () => {
+    // The FF-6 acceptance line, re-asserted against the new arg rule: neither `-y`
+    // nor the package name names a credential, so nothing here may be masked whole.
+    const text = await probe(
+      {
+        type: 'stdio',
+        command: 'npx',
+        args: ['-y', '@modelcontextprotocol/server-filesystem', '/Users/alice/Documents'],
+      },
+      "npm ERR! 404 GET https://registry.npmjs.org/@modelcontextprotocol/server-filesystem; ENOENT: no such file or directory, scandir '/Users/alice/Documents'"
+    );
+    expect(text).toContain('@modelcontextprotocol/server-filesystem');
+    expect(text).toContain('/Users/alice/Documents');
+  });
+
+  it('STATED LIMIT: a lone separator-free arg with no credential flag is NOT masked', async () => {
+    // Pinned deliberately, so the trade is visible rather than assumed. This shape
+    // is indistinguishable from a package name, and masking it whole is the FF-6
+    // regression. Change this test only alongside a real way to tell them apart.
+    const text = await probe({ type: 'stdio', command: 'node', args: [PREFIXLESS_KEY] }, `rejected ${PREFIXLESS_KEY}`);
+    expect(text).toContain(PREFIXLESS_KEY);
+  });
+});
+
 describe('MCP check — the server NAME is user-authored, so all four branches label by id', () => {
   // `server.name` comes straight from the Add Custom field or an imported JSON
   // file, so a credential pasted there becomes a line in a report the Doctor

--- a/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
+++ b/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
@@ -35,6 +35,7 @@ import { checkWorkspaceDrift, checkWorkspaceConfigured } from '@process/doctor/c
 import { collectConfiguredWorkspaces, collectWorkspaceConfigEntries } from '@process/doctor/workspaceInventory';
 import { runDoctor } from '@process/doctor/runner';
 import { redactSecrets } from '@process/utils/secretRedaction';
+import { resolveProjectWorkspacePath } from '@process/utils/workspaceLocation';
 import type { IMcpServer } from '@/common/config/storage';
 import type { DetectedAgent } from '@/common/types/detectedAgent';
 
@@ -632,6 +633,9 @@ describe('workspace inventory — the producer chooses the label', () => {
     listConversations: async () => [
       { id: 'conv-1', name: BARE_SECRET, extra: { workspace: '/gone/chat-ws', customWorkspace: false } },
     ],
+    // These two paths are OUTSIDE the app's base dir, so they are the user's own
+    // and stay verbatim. The app-derived case is the next describe block.
+    appManagedWorkspaceBase: '/Users/a/Documents/Wayland',
   } as unknown as Parameters<typeof collectConfiguredWorkspaces>[0];
 
   it('KNOWN POSITIVE: no scrubber can mask a bare credential used as a chat title', () => {
@@ -668,6 +672,180 @@ describe('workspace inventory — the producer chooses the label', () => {
     expect(result.status).toBe('fail');
     expect(result.detail).not.toContain(BARE_SECRET);
     expect(result.detail).toContain('/gone/ws');
+  });
+});
+
+describe('workspace inventory — for a PROJECT the name re-enters through the path', () => {
+  // The id-label fix closed the LABEL half only. A project's default workspace is
+  // `~/Documents/Wayland/<project-name>` (`allocateProjectWorkspace`) and the leaf
+  // is the sanitised name verbatim, so the drift detail printed the name anyway.
+  // Measured, not reasoned: the detail read
+  // `Project proj-1 -> /Users/a/Documents/Wayland/<the name>`.
+  const BASE = '/Users/a/Documents/Wayland';
+  const managed = `${BASE}/${BARE_SECRET}`;
+
+  const appDerived = {
+    listProjects: async () => [
+      { id: 'proj-1', name: BARE_SECRET, workspace: managed, pinned: false, createTime: 0, modifyTime: 0 },
+    ],
+    listConversations: async () => [
+      { id: 'conv-1', name: BARE_SECRET, extra: { workspace: managed, customWorkspace: false } },
+    ],
+    appManagedWorkspaceBase: BASE,
+  } as unknown as Parameters<typeof collectConfiguredWorkspaces>[0];
+
+  it('KNOWN POSITIVE: the leaf of a managed project workspace IS the sanitised name', () => {
+    // If `sanitizeProjectFolderName` ever stopped passing this shape through, the
+    // assertions below would hold for the wrong reason.
+    expect(resolveProjectWorkspacePath(BASE, BARE_SECRET, () => false)).toBe(managed);
+    // And no scrubber sees it, so the fix cannot be a scrub.
+    expect(redactSecrets(managed)).toContain(BARE_SECRET);
+  });
+
+  it('BARE CANARY: the drift detail carries neither the label nor the path leaf', async () => {
+    const result = await checkWorkspaceDrift({
+      listWorkspaces: () => collectConfiguredWorkspaces(appDerived),
+      // Not vacuous: this is what makes the entries reach the detail at all.
+      pathExists: async () => false,
+    });
+    expect(result.status).toBe('fail');
+    expect(surfaced(result)).not.toContain(BARE_SECRET);
+    // The base dir survives, because that is the half the user acts on.
+    expect(result.detail).toContain(BASE);
+    expect(result.detail).toContain('folder name withheld');
+  });
+
+  it('BARE CANARY: the configured-workspace detail carries neither half', async () => {
+    const result = await checkWorkspaceConfigured({
+      listWorkspaces: () => collectWorkspaceConfigEntries(appDerived),
+      tmpDir: '/var/folders/zz',
+    });
+    expect(result.status).toBe('warn');
+    expect(surfaced(result)).not.toContain(BARE_SECRET);
+    expect(result.detail).toContain(BASE);
+  });
+
+  it('still STATS the real path, so drift is not silently hidden', async () => {
+    // Collapsing `path` into `displayPath` would stat the base dir, which exists,
+    // and this check would stop failing on a missing workspace altogether.
+    const stated: string[] = [];
+    await checkWorkspaceDrift({
+      listWorkspaces: () => collectConfiguredWorkspaces(appDerived),
+      pathExists: async (path) => {
+        stated.push(path);
+        return false;
+      },
+    });
+    expect(stated).toEqual([managed]);
+  });
+
+  it('leaves a path the user chose OUTSIDE the base dir verbatim', async () => {
+    // Deliberate: a user-chosen path is not derived from an entity name, and it is
+    // the one the user most needs named in order to act on it.
+    const own = {
+      listProjects: async () => [
+        { id: 'proj-2', name: 'work', workspace: '/Users/a/code/myapp', pinned: false, createTime: 0, modifyTime: 0 },
+      ],
+      listConversations: async () => [],
+      appManagedWorkspaceBase: BASE,
+    } as unknown as Parameters<typeof collectConfiguredWorkspaces>[0];
+    const result = await checkWorkspaceDrift({
+      listWorkspaces: () => collectConfiguredWorkspaces(own),
+      pathExists: async () => false,
+    });
+    expect(result.detail).toContain('/Users/a/code/myapp');
+    expect(result.detail).not.toContain('withheld');
+  });
+
+  it('withholds a nested path under the base too, not just a direct child', async () => {
+    const nested = {
+      listProjects: async () => [
+        {
+          id: 'proj-3',
+          name: BARE_SECRET,
+          workspace: `${BASE}/${BARE_SECRET}/sub`,
+          pinned: false,
+          createTime: 0,
+          modifyTime: 0,
+        },
+      ],
+      listConversations: async () => [],
+      appManagedWorkspaceBase: BASE,
+    } as unknown as Parameters<typeof collectConfiguredWorkspaces>[0];
+    const result = await checkWorkspaceDrift({
+      listWorkspaces: () => collectConfiguredWorkspaces(nested),
+      pathExists: async () => false,
+    });
+    expect(surfaced(result)).not.toContain(BARE_SECRET);
+  });
+
+  it('a sibling directory whose name merely STARTS with the base is not withheld', async () => {
+    // `relative()` returns `../Waylandia/...` here, and the guard has to reject it
+    // on the separator rather than on a bare `..` prefix.
+    const sibling = {
+      listProjects: async () => [
+        {
+          id: 'proj-4',
+          name: 'x',
+          workspace: `${BASE}ia/mine`,
+          pinned: false,
+          createTime: 0,
+          modifyTime: 0,
+        },
+      ],
+      listConversations: async () => [],
+      appManagedWorkspaceBase: BASE,
+    } as unknown as Parameters<typeof collectConfiguredWorkspaces>[0];
+    const result = await checkWorkspaceDrift({
+      listWorkspaces: () => collectConfiguredWorkspaces(sibling),
+      pathExists: async () => false,
+    });
+    expect(result.detail).toContain(`${BASE}ia/mine`);
+  });
+
+  it('withholds a folder INSIDE the base whose name starts with two dots', async () => {
+    // The fail-open case for a naive `relative().startsWith('..')`: this path is
+    // inside the base, and its relative form `..hidden<key>` starts with `..`, so a
+    // guard without the separator calls it outside and prints the name. A
+    // conversation's `extra.workspace` is not passed through
+    // `sanitizeProjectFolderName`, so this shape is reachable.
+    const dotted = {
+      listProjects: async () => [],
+      listConversations: async () => [
+        { id: 'conv-9', name: 'x', extra: { workspace: `${BASE}/..hidden${BARE_SECRET}`, customWorkspace: true } },
+      ],
+      appManagedWorkspaceBase: BASE,
+    } as unknown as Parameters<typeof collectConfiguredWorkspaces>[0];
+    const result = await checkWorkspaceDrift({
+      listWorkspaces: () => collectConfiguredWorkspaces(dotted),
+      pathExists: async () => false,
+    });
+    expect(result.status).toBe('fail');
+    expect(surfaced(result)).not.toContain(BARE_SECRET);
+  });
+
+  it('withholds when the stored path differs from the base only in case', async () => {
+    // macOS and Windows filesystems are case-insensitive by default, so this names
+    // the same directory.
+    const cased = {
+      listProjects: async () => [
+        {
+          id: 'proj-5',
+          name: BARE_SECRET,
+          workspace: `/Users/a/documents/wayland/${BARE_SECRET}`,
+          pinned: false,
+          createTime: 0,
+          modifyTime: 0,
+        },
+      ],
+      listConversations: async () => [],
+      appManagedWorkspaceBase: BASE,
+    } as unknown as Parameters<typeof collectConfiguredWorkspaces>[0];
+    const result = await checkWorkspaceDrift({
+      listWorkspaces: () => collectConfiguredWorkspaces(cased),
+      pathExists: async () => false,
+    });
+    expect(surfaced(result)).not.toContain(BARE_SECRET);
   });
 });
 

--- a/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
+++ b/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
@@ -54,6 +54,9 @@ const BEARER = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ3YXlsYW5kLXRlc3QifQ.s3cr3tS1gnat
  * is the only kind of fix that cannot regress when a pattern set shifts.
  */
 const PREFIXLESS_KEY = 'a1b2c3d4e5f60718293a4b5c6d7e8f90';
+
+/** Alphanumeric-opening semver build tail, sliced to length by the TAIL BOUND ORACLE. */
+const BUILD_TAIL = 'a1b2c3d4e5f6';
 const PREFIXLESS_ASSIGNMENT = `AZURE_OPENAI_API_KEY=${PREFIXLESS_KEY}`;
 
 /**
@@ -754,7 +757,6 @@ describe('engine reachability check — unbounded `--version` stdout', () => {
    * number to quote about this sink.
    */
   it('TAIL BOUND ORACLE: a build tail passes at 11 characters and is refused at 12', async () => {
-    const tail = (n: number): string => 'a1b2c3d4e5f6'.slice(0, n);
     const cases = await Promise.all(
       (['+', '-'] as const).flatMap((separator) =>
         [11, 12].map(async (n) => ({
@@ -763,7 +765,8 @@ describe('engine reachability check — unbounded `--version` stdout', () => {
           result: await checkEngineReachable(() => ({
             available: true,
             path: '/opt/e',
-            version: `0.13.0${separator}${tail(n)} `,
+            // Alphanumeric-opening tail, the only shape the pattern allows.
+            version: `0.13.0${separator}${BUILD_TAIL.slice(0, n)} `,
           })),
         }))
       )
@@ -772,7 +775,7 @@ describe('engine reachability check — unbounded `--version` stdout', () => {
       const why = `${separator}${n}`;
       if (n === 11) {
         expect(result.status, why).toBe('pass');
-        expect(result.detail, why).toContain(`0.13.0${separator}${tail(11)}`);
+        expect(result.detail, why).toContain(`0.13.0${separator}${BUILD_TAIL.slice(0, 11)}`);
       } else {
         expect(result.status, why).toBe('warn');
         expect(result.detail, why).toContain('did not report a usable version');
@@ -1027,6 +1030,47 @@ describe('MCP check — declaration masking across every credential SHAPE', () =
     );
     expect(text).toContain('/proxy/');
     expect(text).toContain('/stream');
+  });
+
+  /**
+   * THE OTHER SIDE OF THE FLOOR'S OWN BOUNDARY, which was untested.
+   *
+   * The test above exercises 5 and 6 characters only, so nothing pinned where the
+   * rule actually switches. Measured: 7 survives, 8 is masked. That means ordinary
+   * route names DO get masked - `messages` (the Streamable HTTP spec's own path),
+   * `endpoint`, `connectors`, `streamable`, `healthcheck` all read `[redacted]` in
+   * an echoed 404.
+   *
+   * DECIDED, and the threshold is deliberately NOT raised. The trade is asymmetric:
+   * a masked route name costs a reader one word they can recover from their own
+   * settings, while the status code, the hostname and the surrounding path all
+   * survive - whereas an unmasked short path token is a credential in a report with
+   * a "Copy report" button, and nothing recovers that. Raising the floor to clear
+   * `messages` would un-mask every 8-to-11-character path token to buy prettier
+   * 404s, which is the wrong direction for this surface and against the
+   * over-withhold convention the rest of this file follows. Pinned in both
+   * directions so the boundary cannot move unnoticed.
+   */
+  it('URL SEGMENT BOUNDARY: 7 characters survive, 8 are masked', async () => {
+    const survives = await probe(
+      { type: 'sse', url: 'https://mcp.example.com/connect/rpc' },
+      '404 Not Found for /connect/rpc'
+    );
+    expect(survives).toContain('/connect/rpc');
+
+    // `messages` is a REAL MCP route, not a contrived string, which is what makes
+    // this the accepted cost rather than a hypothetical one.
+    const eaten = await probe(
+      { type: 'sse', url: 'https://mcp.example.com/messages/rpc' },
+      '404 Not Found for /messages/rpc on host mcp.example.com'
+    );
+    expect(eaten).not.toContain('messages');
+    expect(eaten).toContain('[redacted]');
+    // NOT VACUOUS, and this is what makes the cost affordable: the code, the host
+    // and the rest of the path all still reach the user.
+    expect(eaten).toContain('404 Not Found');
+    expect(eaten).toContain('mcp.example.com');
+    expect(eaten).toContain('/rpc');
   });
 
   it('does NOT mask a package name or a directory behind an ordinary flag', async () => {

--- a/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
+++ b/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
@@ -696,15 +696,28 @@ describe('engine reachability check — unbounded `--version` stdout', () => {
   });
 
   /**
-   * THE PARTIAL-LEAK FLOOR, measured rather than picked.
+   * THE CORPUS FLOOR - a property of THESE EIGHT BANNERS, not a bound on the sink.
    *
-   * Across the eight adversarial banners the longest CONTIGUOUS run of any of the
-   * five credentials that reaches the surfaced text is 2 characters, and those two
-   * are incidental collisions with the fixed English copy ("Engine binary found
-   * at ..."), not credential material. The bound below is that measurement. For
-   * scale, the equivalent floor on the engine banner before the anchors was 25.
+   * CORRECTION, and the reason the title changed. This oracle used to be called
+   * "no more than 2 contiguous characters of any credential reach the surface", and
+   * a note beside it read "the equivalent floor before the anchors was 25", which
+   * invited the sink-wide reading. That reading is FALSE and was refuted by
+   * execution: `0.13.0+a1b2c3d4e5f ` and `0.13.0-a1b2c3d4e5f ` both return
+   * `status: pass` with detail `Wayland Core engine 0.13.0+a1b2c3d4e5f is
+   * reachable.` - ELEVEN contiguous credential characters surfaced, with this suite
+   * green. Eleven is where the `{0,10}` tail quantifier runs out; at twelve the
+   * pattern refuses the banner entirely and the check warns.
+   *
+   * So 2 is what the eight banners below happen to produce, and those two are
+   * incidental collisions with the fixed English copy ("Engine binary found at
+   * ..."), not credential material. The real bound on the sink is the SHAPE plus
+   * `MAX_VERSION_LENGTH`, which the ANCHOR and CAP oracles above pin directly.
+   * That 11-character build tail is a declared non-finding - a legal semver build
+   * tail is exactly what the allowlist is for - and this oracle is not the place
+   * to relitigate it. What it does establish is that nothing in this corpus
+   * regresses, which is worth keeping and worth naming accurately.
    */
-  it('FLOOR ORACLE: no more than 2 contiguous characters of any credential reach the surface', async () => {
+  it('CORPUS FLOOR ORACLE: none of these eight banners surfaces more than 2 credential characters', async () => {
     const secrets = [PREFIXLESS_KEY, API_KEY, 'A'.repeat(40), 'b'.repeat(46), 'c'.repeat(58)];
     const banners = [
       `1.0.0-sk-ant-api03-${'A'.repeat(40)}`,
@@ -729,6 +742,40 @@ describe('engine reachability check — unbounded `--version` stdout', () => {
       const text = surfaced(result);
       for (const secret of secrets) {
         expect(longestSecretRun(text, secret)).toBeLessThanOrEqual(2);
+      }
+    }
+  });
+
+  /**
+   * THE MEASURED BOUND, stated where the corpus floor above cannot mislead.
+   *
+   * Pinned in both directions so the `{0,10}` quantifier cannot move silently: 11
+   * tail characters pass and are echoed, 12 are refused outright. This is the
+   * number to quote about this sink.
+   */
+  it('TAIL BOUND ORACLE: a build tail passes at 11 characters and is refused at 12', async () => {
+    const tail = (n: number): string => 'a1b2c3d4e5f6'.slice(0, n);
+    const cases = await Promise.all(
+      (['+', '-'] as const).flatMap((separator) =>
+        [11, 12].map(async (n) => ({
+          separator,
+          n,
+          result: await checkEngineReachable(() => ({
+            available: true,
+            path: '/opt/e',
+            version: `0.13.0${separator}${tail(n)} `,
+          })),
+        }))
+      )
+    );
+    for (const { separator, n, result } of cases) {
+      const why = `${separator}${n}`;
+      if (n === 11) {
+        expect(result.status, why).toBe('pass');
+        expect(result.detail, why).toContain(`0.13.0${separator}${tail(11)}`);
+      } else {
+        expect(result.status, why).toBe('warn');
+        expect(result.detail, why).toContain('did not report a usable version');
       }
     }
   });

--- a/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
+++ b/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
@@ -1087,7 +1087,74 @@ describe('workspace inventory — for a PROJECT the name re-enters through the p
   });
 });
 
-describe('runner — the catch-all for every check', () => {
+describe('runner — the whole-surface guarantees', () => {
+  it('NEVER-THROWS ORACLE: an Error whose message getter throws does not escape', async () => {
+    // Reading `error.message` was the hole in the never-throws contract: the
+    // extraction itself threw, the rejection escaped `Promise.all`, `runDoctor`
+    // rejected, and the SECONDARY error reached `doctorBridge` unscrubbed
+    // [executed]. Exotic, but the contract is either true or it is not.
+    class Hostile extends Error {
+      override get message(): string {
+        throw new Error(`secondary carrying ${API_KEY}`);
+      }
+    }
+
+    const report = await runDoctor([
+      {
+        id: 'test.hostile',
+        titleKey: 'test.hostile',
+        category: 'config',
+        run: async () => {
+          throw new Hostile();
+        },
+      },
+    ]);
+
+    const [result] = report.results;
+    expect(result.status).toBe('fail');
+    expect(findsSecret(surfaced(result))).toBe(false);
+    // Still says a check threw, so the failure is not silent.
+    expect(result.detail).toContain('Check threw an error');
+  });
+
+  it('LENGTH ORACLE: an unbounded detail is capped at the report boundary', async () => {
+    // Executed on the unfixed runner a 2,000,000-character probe error produced a
+    // 2,000,052-character detail, which the UI renders and offers to copy.
+    const report = await runDoctor([
+      {
+        id: 'test.huge',
+        titleKey: 'test.huge',
+        category: 'config',
+        run: async () => ({
+          status: 'fail' as const,
+          detail: 'q'.repeat(2_000_000),
+          remediation: 'r'.repeat(2_000_000),
+        }),
+      },
+    ]);
+
+    const [result] = report.results;
+    expect(result.detail).toHaveLength(4_000);
+    expect(result.remediation).toHaveLength(4_000);
+    expect(result.detail).toContain('[truncated]');
+  });
+
+  it('leaves an ordinary detail untouched, including a large real one', async () => {
+    // The cap must not be trimming real diagnostics. 3,000 characters is about a
+    // twenty-server MCP failure, the largest this surface legitimately produces.
+    const real = `${'a'.repeat(3_000)} end`;
+    const report = await runDoctor([
+      {
+        id: 'test.real',
+        titleKey: 'test.real',
+        category: 'config',
+        run: async () => ({ status: 'warn' as const, detail: real }),
+      },
+    ]);
+    expect(report.results[0].detail).toBe(real);
+    expect(report.results[0].detail).not.toContain('[truncated]');
+  });
+
   it('scrubs a credential carried by a thrown check error', async () => {
     const report = await runDoctor([
       {

--- a/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
+++ b/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
@@ -447,6 +447,16 @@ describe('MCP check — the probe error is free-form text from a credential-carr
     // All six of these leaked the full bare value. `PREFIXLESS_KEY` is the canary
     // precisely because no scrubber sees it, so a mask here is the flag rule and
     // nothing else - `--api-key` and `--token` ride along as known positives.
+    //
+    // The PLURALS and the three unmatched spellings are a REGRESSION PIN, added
+    // after the `(?![a-z])` anchor silently narrowed this rule: a plural `s` is a
+    // lowercase letter, so `--tokens`, `--secrets`, `--keys`, `--apikeys`,
+    // `--passwords`, `--credentials`, `--pats` and `--sessions` each masked before
+    // the anchor landed and leaked the full bare value afterwards [executed pre and
+    // post]. `--authorization` is the reachable one - an ordinary option spelling.
+    // `--passwd`, `--sessionid` and `--sessionId` never matched in either version;
+    // `passwd` is already a label in `secretRedaction`'s LABELLED_SECRET_ASSIGNMENT,
+    // so omitting it left two defences disagreeing about one word.
     const flags = [
       '--api-key',
       '--token',
@@ -457,6 +467,18 @@ describe('MCP check — the probe error is free-form text from a credential-carr
       '--passphrase',
       '--pwd',
       '-X-Auth-Token',
+      '--tokens',
+      '--secrets',
+      '--keys',
+      '--apikeys',
+      '--passwords',
+      '--credentials',
+      '--pats',
+      '--sessions',
+      '--authorization',
+      '--passwd',
+      '--sessionid',
+      '--sessionId',
     ];
     // KNOWN POSITIVE for the canary itself: unmasked, this text keeps the value.
     expect(redactSecrets(`auth rejected for ${PREFIXLESS_KEY}`)).toContain(PREFIXLESS_KEY);

--- a/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
+++ b/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
@@ -81,6 +81,30 @@ const findsSecret = (text: string): boolean =>
 /** Separate matcher for the prefixless canary, on the VALUE not the label. */
 const findsPrefixlessKey = (text: string): boolean => text.includes(PREFIXLESS_KEY);
 
+/**
+ * Length of the longest CONTIGUOUS run of `secret` that appears anywhere in
+ * `text`, so a PARTIAL disclosure counts.
+ *
+ * A whole-literal `not.toContain` is not an oracle for a truncating defence: a
+ * 32-character cap satisfies it while still handing out 25 characters of a
+ * credential. That is exactly how the engine banner's two protections came to be
+ * individually unpinned - reverting either one on its own left the suite green,
+ * because the cap trimmed every payload just enough. Assert against this instead
+ * and state the floor.
+ */
+const longestSecretRun = (text: string, secret: string): number => {
+  let best = 0;
+  for (let start = 0; start < secret.length; start += 1) {
+    for (let end = secret.length; end > start + best; end -= 1) {
+      if (text.includes(secret.slice(start, end))) {
+        best = end - start;
+        break;
+      }
+    }
+  }
+  return best;
+};
+
 /** Every string a Doctor result can put in front of the user. */
 const surfaced = (result: { detail: string; remediation?: string }): string =>
   `${result.detail}\n${result.remediation ?? ''}`;
@@ -410,6 +434,106 @@ describe('engine reachability check — unbounded `--version` stdout', () => {
       expect(text).not.toContain(long);
       // Belt-and-braces cap: nothing version-shaped can be long.
       expect(text.length).toBeLessThan(200);
+    }
+  });
+
+  /**
+   * THE ANCHOR ORACLE, and it exists because the assertions above are not one.
+   *
+   * They are whole-literal `not.toContain` checks, and `MAX_VERSION_LENGTH`
+   * truncates every payload above just enough to satisfy them. Executed: with the
+   * anchors reverted to the original unbounded `[\w.+-]*` tail and the 32-char cap
+   * left in place, `0.13.0_<32 hex>` surfaced `0.13.0_f0e9d8c7b6a59483726150413`
+   * with the whole suite still green - 25 characters of a credential.
+   *
+   * So this pins what the ANCHORS do, which is REFUSE these banners rather than
+   * trim them. `warn` is the observable difference: the anchored pattern finds no
+   * version at all, so the check reports a broken build and echoes nothing, while
+   * the unanchored one matches from inside the credential and returns `pass`.
+   */
+  it('ANCHOR ORACLE: each adversarial banner is REFUSED, not merely truncated', async () => {
+    const refused = [
+      // Prerelease tail that runs into a key: the tail must not extend over `-`.
+      `1.0.0-sk-ant-api03-${'A'.repeat(40)}`,
+      // Glued suffix: `_` is `\w`, so the trailing lookahead must reject it.
+      `0.13.0_${PREFIXLESS_KEY}`,
+      // Build tail that runs into a JWT: bounded at 11 characters, so it cannot
+      // reach the end and the whole match fails.
+      `0.13.0+build.${'eyJhbGciOiJIUzI1NiJ9'}.${'b'.repeat(46)}`,
+      // No version banner at all - the leading lookbehind is what stops the search
+      // starting INSIDE the token.
+      `token=sk-ant-1.2.3-${'c'.repeat(58)}`,
+      // Unbounded run after a legal version.
+      `9.9.9-${'x'.repeat(200_000)}`,
+      // A real Anthropic key glued to a legal version.
+      `0.13.0-${API_KEY}`,
+    ];
+
+    const results = await Promise.all(
+      refused.map((version) => checkEngineReachable(() => ({ available: true, path: '/opt/e', version })))
+    );
+
+    for (const result of results) {
+      expect(result.status).toBe('warn');
+      expect(result.detail).toContain('did not report a usable version');
+    }
+  });
+
+  /**
+   * THE CAP ORACLE, independent of the anchors.
+   *
+   * With the anchors in place the only unbounded part of the pattern is `\d+`, so a
+   * long numeric run is the ONLY input that can reach `MAX_VERSION_LENGTH` - which
+   * is the whole point of having a second bound that does not depend on reading a
+   * regex correctly. This banner matches under BOTH the anchored and the unanchored
+   * pattern, so the assertion below moves only when the CAP moves.
+   */
+  it('CAP ORACLE: a version-shaped banner longer than the cap is truncated at exactly 32', async () => {
+    const result = await checkEngineReachable(() => ({
+      available: true,
+      path: '/opt/e',
+      version: `${'9'.repeat(40)}.0.0`,
+    }));
+    expect(result.status).toBe('pass');
+    expect(result.detail).toBe(`Wayland Core engine ${'9'.repeat(32)} is reachable.`);
+    expect(result.detail).not.toContain('9'.repeat(33));
+  });
+
+  /**
+   * THE PARTIAL-LEAK FLOOR, measured rather than picked.
+   *
+   * Across the eight adversarial banners the longest CONTIGUOUS run of any of the
+   * five credentials that reaches the surfaced text is 2 characters, and those two
+   * are incidental collisions with the fixed English copy ("Engine binary found
+   * at ..."), not credential material. The bound below is that measurement. For
+   * scale, the equivalent floor on the engine banner before the anchors was 25.
+   */
+  it('FLOOR ORACLE: no more than 2 contiguous characters of any credential reach the surface', async () => {
+    const secrets = [PREFIXLESS_KEY, API_KEY, 'A'.repeat(40), 'b'.repeat(46), 'c'.repeat(58)];
+    const banners = [
+      `1.0.0-sk-ant-api03-${'A'.repeat(40)}`,
+      `0.13.0_${PREFIXLESS_KEY}`,
+      `0.13.0+build.${'eyJhbGciOiJIUzI1NiJ9'}.${'b'.repeat(46)}`,
+      `token=sk-ant-1.2.3-${'c'.repeat(58)}`,
+      `9.9.9-${'x'.repeat(200_000)}`,
+      `wayland-core 0.13.0 (env ${PREFIXLESS_ASSIGNMENT})`,
+      `${'9'.repeat(40)}.0.0`,
+      `0.13.0-${API_KEY}`,
+    ];
+
+    const results = await Promise.all(
+      banners.map((version) => checkEngineReachable(() => ({ available: true, path: '/opt/e', version })))
+    );
+
+    // KNOWN POSITIVE: the measurement finds a long run when one is really there,
+    // so a row of zeroes below is a result and not a broken helper.
+    expect(longestSecretRun(`banner 0.13.0_${PREFIXLESS_KEY}`, PREFIXLESS_KEY)).toBe(PREFIXLESS_KEY.length);
+
+    for (const result of results) {
+      const text = surfaced(result);
+      for (const secret of secrets) {
+        expect(longestSecretRun(text, secret)).toBeLessThanOrEqual(2);
+      }
     }
   });
 

--- a/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
+++ b/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
@@ -35,6 +35,7 @@ import { checkEngineContractPin, checkEngineReachable } from '@process/doctor/ch
 import { checkWorkspaceDrift, checkWorkspaceConfigured } from '@process/doctor/checks/workspaceChecks';
 import { collectConfiguredWorkspaces, collectWorkspaceConfigEntries } from '@process/doctor/workspaceInventory';
 import { runDoctor } from '@process/doctor/runner';
+import { validateMcpServer } from '@process/services/mcpServices/validateMcpServer';
 import { redactSecrets } from '@process/utils/secretRedaction';
 import { resolveProjectWorkspacePath } from '@process/utils/workspaceLocation';
 import type { IMcpServer } from '@/common/config/storage';
@@ -286,6 +287,103 @@ describe('MCP check — the probe error is free-form text from a credential-carr
     });
     expect(missingDir.detail).toContain('ENOENT: no such file or directory');
     expect(missingDir.detail).toContain("scandir '/Users/alice/Documents'");
+  });
+
+  /**
+   * THE THROWN-VALIDATOR ROUTE, end to end through the real validator.
+   *
+   * `doctorServerLabel` emits the id and not the name, and that closed the LABEL.
+   * It did nothing for the MESSAGE: `McpService.testMcpConnection` calls
+   * `validateMcpServer` SYNCHRONOUSLY before it spawns anything, the validator
+   * interpolates the name into its throw (`Invalid MCP server URL for "<name>":
+   * <url>`), and `probeWithTimeout` converts that throw into
+   * `{ success: false, error: error.message }` - straight into the errored branch.
+   * Executed on the unfixed check the detail read `mcp_5c1a7e64-... (Invalid MCP
+   * server URL for "f0e9d8c7b6a5948372615041302f1e0d": [redacted])`: id right, url
+   * masked, name whole.
+   *
+   * `SAFE_MCP_NAME` is `[A-Za-z0-9_.-]+`, so a bare 32-hex name is storable, and the
+   * declarations that trip these throws are precisely the older installs and JSON
+   * imports `probeWithTimeout`'s catch exists for.
+   *
+   * NOT A VACUOUS ORACLE: `id` and `name` are deliberately DIFFERENT here, so
+   * `not.toContain(name)` cannot be satisfied by the label, and the id is asserted
+   * present so the check has not simply gone quiet.
+   */
+  it('THROWN-VALIDATOR CANARY: the real validator cannot carry the server NAME out', async () => {
+    const id = 'mcp_5c1a7e64-0f2b-4d90-9a11-6b83c2f4de07';
+    const declarations: Array<[string, unknown]> = [
+      // The unparseable-URL throw.
+      ['bad url', { type: 'streamable_http', url: 'not-a-valid-url' }],
+      // The scheme throw.
+      ['bad scheme', { type: 'sse', url: 'ftp://mcp.example.com/sse' }],
+      // The SSRF throw, which interpolates the name from a THIRD call site.
+      ['metadata host', { type: 'http', url: 'http://169.254.169.254/latest/meta-data/' }],
+      // The env-key throw, on a different transport kind entirely.
+      ['bad env key', { type: 'stdio', command: 'node', args: [], env: { 'bad-key': 'value' } }],
+    ];
+
+    const probed = await Promise.all(
+      declarations.map(async ([why, transport]) => {
+        const declaration = { id, name: PREFIXLESS_KEY, enabled: true, transport } as unknown as IMcpServer;
+        // KNOWN POSITIVE: the validator really does throw, and its raw message
+        // really does carry the name - so a clean detail below is masking, not luck.
+        let raw = '';
+        try {
+          validateMcpServer(declaration);
+        } catch (error) {
+          raw = (error as Error).message;
+        }
+        const result = await checkMcpServers({
+          listServers: async () => [declaration],
+          testConnection: async (candidate) => {
+            validateMcpServer(candidate);
+            return { success: true };
+          },
+        });
+        return { why, raw, result };
+      })
+    );
+
+    for (const { why, raw, result } of probed) {
+      expect(raw, `${why}: expected the validator to throw`).toContain(PREFIXLESS_KEY);
+      // And no scrubber sees it, which is why the fix has to be structural.
+      expect(redactSecrets(raw), why).toContain(PREFIXLESS_KEY);
+      expect(result.status, why).toBe('fail');
+      expect(result.detail, why).not.toContain(PREFIXLESS_KEY);
+      // Not vacuous: the row still names WHICH server, by its app-generated id.
+      expect(result.detail, why).toContain(id);
+    }
+  });
+
+  it('THROWN-VALIDATOR CANARY: and through the whole runner, not just the check', async () => {
+    // `runDoctor`'s catch-all runs `redactSecrets` and knows nothing about the
+    // declaration, so a route that escaped `checkMcpServers` would land there
+    // unmasked. Pinned end to end so the two layers cannot both be assumed.
+    const report = await runDoctor([
+      {
+        id: 'mcp.servers',
+        titleKey: 'settings.doctor.checks.mcpServers',
+        category: 'mcp',
+        run: () =>
+          checkMcpServers({
+            listServers: async () => [
+              {
+                id: 'mcp_11112222',
+                name: PREFIXLESS_KEY,
+                enabled: true,
+                transport: { type: 'streamable_http', url: 'not-a-valid-url' },
+              } as unknown as IMcpServer,
+            ],
+            testConnection: async (candidate) => {
+              validateMcpServer(candidate);
+              return { success: true };
+            },
+          }),
+      },
+    ]);
+    expect(surfaced(report.results[0])).not.toContain(PREFIXLESS_KEY);
+    expect(report.results[0].detail).toContain('mcp_11112222');
   });
 
   it('PREFIXLESS CANARY: masks a token embedded in a hosted endpoint URL', async () => {

--- a/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
+++ b/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
@@ -1245,6 +1245,66 @@ describe('MCP check — the server NAME is user-authored, so all four branches l
     // Not vacuous: the branch really did name this server, by its id.
     expect(outcome.detail).toContain(server.id);
   });
+
+  it('NEVER-THROWS ORACLE: a declaration with no name at all still reports every server', async () => {
+    // REGRESSION PIN. `IMcpServer.name` is declared non-optional, so reading
+    // `.length` off it type-checks - but a stored declaration is not a type. The
+    // config migration copies `mcp.config` entries VERBATIM out of an external
+    // `wayland-config.txt`, so a nameless entry reaches the check [executed: it threw
+    // `Cannot read properties of undefined (reading 'length')` straight out of
+    // `checkMcpServers`]. Not a leak: a diagnostic fail-closed. The throw escapes into
+    // `runOne`'s per-check catch and collapses the whole MCP row to `Check threw an
+    // error: ...`, destroying the healthy servers' per-server detail too - the #273
+    // mode `probeWithTimeout`'s catch exists to prevent.
+    const results = await Promise.all(
+      [undefined, null].map(async (name) => ({
+        name: String(name),
+        detail: (
+          await checkMcpServers({
+            listServers: async () =>
+              [
+                { id: 'mcp_nameless', name, enabled: true, transport: { type: 'stdio', command: 'node' } },
+                { id: 'mcp_healthy', name: 'srv', enabled: true, transport: { type: 'stdio', command: 'node' } },
+              ] as unknown as IMcpServer[],
+            testConnection: async (server) => ({ success: false, error: `boom ${server.id}` }),
+          })
+        ).detail,
+      }))
+    );
+
+    for (const { name, detail } of results) {
+      // Both servers keep their own detail, which is what the throw destroyed.
+      expect(detail, name).toContain('mcp_nameless');
+      expect(detail, name).toContain('mcp_healthy');
+    }
+  });
+
+  it('NAME FLOOR: a 2-3 char name is not masked, a 4-char one is', async () => {
+    // The floor exists so a server named `db` does not blank every "db" in the probe
+    // text - the FF-6 direction, one letter at a time. Both sides are pinned because
+    // dropping the condition and pushing unconditionally left the suite fully green.
+    const detail = async (name: string, error: string): Promise<string> =>
+      (
+        await checkMcpServers({
+          listServers: async () => [
+            {
+              id: 'mcp_floor',
+              name,
+              enabled: true,
+              transport: { type: 'stdio', command: 'node' },
+            } as unknown as IMcpServer,
+          ],
+          testConnection: async () => ({ success: false, error }),
+        })
+      ).detail;
+
+    // BELOW the floor: survives, quotes and all.
+    expect(await detail('db', 'cannot open "db"')).toContain('"db"');
+    expect(await detail('abc', 'cannot open "abc"')).toContain('"abc"');
+    // AT the floor: masked, so the assertions above are a boundary and not a no-op.
+    expect(await detail('abcd', 'cannot open "abcd"')).not.toContain('"abcd"');
+    expect(await detail('abcd', 'cannot open "abcd"')).toContain('[redacted]');
+  });
 });
 
 describe('workspace inventory — the producer chooses the label', () => {

--- a/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
+++ b/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
@@ -28,6 +28,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { checkMcpServers } from '@process/doctor/checks/mcpChecks';
+import type { McpTestResult } from '@process/doctor/checks/mcpChecks';
 import { checkBackends } from '@process/doctor/checks/backendChecks';
 import { checkEngineContractPin, checkEngineReachable } from '@process/doctor/checks/engineChecks';
 import { checkWorkspaceDrift, checkWorkspaceConfigured } from '@process/doctor/checks/workspaceChecks';
@@ -567,6 +568,55 @@ describe('MCP check — a THROWN probe must not bypass the declaration masking',
     expect(result.detail).toContain('ok');
     expect(result.detail).toContain('plain failure');
     expect(findsPrefixlessKey(surfaced(result))).toBe(false);
+  });
+});
+
+describe('MCP check — the server NAME is user-authored, so all four branches label by id', () => {
+  // `server.name` comes straight from the Add Custom field or an imported JSON
+  // file, so a credential pasted there becomes a line in a report the Doctor
+  // panel offers to copy - the same defect as the conversation name, in a file
+  // that renders it four separate times. `enabled: true` is load-bearing:
+  // `checkMcpServers` filters on it, and a harness that omits it exercises
+  // nothing at all.
+  const named = (): IMcpServer =>
+    ({
+      id: 'mcp_5c1a7e64-0f2b-4d90-9a11-6b83c2f4de07',
+      name: BARE_SECRET,
+      enabled: true,
+      transport: { type: 'stdio', command: 'node' },
+    }) as unknown as IMcpServer;
+
+  it('KNOWN POSITIVE: the harness reaches the check at all, and no scrubber can mask this name', async () => {
+    // Two controls in one. First: a DISABLED server is filtered out, so if the
+    // assertions below ever pass because the server never reached the loop, this
+    // control is the only thing that would notice.
+    const skipped = await checkMcpServers({
+      listServers: async () => [{ ...named(), enabled: false } as IMcpServer],
+      testConnection: async () => ({ success: false, error: 'boom' }),
+    });
+    expect(skipped.detail).toBe('No MCP servers are enabled.');
+    // Second: the scrub-only option was never available for this sink.
+    expect(redactSecrets(BARE_SECRET)).toContain(BARE_SECRET);
+  });
+
+  const branches: Array<{ label: string; result: McpTestResult | 'hang'; expect: 'fail' | 'warn' }> = [
+    { label: 'errored', result: { success: false, error: 'MCP error -32000: Connection closed' }, expect: 'fail' },
+    { label: 'needsAuth', result: { success: false, needsAuth: true }, expect: 'warn' },
+    { label: 'toolless', result: { success: true, tools: [] }, expect: 'warn' },
+    { label: 'timedOut', result: 'hang', expect: 'fail' },
+  ];
+
+  it.each(branches)('BARE CANARY: the $label branch names the id, not the name', async ({ result, expect: status }) => {
+    const server = named();
+    const outcome = await checkMcpServers({
+      listServers: async () => [server],
+      testConnection: result === 'hang' ? () => new Promise<McpTestResult>(() => {}) : async () => result,
+      perServerTimeoutMs: 25,
+    });
+    expect(outcome.status).toBe(status);
+    expect(surfaced(outcome)).not.toContain(BARE_SECRET);
+    // Not vacuous: the branch really did name this server, by its id.
+    expect(outcome.detail).toContain(server.id);
   });
 });
 

--- a/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
+++ b/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
@@ -1319,6 +1319,27 @@ describe('runner — the whole-surface guarantees', () => {
     expect(result.detail).toContain('Check threw an error');
   });
 
+  it('NEVER-THROWS ORACLE: an outcome missing its detail does not reject the report', async () => {
+    // `bounded` runs OUTSIDE the per-check guard - `runOne`'s trailing `try` has a
+    // `finally` and no `catch` - so `boundedField(undefined)` read
+    // `undefined.length` and `runDoctor` REJECTED with `Cannot read properties of
+    // undefined (reading 'length')` [executed]. TypeScript forbids this outcome, and
+    // so did it forbid the hostile-getter case guarded above; bounding every field
+    // is what introduced the exposure, and pre-delta the same input was harmless.
+    const report = await runDoctor([
+      {
+        id: 'test.detailless',
+        titleKey: 'test.detailless',
+        category: 'config',
+        run: async () => ({ status: 'pass' }) as never,
+      },
+    ]);
+    expect(report.results).toHaveLength(1);
+    expect(report.results[0].detail).toBe('');
+    // Not vacuous: the report still aggregates, so the battery completed.
+    expect(report.counts.pass).toBe(1);
+  });
+
   it('LENGTH ORACLE: an unbounded detail is capped at the report boundary', async () => {
     // Executed on the unfixed runner a 2,000,000-character probe error produced a
     // 2,000,052-character detail, which the UI renders and offers to copy.

--- a/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
+++ b/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
@@ -29,7 +29,8 @@
 import { describe, expect, it } from 'vitest';
 import { checkMcpServers } from '@process/doctor/checks/mcpChecks';
 import { checkBackends } from '@process/doctor/checks/backendChecks';
-import { checkEngineContractPin } from '@process/doctor/checks/engineChecks';
+import { checkEngineContractPin, checkEngineReachable } from '@process/doctor/checks/engineChecks';
+import { checkWorkspaceDrift, checkWorkspaceConfigured } from '@process/doctor/checks/workspaceChecks';
 import { runDoctor } from '@process/doctor/runner';
 import type { IMcpServer } from '@/common/config/storage';
 import type { DetectedAgent } from '@/common/types/detectedAgent';
@@ -37,12 +38,27 @@ import type { DetectedAgent } from '@/common/types/detectedAgent';
 const API_KEY = 'sk-ant-api03-Zx91QmT4LpVn7BdKe0RsYcHu2WjAgF6oXlP3NtEbQvMk8ZaSdCyRfGhJ';
 const BEARER = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ3YXlsYW5kLXRlc3QifQ.s3cr3tS1gnatureV4lu3';
 
+/**
+ * THE PREFIXLESS CANARY. A 32-hex value behind a PREFIXED label - the common
+ * spelling in the wild, and the one `redactSecrets` cannot see: its label rule
+ * anchors a word boundary before the label and there is no boundary between `_`
+ * and a letter, so `AZURE_OPENAI_API_KEY=<value>` survives a scrub entirely
+ * (#1026). Any sink that keeps this out is doing so STRUCTURALLY - by dropping
+ * the text, matching the declaration literally, or allowlisting a shape - which
+ * is the only kind of fix that cannot regress when a pattern set shifts.
+ */
+const PREFIXLESS_KEY = 'a1b2c3d4e5f60718293a4b5c6d7e8f90';
+const PREFIXLESS_ASSIGNMENT = `AZURE_OPENAI_API_KEY=${PREFIXLESS_KEY}`;
+
 /** Distinctive prefixes as well as whole values, so a partial leak still counts. */
 const findsSecret = (text: string): boolean =>
   text.includes(API_KEY) ||
   text.includes('sk-ant-api03-Zx91') ||
   text.includes(BEARER) ||
   text.includes('s3cr3tS1gnatureV4lu3');
+
+/** Separate matcher for the prefixless canary, on the VALUE not the label. */
+const findsPrefixlessKey = (text: string): boolean => text.includes(PREFIXLESS_KEY);
 
 /** Every string a Doctor result can put in front of the user. */
 const surfaced = (result: { detail: string; remediation?: string }): string =>
@@ -75,6 +91,96 @@ describe('MCP check — the probe error is free-form text from a credential-carr
     expect(result.detail).toContain('notion');
   });
 
+  it('PREFIXLESS CANARY: masks a declared env value the server echoed on stderr', async () => {
+    const stdio = {
+      id: 'azure',
+      name: 'azure',
+      enabled: true,
+      transport: {
+        type: 'stdio',
+        command: 'node',
+        args: ['./server.js'],
+        env: { AZURE_OPENAI_API_KEY: PREFIXLESS_KEY },
+      },
+    } as unknown as IMcpServer;
+
+    // The real shape: the child dies before the handshake and `McpProtocol`
+    // appends up to 300 characters of its stderr as `Server output: ...`.
+    const result = await checkMcpServers({
+      listServers: async () => [stdio],
+      testConnection: async () => ({
+        success: false,
+        error: `MCP error -32000: Connection closed. Server output: Traceback: config error with ${PREFIXLESS_ASSIGNMENT} at startup`,
+      }),
+    });
+
+    expect(result.status).toBe('fail');
+    // `redactSecrets` alone cannot do this - see PREFIXLESS_KEY. It is masked
+    // because the value is in `transport.env`, matched literally.
+    expect(findsPrefixlessKey(surfaced(result))).toBe(false);
+    // The diagnostic still identifies the server and the failure.
+    expect(result.detail).toContain('azure');
+    expect(result.detail).toContain('Connection closed');
+  });
+
+  it('PREFIXLESS CANARY: masks a declared header value and a declared arg', async () => {
+    const declared = {
+      id: 'hosted',
+      name: 'hosted',
+      enabled: true,
+      transport: {
+        type: 'http',
+        url: 'https://mcp.example.com',
+        headers: { 'X-Api-Key': PREFIXLESS_KEY },
+      },
+    } as unknown as IMcpServer;
+    const withArg = {
+      id: 'argy',
+      name: 'argy',
+      enabled: true,
+      transport: { type: 'stdio', command: 'node', args: ['./s.js', `--api-key=${PREFIXLESS_KEY}`] },
+    } as unknown as IMcpServer;
+
+    // Both spellings the server can echo: the BARE secret on its own, and the
+    // whole wrapped token it was declared as.
+    const echoes = [
+      `rejected request carrying ${PREFIXLESS_KEY}`,
+      `Usage: server --api-key=${PREFIXLESS_KEY}`,
+      `X-Api-Key: ${PREFIXLESS_KEY} was refused`,
+    ];
+    const cases = [declared, withArg].flatMap((subject) => echoes.map((echo) => ({ subject, echo })));
+    const results = await Promise.all(
+      cases.map(async ({ subject, echo }) => ({
+        subject,
+        outcome: await checkMcpServers({
+          listServers: async () => [subject],
+          testConnection: async () => ({ success: false, error: echo }),
+        }),
+      }))
+    );
+    for (const { subject, outcome } of results) {
+      expect(findsPrefixlessKey(surfaced(outcome))).toBe(false);
+      expect(outcome.detail).toContain(subject.name);
+    }
+  });
+
+  it('leaves a short non-secret env value alone so the diagnostic survives', async () => {
+    // A blanket literal replacement with no length floor would blank the word
+    // "production" out of the probe's own error text.
+    const server2 = {
+      id: 'plain',
+      name: 'plain',
+      enabled: true,
+      transport: { type: 'stdio', command: 'node', env: { NODE_ENV: 'prod', PORT: '3000' } },
+    } as unknown as IMcpServer;
+    const result = await checkMcpServers({
+      listServers: async () => [server2],
+      testConnection: async () => ({ success: false, error: 'listen EADDRINUSE on port 3000 in prod mode' }),
+    });
+    expect(result.detail).toContain('3000');
+    expect(result.detail).toContain('prod');
+  });
+
   it('scrubs an api_key echoed from a stdio server env', async () => {
     const result = await checkMcpServers({
       listServers: async () => [server('custom')],
@@ -105,6 +211,72 @@ describe('backends check — loader errors come from credential-bearing config s
     expect(findsSecret(surfaced(result))).toBe(false);
     // Still reports that a loader failed, and how many.
     expect(result.detail).toContain('1 loader error(s)');
+  });
+});
+
+describe('engine reachability check — unbounded `--version` stdout', () => {
+  it('PREFIXLESS CANARY: surfaces only the version number, never the rest of the banner', async () => {
+    // `detectWCore` hands back whatever `execFileSync` printed, unvalidated and
+    // unbounded (`binaryResolver.ts`).
+    const result = await checkEngineReachable(() => ({
+      available: true,
+      path: '/opt/wayland/engine',
+      version: `wayland-core 0.13.0 (env ${PREFIXLESS_ASSIGNMENT})`,
+    }));
+
+    expect(result.status).toBe('pass');
+    expect(findsPrefixlessKey(surfaced(result))).toBe(false);
+    // Still actionable: the version the user needs is still reported.
+    expect(result.detail).toContain('0.13.0');
+  });
+
+  it('warns without echoing stdout when it carries no version number', async () => {
+    const result = await checkEngineReachable(() => ({
+      available: true,
+      path: '/opt/wayland/engine',
+      version: `garbage ${PREFIXLESS_ASSIGNMENT}`,
+    }));
+
+    expect(result.status).toBe('warn');
+    expect(findsPrefixlessKey(surfaced(result))).toBe(false);
+    expect(result.detail).toContain('did not report a usable version');
+  });
+});
+
+/**
+ * SCRUB-ONLY, and knowingly incomplete. A chat title IS user prose, so unlike a
+ * TOML parse error or an MCP declaration there is nothing structural to strip.
+ * The prefixed-label form `AZURE_OPENAI_API_KEY=<value>` therefore still survives
+ * both labels - verified by execution - exactly as it does in backendChecks, and
+ * it is blocked on the same fix (#1026). It is deliberately NOT pinned by an
+ * assertion here: the scrub call is already the regression guard, #1026 closes
+ * the prefixed form through that same call with no further change to this file,
+ * and a test asserting the gap stays open would only red out that lane's CI.
+ */
+describe('workspace checks — labels built from auto-generated chat titles', () => {
+  // A conversation's name is generated from the user's FIRST MESSAGE, so pasting
+  // a credential into chat makes it the chat title (`doctor/registry.ts`).
+  const leakyLabel = `Chat "Rotate my ${API_KEY} please"`;
+
+  it('scrubs the label in the drift check', async () => {
+    const result = await checkWorkspaceDrift({
+      listWorkspaces: async () => [{ label: leakyLabel, path: '/gone/workspace' }],
+      pathExists: async () => false,
+    });
+    expect(result.status).toBe('fail');
+    expect(findsSecret(surfaced(result))).toBe(false);
+    // Still names the path so the user can act.
+    expect(result.detail).toContain('/gone/workspace');
+  });
+
+  it('scrubs the label in the configured check', async () => {
+    const result = await checkWorkspaceConfigured({
+      listWorkspaces: async () => [{ label: leakyLabel, path: '/tmp/throwaway', customWorkspace: false }],
+      tmpDir: '/tmp',
+    });
+    expect(result.status).toBe('warn');
+    expect(findsSecret(surfaced(result))).toBe(false);
+    expect(result.detail).toContain('/tmp/throwaway');
   });
 });
 

--- a/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
+++ b/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
@@ -486,6 +486,85 @@ describe('MCP check — the probe error is free-form text from a credential-carr
     }
   });
 
+  it('FLAG RULE — a credential-naming token that merely CONTAINS a separator still flags', async () => {
+    // REGRESSION PIN. The no-own-value condition was first written as "the token
+    // contains no `=`, `:` or whitespace anywhere", using that as a proxy for
+    // "already carries its own value". The proxy is wrong, and the ordinary Windows
+    // spelling of the pinned Unix oracle (`x-auth-helper`, two rows below) is enough
+    // to defeat it: a drive letter is a `:`. Each row masked before the proxy landed
+    // and leaked the full bare value afterwards [executed pre and post].
+    //
+    // Pinned in BOTH positions, because `command` counts as the token before
+    // `args[0]` and a fix on one position would be worth nothing on the other.
+    const tokens = [
+      'x-auth-helper',
+      '/usr/local/bin/x-auth-helper',
+      'C:\\tools\\x-auth-helper.exe',
+      '/App Support/x-auth-helper',
+      'Authorization: Bearer',
+    ];
+    // KNOWN POSITIVE for the canary itself: unmasked, this text keeps the value.
+    expect(redactSecrets(`auth rejected for ${PREFIXLESS_KEY}`)).toContain(PREFIXLESS_KEY);
+
+    const probe = async (transport: unknown): Promise<string> =>
+      (
+        await checkMcpServers({
+          listServers: async () => [{ id: 'mcp_x', name: 'srv', enabled: true, transport } as unknown as IMcpServer],
+          testConnection: async () => ({ success: false, error: `auth rejected for ${PREFIXLESS_KEY}` }),
+        })
+      ).detail;
+
+    const results = await Promise.all(
+      tokens.flatMap((token) => [
+        probe({ type: 'stdio', command: 'node', args: [token, PREFIXLESS_KEY] }).then((detail) => ({
+          why: `args[i-1] ${token}`,
+          detail,
+        })),
+        probe({ type: 'stdio', command: token, args: [PREFIXLESS_KEY] }).then((detail) => ({
+          why: `command ${token}`,
+          detail,
+        })),
+      ])
+    );
+
+    for (const { why, detail } of results) {
+      expect(detail, why).not.toContain(PREFIXLESS_KEY);
+      expect(detail, why).toContain('[redacted]');
+    }
+
+    // THE OTHER DIRECTION, so the row above cannot be satisfied by deleting the
+    // condition outright: a separator AFTER the credential word means the token
+    // already yields the value through `unwrapVariants`, and flagging the next
+    // argument too costs a real path. `X-Api-Key: <v>` is the header spelling of the
+    // same thing, and it must NOT flag either.
+    const carriers = await Promise.all(
+      [`--api-key=${PREFIXLESS_KEY}`, `X-Api-Key: ${PREFIXLESS_KEY}`].map(async (carries) => ({
+        carries,
+        detail: (
+          await checkMcpServers({
+            listServers: async () => [
+              {
+                id: 'mcp_x',
+                name: 'srv',
+                enabled: true,
+                transport: { type: 'stdio', command: 'npx', args: ['-y', carries, '/Users/alice/Documents'] },
+              } as unknown as IMcpServer,
+            ],
+            testConnection: async () => ({
+              success: false,
+              error: "ENOENT: no such file or directory, scandir '/Users/alice/Documents'",
+            }),
+          })
+        ).detail,
+      }))
+    );
+
+    for (const { carries, detail } of carriers) {
+      expect(detail, carries).toContain('/Users/alice/Documents');
+      expect(detail, carries).not.toContain('[redacted]');
+    }
+  });
+
   it('PREFIXLESS CANARY: masks a token embedded in a hosted endpoint URL', async () => {
     // Path-embedded is the standard shape for Zapier / Smithery / Composio, and
     // undici echoes the URL in its own error text.

--- a/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
+++ b/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
@@ -15,6 +15,15 @@
  *
  * The engine-`config.toml` sink - the advisory's primary defect - is covered
  * separately and in more depth by `engineConfigParseErrorRedaction.test.ts`.
+ *
+ * SCOPE OF WHAT THESE PROVE: the sinks below are free-form text with no
+ * structure to strip, so `redactSecrets` is all they have, and it is best-effort.
+ * Every secret used here carries a recognisable VALUE prefix (`sk-ant-`, a JWT
+ * `eyJ` header), which is the rule that masks them. The scrubber's LABEL rule
+ * misses the prefixed spelling `ANTHROPIC_API_KEY=<prefixless value>` (#1026,
+ * owned elsewhere), so these tests must not be read as proving those sinks
+ * cannot leak - only that they no longer pass recognisable secrets straight
+ * through, which is what they previously did.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -70,6 +79,9 @@ describe('MCP check — the probe error is free-form text from a credential-carr
     const result = await checkMcpServers({
       listServers: async () => [server('custom')],
       testConnection: async () => ({
+        // Masked on the strength of the `sk-ant-` VALUE prefix. The
+        // `ANTHROPIC_API_KEY=` label itself does not trigger the scrubber's
+        // label rule (#1026) - that is why the value's shape matters here.
         success: false,
         error: `spawn failed: ANTHROPIC_API_KEY=${API_KEY} node ./server.js`,
       }),

--- a/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
+++ b/tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts
@@ -26,6 +26,7 @@
  * through, which is what they previously did.
  */
 
+import { sep } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { checkMcpServers } from '@process/doctor/checks/mcpChecks';
 import type { McpTestResult } from '@process/doctor/checks/mcpChecks';
@@ -935,7 +936,13 @@ describe('workspace inventory — for a PROJECT the name re-enters through the p
   it('KNOWN POSITIVE: the leaf of a managed project workspace IS the sanitised name', () => {
     // If `sanitizeProjectFolderName` ever stopped passing this shape through, the
     // assertions below would hold for the wrong reason.
-    expect(resolveProjectWorkspacePath(BASE, BARE_SECRET, () => false)).toBe(managed);
+    // `resolveProjectWorkspacePath` builds the path with `path.join`, so on Windows
+    // it comes back separated by backslashes. Compare on POSIX separators rather
+    // than rewriting the fixtures: `${BASE}ia/mine` below is a deliberate
+    // string-prefix probe, and mixing separators into it would change what the
+    // containment check is being asked.
+    const produced = resolveProjectWorkspacePath(BASE, BARE_SECRET, () => false);
+    expect(produced.split(sep).join('/')).toBe(managed);
     // And no scrubber sees it, so the fix cannot be a scrub.
     expect(redactSecrets(managed)).toContain(BARE_SECRET);
   });

--- a/tests/unit/process/doctor/engineConfigParseErrorRedaction.test.ts
+++ b/tests/unit/process/doctor/engineConfigParseErrorRedaction.test.ts
@@ -214,13 +214,95 @@ describe('engine config target — the ACTIVE profile, not the native config', (
     expect(result.status).toBe('ok');
   });
 
-  it('names the inspected path in the Doctor detail', async () => {
+  /**
+   * PREMISE CORRECTED. This test used to assert the FULL active path appeared in
+   * both the detail and the remediation, and in doing so it PINNED a leak of
+   * exactly the class this file exists to close: under a named profile the path's
+   * own segment IS the user-authored profile name (`PROFILE_NAME_RE` accepts a
+   * 32-hex key or an `sk-ant-` token whole), so "names the inspected path" and
+   * "names the profile" were the same sentence. It fired on every run, not only on
+   * a fault - see the healthy-config case below.
+   *
+   * What the check owes the user is the LOCATION, not the name: the profiles root
+   * (where they look in Finder) and the line/column. Those are asserted positively
+   * so this cannot pass by saying nothing.
+   */
+  it('withholds the profile NAME from both Doctor fields while staying actionable', async () => {
+    await mkdir(join(profilesRootDir, BARE_SECRET), { recursive: true });
+    await writeFile(activeMarkerPath(), BARE_SECRET, 'utf-8');
     const activePath = await resolveActiveConfigPath();
     await writeFile(activePath, 'oops = = =', 'utf-8');
+
+    // KNOWN POSITIVE: the real path genuinely carries the name, and no scrubber
+    // sees it - so a clean assertion below is the fix working, not luck.
+    expect(activePath).toContain(BARE_SECRET);
+    expect(redactSecrets(activePath)).toContain(BARE_SECRET);
+
     const outcome = await checkEngineConfigIntegrity(() => probeEngineConfig());
     expect(outcome.status).toBe('fail');
-    expect(outcome.detail).toContain(activePath);
-    expect(outcome.remediation).toContain(activePath);
+    const surfaced = `${outcome.detail}\n${outcome.remediation ?? ''}`;
+    expect(surfaced).not.toContain(BARE_SECRET);
+    // BOTH fields, separately: the leak lived in two places, so one assertion over
+    // the join would have passed on a half-fix.
+    expect(outcome.detail).not.toContain(BARE_SECRET);
+    expect(outcome.remediation).not.toContain(BARE_SECRET);
+    // NOT VACUOUS: each field still names where to look and what to fix.
+    expect(outcome.detail).toContain(profilesRootDir);
+    expect(outcome.remediation).toContain(profilesRootDir);
+    expect(outcome.detail).toContain('(profile name withheld)');
+    expect(outcome.remediation).toContain('(profile name withheld)');
+    expect(outcome.detail).toContain('line 1, column 8');
+
+    // And Reveal-in-Finder still gets the REAL file: withholding is a RENDERING
+    // decision, so collapsing `path` into `displayPath` would break the panel.
+    const probe = await probeEngineConfig();
+    expect(probe.status === 'corrupt' && probe.path).toBe(activePath);
+  });
+
+  it('withholds the profile NAME on a HEALTHY config too, not just on a fault', async () => {
+    // The pass branch names the path as well, so the name reached the report on
+    // EVERY Doctor run [executed: `Engine config.toml (.../<name>/config.toml)
+    // parses cleanly.`]. Treating this as an error-path concern was the mistake.
+    await mkdir(join(profilesRootDir, BARE_SECRET), { recursive: true });
+    await writeFile(activeMarkerPath(), BARE_SECRET, 'utf-8');
+    await writeFile(await resolveActiveConfigPath(), 'ok = true', 'utf-8');
+
+    const outcome = await checkEngineConfigIntegrity(() => probeEngineConfig());
+    expect(outcome.status).toBe('pass');
+    expect(outcome.detail).not.toContain(BARE_SECRET);
+    expect(outcome.detail).toContain('(profile name withheld)');
+    expect(outcome.detail).toContain('parses cleanly');
+  });
+
+  /**
+   * THE OVER-FIX ORACLE. Withholding unconditionally would be the easy wrong fix:
+   * the native config dir is `<config-base>/wayland-core` and carries no
+   * user-authored segment at all, so withholding it costs the user the one path
+   * they actually need and protects nothing. This is the assertion that reds if
+   * `displayPath` is ever set without consulting the active profile.
+   */
+  it('OVER-FIX ORACLE: the NATIVE profile keeps its real path verbatim', async () => {
+    const nativeHome = await mkdtemp(join(tmpdir(), 'doctor-native-'));
+    const previousHome = process.env.WAYLAND_HOME;
+    process.env.WAYLAND_HOME = nativeHome;
+    try {
+      // No active marker at all, so `getActiveProfile` selects `@native`.
+      await rm(activeMarkerPath(), { force: true });
+      await writeFile(join(nativeHome, 'config.toml'), 'ok = true', 'utf-8');
+
+      const probe = await probeEngineConfig();
+      expect(probe.status).toBe('ok');
+      expect(probe.status === 'ok' && probe.displayPath).toBeUndefined();
+
+      const outcome = await checkEngineConfigIntegrity(() => probeEngineConfig());
+      expect(outcome.status).toBe('pass');
+      expect(outcome.detail).toContain(join(nativeHome, 'config.toml'));
+      expect(outcome.detail).not.toContain('withheld');
+    } finally {
+      if (previousHome === undefined) delete process.env.WAYLAND_HOME;
+      else process.env.WAYLAND_HOME = previousHome;
+      await rm(nativeHome, { recursive: true, force: true });
+    }
   });
 
   it('reports an unresolvable profile as its own fault, not a parse failure', async () => {

--- a/tests/unit/process/doctor/engineConfigParseErrorRedaction.test.ts
+++ b/tests/unit/process/doctor/engineConfigParseErrorRedaction.test.ts
@@ -1,0 +1,149 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * GHSA-2g2m-r86j-jg6h - the engine-config integrity check must not carry the
+ * user's provider credentials into the Doctor report.
+ *
+ * `smol-toml` parse errors echo the offending source line AND its neighbours
+ * verbatim. The engine's `config.toml` holds real `api_key` values, and the
+ * Doctor panel has a "Copy report" button and exists to be shared with support,
+ * so a malformed line anywhere near a credential put that credential into the
+ * shared report.
+ *
+ * These tests run the REAL path end to end: a real corrupt file on disk, the
+ * real `readConfig` (so a real `smol-toml` error), the real producer
+ * (`probeEngineConfig`) and the real check. Nothing about the error text is
+ * simulated.
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { readConfig } from '@process/agent/wcore/configBridge';
+import { probeEngineConfig } from '@process/doctor/engineConfigProbe';
+import { checkEngineConfigIntegrity } from '@process/doctor/checks/configChecks';
+
+/**
+ * A realistically-shaped Anthropic key. The malformed line sits IMMEDIATELY
+ * BELOW it, which is what puts it inside the parser's echoed context block.
+ */
+const API_KEY = 'sk-ant-api03-Zx91QmT4LpVn7BdKe0RsYcHu2WjAgF6oXlP3NtEbQvMk8ZaSdCyRfGhJ';
+
+/**
+ * The matcher every "no secret survived" assertion below depends on. Checks a
+ * distinctive PREFIX as well as the whole value, so a truncated or partially
+ * masked leak still counts as a leak.
+ */
+const findsKey = (text: string): boolean => text.includes(API_KEY) || text.includes('sk-ant-api03-Zx91');
+
+const CORRUPT_CONFIG = [
+  '[providers.anthropic]',
+  `api_key = "${API_KEY}"`,
+  'base_url = "https://api.anthropic.com" oops',
+  '',
+  '[security]',
+  'backend = "plaintext"',
+].join('\n');
+
+const VALID_CONFIG = ['[providers.anthropic]', `api_key = "${API_KEY}"`, ''].join('\n');
+
+let dir: string;
+let configPath: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'doctor-config-leak-'));
+  configPath = join(dir, 'config.toml');
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+/** Run the whole production path over the file currently at `configPath`. */
+async function doctorOutcome() {
+  return checkEngineConfigIntegrity(() => probeEngineConfig(configPath));
+}
+
+describe('engine config parse errors (GHSA-2g2m-r86j-jg6h)', () => {
+  beforeEach(async () => {
+    await writeFile(configPath, CORRUPT_CONFIG, 'utf-8');
+  });
+
+  it('KNOWN POSITIVE: the raw parse error really does carry the api_key', async () => {
+    let raw = '';
+    try {
+      await readConfig(configPath);
+    } catch (error) {
+      raw = error instanceof Error ? error.message : String(error);
+    }
+    // If this ever stops holding, every "no key found" assertion below is
+    // vacuous and proves nothing.
+    expect(raw).not.toBe('');
+    expect(findsKey(raw)).toBe(true);
+  });
+
+  it('does not put the api_key into the Doctor detail or remediation', async () => {
+    const result = await doctorOutcome();
+    expect(result.status).toBe('fail');
+    expect(findsKey(result.detail)).toBe(false);
+    expect(findsKey(result.remediation ?? '')).toBe(false);
+  });
+
+  it('drops the echoed source block entirely, not just the credential in it', async () => {
+    const result = await doctorOutcome();
+    // Masking the key but keeping the echoed lines would still hand out the
+    // user's config: `base_url`, the `[security]` backend, whatever else the
+    // parser chose to quote. The whole block goes.
+    expect(result.detail).not.toContain('api_key');
+    expect(result.detail).not.toContain('base_url');
+    expect(result.detail).not.toContain('\n');
+    expect(result.remediation ?? '').not.toContain('\n');
+  });
+
+  it('still reports an actionable position (line and column numbers)', async () => {
+    const result = await doctorOutcome();
+    expect(result.detail).toMatch(/line 3/);
+    expect(result.detail).toMatch(/column \d+/);
+    expect(result.remediation).toMatch(/line 3, column \d+/);
+  });
+
+  it('keeps the human-readable reason', async () => {
+    const result = await doctorOutcome();
+    expect(result.detail).toContain('Invalid TOML document');
+  });
+});
+
+describe('engine config integrity — non-corrupt paths', () => {
+  it('passes on a config that parses, without echoing its contents', async () => {
+    await writeFile(configPath, VALID_CONFIG, 'utf-8');
+    const result = await doctorOutcome();
+    expect(result.status).toBe('pass');
+    expect(findsKey(result.detail)).toBe(false);
+  });
+
+  it('passes as a fresh install when the file is absent', async () => {
+    const result = await doctorOutcome();
+    expect(result.status).toBe('pass');
+    expect(result.detail.toLowerCase()).toContain('fresh install');
+  });
+});
+
+describe('checkEngineConfigIntegrity defence in depth', () => {
+  it('scrubs a credential even when the injected producer failed to', async () => {
+    // The producer sanitises, but this check is dependency-injected and every
+    // future caller inherits the copy-to-support blast radius.
+    const result = await checkEngineConfigIntegrity(async () => ({
+      status: 'corrupt' as const,
+      message: `unsanitised: api_key = "${API_KEY}"`,
+      line: 7,
+      column: 11,
+    }));
+    expect(findsKey(result.detail)).toBe(false);
+    expect(result.detail).toContain('line 7, column 11');
+  });
+});

--- a/tests/unit/process/doctor/engineConfigParseErrorRedaction.test.ts
+++ b/tests/unit/process/doctor/engineConfigParseErrorRedaction.test.ts
@@ -96,9 +96,12 @@ describe('engine config parse errors (GHSA-2g2m-r86j-jg6h)', () => {
 
   it('drops the echoed source block entirely, not just the credential in it', async () => {
     const result = await doctorOutcome();
-    // Masking the key but keeping the echoed lines would still hand out the
-    // user's config: `base_url`, the `[security]` backend, whatever else the
-    // parser chose to quote. The whole block goes.
+    // This is the assertion that actually carries the fix, and it holds WITHOUT
+    // relying on `redactSecrets`. Masking alone is not enough on two counts:
+    // the echoed lines would still hand out the rest of the user's config
+    // (`base_url`, the `[security]` backend, whatever else the parser quoted),
+    // and the scrubber misses the prefixed label form `ANTHROPIC_API_KEY=<value>`
+    // outright (#1026). The whole block goes.
     expect(result.detail).not.toContain('api_key');
     expect(result.detail).not.toContain('base_url');
     expect(result.detail).not.toContain('\n');

--- a/tests/unit/process/doctor/engineConfigParseErrorRedaction.test.ts
+++ b/tests/unit/process/doctor/engineConfigParseErrorRedaction.test.ts
@@ -20,11 +20,12 @@
  * simulated.
  */
 
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { readConfig } from '@process/agent/wcore/configBridge';
+import { readConfig, resolveUserConfigPath } from '@process/agent/wcore/configBridge';
+import { activeMarkerPath, resolveActiveConfigPath } from '@process/agent/wcore/profilePaths';
 import { probeEngineConfig } from '@process/doctor/engineConfigProbe';
 import { checkEngineConfigIntegrity } from '@process/doctor/checks/configChecks';
 
@@ -148,5 +149,81 @@ describe('checkEngineConfigIntegrity defence in depth', () => {
     }));
     expect(findsKey(result.detail)).toBe(false);
     expect(result.detail).toContain('line 7, column 11');
+  });
+});
+
+describe('engine config target — the ACTIVE profile, not the native config', () => {
+  /**
+   * With a named profile active these two paths differ, and the check used to
+   * read the native one while the recovery panel mounted under the same row read
+   * the active one. The user-visible result was a row that failed forever, a panel
+   * beneath it reporting `ok`, and Reveal opening neither file.
+   *
+   * The active path is the correct side: the engine spawn sets `WAYLAND_HOME` from
+   * `resolveActiveConfigDir()` (`WCoreAgent.resolveWaylandHomeForLaunch`) and Core
+   * treats `$WAYLAND_HOME` as the literal config dir, so the active profile's
+   * `config.toml` IS the file the engine launches against.
+   */
+  let profilesRootDir: string;
+  const previousRoot = process.env.WAYLAND_PROFILES_ROOT;
+
+  beforeEach(async () => {
+    profilesRootDir = await mkdtemp(join(tmpdir(), 'doctor-profiles-'));
+    process.env.WAYLAND_PROFILES_ROOT = profilesRootDir;
+    await mkdir(join(profilesRootDir, 'work'), { recursive: true });
+    await writeFile(activeMarkerPath(), 'work', 'utf-8');
+  });
+
+  afterEach(async () => {
+    if (previousRoot === undefined) delete process.env.WAYLAND_PROFILES_ROOT;
+    else process.env.WAYLAND_PROFILES_ROOT = previousRoot;
+    await rm(profilesRootDir, { recursive: true, force: true });
+  });
+
+  it('the two paths really do diverge under a named profile (known positive)', async () => {
+    // Without this, every assertion below would hold vacuously on a machine where
+    // the active profile happens to be `default`.
+    expect(await resolveActiveConfigPath()).not.toBe(resolveUserConfigPath());
+  });
+
+  it('probes the active profile config and reports that path', async () => {
+    const activePath = await resolveActiveConfigPath();
+    await writeFile(activePath, 'oops = = =', 'utf-8');
+
+    const result = await probeEngineConfig();
+    expect(result.status).toBe('corrupt');
+    // The same target the recovery panel resolves through, so the row and the
+    // panel cannot disagree about which file they mean.
+    expect(result.status === 'corrupt' && result.path).toBe(activePath);
+    expect(result.status === 'corrupt' && result.path).not.toBe(resolveUserConfigPath());
+  });
+
+  it('a clean active config passes even when the native one is corrupt', async () => {
+    // The exact inversion of the shipped bug.
+    await writeFile(await resolveActiveConfigPath(), 'ok = true', 'utf-8');
+    const result = await probeEngineConfig();
+    expect(result.status).toBe('ok');
+  });
+
+  it('names the inspected path in the Doctor detail', async () => {
+    const activePath = await resolveActiveConfigPath();
+    await writeFile(activePath, 'oops = = =', 'utf-8');
+    const outcome = await checkEngineConfigIntegrity(() => probeEngineConfig());
+    expect(outcome.status).toBe('fail');
+    expect(outcome.detail).toContain(activePath);
+    expect(outcome.remediation).toContain(activePath);
+  });
+
+  it('reports an unresolvable profile as its own fault, not a parse failure', async () => {
+    // A marker naming a profile whose directory does not exist is fail-closed by
+    // the #278 contract.
+    await writeFile(activeMarkerPath(), 'missing', 'utf-8');
+    const result = await probeEngineConfig();
+    expect(result.status).toBe('unresolved');
+
+    const outcome = await checkEngineConfigIntegrity(() => probeEngineConfig());
+    expect(outcome.status).toBe('fail');
+    expect(outcome.detail).toContain('could not be resolved');
+    expect(outcome.detail).not.toContain('could not be parsed');
   });
 });

--- a/tests/unit/process/doctor/engineConfigParseErrorRedaction.test.ts
+++ b/tests/unit/process/doctor/engineConfigParseErrorRedaction.test.ts
@@ -29,7 +29,7 @@ import { ProfileIsolationError, activeMarkerPath, resolveActiveConfigPath } from
 import { probeEngineConfig } from '@process/doctor/engineConfigProbe';
 import { checkEngineConfigIntegrity } from '@process/doctor/checks/configChecks';
 import { redactSecrets } from '@process/utils/secretRedaction';
-import { summarizeTomlError } from '@process/utils/tomlErrorSummary';
+import { summarizeTomlError, tomlErrorPosition } from '@process/utils/tomlErrorSummary';
 
 /**
  * A BARE credential used as a profile name. `PROFILE_NAME_RE` allows 64 characters
@@ -369,6 +369,38 @@ describe('summarizeTomlError layers', () => {
       const summary = summarizeTomlError(new Error(`Invalid TOML document: invalid value${separator}${BARE_SECRET}`));
       expect(summary).toBe('Invalid TOML document: invalid value');
     }
+  });
+
+  it('NEVER-THROWS ORACLE: a hostile message getter is contained, not propagated', () => {
+    // `probeEngineConfig` documents "Never throws". Reading `error.message` was the
+    // hole: the getter threw, the throw propagated out of the probe's own catch and
+    // falsified the contract [executed]. Nothing leaked today only because the
+    // runner's `safeErrorMessage` happened to be downstream, which is a coincidence
+    // and not a defence.
+    class Hostile extends Error {
+      override get message(): string {
+        throw new Error(`secondary carrying ${BARE_SECRET}`);
+      }
+    }
+    // KNOWN POSITIVE: the getter really does throw, so the assertions are real.
+    expect(() => new Hostile().message).toThrow();
+
+    const summary = summarizeTomlError(new Hostile());
+    expect(summary).toBe('(the parse error could not be read)');
+    expect(summary).not.toContain(BARE_SECRET);
+  });
+
+  it('NEVER-THROWS ORACLE: a hostile position getter is contained too', () => {
+    // Same exposure in `tomlErrorPosition`: the DESTRUCTURE reads the properties, so
+    // a throwing getter throws before any type test runs. Position is optional to
+    // every caller, so `null` is the right containment.
+    const hostile = {
+      get line(): number {
+        throw new Error('line getter exploded');
+      },
+    };
+    expect(() => hostile.line).toThrow();
+    expect(tomlErrorPosition(hostile)).toBeNull();
   });
 
   it('CAP ORACLE: a single-line 500,000-character message is capped at 200', () => {

--- a/tests/unit/process/doctor/engineConfigParseErrorRedaction.test.ts
+++ b/tests/unit/process/doctor/engineConfigParseErrorRedaction.test.ts
@@ -25,9 +25,18 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { readConfig, resolveUserConfigPath } from '@process/agent/wcore/configBridge';
-import { activeMarkerPath, resolveActiveConfigPath } from '@process/agent/wcore/profilePaths';
+import { ProfileIsolationError, activeMarkerPath, resolveActiveConfigPath } from '@process/agent/wcore/profilePaths';
 import { probeEngineConfig } from '@process/doctor/engineConfigProbe';
 import { checkEngineConfigIntegrity } from '@process/doctor/checks/configChecks';
+import { redactSecrets } from '@process/utils/secretRedaction';
+import { summarizeTomlError } from '@process/utils/tomlErrorSummary';
+
+/**
+ * A BARE credential used as a profile name. `PROFILE_NAME_RE` allows 64 characters
+ * of `[A-Za-z0-9._-]`, so this is a legal profile name, and nothing in any
+ * scrubber can match it - no label, no assignment, no recognisable prefix.
+ */
+const BARE_SECRET = 'f0e9d8c7b6a5948372615041302f1e0d';
 
 /**
  * A realistically-shaped Anthropic key. The malformed line sits IMMEDIATELY
@@ -225,5 +234,99 @@ describe('engine config target — the ACTIVE profile, not the native config', (
     expect(outcome.status).toBe('fail');
     expect(outcome.detail).toContain('could not be resolved');
     expect(outcome.detail).not.toContain('could not be parsed');
+  });
+
+  it('BARE CANARY: the unresolved branch never carries the profile NAME', async () => {
+    // `ProfileIsolationError` interpolates the profile name into the FIRST line of
+    // its own message, so the first-line-only defence was inert here and the scrub
+    // cannot see a bare value. A profile name is user-authored - PROFILE_NAME_RE
+    // allows 64 characters of [A-Za-z0-9._-], which fits this exactly.
+    await mkdir(join(profilesRootDir, BARE_SECRET), { recursive: true });
+    await writeFile(activeMarkerPath(), BARE_SECRET, 'utf-8');
+    // Make the resolved dir unusable so the isolation error is the one that throws.
+    await rm(join(profilesRootDir, BARE_SECRET), { recursive: true, force: true });
+
+    const result = await probeEngineConfig();
+    expect(result.status).toBe('unresolved');
+    expect(result.status === 'unresolved' && result.message).not.toContain(BARE_SECRET);
+
+    const outcome = await checkEngineConfigIntegrity(() => probeEngineConfig());
+    expect(`${outcome.detail}\n${outcome.remediation ?? ''}`).not.toContain(BARE_SECRET);
+    // Not vacuous: it still says which fault this is, and stays actionable.
+    expect(outcome.status).toBe('fail');
+    expect(outcome.detail).toContain('could not be resolved');
+    expect(outcome.remediation).toContain('default profile');
+  });
+
+  it('KNOWN POSITIVE: the raw isolation error really does carry the name on line 1', async () => {
+    // Without this the assertions above could pass because nothing threw.
+    const raw = new ProfileIsolationError(BARE_SECRET, 'directory does not exist').message;
+    expect(raw.split('\n', 1)[0]).toContain(BARE_SECRET);
+    // And no scrubber sees it, which is why the fix is a constant and not a scrub.
+    expect(redactSecrets(raw)).toContain(BARE_SECRET);
+  });
+});
+
+/**
+ * The summarizer's own three layers, each pinned on its own.
+ *
+ * Layer 1 (first line only) was already pinned by the real-file tests above. These
+ * cover the two line terminators layer 1 used to miss, the length cap, and the
+ * `redactSecrets` backstop - which was previously unpinned entirely: removing the
+ * scrub call left the whole suite green.
+ */
+describe('summarizeTomlError layers', () => {
+  it('CR ORACLE: a bare carriage return ends the line', () => {
+    const summary = summarizeTomlError(new Error(`Invalid TOML document: invalid value\rsecret ${BARE_SECRET}`));
+    expect(summary).toBe('Invalid TOML document: invalid value');
+    expect(summary).not.toContain(BARE_SECRET);
+  });
+
+  it('U+2028 / U+2029 ORACLE: both JavaScript line separators end the line', () => {
+    for (const separator of ['\u2028', '\u2029']) {
+      const summary = summarizeTomlError(new Error(`Invalid TOML document: invalid value${separator}${BARE_SECRET}`));
+      expect(summary).toBe('Invalid TOML document: invalid value');
+    }
+  });
+
+  it('CAP ORACLE: a single-line 500,000-character message is capped at 200', () => {
+    // Executed on the unfixed helper this returned all 500,032 characters.
+    const summary = summarizeTomlError(new Error(`Invalid TOML document: ${'q'.repeat(500_000)}`));
+    expect(summary).toHaveLength(200);
+  });
+
+  it('BACKSTOP ORACLE: a recognisable credential on the first line is scrubbed', () => {
+    // The one layer that had no oracle at all. Real smol-toml never puts file
+    // content on line 1, so only a synthetic producer reaches this - which is
+    // exactly why it is a backstop and exactly why it still has to be pinned.
+    const summary = summarizeTomlError(new Error(`Invalid TOML document: rejected ${API_KEY} on line 1`));
+    expect(findsKey(summary)).toBe(false);
+    expect(summary).toContain('Invalid TOML document');
+  });
+
+  it('ORDER ORACLE: a credential straddling the cap is masked, not truncated', () => {
+    // Pins scrub-BEFORE-cap, and the placement is arithmetic, not a guess.
+    // `redactSecrets` floors every rule at 8 characters [measured: a 7-character
+    // fragment behind `api_key = "` comes back untouched, an 8-character one comes
+    // back `[redacted]`], so a cap applied FIRST that leaves exactly 7 characters
+    // of the value hands those 7 characters out. Scrubbing first sees the value
+    // whole and masks all of it.
+    const value = 'a1b2c3d4e5f60718293a4b5c6d7e8f90';
+    const line = `Invalid TOML document: ${'q'.repeat(158)} api_key = "${value}"`;
+    // KNOWN POSITIVE for the placement: exactly 7 characters fall before the cap.
+    expect(line.indexOf(value)).toBe(193);
+    const summary = summarizeTomlError(new Error(line));
+    expect(summary).not.toContain(value.slice(0, 7));
+    // The mask lands so close to the boundary that the cap trims its own tail,
+    // which is exactly the right way round.
+    expect(summary).toContain('[redact');
+    expect(summary).toHaveLength(200);
+  });
+
+  it('keeps a real parser reason intact and unchanged', () => {
+    // The cap must not be trimming ordinary output: the longest reason measured
+    // across ten real corrupt files is 87 characters.
+    const reason = 'Invalid TOML document: only letter, numbers, dashes and underscores are allowed in keys';
+    expect(summarizeTomlError(new Error(`${reason}\n\n2:  api_key = "${API_KEY}"`))).toBe(reason);
   });
 });


### PR DESCRIPTION
Closes the credential-disclosure defect in private advisory **GHSA-2g2m-r86j-jg6h**. Mechanics are in the advisory, not here.

## The shared helper

`desktopProfileSplice.ts` already stripped the echoed source out of this exact class of parse error and documented why. `doctor/registry.ts` passed `error.message` through untouched. Two components, opposite conclusions about the same data, and the one on the copy-to-support surface was the one that leaked.

That logic is now `src/process/utils/tomlErrorSummary.ts` and **both** call sites use it:

| Call site | Before | After |
| --- | --- | --- |
| `agent/wcore/desktopProfileSplice.ts` | private `summarizeTomlError` | imports the shared helper |
| `doctor/registry.ts` → `doctor/engineConfigProbe.ts` | raw `error.message` | imports the shared helper |

It keeps the first line (the human-readable reason), drops the echoed block, then runs the survivor through `redactSecrets` from `utils/secretRedaction.ts`. No new patterns, no fork of that module.

The strip happens at the **producer** so no consumer can leak it. That producer moved out of `registry.ts` into `doctor/engineConfigProbe.ts` — a security boundary reachable only through Electron singletons is a boundary nobody can test, and this one now has no Electron dependency.

## Still actionable

`smol-toml`'s `TomlError` carries `line` and `column` as numbers, so the position is reported and the text is not:

```
detail:      The engine's config.toml could not be parsed at line 3, column 40: Invalid TOML document: each key-value declaration must be followed by an end-of-line
remediation: Fix the TOML syntax at line 3, column 40 in the engine config.toml, or remove the file to regenerate defaults.
```

## Doctor-surface audit

All 13 registered checks, and what each puts in front of the user:

| Check | Free-form error text? | Credential-bearing source? | Action |
| --- | --- | --- | --- |
| `config.engineConfig` | raw `smol-toml` message | **yes** — the user's real `config.toml` | **the advisory defect.** Strip at producer + scrub |
| `mcp.servers` | probe `result.error` (HTTP body / spawned stderr) | **yes** — the declaration carries `env` API keys, `headers.Authorization`, and the bearer `McpService.attachOAuthToken` adds | scrub |
| `backends.detected` | `AgentRegistry.getLoadErrors()`, raw `error.message` | **yes** — managed-install manifests and remote-agent rows | scrub |
| `engine.contractPin` | raw fs `error.message` | no — reads the engine **binary** | scrubbed for uniformity |
| *(runner catch-all)* | raw thrown `error.message`, for every check | unknown by construction | scrub |
| `providers.connectivity` | no — `ConnectError` is a closed union (`unauthorized` / `no-credit` / `offline` / …) | reads creds, never echoes them | none needed |
| `models.registry` | no — counts and provider ids only | n/a | none needed |
| `engine.reachable` | no | n/a | none needed |
| `engine.routing` | no — counts only | n/a | none needed |
| `workspace.drift` | no — paths and project/chat names | n/a | none needed |
| `workspace.configured` | no — same | n/a | none needed |
| `config.paths` | no — two static resolved dirs | n/a | none needed |
| `config.appArchitecture` | no — `process.platform` / `arch` | n/a | none needed |
| `config.secretStorage` | no — a boolean | n/a | none needed |

The uniform rule is now: no raw error text reaches a Doctor detail. A per-check judgement call is what the next check author gets wrong.

## Verified by execution

`tests/unit/process/doctor/engineConfigParseErrorRedaction.test.ts` writes a real corrupt `config.toml` whose malformed line sits immediately below a realistic `api_key`, then runs the real `readConfig`, the real producer and the real check. **Fail-before against this branch's base:** 2 assertions failed, and the failure output was the credential itself. `tests/unit/process/doctor/doctorSurfaceSecretRedaction.test.ts`: 5 of 6 failed against the base check files.

Both files carry a **known-positive control** asserting the matcher *does* find the key in the unsanitised text — a "no secret found" result is worthless without it. Post-fix: 14/14 pass.

## The scrubber is a backstop, not the fix

`redactSecrets` has a confirmed hole (**#1026**, owned elsewhere, not touched here): its labelled-assignment rule anchors a word boundary before the label, so `ANTHROPIC_API_KEY=<value>` and `my_api_key = "<value>"` survive whenever the value carries no recognisable prefix. Verified by execution.

So the engine-config fix does **not** rest on the scrubber. The assertion that carries it — `drops the echoed source block entirely` — asserts the block is *gone*, not that the credential inside it was masked. Comments and test names say which layer each assertion depends on, and the sweep tests state plainly that they prove those free-form sinks no longer pass *recognisable* secrets through, not that they cannot leak.

## Notes

- **No i18n change.** Only the check *title* is an i18n key (`settings.doctor.checks.engineConfig`, untouched). Doctor `detail` / `remediation` are English literals produced in the main process and rendered verbatim — confirmed by grepping the locale tree. No 12-locale work, no `i18n-keys.d.ts` regeneration.
- `src/common/adapter/bridgeAllowlist.ts` is byte-identical to `main` (`git diff` against `ferrox/main` is empty).
- Full unit suite: **18164 passed, 3 failed**. The 3 are `acpAgentManagerNpmFallback.test.ts`, pre-existing and host-caused (a real `wayland-nano` at `/Users/seandonahoe/.local/bin/wayland-nano` defeats the not-on-PATH fixture). `tsc --noEmit` clean, `oxlint` clean, `oxfmt` on touched files only.
- Dependency tree checked: `bun install` reports no changes, so no stale-`node_modules` artifacts in the suite result.
- Out of scope by design: the in-app recovery UI for #1024, and #1026.
