### PR TITLE
ci: retry bun install so a GitHub API wobble cannot red a check

### DIFF
--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -82,7 +82,19 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        shell: bash
+        run: |
+          # Retry: package.json pins a GitHub git dependency, so install traffic
+          # hits api.github.com and an API 504 reds out this check for reasons
+          # unrelated to the diff. Not a flaky-test workaround. Backoff 20s/40s
+          # because an API outage outlasts a transient git fetch.
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then exit 0; fi
+            echo "bun install attempt $attempt of 3 failed" >&2
+            if [[ $attempt -lt 3 ]]; then sleep $(( attempt * 20 )); fi
+          done
+          echo "bun install failed after 3 attempts (GitHub API or registry unreachable)" >&2
+          exit 1
 
       - name: Run postinstall
         run: bun run postinstall || true
@@ -149,7 +161,19 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        shell: bash
+        run: |
+          # Retry: package.json pins a GitHub git dependency, so install traffic
+          # hits api.github.com and an API 504 reds out this check for reasons
+          # unrelated to the diff. Not a flaky-test workaround. Backoff 20s/40s
+          # because an API outage outlasts a transient git fetch.
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then exit 0; fi
+            echo "bun install attempt $attempt of 3 failed" >&2
+            if [[ $attempt -lt 3 ]]; then sleep $(( attempt * 20 )); fi
+          done
+          echo "bun install failed after 3 attempts (GitHub API or registry unreachable)" >&2
+          exit 1
 
       - name: Generate structured exact capability acceptance receipts
         shell: bash

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -309,7 +309,19 @@ jobs:
           bun-version: latest
 
       - name: Install deps (for the connect probe)
-        run: bun install --frozen-lockfile
+        shell: bash
+        run: |
+          # Retry: package.json pins a GitHub git dependency, so install traffic
+          # hits api.github.com and an API 504 reds out this check for reasons
+          # unrelated to the diff. Not a flaky-test workaround. Backoff 20s/40s
+          # because an API outage outlasts a transient git fetch.
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then exit 0; fi
+            echo "bun install attempt $attempt of 3 failed" >&2
+            if [[ $attempt -lt 3 ]]; then sleep $(( attempt * 20 )); fi
+          done
+          echo "bun install failed after 3 attempts (GitHub API or registry unreachable)" >&2
+          exit 1
 
       - name: Resolve tag
         id: tag
@@ -760,7 +772,19 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        shell: bash
+        run: |
+          # Retry: package.json pins a GitHub git dependency, so install traffic
+          # hits api.github.com and an API 504 reds out this check for reasons
+          # unrelated to the diff. Not a flaky-test workaround. Backoff 20s/40s
+          # because an API outage outlasts a transient git fetch.
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then exit 0; fi
+            echo "bun install attempt $attempt of 3 failed" >&2
+            if [[ $attempt -lt 3 ]]; then sleep $(( attempt * 20 )); fi
+          done
+          echo "bun install failed after 3 attempts (GitHub API or registry unreachable)" >&2
+          exit 1
 
       - name: Build the getwayland payload (syncs version to the release)
         working-directory: installer

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -106,7 +106,19 @@ jobs:
           bun-version: '1.3'
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        shell: bash
+        run: |
+          # Retry: package.json pins a GitHub git dependency, so install traffic
+          # hits api.github.com and an API 504 reds out this check for reasons
+          # unrelated to the diff. Not a flaky-test workaround. Backoff 20s/40s
+          # because an API outage outlasts a transient git fetch.
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then exit 0; fi
+            echo "bun install attempt $attempt of 3 failed" >&2
+            if [[ $attempt -lt 3 ]]; then sleep $(( attempt * 20 )); fi
+          done
+          echo "bun install failed after 3 attempts (GitHub API or registry unreachable)" >&2
+          exit 1
 
       - name: Generate structured exact capability acceptance receipts
         shell: bash
