### PR TITLE
Stop the recovery inventory bound test timing out on Windows shards

### DIFF
--- a/tests/unit/process/services/recovery/recoveryCapture.test.ts
+++ b/tests/unit/process/services/recovery/recoveryCapture.test.ts
@@ -163,7 +163,12 @@ describe('Desktop recovery mutation epoch', () => {
     value.userDataRoot = userDataRoot;
 
     await expect(fingerprintDesktopRecoveryState(value)).rejects.toThrow('bounded content inventory');
-  }, 30_000);
+    // The fixture is 20,001 real files and the walker then opens a read stream
+    // for the 20,000 it accepts before the bound trips, so the cost is inherent
+    // to what is being asserted. A Windows runner measured 34.4s against the
+    // previous 30s budget, which reddened every required Unit Tests rollup for
+    // whichever pull request happened to draw a slow runner.
+  }, 180_000);
 });
 
 describe('Desktop-only production capture boundary', () => {


### PR DESCRIPTION
## What

Raises the per-test timeout on `bounds content hashing and rejects a 20,001-entry authority tree` from 30s to 180s.

## Why

The test is on `main` and has nothing to do with any open pull request, but it reddens them.

`addPathToEpoch` accepts `MAX_RECOVERY_INVENTORY_ENTRIES_PER_ROOT` (20,000) entries before it throws, and it opens a read stream for every one of them. So the fixture has to be 20,001 real files, and the walker has to fully hash 20,000 of them, before the assertion can fire. That cost is inherent to what is being asserted, not incidental.

On a Windows runner that measured **34,393ms** against the test's own 30,000ms budget:

```
x bounds content hashing and rejects a 20,001-entry authority tree 34393ms
Error: Test timed out in 30000ms.
Test Files  1 failed | 404 passed | 6 skipped (411)
Tests  1 failed | 4869 passed | 33 skipped (4903)
```

That single shard failure took out all three required `Unit Tests (<os>)` rollups, including macos-14 and ubuntu-latest whose own shards were all green. Verified from one run:

```
failure  Unit Tests (macos-14)              run=32028930037
failure  Unit Tests (ubuntu-latest)         run=32028930037
failure  Unit Tests (windows-2022)          run=32028930037
failure  Unit Tests Shard (windows-2022 1/4) run=32028930037
success  ...all 11 other shards
```

It blocked #1011, which changes six files with no relationship to recovery capture.

## Why a budget and not a smaller fixture

The bound is a module constant with no injection point, and the check runs before content is read, so the branch cannot be reached with fewer entries without changing production code to suit a test. Nothing about the assertion, the fixture, or the error being matched changes here. Same precedent as #1028.

## Verified

- The file's 22 tests pass, 8.99s on darwin-arm64.
- `oxlint` and `oxfmt --check` clean on the touched file.