### PR TITLE
Report the newest log files in diagnostics, not the directory's first

### DIFF
--- a/src/process/resources/builtinMcp/conciergeDiagServer.ts
+++ b/src/process/resources/builtinMcp/conciergeDiagServer.ts
@@ -875,23 +875,42 @@ export const createConciergeDiagServer = (deps: ConciergeDiagDeps = {}) => {
         lines: [],
       };
     }
-    let files: string[];
+    // #1038: readdirSync returns DIRECTORY order, not sorted and not by time, so
+    // taking the first MAX_LOG_FILES entries kept an arbitrary subset that in
+    // practice skewed oldest. A diagnostics bundle then reported stale lines
+    // under the heading "recent errors", and every triage that trusted it was
+    // reading the wrong data. Select by mtime, newest first, then walk the
+    // survivors oldest-first so the trailing MAX_LOG_LINES slice below really is
+    // the most recent output rather than whichever file happened to be last.
+    let files: Array<{ name: string; stat: fs.Stats }>;
     try {
       files = fs
         .readdirSync(logDir)
         .filter((f) => f.endsWith('.log') || f.endsWith('.txt'))
-        .slice(0, MAX_LOG_FILES);
+        .map((name) => {
+          try {
+            const stat = fs.statSync(path.join(logDir, name));
+            return stat.isFile() ? { name, stat } : null;
+          } catch {
+            // Vanished or turned unreadable between readdir and stat. A rotating
+            // log directory does this routinely, and one missing file must not
+            // cost the whole section.
+            return null;
+          }
+        })
+        .filter((entry): entry is { name: string; stat: fs.Stats } => entry !== null)
+        .sort((left, right) => right.stat.mtimeMs - left.stat.mtimeMs)
+        .slice(0, MAX_LOG_FILES)
+        .reverse();
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       return { available: false, source: `log dir read failed: ${scrubHome(message)}`, lines: [] };
     }
 
     const collected: string[] = [];