@@ -228,7 +240,19 @@ jobs:
             libxss1 libatspi2.0-dev libgtk-3-dev libxrandr2 libasound2-dev xvfb
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        shell: bash
+        run: |
+          # Retry: package.json pins a GitHub git dependency, so install traffic
+          # hits api.github.com and an API 504 reds out this check for reasons
+          # unrelated to the diff. Not a flaky-test workaround. Backoff 20s/40s
+          # because an API outage outlasts a transient git fetch.
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then exit 0; fi
+            echo "bun install attempt $attempt of 3 failed" >&2
+            if [[ $attempt -lt 3 ]]; then sleep $(( attempt * 20 )); fi
+          done
+          echo "bun install failed after 3 attempts (GitHub API or registry unreachable)" >&2
+          exit 1
 
       - name: Postinstall (CI uses prebuilt binaries; see scripts/postinstall.js)
         run: bun run postinstall || true

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -189,7 +189,19 @@ jobs:
           cache: true
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        shell: bash
+        run: |
+          # Retry: package.json pins a GitHub git dependency, so install traffic
+          # hits api.github.com and an API 504 reds out this check for reasons
+          # unrelated to the diff. Not a flaky-test workaround. Backoff 20s/40s
+          # because an API outage outlasts a transient git fetch.
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then exit 0; fi
+            echo "bun install attempt $attempt of 3 failed" >&2
+            if [[ $attempt -lt 3 ]]; then sleep $(( attempt * 20 )); fi
+          done
+          echo "bun install failed after 3 attempts (GitHub API or registry unreachable)" >&2
+          exit 1
 
       - name: Run postinstall
         run: npm run postinstall || true
@@ -317,7 +329,19 @@ jobs:
           Add-MpPreference -ExclusionPath "${{ github.workspace }}"
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        shell: bash
+        run: |
+          # Retry: package.json pins a GitHub git dependency, so install traffic
+          # hits api.github.com and an API 504 reds out this check for reasons
+          # unrelated to the diff. Not a flaky-test workaround. Backoff 20s/40s
+          # because an API outage outlasts a transient git fetch.
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then exit 0; fi
+            echo "bun install attempt $attempt of 3 failed" >&2
+            if [[ $attempt -lt 3 ]]; then sleep $(( attempt * 20 )); fi
+          done
+          echo "bun install failed after 3 attempts (GitHub API or registry unreachable)" >&2
+          exit 1
 
       - name: Run postinstall
         run: npm run postinstall || true
@@ -611,7 +635,19 @@ jobs:
           cache: true
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        shell: bash
+        run: |
+          # Retry: package.json pins a GitHub git dependency, so install traffic
+          # hits api.github.com and an API 504 reds out this check for reasons
+          # unrelated to the diff. Not a flaky-test workaround. Backoff 20s/40s
+          # because an API outage outlasts a transient git fetch.
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then exit 0; fi
+            echo "bun install attempt $attempt of 3 failed" >&2
+            if [[ $attempt -lt 3 ]]; then sleep $(( attempt * 20 )); fi
+          done
+          echo "bun install failed after 3 attempts (GitHub API or registry unreachable)" >&2
+          exit 1
 
       - name: Run postinstall
         run: npm run postinstall || true
@@ -705,7 +741,19 @@ jobs:
           cache: true
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        shell: bash
+        run: |
+          # Retry: package.json pins a GitHub git dependency, so install traffic
+          # hits api.github.com and an API 504 reds out this check for reasons
+          # unrelated to the diff. Not a flaky-test workaround. Backoff 20s/40s
+          # because an API outage outlasts a transient git fetch.
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then exit 0; fi
+            echo "bun install attempt $attempt of 3 failed" >&2
+            if [[ $attempt -lt 3 ]]; then sleep $(( attempt * 20 )); fi
+          done
+          echo "bun install failed after 3 attempts (GitHub API or registry unreachable)" >&2
+          exit 1
 
       - name: Run postinstall
         run: npm run postinstall || true
@@ -776,7 +824,19 @@ jobs:
             pr-checks-bun-${{ runner.os }}-
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        shell: bash
+        run: |
+          # Retry: package.json pins a GitHub git dependency, so install traffic
+          # hits api.github.com and an API 504 reds out this check for reasons
+          # unrelated to the diff. Not a flaky-test workaround. Backoff 20s/40s
+          # because an API outage outlasts a transient git fetch.
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then exit 0; fi
+            echo "bun install attempt $attempt of 3 failed" >&2
+            if [[ $attempt -lt 3 ]]; then sleep $(( attempt * 20 )); fi
+          done
+          echo "bun install failed after 3 attempts (GitHub API or registry unreachable)" >&2
+          exit 1
 
       - name: Postinstall (CI uses prebuilt binaries; see scripts/postinstall.js)
         run: bun run postinstall || true

