### PR TITLE
Mask prefixed secret labels, npm and Hugging Face tokens (#1026)

### DIFF
--- a/src/process/utils/secretRedaction.ts
+++ b/src/process/utils/secretRedaction.ts
@@ -89,6 +89,13 @@ const SECRET_PATTERNS: RegExp[] = [
   /\bgithub_pat_[A-Za-z0-9_]{20,}/g, // GitHub fine-grained PAT
   /\bglpat-[A-Za-z0-9_-]{8,}/g, // GitLab PAT
   /\bgsk_[A-Za-z0-9]{20,}/g, // Groq
+  // npm automation/publish token and Hugging Face user access token. Both carry
+  // an underscore INSIDE the prefix, and the `{20,}` floor over a class that
+  // omits `_` is what keeps them off ordinary npm env vars: `npm_config_cache`
+  // and `npm_lifecycle_script` have no 20-character unbroken alphanumeric run,
+  // so they cannot reach the floor. No trailing `\b`, per the rule above.
+  /\bnpm_[A-Za-z0-9]{20,}/g, // npm access token
+  /\bhf_[A-Za-z0-9]{20,}/g, // Hugging Face access token
   /\br8_[A-Za-z0-9]{20,}/g, // Replicate
   /\bdop_v1_[A-Za-z0-9]{20,}/g, // DigitalOcean
   /\bya29\.[A-Za-z0-9_.-]{8,}/g, // Google OAuth access token
@@ -126,9 +133,56 @@ const SECRET_PATTERNS: RegExp[] = [
  * {@link SECRET_PATTERNS} rather than indexed inside it: an index-based special
  * case silently mis-applies itself the moment somebody inserts a pattern above
  * it, which it did on the first attempt here.
+ *
+ * The labels are a list rather than an inline alternation, and exported, so the
+ * suite can ENUMERATE them instead of spot-checking a few. #1026 survived
+ * because the tests covered the bare form of two labels; a new label added here
+ * is now automatically held to the prefixed form too.
  */
-const LABELLED_SECRET_ASSIGNMENT =
-  /\b(api[_-]?key|auth[_-]?token|access[_-]?token|refresh[_-]?token|client[_-]?secret|password|passwd)(\s*[:=]\s*)["']?[^\s"',}]{8,}["']?/gi;
+export const LABELLED_SECRET_LABELS: readonly string[] = [
+  'api[_-]?key',
+  'auth[_-]?token',
+  'access[_-]?token',
+  'refresh[_-]?token',
+  // `AWS_SECRET_ACCESS_KEY` (#1026). Its 40-character value has no prefix and no
+  // shape worth keying on - 40 characters of the base64 alphabet is also every
+  // git SHA and every sha1 digest in a build log - so the label is the ONLY
+  // high-confidence signal, and until #1026 the label could not be reached.
+  // Listed before `access[_-]?token` would matter only for a shared prefix; it
+  // does not share one, and alternation backtracks through every branch anyway.
+  'secret[_-]?access[_-]?key',
+  'client[_-]?secret',
+  'password',
+  'passwd',
+];
+
+/**
+ * #1026: the leading anchor is a NEGATIVE LOOKBEHIND, not `\b`.
+ *
+ * `\b` here was unreachable for the common case and that was a live leak. There
+ * is no word boundary between `_` and a letter because both are word characters,
+ * so `ANTHROPIC_API_KEY=...`, `AZURE_OPENAI_API_KEY=...` and `my_api_key=...` all
+ * failed to match while the bare `API_KEY=...` matched. Environment variables are
+ * conventionally PREFIXED, so the shape that escaped was the shape that actually
+ * appears in agent stderr and error text.
+ *
+ * This is the mirror image of the four escapes fixed in #1004: there a TRAILING
+ * boundary could not match because the character class omitted a word character;
+ * here a LEADING boundary could not match because the preceding character was a
+ * word character.
+ *
+ * `(?<![A-Za-z0-9])` still refuses to match inside a longer alphanumeric run, so
+ * `notmyapikey=` is not a label, while permitting the `_`, `-` and `.` that
+ * actually separate a prefix from a label. It is a strict WIDENING: every
+ * position where `\b` succeeded had a non-word character before it, and a
+ * non-word character is also a non-alphanumeric one, so nothing that was masked
+ * before can stop being masked. Single-character, fixed-width and outside the
+ * quantified section, so it adds no backtracking.
+ */
+const LABELLED_SECRET_ASSIGNMENT = new RegExp(
+  `(?<![A-Za-z0-9])(${LABELLED_SECRET_LABELS.join('|')})(\\s*[:=]\\s*)["']?[^\\s"',}]{8,}["']?`,
+  'gi'
+);
 
 /**
  * `scheme://user:PASSWORD@host` - the password segment of a URL or DSN. No

--- a/src/process/utils/secretRedaction.ts
+++ b/src/process/utils/secretRedaction.ts
@@ -154,6 +154,12 @@ export const LABELLED_SECRET_LABELS: readonly string[] = [
   'client[_-]?secret',
   'password',
   'passwd',
+  // #1042 routed this here rather than editing its own branch, because that PR
+  // newly puts a backup passphrase on the IPC payload and this array is the only
+  // backstop for it. `password` and `passwd` already matched; `passphrase` did
+  // not, so `passphrase=`, `pass_phrase:` and a JSON `"passphrase"` all survived
+  // verbatim. Verified by execution with `password=` as the known positive.
+  'pass[_-]?phrase',
 ];
 
 /**

--- a/src/process/utils/secretRedaction.ts
+++ b/src/process/utils/secretRedaction.ts
@@ -171,6 +171,10 @@ export const LABELLED_SECRET_LABELS: readonly string[] = [
  * here a LEADING boundary could not match because the preceding character was a
  * word character.
  *
+ * Not a novel construct here: `@common/utils/redactCommandSecrets` already used
+ * `(?<![A-Za-z0-9])` for this exact reason, with a comment saying so. The sibling
+ * bank had the rule right and the canonical one did not.
+ *
  * `(?<![A-Za-z0-9])` still refuses to match inside a longer alphanumeric run, so
  * `notmyapikey=` is not a label, while permitting the `_`, `-` and `.` that
  * actually separate a prefix from a label. It is a strict WIDENING: every
@@ -198,12 +202,67 @@ const LABELLED_SECRET_ASSIGNMENT = new RegExp(
  */
 const URL_USERINFO_PASSWORD = /(\b[a-z][a-z0-9+.-]*:\/\/[^\s:@/]+:)([^\s@/]+)(@)/gi;
 
+/**
+ * Mask every {@link SECRET_PATTERNS} match as ONE pass over the ORIGINAL text.
+ *
+ * It used to be a sequential `replace` per pattern, and that made the result
+ * order-dependent in a way that leaked. A narrow rule firing first injects the
+ * `[` and `]` of the marker, those characters are outside the wider rules'
+ * character classes, so the wider match aborts and the REST of the credential
+ * survives. Reproduced on a webhook URL whose middle path segment is an npm
+ * token: the narrow `npm_` rule masked the segment, the Slack-webhook rule then
+ * could not match the mangled URL, and the third path segment - which is part of
+ * the credential - reached the output. Same for a JWT whose payload segment
+ * carries a vendor prefix.
+ *
+ * This is a whole CLASS, not one bug: ten pattern pairs on `main` had it
+ * (`ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_`, `github_pat_`, `glpat-`, `gsk_`, `r8_`,
+ * `dop_v1_` all sit before the JWT, `Authorization:` and webhook rules), and
+ * reordering the array only moves which pairs are affected. Collecting spans
+ * against the pristine text and merging them removes the ordering question
+ * instead of re-answering it, so a pattern added later cannot re-open it.
+ *
+ * Measured on 506 container/token combinations carrying 682 sensitive segments:
+ * sequential masking leaked 142 of them, this leaks 10, and all 10 are the
+ * generator's own bookkeeping (a public JWT header, and `ya29.`/`1//` values that
+ * cannot form a real webhook path) which sequential masking also left. Zero
+ * weakenings against the previous behaviour there or across a 4200-case
+ * labelled-assignment corpus.
+ *
+ * Every pattern must carry `/g`. That was already required - a non-global
+ * pattern under the old `replace` would have masked only the FIRST occurrence
+ * per line - but `matchAll` turns the mistake into a loud throw rather than a
+ * silent under-mask.
+ */
+function maskPatternMatches(text: string): string {
+  const spans: Array<[number, number]> = [];
+  for (const pattern of SECRET_PATTERNS) {
+    for (const match of text.matchAll(pattern)) {
+      if (match[0].length > 0) spans.push([match.index, match.index + match[0].length]);
+    }
+  }
+  if (spans.length === 0) return text;
+  spans.sort((left, right) => left[0] - right[0] || left[1] - right[1]);
+  const merged: Array<[number, number]> = [];
+  for (const span of spans) {
+    const last = merged.at(-1);
+    // `<=`, not `<`: an overlapping OR touching span is one credential, so
+    // `Bearer npm_...` produces a single marker rather than two adjacent ones.
+    if (last && span[0] <= last[1]) last[1] = Math.max(last[1], span[1]);
+    else merged.push([span[0], span[1]]);
+  }
+  let built = '';
+  let cursor = 0;
+  for (const [start, end] of merged) {
+    built += text.slice(cursor, start) + '[redacted]';
+    cursor = end;
+  }
+  return built + text.slice(cursor);
+}
+
 export function redactSecrets(text: string): string {
   if (!text) return text;
-  let out = text;
-  for (const pattern of SECRET_PATTERNS) {
-    out = out.replace(pattern, '[redacted]');
-  }
+  let out = maskPatternMatches(text);
   // Label preserved, value masked, so the diagnostic still reads sensibly.
   out = out.replace(
     LABELLED_SECRET_ASSIGNMENT,

--- a/src/process/utils/secretRedaction.ts
+++ b/src/process/utils/secretRedaction.ts
@@ -219,15 +219,45 @@ const URL_USERINFO_PASSWORD = /(\b[a-z][a-z0-9+.-]*:\/\/[^\s:@/]+:)([^\s@/]+)(@)
  * (`ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_`, `github_pat_`, `glpat-`, `gsk_`, `r8_`,
  * `dop_v1_` all sit before the JWT, `Authorization:` and webhook rules), and
  * reordering the array only moves which pairs are affected. Collecting spans
- * against the pristine text and merging them removes the ordering question
- * instead of re-answering it, so a pattern added later cannot re-open it.
+ * against the pristine text and merging them removes the ordering question for
+ * {@link SECRET_PATTERNS}, so a pattern added to THAT array later cannot re-open
+ * it.
+ *
+ * It does not close the question for the two rules that run AFTER this function,
+ * over its output. Those are still sequential, and still lose an anchor:
+ * `1//<refresh-token>` immediately followed by `postgres://user:pw@host` still
+ * leaks `pw`, because the greedy `1//` span swallows the `postgres` scheme that
+ * {@link URL_USERINFO_PASSWORD} needs to anchor on. Sequential masking leaked it
+ * too, so this is not a regression, but the ordering claim above stops at the
+ * end of this function. #1037 owns the anchor rules.
  *
  * Measured on 506 container/token combinations carrying 682 sensitive segments:
  * sequential masking leaked 142 of them, this leaks 10, and all 10 are the
  * generator's own bookkeeping (a public JWT header, and `ya29.`/`1//` values that
- * cannot form a real webhook path) which sequential masking also left. Zero
- * weakenings against the previous behaviour there or across a 4200-case
- * labelled-assignment corpus.
+ * cannot form a real webhook path) which sequential masking also left.
+ *
+ * On weakenings, stated exactly, because an earlier version of this comment
+ * claimed zero and that was FALSE. Where two credentials are SEPARATED by
+ * anything at all - space, comma, quote, ampersand, newline, pipe, semicolon -
+ * there are zero: 447216 segment checks over every ordered triple of the pattern
+ * set under seven separators found none, against both sequential masking and
+ * `main`, and the 4200-case labelled-assignment corpus is likewise unchanged.
+ *
+ * Two credentials concatenated with NO separator between them are the exception,
+ * and there sequential masking had coverage this loses. It had it by ACCIDENT:
+ * injecting `[redacted]` put a non-word character into the text, and a later
+ * `\b`-anchored rule then matched at a boundary that does not exist in the
+ * pristine string. Only the two FIXED-LENGTH rules can stop mid-run and hand a
+ * following rule that boundary (`AKIA`/`ASIA`, `AIza`); every other class is
+ * greedy over `[A-Za-z0-9]` and eats the following letters instead. The rules
+ * that lose out are the later `\b`-anchored ones: `AIza`, the JWT, the
+ * `Authorization:` header and the Slack webhook. Nine ordered pairs and 295
+ * ordered triples of the pattern set behave this way, against 1442 triples this
+ * masks and sequential masking leaked, so even the no-separator shape is a large
+ * net improvement. `AKIAIOSFODNN7EXAMPLE` immediately followed by a JWT is
+ * pinned in the suite so the boundary is recorded rather than assumed, and two
+ * distinct high-entropy credentials glued together with no delimiter is not a
+ * shape subprocess stderr produces.
  *
  * Every pattern must carry `/g`. That was already required - a non-global
  * pattern under the old `replace` would have masked only the FIRST occurrence

--- a/tests/fixtures/secretCorpus.ts
+++ b/tests/fixtures/secretCorpus.ts
@@ -31,6 +31,15 @@ const SYNTHETIC_SLACK_WEBHOOK = ['https://hooks.slack.com', 'services', 'T000000
   '/'
 );
 
+/**
+ * Assembled at runtime for the same reason as the webhook above: a literal
+ * 40-character AWS secret shape in a source file is what a secret scanner is
+ * built to find, and a blocked push is a worse outcome than a joined string. The
+ * value is doubly synthetic - it says EXAMPLE twice - and only its SHAPE (40
+ * characters, base64 alphabet with a `/`) is load-bearing for the regex.
+ */
+const SYNTHETIC_AWS_SECRET = ['EXAMPLEsecret', 'EXAMPLEsecret', 'EXAMPLE01234'].join('/');
+
 export const SECRET_CORPUS: readonly SecretCase[] = [
   {
     label: 'OpenAI/Anthropic-style sk- key',
@@ -159,6 +168,62 @@ export const SECRET_CORPUS: readonly SecretCase[] = [
     text: 'oauth refresh failed: client_secret=sUp3rS3cr3tV4lue',
     secret: 'sUp3rS3cr3tV4lue',
   },
+  {
+    // #1026. The PREFIXED form, which is the form that actually occurs: every
+    // provider ships its key as a prefixed environment variable, so this is the
+    // shape an engine echoes. A leading `\b` before the label cannot match here
+    // - `_` and `A` are both word characters, so there is no boundary between
+    // them - and the whole assignment used to survive untouched.
+    // The value deliberately carries NO recognizable prefix. The first draft of
+    // this case used an `sk-` value and PASSED on unfixed main - the prefix rule
+    // caught it and the label rule never ran, so it proved nothing about the
+    // defect. A labelled-assignment case is only a test of the label if the value
+    // is unrecognizable on its own.
+    label: 'prefixed ANTHROPIC_API_KEY assignment',
+    text: 'engine exited 1: ANTHROPIC_API_KEY=not-a-real-key-0123456789 rejected',
+    secret: 'not-a-real-key-0123456789',
+  },
+  {
+    label: 'prefixed OPENAI_API_KEY assignment',
+    text: 'env dump: OPENAI_API_KEY=totally-synthetic-value-0123',
+    secret: 'totally-synthetic-value-0123',
+  },
+  {
+    // Lowercase, and a prefix that is not a provider name: the defect is about
+    // the character before the label, not about who owns the key.
+    label: 'lowercase my_api_key assignment',
+    text: 'config parse failed at my_api_key=hunter2hunter2',
+    secret: 'hunter2hunter2',
+  },
+  {
+    // 32 hex characters carry no recognizable prefix, so the label is the ONLY
+    // thing that can catch this shape - and the label was unreachable.
+    label: 'prefixed AZURE_OPENAI_API_KEY with a 32-hex value',
+    text: 'deployment auth failed: AZURE_OPENAI_API_KEY=0123456789abcdef0123456789abcdef',
+    secret: '0123456789abcdef0123456789abcdef',
+  },
+  {
+    // A 40-character AWS secret access key. Caught by its LABEL, never by its
+    // shape: 40 characters of the base64 alphabet is also a git commit SHA, a
+    // sha1 digest and half the hashes in a build log, so a bare 40-run rule here
+    // would mask the log lines this module exists to keep readable.
+    label: 'labelled AWS secret access key (40 chars)',
+    text: `credentials rejected: AWS_SECRET_ACCESS_KEY=${SYNTHETIC_AWS_SECRET}`,
+    secret: SYNTHETIC_AWS_SECRET,
+  },
+  {
+    // Length deliberately not the real 36-character body, for the same reason
+    // the GitHub cases above are 32 and not 36: keep the shape, not the
+    // scanner-detectable literal.
+    label: 'npm access token',
+    text: 'npm publish failed with npm_EXAMPLEnotarealtoken0123456789',
+    secret: 'npm_EXAMPLEnotarealtoken0123456789',
+  },
+  {
+    label: 'Hugging Face access token',
+    text: 'model download refused: hf_EXAMPLEnotarealtoken0123456789',
+    secret: 'hf_EXAMPLEnotarealtoken0123456789',
+  },
 ];
 
 /** Lines that must pass through redaction completely untouched. */
@@ -168,4 +233,16 @@ export const CLEAN_CORPUS: readonly string[] = [
   'invalid_provider',
   'Profile __wayland_desktop_session not found in config',
   'password must be at least 8 characters',
+  // #1026 widened the labelled-assignment rule to reach a label preceded by `_`.
+  // These are the lines that must NOT start disappearing as a result: a label
+  // with no assignment at all, and label-shaped substrings that are ordinary
+  // prose or ordinary configuration.
+  'set the ANTHROPIC_API_KEY environment variable and retry',
+  'AWS_SECRET_ACCESS_KEY is not set',
+  'npm_config_cache=/Users/example/.npm/_cacache',
+  'passwordless login is enabled',
+  'hf_hub download skipped',
+  // The reason this module refuses a bare 40-character rule for the AWS secret
+  // shape: a 40-character run is also every git SHA in every build log.
+  'built ok at commit 0123456789abcdef0123456789abcdef01234567',
 ];

--- a/tests/unit/secretRedaction.test.ts
+++ b/tests/unit/secretRedaction.test.ts
@@ -97,6 +97,69 @@ describe('a narrow pattern inside a wider one does not split the wider match', (
 });
 
 /**
+ * The two places single-pass span merging does NOT help, pinned so neither is
+ * carried as a claim again. The doc comment on `maskPatternMatches` used to say
+ * there were zero weakenings; there are two shapes, both recorded here.
+ *
+ * Neither is merge-blocking and neither is a regression against the sequential
+ * masking that shipped before it. They are pinned because the module's comment is
+ * load-bearing security documentation, and an unpinned comment is how #1004 and
+ * #1026 both shipped.
+ */
+describe('the limits of single-pass span merging, pinned rather than claimed', () => {
+  const AWS_ACCESS_KEY_ID = 'AKIAIOSFODNN7EXAMPLE';
+  const JWT = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+
+  /**
+   * Sequential masking caught this JWT, and it did so by ACCIDENT: it injected
+   * `[redacted]`, `]` is a non-word character, and the JWT's leading `\b` then
+   * matched a boundary the pristine string does not contain. Only the two
+   * FIXED-LENGTH rules can stop mid-run and supply that boundary, so this is the
+   * whole shape, not a sample of a large class.
+   *
+   * `toBe` on the exact string, deliberately. If anyone closes this - by looping
+   * to a fixed point, or by fixing the anchors in #1037 - this test fails and the
+   * doc comment has to be brought with it, which is the point.
+   */
+  it('a credential glued to an AWS key id with NO separator keeps its own coverage only if it has an anchor', () => {
+    const out = redactSecrets(`err ${AWS_ACCESS_KEY_ID}${JWT} done`);
+    expect(out, 'the AWS key id itself must still be masked').not.toContain(AWS_ACCESS_KEY_ID);
+    expect(out).toBe(`err [redacted]${JWT} done`);
+  });
+
+  it('the same two credentials separated by a single space are BOTH masked (the shape that actually occurs)', () => {
+    // The control that makes the test above a narrow boundary rather than a hole:
+    // any separator at all, and there is no loss.
+    expect(redactSecrets(`err ${AWS_ACCESS_KEY_ID} ${JWT} done`)).toBe('err [redacted] [redacted] done');
+  });
+
+  /**
+   * An accepted READABILITY cost, not a leak. The `Authorization:` rule eats its
+   * own header name whenever no narrower rule pre-empts it - true on `main` too,
+   * for a header carrying a value with no vendor prefix - and merging makes that
+   * fire in one more case, where a narrower vendor rule also matched. The over-
+   * match corpus had no Authorization-header-carrying-a-vendor-token line, so it
+   * reported no change here. This is that line.
+   */
+  it('masking an Authorization header carrying a vendor token also consumes the header name', () => {
+    const token = `ghp_${'A'.repeat(36)}`;
+    expect(redactSecrets(`Authorization: ${token} failed for repo owner/name`)).toBe(
+      '[redacted] failed for repo owner/name'
+    );
+    // The `Bearer` form keeps the header name, because the Bearer rule starts
+    // after the colon. Most real headers are this shape.
+    expect(redactSecrets(`Authorization: Bearer ${token} failed`)).toBe('Authorization: [redacted] failed');
+  });
+
+  it('the two pass-2 rules still run sequentially, so a swallowed scheme still costs a DSN password', () => {
+    // `1//` is greedy over letters, so it eats the `postgres` scheme that
+    // URL_USERINFO_PASSWORD anchors on. Sequential masking lost this too.
+    const out = redactSecrets(`1//${'abcdefghijklmnop'}postgres://user:s3cr3tp4ss@host`);
+    expect(out).toBe('[redacted]://user:s3cr3tp4ss@host');
+  });
+});
+
+/**
  * The coverage CLASS that was missing, and the reason #1026 shipped: the suite
  * above tests labelled assignments in their BARE form (`api_key=`, `client_secret=`),
  * which is the one form the broken leading `\b` could still match. Every prefixed

--- a/tests/unit/secretRedaction.test.ts
+++ b/tests/unit/secretRedaction.test.ts
@@ -28,6 +28,72 @@ describe('redactSecrets (canonical)', () => {
   it('keeps the label of a masked assignment so the diagnostic still reads', () => {
     expect(redactSecrets('api_key = "hunter2hunter2"')).toContain('api_key');
   });
+
+  /**
+   * The oracle above - `not.toContain(secret)` plus `toContain('[redacted]')` -
+   * is satisfied by a PARTIAL replacement, and a partial replacement is exactly
+   * how a credential leaks. That blind spot is not hypothetical: it is why this
+   * suite was green while a webhook URL was reaching the output with one of its
+   * three path segments intact.
+   *
+   * So: no 8-character window of any corpus secret may survive. A window, not the
+   * whole string, is what makes this able to see a partial mask at all.
+   */
+  const WINDOW = 8;
+
+  it('every corpus secret is long enough for the window oracle to bite', () => {
+    const tooShort = SECRET_CORPUS.filter((entry) => entry.secret.length < WINDOW).map((entry) => entry.label);
+    expect(tooShort).toEqual([]);
+  });
+
+  it.each(SECRET_CORPUS.map((entry) => [entry.label, entry] as const))(
+    'leaves no %s fragment behind, not just the whole run',
+    (_label, entry) => {
+      const out = redactSecrets(entry.text);
+      const windows = Array.from({ length: entry.secret.length - WINDOW + 1 }, (_unused, at) =>
+        entry.secret.slice(at, at + WINDOW)
+      );
+      expect(windows.filter((window) => out.includes(window))).toEqual([]);
+    }
+  );
+});
+
+/**
+ * Composition, which no per-pattern test can see. A narrow rule that fires first
+ * injects the `[` and `]` of the marker; those characters sit outside the wider
+ * rules' character classes, so the wider match aborts and the remainder of the
+ * credential survives. Each container below is a credential IN WHOLE - a webhook
+ * URL, a JWT, an `Authorization:` header - so the only correct output is the
+ * marker and nothing else. `toBe`, deliberately: `not.toContain` is the oracle
+ * that missed this.
+ */
+describe('a narrow pattern inside a wider one does not split the wider match', () => {
+  // Synthetic, and shaped to reach the `{20,}` floor without being a real token.
+  const INNER = `npm_${'A'.repeat(24)}`;
+  const THIRD_SEGMENT = 'C'.repeat(24);
+  const JWT_SIGNATURE = 'dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+
+  const CONTAINERS: ReadonlyArray<readonly [string, string]> = [
+    [
+      'Slack incoming-webhook URL whose middle path segment is a vendor token',
+      ['https://hooks.slack.com', 'services', 'T00000000', INNER, THIRD_SEGMENT].join('/'),
+    ],
+    ['JWT whose payload segment is a vendor token', `eyJhbGciOiJIUzI1NiJ9.${INNER}.${JWT_SIGNATURE}`],
+    ['Authorization header carrying a vendor token with no scheme', `Authorization: ${INNER}`],
+  ];
+
+  it.each(CONTAINERS)('masks the whole %s', (_label, text) => {
+    expect(redactSecrets(text)).toBe('[redacted]');
+  });
+
+  it('the containers really are whole-credential (control against a vacuous toBe)', () => {
+    // Each container must carry BOTH the inner token and something outside it,
+    // or `toBe('[redacted]')` would prove nothing about the composition.
+    for (const [label, text] of CONTAINERS) {
+      expect(text, label).toContain(INNER);
+      expect(text.length, label).toBeGreaterThan(INNER.length + 10);
+    }
+  });
 });
 
 /**

--- a/tests/unit/secretRedaction.test.ts
+++ b/tests/unit/secretRedaction.test.ts
@@ -7,7 +7,7 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { relative, resolve, sep } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { redactSecrets } from '@process/utils/secretRedaction';
+import { LABELLED_SECRET_LABELS, redactSecrets } from '@process/utils/secretRedaction';
 import { CLEAN_CORPUS, SECRET_CORPUS } from '../fixtures/secretCorpus';
 
 describe('redactSecrets (canonical)', () => {
@@ -27,6 +27,93 @@ describe('redactSecrets (canonical)', () => {
 
   it('keeps the label of a masked assignment so the diagnostic still reads', () => {
     expect(redactSecrets('api_key = "hunter2hunter2"')).toContain('api_key');
+  });
+});
+
+/**
+ * The coverage CLASS that was missing, and the reason #1026 shipped: the suite
+ * above tests labelled assignments in their BARE form (`api_key=`, `client_secret=`),
+ * which is the one form the broken leading `\b` could still match. Every prefixed
+ * form - the form an environment variable actually takes - went untested and
+ * unmasked.
+ *
+ * So this does not spot-check a few prefixes. It enumerates the module's own
+ * label list, expands each label into every spelling the pattern accepts, and
+ * asserts the prefixed assignment is masked in all of them. A label added to
+ * `LABELLED_SECRET_LABELS` later is covered here without anyone remembering to
+ * come back.
+ */
+describe('every labelled secret is masked in its PREFIXED form (#1026)', () => {
+  /** Unrecognizable on its own: no vendor prefix, so ONLY the label can catch it. */
+  const VALUE = 'not-a-real-value-0123456789';
+
+  /**
+   * Expand one label fragment into the concrete spellings it accepts. `[_-]?` is
+   * the only regex construct the label list uses; a fragment this cannot read
+   * FAILS rather than being silently skipped, because a label the expander does
+   * not understand is a label this suite is not actually covering.
+   */
+  function spellings(fragment: string): string[] {
+    expect(
+      fragment.replaceAll('[_-]?', ''),
+      `label ${fragment} uses regex syntax this test cannot expand - extend spellings()`
+    ).toMatch(/^[a-z]+$/);
+    return fragment
+      .split('[_-]?')
+      .slice(1)
+      .reduce<string[]>(
+        (acc, part) => acc.flatMap((sofar) => ['_', '-', ''].map((joiner) => `${sofar}${joiner}${part}`)),
+        [fragment.split('[_-]?')[0]]
+      );
+  }
+
+  // Real provider prefixes, a user-invented one, and the separators that occur
+  // in practice. `''` keeps the bare form covered too.
+  const PREFIXES = ['', 'ANTHROPIC_', 'AZURE_OPENAI_', 'my_', 'x-', 'wayland.'];
+
+  const cases = LABELLED_SECRET_LABELS.flatMap((fragment) =>
+    spellings(fragment).flatMap((spelling) =>
+      [spelling, spelling.toUpperCase()].flatMap((cased) =>
+        PREFIXES.map((prefix) => ({
+          name: `${prefix}${cased}`,
+          text: `child exited 1: ${prefix}${cased}=${VALUE}`,
+        }))
+      )
+    )
+  );
+
+  it(`covers all ${LABELLED_SECRET_LABELS.length} labels as ${cases.length} prefixed assignments`, () => {
+    expect(LABELLED_SECRET_LABELS.length).toBeGreaterThanOrEqual(8);
+    const survived = cases.filter(({ text }) => redactSecrets(text).includes(VALUE)).map(({ text }) => text);
+    expect(survived).toEqual([]);
+  });
+
+  it('every case really carries the value, and the mask really fires (control)', () => {
+    // A "no secret found" result means nothing unless the input demonstrably
+    // contained one and the redactor demonstrably acted on it.
+    const wrong = cases
+      .filter(({ text }) => !text.includes(VALUE) || !redactSecrets(text).includes('[redacted]'))
+      .map(({ text }) => text);
+    expect(wrong).toEqual([]);
+  });
+
+  it('the harness is not vacuous: an unlabelled variable of the same shape survives', () => {
+    // If this ever starts being masked, the sweep above stops proving anything
+    // about labels and the module has started masking on shape alone.
+    const line = `child exited 1: ANTHROPIC_HOSTNAME=${VALUE}`;
+    expect(redactSecrets(line)).toBe(line);
+  });
+
+  it('keeps the prefix and the label so the diagnostic still names the variable', () => {
+    const out = redactSecrets(`child exited 1: ANTHROPIC_API_KEY=${VALUE}`);
+    expect(out).toBe('child exited 1: ANTHROPIC_API_KEY=[redacted]');
+  });
+
+  it('does not treat a label buried inside a longer alphanumeric run as a label', () => {
+    // The lookbehind still refuses `[A-Za-z0-9]` before the label, so this is
+    // NOT an assignment of anything called a key.
+    const line = `notmyapikey=${VALUE}`;
+    expect(redactSecrets(line)).toBe(line);
   });
 });
 

--- a/tests/unit/secretRedaction.test.ts
+++ b/tests/unit/secretRedaction.test.ts
@@ -36,10 +36,20 @@ describe('redactSecrets (canonical)', () => {
    * suite was green while a webhook URL was reaching the output with one of its
    * three path segments intact.
    *
-   * So: no 8-character window of any corpus secret may survive. A window, not the
-   * whole string, is what makes this able to see a partial mask at all.
+   * So: no short window of any corpus secret may survive. A window, not the whole
+   * string, is what makes this able to see a partial mask at all.
+   *
+   * The window length is the oracle's FLOOR, so it is measured, not picked. With
+   * a tail-leak mutation injected into the masker, 24 of these tests fail when
+   * the surviving tail is at least WINDOW characters and only the 3 whole-string
+   * `toBe` tests below fail when it is shorter - so at WINDOW = 8 a 7-character
+   * survival of a corpus secret passed green, and the two shortest corpus secrets
+   * are 10 and 11 characters. 4 is the tightest value that still leaves this
+   * suite green: at 3, `cre` and `npm` collide with ordinary words in the
+   * surrounding log text and the oracle starts reporting leaks that are not
+   * there.
    */
-  const WINDOW = 8;
+  const WINDOW = 4;
 
   it('every corpus secret is long enough for the window oracle to bite', () => {
     const tooShort = SECRET_CORPUS.filter((entry) => entry.secret.length < WINDOW).map((entry) => entry.label);

--- a/tests/unit/secretRedaction.test.ts
+++ b/tests/unit/secretRedaction.test.ts
@@ -227,6 +227,30 @@ describe('every labelled secret is masked in its PREFIXED form (#1026)', () => {
     expect(survived).toEqual([]);
   });
 
+  // #1042 put a backup passphrase on the IPC payload and this array is its only
+  // backstop, so pin the label explicitly. The generated cases above cover it
+  // only for as long as it stays in the array; this fails if someone takes it
+  // out, which the generated suite cannot notice by construction.
+  it('masks a passphrase label in every separator spelling (#1042 backstop)', () => {
+    const shapes = [
+      `restore failed: passphrase=${VALUE}`,
+      `restore failed: pass_phrase: ${VALUE}`,
+      `restore failed: pass-phrase=${VALUE}`,
+      `restore failed: PASSPHRASE=${VALUE}`,
+      `restore failed: BACKUP_PASSPHRASE=${VALUE}`,
+    ];
+    expect(LABELLED_SECRET_LABELS).toContain('pass[_-]?phrase');
+    for (const text of shapes) {
+      expect(redactSecrets(text)).not.toContain(VALUE);
+    }
+    // Control: the value really is present and long enough to be maskable, and
+    // ordinary prose using the word is not mangled.
+    expect(shapes.every((t) => t.includes(VALUE))).toBe(true);
+    expect(redactSecrets('the user typed a passphrase and it was wrong')).toBe(
+      'the user typed a passphrase and it was wrong'
+    );
+  });
+
   it('every case really carries the value, and the mask really fires (control)', () => {
     // A "no secret found" result means nothing unless the input demonstrably
     // contained one and the redactor demonstrably acted on it.


### PR DESCRIPTION
Fixes #1026.

## The defect

`LABELLED_SECRET_ASSIGNMENT` anchored a leading word boundary before the label. There is no word boundary between an underscore and a letter, because both are word characters, so the PREFIXED form of every label never matched, and environment variables are conventionally prefixed, so the shape that escaped is the shape that actually appears in agent stderr and error text.

Verified by execution on the parent commit (29b71da20), not by reading:

| input | on main | after |
| --- | --- | --- |
| ANTHROPIC_API_KEY=(no-prefix value) | SURVIVES | masked |
| OPENAI_API_KEY=(no-prefix value) | SURVIVES | masked |
| my_api_key=(value) | SURVIVES | masked |
| AZURE_OPENAI_API_KEY=(32 hex) | SURVIVES | masked |
| AWS_SECRET_ACCESS_KEY=(40 chars) | SURVIVES | masked |
| npm_ token | SURVIVES | masked |
| hf_ token | SURVIVES | masked |
| API_KEY=(value) | masked | masked |

This is the mirror image of the four escapes fixed in #1004: there a TRAILING boundary could not match because the character class omitted a word character; here a LEADING boundary could not match because the preceding character was a word character.

## The pattern change, and why it is safe

The leading anchor is now a negative lookbehind for a single alphanumeric character. It still refuses to match a label buried inside a longer alphanumeric run (`notmyapikey=` is not a label, pinned by a test) but permits the `_`, `-` and `.` that separate a prefix from a label.

It is a strict widening, not a rewrite of the rule. Every position where the old boundary succeeded had a non-word character before it, and a non-word character is also a non-alphanumeric one, so no shape that was masked before can stop being masked. Proved rather than argued: a differential run of main's pattern set against this one over a prefix/label/separator/value grid reports **0 weakenings**, re-confirmed independently at 4992 cases with 3768 newly masked and 1224 unchanged.

No backtracking risk: the lookbehind is single-character, fixed-width, and sits outside the quantified section.

## Second change: masking is one pass over the pristine text

Sequential per-pattern `replace` made the result order-dependent in a way that leaked. A narrow rule firing first injects the `[` and `]` of the marker, those characters sit outside the wider rules' character classes, so the wider match aborts and the REST of the credential survives. This is a whole class, not one bug: ten pattern pairs had it. `maskPatternMatches` now collects spans against the pristine text, merges touching spans, and replaces once.

Measured on 506 container/token combinations carrying 682 sensitive segments: sequential masking leaked 142, this leaks 10, and all 10 are the generator's own bookkeeping that sequential masking also left.

**Weakenings, stated exactly.** An earlier version of this PR and of the doc comment claimed zero weakenings. That was FALSE and is corrected in this branch.

- For any input where two credentials are SEPARATED by anything at all (space, comma, quote, ampersand, newline, pipe, semicolon) there are **zero weakenings**: 447216 segment checks over every ordered triple of the pattern set under seven separators, against both sequential masking and `main`, found none.
- Two credentials concatenated with **no separator** can lose coverage that sequential masking had by ACCIDENT. Injecting `[redacted]` put a non-word character into the text, and a later boundary-anchored rule then matched a boundary that does not exist in the pristine string. Only the two fixed-length rules (`AKIA`/`ASIA`, `AIza`) can stop mid-run and supply it; every other class is greedy over `[A-Za-z0-9]`. The rules that lose out are the later boundary-anchored ones: `AIza`, the JWT, `Authorization:` and the Slack webhook.
- Scale of it: 9 ordered pairs and 295 ordered triples of the pattern set, against 1442 triples this masks and sequential masking leaked. Even the no-separator shape is a large net improvement (triple-corpus leaks go from 17993 to 16846).
- `AKIAIOSFODNN7EXAMPLE` immediately followed by a JWT is now **pinned as a test**, with a space-separated control alongside it, so the boundary is recorded rather than assumed. If anyone closes it, the test fails and the doc comment has to come with it.

Merging is provably neutral for over-redaction: a merged span is the union of matched spans and touching means `end == start`, so every character in the union is inside some match. 50000 innocuous lines and 3.4M characters changed nothing, 20 Unicode probes were byte-identical to main, and output is idempotent and deterministic across 300 random permutations of the pattern array.

Span merging closes the ordering question for `SECRET_PATTERNS` **only**. The two rules that run after it, over its output, are still sequential and still lose an anchor: `1//<refresh-token>postgres://user:pw@host` leaks `pw`, because the greedy `1//` span swallows the `postgres` scheme that `URL_USERINFO_PASSWORD` needs. Sequential masking leaked it too, so it is not a regression. Pinned as a test, and left to #1037, which owns the anchor rules.

A three-line fixed point (loop `maskPatternMatches` until stable) was built and measured, and is deliberately **not** included. It closes every no-separator weakening and cuts triple-corpus leaks to 15369 with zero new over-redaction, but it reintroduces exactly the marker dependence this change exists to remove, it does not close the pass-2 anchor loss, and every shape it recovers requires two distinct high-entropy credentials glued together with no delimiter, which is not a shape subprocess stderr produces. Cost was free on clean lines and 2.0x on a line that carries a secret.

## Also folded in

- **AWS secret access key**, via a `secret[_-]?access[_-]?key` label. The 40-character value is caught by the LABEL and deliberately NOT by its shape, because 40 characters of the base64 alphabet is also every git SHA and sha1 digest in a build log, and masking those would make the logs this module exists to keep readable useless. A 40-char SHA line is pinned in the clean corpus to hold that line.
- **npm and Hugging Face prefixes**, with the same `{20,}` floor over a class that omits `_` as the sibling vendor prefixes. That floor is what keeps them off `npm_config_cache`, `npm_lifecycle_script` and `hf_hub_download`, none of which have a 20-character unbroken alphanumeric run.

Noted and deliberately NOT done, to keep the diff to the reported defect: a bare `SECRET_KEY=` label (Django, MinIO, S3-compatible providers) is still unmatched. Say the word and it is one line.

## The missing coverage class

The old suite exercised the bare form of two labels, which is the one form the broken anchor could still match, and that is why this shipped. The label list is now an exported array rather than an inline alternation so the suite can ENUMERATE it: 8 labels, expanded into every spelling the pattern accepts, across 6 prefixes and both casings, is **312 prefixed assignments** asserted masked. A label added later is held to the prefixed form without anyone remembering to come back. A label written in regex syntax the expander cannot read fails the test rather than being silently skipped.

## Known positives, not vacuous negatives

Every negative assertion is paired with a control. The first draft of the ANTHROPIC_API_KEY case used an `sk-` value and PASSED on unfixed main: the prefix rule caught it and the label rule never ran, so it proved nothing about the defect. The committed values carry no recognizable prefix, so only the label can catch them. The sweep additionally asserts the input really contains the value, that `[redacted]` really appears in the output, and that an unlabelled variable of the same shape (`ANTHROPIC_HOSTNAME=`) still passes through untouched. If that ever starts being masked, the sweep has stopped testing labels.

## The window oracle's floor is now measured, not picked

`not.toContain(secret)` plus `toContain('[redacted]')` is satisfied by a partial replacement, and a partial replacement is exactly how a credential leaks, so the suite also asserts that no short window of any corpus secret survives. That window length is the oracle's floor, and it was undocumented at 8.

Mutation-tested: with a tail-leak injected into the masker, 24 tests fail when the surviving tail is at least WINDOW characters, and only the 3 whole-string `toBe` composition tests fail when it is shorter. At WINDOW = 8 a 7-character survival of a corpus secret passed green, and the two shortest corpus secrets are 10 and 11 characters. WINDOW is now **4**, which catches tail leaks of 4, 5 and 7 characters (24 tests each) and leaves the suite green. 3 is too low: `cre` and `npm` collide with ordinary words in the surrounding log text.

## Over-matching

Realistic innocuous log lines (npm env vars, `hf_hub_download`, `passwordless`, `reset_password_token_expired`, a 40-char commit SHA, a sha256 digest, a DSN with no password, prose mentioning `ANTHROPIC_API_KEY` with no assignment): **0 changed**. Six are pinned in `CLEAN_CORPUS`, which asserts byte-identical passthrough.

One accepted readability cost the earlier corpus could not see, because it had no Authorization-header-carrying-a-vendor-token line:

| input | on main | after |
| --- | --- | --- |
| `Authorization: ghp_<token> failed for repo owner/name` | `Authorization: [redacted] failed for repo owner/name` | `[redacted] failed for repo owner/name` |

The header name is consumed. This is a readability cost, not a leak. The `Authorization:` rule already eats its own header name whenever no narrower rule pre-empts it (true on main for a header carrying a value with no vendor prefix), and merging makes it fire in one more case. The `Bearer` form, which is what most real headers look like, keeps the header name. Both are pinned as tests.

## Verification

- `tests/unit/secretRedaction.test.ts` and `tests/unit/secretRedaction.superset.test.ts`: 100 passed, **no existing assertion relaxed, skipped or deleted**.
- Fail-before on the new pins: reverting the module to sequential masking fails 5 tests, including both new `toBe` pins. Applying the rejected fixed point fails exactly 1, the AWS-key-plus-JWT boundary pin, and nothing else.
- Fail-before on the original defect: 8 tests fail on the parent commit; with only the leading anchor reverted, the 312-case sweep fails and lists exactly the underscore-prefixed spellings.
- `tsc --noEmit`: clean.
- `oxlint` and `oxfmt --check` clean on the touched files.

`bridgeAllowlist.ts` is byte-identical to main (empty `git diff`).

Scope note: this touches only `src/process/utils/secretRedaction.ts` plus its tests and fixtures. No Doctor check files are touched, so PR #1029's finding F2 (`backendChecks.ts:52` is scrub-only) is unblocked by this landing.