-    for (const file of files) {
+    for (const { name: file, stat } of files) {
       const full = path.join(logDir, file);
       try {
-        const stat = fs.statSync(full);
-        if (!stat.isFile()) continue;
         const start = Math.max(0, stat.size - MAX_LOG_TAIL_BYTES);
         const fd = fs.openSync(full, 'r');
         try {

--- a/tests/unit/process/resources/builtinMcp/conciergeDiagServer.test.ts
+++ b/tests/unit/process/resources/builtinMcp/conciergeDiagServer.test.ts
@@ -373,6 +373,68 @@ describe('createConciergeDiagServer — recentErrors (logs)', () => {
     expect(serialized).toContain('/Users/<user>');
     expect(serialized).toContain('C:\\\\Users\\\\<user>');
   });
+
+  // #1038: readdirSync returns directory order, so keeping the FIRST
+  // MAX_LOG_FILES entries dropped the newest logs and the section reported
+  // stale lines as "recent". Eight files, mtimes set explicitly, and the two
+  // newest are also last alphabetically AND last created, so any
+  // implementation that takes the first six of either ordering loses them.
+  it('reports the NEWEST log files, not whichever the directory listed first', () => {
+    const logDir = tmp('logs-rotating');
+    fs.mkdirSync(logDir);
+    const base = Date.UTC(2026, 0, 1) / 1000;
+    // a1 oldest through a8 newest, one hour apart.
+    for (let index = 1; index <= 8; index += 1) {
+      const file = path.join(logDir, `a${index}.log`);
+      fs.writeFileSync(file, `error: marker for file ${index}\n`);
+      const when = base + index * 3600;
+      fs.utimesSync(file, when, when);
+    }
+
+    const server = createConciergeDiagServer({ logDir });
+    const result = server.recentErrors();
+    const joined = result.lines.join('\n');
+
+    expect(result.available).toBe(true);
+    // The six newest are present.
+    for (const index of [3, 4, 5, 6, 7, 8]) {
+      expect(joined).toContain(`marker for file ${index}`);
+    }
+    // The two oldest fell outside MAX_LOG_FILES and must be gone.
+    expect(joined).not.toContain('marker for file 1');
+    expect(joined).not.toContain('marker for file 2');
+  });
+
+  // The trailing MAX_LOG_LINES slice only means "most recent" if the files are
+  // walked oldest-first. Otherwise a truncated section can keep the oldest
+  // lines and discard the newest, which is the same defect one layer down.
+  it('orders collected lines oldest-first so a truncated tail keeps the newest', () => {
+    const logDir = tmp('logs-order');
+    fs.mkdirSync(logDir);
+    const base = Date.UTC(2026, 0, 1) / 1000;
+    // The NEWER file is deliberately created first and named to sort first, so
+    // both plausible readdir orders (creation and name) put it ahead of the
+    // older one. Selecting by mtime has to reverse that; directory order alone
+    // leaves the newest line first, where a truncating tail slice drops it.
+    for (const [name, ageHours] of [
+      ['a-newer', 2],
+      ['b-older', 1],
+    ] as const) {
+      const file = path.join(logDir, `${name}.log`);
+      fs.writeFileSync(file, `error: ${name} entry\n`);
+      const when = base + ageHours * 3600;
+      fs.utimesSync(file, when, when);
+    }
+
+    const server = createConciergeDiagServer({ logDir });
+    const lines = server.recentErrors().lines;
+    const olderAt = lines.findIndex((line) => line.includes('b-older entry'));
+    const newerAt = lines.findIndex((line) => line.includes('a-newer entry'));
+
+    expect(olderAt).toBeGreaterThanOrEqual(0);
+    expect(newerAt).toBeGreaterThanOrEqual(0);
+    expect(newerAt).toBeGreaterThan(olderAt);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/process/resources/builtinMcp/conciergeDiagServer.test.ts
+++ b/tests/unit/process/resources/builtinMcp/conciergeDiagServer.test.ts
@@ -376,18 +376,31 @@ describe('createConciergeDiagServer — recentErrors (logs)', () => {
 
   // #1038: readdirSync returns directory order, so keeping the FIRST
   // MAX_LOG_FILES entries dropped the newest logs and the section reported
-  // stale lines as "recent". Eight files, mtimes set explicitly, and the two
-  // newest are also last alphabetically AND last created, so any
-  // implementation that takes the first six of either ordering loses them.
+  // stale lines as "recent".
+  //
+  // The fixture puts the NEWEST files in the MIDDLE of the alphabet on purpose.
+  // An earlier version named them so the newest sorted last, on the reasoning
+  // that any implementation taking "the first six" would lose them. That only
+  // held for a FORWARD directory order: reversed, the newest two land first and
+  // the buggy slice keeps them, so the test passed against the bug. Measured
+  // across 200 shuffled orders, the buggy implementation survived 28 of them.
+  // With the newest in the middle, neither direction can reach them by accident.
   it('reports the NEWEST log files, not whichever the directory listed first', () => {
     const logDir = tmp('logs-rotating');
     fs.mkdirSync(logDir);
     const base = Date.UTC(2026, 0, 1) / 1000;
-    // a1 oldest through a8 newest, one hour apart.
-    for (let index = 1; index <= 8; index += 1) {
-      const file = path.join(logDir, `a${index}.log`);
-      fs.writeFileSync(file, `error: marker for file ${index}\n`);
-      const when = base + index * 3600;
+    // Alphabetical position is deliberately uncorrelated with age: the `m` pair
+    // is newest, the `z` block is middle-aged, the `a` block is oldest.
+    const fixture = [
+      ...Array.from({ length: 6 }, (_, i) => ({ name: `a${i + 1}`, ageHours: i + 1 })),
+      ...Array.from({ length: 6 }, (_, i) => ({ name: `z${i + 1}`, ageHours: i + 10 })),
+      { name: 'm1', ageHours: 20 },
+      { name: 'm2', ageHours: 21 },
+    ];
+    for (const { name, ageHours } of fixture) {
+      const file = path.join(logDir, `${name}.log`);
+      fs.writeFileSync(file, `error: marker for ${name}\n`);
+      const when = base + ageHours * 3600;
       fs.utimesSync(file, when, when);
     }
 
@@ -396,44 +409,60 @@ describe('createConciergeDiagServer — recentErrors (logs)', () => {
     const joined = result.lines.join('\n');
 
     expect(result.available).toBe(true);
-    // The six newest are present.
-    for (const index of [3, 4, 5, 6, 7, 8]) {
-      expect(joined).toContain(`marker for file ${index}`);
+    // The six newest by mtime, and nothing else: m2, m1, then z6 down to z3.
+    for (const name of ['m2', 'm1', 'z6', 'z5', 'z4', 'z3']) {
+      expect(joined).toContain(`marker for ${name}`);
     }
-    // The two oldest fell outside MAX_LOG_FILES and must be gone.
-    expect(joined).not.toContain('marker for file 1');
-    expect(joined).not.toContain('marker for file 2');
+    // Everything older fell outside MAX_LOG_FILES. The `a` block is first in
+    // directory order, which is exactly what the old implementation kept.
+    for (const name of ['a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'z1', 'z2']) {
+      expect(joined).not.toContain(`marker for ${name}`);
+    }
   });
 
   // The trailing MAX_LOG_LINES slice only means "most recent" if the files are
-  // walked oldest-first. Otherwise a truncated section can keep the oldest
-  // lines and discard the newest, which is the same defect one layer down.
+  // walked oldest-first. Otherwise a truncated section keeps the OLDEST lines
+  // and discards the newest, which is the same defect one layer down and the
+  // half a user actually feels.
+  //
+  // An earlier version of this test used two files of one line each. That
+  // proved the ordering but never activated the slice at all, because two
+  // matching lines against MAX_LOG_LINES of 40 makes `slice(-40)` a no-op, so
+  // the assertion in the name was not the assertion being made. This fixture
+  // carries 60 matching lines so truncation genuinely fires, and the newer file
+  // sorts FIRST alphabetically so directory order alone would put its lines at
+  // the front, where the tail slice throws them away.
   it('orders collected lines oldest-first so a truncated tail keeps the newest', () => {
     const logDir = tmp('logs-order');
     fs.mkdirSync(logDir);
     const base = Date.UTC(2026, 0, 1) / 1000;
-    // The NEWER file is deliberately created first and named to sort first, so
-    // both plausible readdir orders (creation and name) put it ahead of the
-    // older one. Selecting by mtime has to reverse that; directory order alone
-    // leaves the newest line first, where a truncating tail slice drops it.
+    const LINES_PER_FILE = 30;
     for (const [name, ageHours] of [
       ['a-newer', 2],
       ['b-older', 1],
     ] as const) {
+      const body = Array.from(
+        { length: LINES_PER_FILE },
+        (_, i) => `error: ${name} entry ${i}`
+      ).join('\n');
       const file = path.join(logDir, `${name}.log`);
-      fs.writeFileSync(file, `error: ${name} entry\n`);
+      fs.writeFileSync(file, `${body}\n`);
       const when = base + ageHours * 3600;
       fs.utimesSync(file, when, when);
     }
 
     const server = createConciergeDiagServer({ logDir });
     const lines = server.recentErrors().lines;
-    const olderAt = lines.findIndex((line) => line.includes('b-older entry'));
-    const newerAt = lines.findIndex((line) => line.includes('a-newer entry'));
 
-    expect(olderAt).toBeGreaterThanOrEqual(0);
-    expect(newerAt).toBeGreaterThanOrEqual(0);
-    expect(newerAt).toBeGreaterThan(olderAt);
+    // Truncation really happened: 60 matching lines in, MAX_LOG_LINES out.
+    expect(lines).toHaveLength(40);
+    // What survived the tail slice is the NEWER file, not the older one.
+    const newerKept = lines.filter((line) => line.includes('a-newer entry')).length;
+    const olderKept = lines.filter((line) => line.includes('b-older entry')).length;
+    expect(newerKept).toBe(LINES_PER_FILE);
+    expect(olderKept).toBe(40 - LINES_PER_FILE);
+    // And the newest line of all is the last one retained.
+    expect(lines.at(-1)).toContain(`a-newer entry ${LINES_PER_FILE - 1}`);
   });
 });
 

--- a/tests/unit/process/resources/builtinMcp/conciergeDiagServer.test.ts
+++ b/tests/unit/process/resources/builtinMcp/conciergeDiagServer.test.ts
@@ -423,24 +423,38 @@ describe('createConciergeDiagServer — recentErrors (logs)', () => {
   // The trailing MAX_LOG_LINES slice only means "most recent" if the files are
   // walked oldest-first. Otherwise a truncated section keeps the OLDEST lines
   // and discards the newest, which is the same defect one layer down and the
-  // half a user actually feels.
+  // half a user actually feels. It is also the half that decides what a user
+  // pastes into a support ticket: `collectBugReport.ts` slices this down again
+  // to MAX_ERROR_LINES of 8.
   //
-  // An earlier version of this test used two files of one line each. That
-  // proved the ordering but never activated the slice at all, because two
-  // matching lines against MAX_LOG_LINES of 40 makes `slice(-40)` a no-op, so
-  // the assertion in the name was not the assertion being made. This fixture
-  // carries 60 matching lines so truncation genuinely fires, and the newer file
-  // sorts FIRST alphabetically so directory order alone would put its lines at
-  // the front, where the tail slice throws them away.
+  // This test has been wrong twice, in two different ways, so both are recorded.
+  // First it used two files of ONE line each, which proved the ordering but never
+  // activated the slice at all, because two lines against MAX_LOG_LINES of 40
+  // makes `slice(-40)` a no-op. The rewrite added 30 lines per file so truncation
+  // genuinely fires -- and reintroduced the exact defect the earlier audit had
+  // condemned, by relying on the newer file sorting FIRST alphabetically so that
+  // "directory order alone" would bury its lines. That is an assumption about
+  // readdir order, i.e. an accident of APFS. With only two files there are only
+  // two possible orders, and the buggy implementation passed in one of them:
+  // measured across 250 shuffled orders it survived 130 of them, 52%.
+  //
+  // So this fixture reuses the 14-file layout above, where alphabetical position
+  // is uncorrelated with age and the newest files sit in the MIDDLE. Selection
+  // and ordering are then proved by one fixture, and the buggy implementation
+  // survives 0 of 250 shuffled orders.
   it('orders collected lines oldest-first so a truncated tail keeps the newest', () => {
     const logDir = tmp('logs-order');
     fs.mkdirSync(logDir);
     const base = Date.UTC(2026, 0, 1) / 1000;
-    const LINES_PER_FILE = 30;
-    for (const [name, ageHours] of [
-      ['a-newer', 2],
-      ['b-older', 1],
-    ] as const) {
+    const LINES_PER_FILE = 10;
+    // Same shape as the selection test: `m` newest, `z` middle, `a` oldest.
+    const fixture = [
+      ...Array.from({ length: 6 }, (_, i) => ({ name: `a${i + 1}`, ageHours: i + 1 })),
+      ...Array.from({ length: 6 }, (_, i) => ({ name: `z${i + 1}`, ageHours: i + 10 })),
+      { name: 'm1', ageHours: 20 },
+      { name: 'm2', ageHours: 21 },
+    ];
+    for (const { name, ageHours } of fixture) {
       const body = Array.from({ length: LINES_PER_FILE }, (_, i) => `error: ${name} entry ${i}`).join('\n');
       const file = path.join(logDir, `${name}.log`);
       fs.writeFileSync(file, `${body}\n`);
@@ -450,16 +464,71 @@ describe('createConciergeDiagServer — recentErrors (logs)', () => {
 
     const server = createConciergeDiagServer({ logDir });
     const lines = server.recentErrors().lines;
+    const countFor = (name: string) => lines.filter((line) => line.includes(`${name} entry`)).length;
 
-    // Truncation really happened: 60 matching lines in, MAX_LOG_LINES out.
+    // MAX_LOG_FILES picks the six newest (m2, m1, z6..z3) = 60 matching lines,
+    // and MAX_LOG_LINES then keeps the trailing 40. Truncation really happened.
     expect(lines).toHaveLength(40);
-    // What survived the tail slice is the NEWER file, not the older one.
-    const newerKept = lines.filter((line) => line.includes('a-newer entry')).length;
-    const olderKept = lines.filter((line) => line.includes('b-older entry')).length;
-    expect(newerKept).toBe(LINES_PER_FILE);
-    expect(olderKept).toBe(40 - LINES_PER_FILE);
+    // The four NEWEST of the selected six survive the tail slice in full.
+    for (const name of ['z5', 'z6', 'm1', 'm2']) {
+      expect(countFor(name)).toBe(LINES_PER_FILE);
+    }
+    // z3 and z4 were selected as files but their lines fell off the front of the
+    // slice; z1, z2 and the whole `a` block never made the file cut at all.
+    for (const name of ['a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'z1', 'z2', 'z3', 'z4']) {
+      expect(countFor(name)).toBe(0);
+    }
     // And the newest line of all is the last one retained.
-    expect(lines.at(-1)).toContain(`a-newer entry ${LINES_PER_FILE - 1}`);
+    expect(lines.at(-1)).toContain(`m2 entry ${LINES_PER_FILE - 1}`);
+  });
+
+  // Both guards below are behaviour this change introduced, and both were
+  // uncovered: reverting either left the whole file green.
+  it('does not let a directory named like a log consume a file slot', () => {
+    const logDir = tmp('logs-dir-entry');
+    fs.mkdirSync(logDir);
+    const base = Date.UTC(2026, 0, 1) / 1000;
+    for (let i = 1; i <= 6; i += 1) {
+      const file = path.join(logDir, `f${i}.log`);
+      fs.writeFileSync(file, `error: marker for f${i}\n`);
+      const when = base + i * 3600;
+      fs.utimesSync(file, when, when);
+    }
+    // Deliberately the NEWEST entry in the directory, so without the isFile()
+    // guard it wins a slot and evicts the oldest real file.
+    const dir = path.join(logDir, 'zz-dir.log');
+    fs.mkdirSync(dir);
+    fs.utimesSync(dir, base + 99 * 3600, base + 99 * 3600);
+
+    const result = createConciergeDiagServer({ logDir }).recentErrors();
+    const joined = result.lines.join('\n');
+
+    expect(result.available).toBe(true);
+    for (let i = 1; i <= 6; i += 1) {
+      expect(joined).toContain(`marker for f${i}`);
+    }
+  });
+
+  it('drops an entry that cannot be stat-ed rather than failing the section', () => {
+    const logDir = tmp('logs-vanished');
+    fs.mkdirSync(logDir);
+    const base = Date.UTC(2026, 0, 1) / 1000;
+    for (const name of ['keep1', 'keep2']) {
+      const file = path.join(logDir, `${name}.log`);
+      fs.writeFileSync(file, `error: marker for ${name}\n`);
+      fs.utimesSync(file, base, base);
+    }
+    // A real dangling symlink, not a mock: statSync follows it and throws ENOENT,
+    // which is what a log rotated away between readdir and stat looks like.
+    fs.symlinkSync(path.join(logDir, 'gone.log'), path.join(logDir, 'dangling.log'));
+
+    const result = createConciergeDiagServer({ logDir }).recentErrors();
+    const joined = result.lines.join('\n');
+
+    expect(result.available).toBe(true);
+    expect(joined).toContain('marker for keep1');
+    expect(joined).toContain('marker for keep2');
+    expect(joined).not.toContain('dangling');
   });
 });
 

--- a/tests/unit/process/resources/builtinMcp/conciergeDiagServer.test.ts
+++ b/tests/unit/process/resources/builtinMcp/conciergeDiagServer.test.ts
@@ -441,10 +441,7 @@ describe('createConciergeDiagServer — recentErrors (logs)', () => {
       ['a-newer', 2],
       ['b-older', 1],
     ] as const) {
-      const body = Array.from(
-        { length: LINES_PER_FILE },
-        (_, i) => `error: ${name} entry ${i}`
-      ).join('\n');
+      const body = Array.from({ length: LINES_PER_FILE }, (_, i) => `error: ${name} entry ${i}`).join('\n');
       const file = path.join(logDir, `${name}.log`);
       fs.writeFileSync(file, `${body}\n`);
       const when = base + ageHours * 3600;


### PR DESCRIPTION
Fixes #1038

## What was wrong

`readdirSync` returns entries in DIRECTORY order. It is not sorted and it is not by time. `readRecentErrors` then took the first `MAX_LOG_FILES` (6) entries, which kept an arbitrary subset that in practice skews oldest, and presented them to the model and to us under the heading "recent errors".

That means every triage that trusted a Recent errors block may have been reading the wrong data. This was confirmed twice against real incoming reports.

There is a second layer of the same defect. `collected.slice(-MAX_LOG_LINES)` is commented "keep only the most recent lines", but `collected` was ordered by the file iteration order, so the tail was really "the last lines of whichever file happened to be processed last".

## The fix

Stat the candidates during selection, sort by mtime newest-first, take the newest `MAX_LOG_FILES`, then reverse so the survivors are walked oldest-first. That makes the trailing slice genuinely the most recent output.

Statting at selection also removes a second `statSync` per file and tolerates a log that rotates away between `readdir` and `stat`, which a rotating log directory does routinely.

## Verified

Both regression tests were mutation-tested. Reverting the selection while keeping the tests:

```
x reports the NEWEST log files, not whichever the directory listed first
    AssertionError: expected 'a1.log: error: marker for file 1\na2...' to contain 'marker for file 7'
x orders collected lines oldest-first so a truncated tail keeps the newest
  Tests  2 failed | 40 passed | 9 skipped (51)
```

With the fix in place: 42 passed, 9 skipped.

The first test uses 8 files with explicitly set mtimes, where the two newest are also last alphabetically AND last created, so any implementation taking the first six of either ordering loses them. The second names the newer file to sort first, so directory order alone would leave the newest line at the front where a truncating tail drops it.

## Note on lint, worth reading

`oxlint` does not inspect either changed file, and it will not inspect them in CI either. `.oxlintrc.json` line 81 lists `resources/` in `ignorePatterns`, which matches anywhere in a path, so `src/process/resources/` is excluded along with the bundled-assets directory the pattern was written for.

Proven with matched controls, identical file content in two locations:

```
src/process/utils/__kpprobe.ts       -> Found 0 warnings and 2 errors.  1 file
src/process/resources/__kpprobe.ts   -> Found 0 warnings and 0 errors.  0 files
```

That blind spot covers 19 tracked source files under `src/process/resources/`, including all six builtin MCP servers, plus 82 under `scripts/`. Filed separately; not fixed here because widening the lint surface will surface pre-existing findings across a hundred files and that does not belong in a bug fix.

`oxfmt --check` does inspect both files and reports correct format.