--- a/.github/workflows/pr-e2e-artifacts.yml
+++ b/.github/workflows/pr-e2e-artifacts.yml
@@ -37,7 +37,19 @@ jobs:
         uses: extractions/setup-just@v2
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        shell: bash
+        run: |
+          # Retry: package.json pins a GitHub git dependency, so install traffic
+          # hits api.github.com and an API 504 reds out this check for reasons
+          # unrelated to the diff. Not a flaky-test workaround. Backoff 20s/40s
+          # because an API outage outlasts a transient git fetch.
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then exit 0; fi
+            echo "bun install attempt $attempt of 3 failed" >&2
+            if [[ $attempt -lt 3 ]]; then sleep $(( attempt * 20 )); fi
+          done
+          echo "bun install failed after 3 attempts (GitHub API or registry unreachable)" >&2
+          exit 1
 
       - name: Run postinstall
         run: npm run postinstall || true

--- a/.github/workflows/protected-platform-package-observer.yml
+++ b/.github/workflows/protected-platform-package-observer.yml
@@ -125,7 +125,19 @@ jobs:
 
       - name: Install protected observer dependencies
         working-directory: trust
-        run: bun install --frozen-lockfile
+        shell: bash
+        run: |
+          # Retry: package.json pins a GitHub git dependency, so install traffic
+          # hits api.github.com and an API 504 reds out this check for reasons
+          # unrelated to the diff. Not a flaky-test workaround. Backoff 20s/40s
+          # because an API outage outlasts a transient git fetch.
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then exit 0; fi
+            echo "bun install attempt $attempt of 3 failed" >&2
+            if [[ $attempt -lt 3 ]]; then sleep $(( attempt * 20 )); fi
+          done
+          echo "bun install failed after 3 attempts (GitHub API or registry unreachable)" >&2
+          exit 1
 
       - name: Capture empty pre-download package state
         id: package-state

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -55,7 +55,19 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        shell: bash
+        run: |
+          # Retry: package.json pins a GitHub git dependency, so install traffic
+          # hits api.github.com and an API 504 reds out this check for reasons
+          # unrelated to the diff. Not a flaky-test workaround. Backoff 20s/40s
+          # because an API outage outlasts a transient git fetch.
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then exit 0; fi
+            echo "bun install attempt $attempt of 3 failed" >&2
+            if [[ $attempt -lt 3 ]]; then sleep $(( attempt * 20 )); fi
+          done
+          echo "bun install failed after 3 attempts (GitHub API or registry unreachable)" >&2
+          exit 1
 
       - name: Build the getwayland payload (syncs version to app/package.json)
         working-directory: installer

--- a/.github/workflows/release-acceptance-trust-root.yml
+++ b/.github/workflows/release-acceptance-trust-root.yml
@@ -83,7 +83,17 @@ jobs:
         run: |
           set -euo pipefail
           [[ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" && -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]] || exit 1
-          bun install --frozen-lockfile
+          # Retry: package.json pins a GitHub git dependency, so install traffic
+          # hits api.github.com and an API 504 reds out this check for reasons
+          # unrelated to the diff. Not a flaky-test workaround. Backoff 20s/40s
+          # because an API outage outlasts a transient git fetch.
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then exit 0; fi
+            echo "bun install attempt $attempt of 3 failed" >&2
+            if [[ $attempt -lt 3 ]]; then sleep $(( attempt * 20 )); fi
+          done
+          echo "bun install failed after 3 attempts (GitHub API or registry unreachable)" >&2
+          exit 1
 
       - name: Run untrusted candidate gates and capture raw outputs
         working-directory: candidate

--- a/.github/workflows/release-gates.yml
+++ b/.github/workflows/release-gates.yml
@@ -53,7 +53,19 @@ jobs:
           cache: true
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        shell: bash
+        run: |
+          # Retry: package.json pins a GitHub git dependency, so install traffic
+          # hits api.github.com and an API 504 reds out this check for reasons
+          # unrelated to the diff. Not a flaky-test workaround. Backoff 20s/40s
+          # because an API outage outlasts a transient git fetch.
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then exit 0; fi
+            echo "bun install attempt $attempt of 3 failed" >&2
+            if [[ $attempt -lt 3 ]]; then sleep $(( attempt * 20 )); fi
+          done
+          echo "bun install failed after 3 attempts (GitHub API or registry unreachable)" >&2
+          exit 1
 
       - name: Run postinstall
         run: npm run postinstall || true

--- a/.github/workflows/skill-pack-av.yml
+++ b/.github/workflows/skill-pack-av.yml
@@ -45,7 +45,19 @@ jobs:
         with:
           bun-version: latest
       - name: Install deps
-        run: bun install --frozen-lockfile
+        shell: bash
+        run: |
+          # Retry: package.json pins a GitHub git dependency, so install traffic
+          # hits api.github.com and an API 504 reds out this check for reasons
+          # unrelated to the diff. Not a flaky-test workaround. Backoff 20s/40s
+          # because an API outage outlasts a transient git fetch.
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then exit 0; fi
+            echo "bun install attempt $attempt of 3 failed" >&2
+            if [[ $attempt -lt 3 ]]; then sleep $(( attempt * 20 )); fi
+          done
+          echo "bun install failed after 3 attempts (GitHub API or registry unreachable)" >&2
+          exit 1
       - name: Build skill pack
         run: bun run build:skill-pack
       - name: Verify pack (no loose .md, neutral blob, low entropy, byte-exact)
@@ -62,7 +74,19 @@ jobs:
         with:
           bun-version: latest
       - name: Install deps
-        run: bun install --frozen-lockfile
+        shell: bash
+        run: |
+          # Retry: package.json pins a GitHub git dependency, so install traffic
+          # hits api.github.com and an API 504 reds out this check for reasons
+          # unrelated to the diff. Not a flaky-test workaround. Backoff 20s/40s
+          # because an API outage outlasts a transient git fetch.
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then exit 0; fi
+            echo "bun install attempt $attempt of 3 failed" >&2
+            if [[ $attempt -lt 3 ]]; then sleep $(( attempt * 20 )); fi
+          done
+          echo "bun install failed after 3 attempts (GitHub API or registry unreachable)" >&2
+          exit 1
       - name: Build skill pack
         run: bun run build:skill-pack
       - name: Update Defender signatures

--- a/.github/workflows/wsl-detect-live.yml
+++ b/.github/workflows/wsl-detect-live.yml
@@ -42,7 +42,18 @@ jobs:
         # --ignore-scripts: this job only needs the AcpDetector module + vitest;
         # skipping postinstalls avoids the officecli binary-fetch tar failure on
         # Windows (Git-bash tar misreads the C:\ path) which is irrelevant here.
-        run: bun install --frozen-lockfile --ignore-scripts
+        run: |
+          # Retry: package.json pins a GitHub git dependency, so install traffic
+          # hits api.github.com and an API 504 reds out this check for reasons
+          # unrelated to the diff. Not a flaky-test workaround. Backoff 20s/40s
+          # because an API outage outlasts a transient git fetch.
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile --ignore-scripts; then exit 0; fi
+            echo "bun install attempt $attempt of 3 failed" >&2
+            if [[ $attempt -lt 3 ]]; then sleep $(( attempt * 20 )); fi
+          done
+          echo "bun install failed after 3 attempts (GitHub API or registry unreachable)" >&2
+          exit 1
 
       - name: Install WSL + Ubuntu
         uses: Vampire/setup-wsl@v3


### PR DESCRIPTION
## What this fixes

`package.json` pins `@whiskeysockets/baileys` as a GitHub git dependency, so every `bun install --frozen-lockfile` in CI resolves a tarball through `api.github.com`. None of those install steps retried. When the GitHub API wobbles, an arbitrary check goes red for reasons that have nothing to do with the pull request.

Recovered from failing jobs today:

```
error: GET https://api.github.com/repos/whiskeysockets/libsignal-node/tarball/bcea72d - 504
##[error]Process completed with exit code 1.
```

PR #1022 lost its I18n Check and three macOS shards to this, twice, and each failure cost a diagnosis cycle before anyone identified it as infrastructure.

## What changed

19 install steps now use the retry idiom this repo already uses for the Constitution producer-commit fetch in `pr-checks.yml`: three attempts, the attempt number to stderr, a sleep between, an explicit final failure line, nonzero exit.

The sleep backs off 20s then 40s instead of the 5s used for a transient git fetch, because a GitHub API 504 outlasts a git hiccup, and because `_build-reusable.yml` already waits 30s for this same command. The backoff is skipped after the final attempt so a doomed job does not burn a minute of macOS runner time.

Every retry block carries a four line comment saying why it exists, so a future reader does not mistake it for a flaky-test workaround. The tests are fine. The network is not.

## Occurrence count

Re-derived by grep: 22 mentions of `bun install` across the workflows, of which 20 are project installs. That matches the brief's count of 20, but the brief's claim that none of them retry is **wrong on one site**:

- `_build-reusable.yml:245` already wraps its packaged-build install in `nick-fields/retry@v3` with `max_attempts: 3` and `retry_wait_seconds: 30`. It is already covered and was left alone.

So 19 sites needed the fix, not 20. Also left alone: `_build-reusable.yml:272` `bun install --global node-gyp`, which resolves from the npm registry rather than the GitHub API and is not exposed to this failure mode.

## Windows

Four steps genuinely needed `shell: bash`, because their job can land on a Windows runner where the default shell is `pwsh` and a bash `for` loop would not parse:

| File | Job | Runner |
|---|---|---|
| `pr-checks.yml` | `unit-tests` | `windows-2022` (matrix) |
| `build-matrix.yml` | `build` | `windows-2022`, `windows-11-arm` (matrix) |
| `protected-platform-package-observer.yml` | `observe` | `windows-2022`, `windows-11-arm` (matrix) |
| `skill-pack-av.yml` | `defender-scan` | `windows-latest` |

13 more steps that run only on ubuntu or macOS were given the declaration too, because the house idiom being copied carries `shell: bash`, and because a future matrix gaining a Windows entry would otherwise reintroduce this exact breakage silently. Two sites already declared it and were left as they were.

`pr-checks.yml` unit-tests runs on this PR, so the Windows bash path is exercised by CI here rather than taken on trust.

## Verification

- **YAML parse**: all 11 files load clean under PyYAML 6.0.3.
- **Structural diff**: before and after parsed with the same parser and flattened to leaf paths. Exactly 36 leaf differences: 19 changed `run` bodies and 17 added `shell` keys. Machine-asserted that nothing else differs, so no reordering, no re-indented siblings, no changed `needs`, `if`, or `runs-on`.
- **No job name and no step name changed** in any of the 11 files. Job keys, job display names, and full step-name lists are identical before and after. This matters because required checks match by name and a renamed check reads as a missing check, which counts as a pass.
- **Retry loop executed locally**, not reasoned about. Fails twice then succeeds: three attempts, exit 0. Always fails: three attempts, exit 1, elapsed exactly 60s confirming 20+40 with no wasted trailing sleep.
- **actionlint 1.7.12**: 77 findings before, 77 after, byte-identical once line numbers are normalized. Zero new findings. All 77 are pre-existing and untouched by this change.
- No source or test files touched. `package.json` and `bun.lock` are untouched: this is retry only, the dependency itself is unchanged.

## Two things to know

**`protected-platform-package-observer.yml` is inert until #1035.** That workflow runs from the protected `release-trust-v1` branch, not from `main`. Fixing it here makes it correct when a human next refreshes that branch. Nothing was pushed to `release-trust-v1`.

**setup-bun is a second leg of the same outage and is NOT fixed here.** The other recovered log line was:

```
##[error]Error: Failed to fetch url https://api.github.com/repos/oven-sh/bun/git/refs/tags. (status code: 504, status text: Gateway Timeout)
```

`oven-sh/setup-bun@v2` exposes no retry input. Its inputs are `bun-version`, `bun-version-file`, `bun-download-url`, `registries`, `registry-url`, `scope`, `no-cache`, `token`. I checked the action's own `action.yml` rather than guessing. A `uses:` step cannot be retried without restructuring it into a duplicated `continue-on-error` pair, which is out of scope for this change.

Worth knowing for whoever picks that up: `src/download-url.ts` only calls `api.github.com/repos/oven-sh/bun/git/refs/tags` when the requested version is not strict semver. So `bun-version: latest` and `bun-version: '1.3'` are exposed, and `'1.3.14'` is not. Pinning exact versions would remove that API call entirely, but it is a real behavior change across roughly 20 steps and belongs in its own PR.
