### PR TITLE
ci: clone connector sources over ssh on windows-arm64

### DIFF
--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -307,8 +307,14 @@ jobs:
           WAYLANDMCP_DEPLOY_KEY: ${{ secrets.WAYLANDMCP_DEPLOY_KEY }}
         run: |
           set -euo pipefail
-          key="$RUNNER_TEMP/waylandmcp_deploy_key"
+          # $HOME, not $RUNNER_TEMP. Both name a real directory, but RUNNER_TEMP
+          # holds a WINDOWS path and ssh eats its backslashes as escapes when it
+          # is interpolated into GIT_SSH_COMMAND, so the key argument arrives as
+          # "C:a_temp/..." and ssh falls back to no identity. In Git bash $HOME
+          # is a POSIX path and survives the same interpolation intact.
+          key="$HOME/.ssh/waylandmcp_deploy_key"
           trap 'rm -f "$key"' EXIT
+          mkdir -p "$HOME/.ssh"
           printf '%s\n' "$WAYLANDMCP_DEPLOY_KEY" > "$key"
           chmod 600 "$key"
           export GIT_SSH_COMMAND="ssh -i $key -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"

--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -286,7 +286,40 @@ jobs:
       # record. WAYLANDMCP_REF follows the WAYLAND_HUB_TAG named-constant
       # convention; tests/unit/scripts/waylandmcpSourcePin.test.ts holds the four
       # copies byte-identical so they cannot drift apart.
+      # windows-11-arm ONLY. actions/checkout's ssh-key mode cannot authenticate
+      # on this runner image: both @v4 and @v6 fail identically after three
+      # retries with "git@github.com: Permission denied (publickey)", proven on
+      # the runner itself before this step was written. Every other target
+      # authenticates fine, so the action below is left exactly as it was for
+      # them rather than swapping ten working jobs onto an untested mechanism.
+      # The difference is which ssh binary runs: the action invokes Windows
+      # native OpenSSH (C:\Windows\System32\OpenSSH\ssh.exe), which rejects the
+      # key the action writes, while the bash shell here uses Git's bundled
+      # OpenSSH (C:\Program Files\Git\usr\bin\ssh.exe), which accepts it. The
+      # clone lands the pinned commit as a detached HEAD, so the provenance
+      # assertion in the relocate step below is unchanged and still authoritative.
+      # The key is written under RUNNER_TEMP and removed on step exit, which is
+      # what persist-credentials:false buys on the other targets.
+      - name: Checkout @wayland MCP connector sources (windows-arm64)
+        if: runner.os == 'Windows' && runner.arch == 'ARM64'
+        shell: bash
+        env:
+          WAYLANDMCP_DEPLOY_KEY: ${{ secrets.WAYLANDMCP_DEPLOY_KEY }}
+        run: |
+          set -euo pipefail
+          key="$RUNNER_TEMP/waylandmcp_deploy_key"
+          trap 'rm -f "$key"' EXIT
+          printf '%s\n' "$WAYLANDMCP_DEPLOY_KEY" > "$key"
+          chmod 600 "$key"
+          export GIT_SSH_COMMAND="ssh -i $key -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
+          rm -rf waylandmcp
+          git clone --no-checkout git@github.com:FerroxLabs/waylandmcp.git waylandmcp
+          cd waylandmcp
+          git fetch --depth 1 origin "$WAYLANDMCP_REF"
+          git checkout --detach FETCH_HEAD
+
       - name: Checkout @wayland MCP connector sources
+        if: "!(runner.os == 'Windows' && runner.arch == 'ARM64')"
         uses: actions/checkout@v6
         with:
           repository: FerroxLabs/waylandmcp

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -136,7 +136,14 @@ jobs:
   build:
     name: Build (${{ matrix.release_track }} / ${{ matrix.platform }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    # 120, matching `_build-reusable.yml`, because this job exists to prove that
+    # workflow's builds and a gate given less budget than the thing it gates
+    # cannot gate it. At 60 every Windows target was killed mid-`Run packaged
+    # build` at ~51-53 minutes and reported as CANCELLED, which reds out
+    # identically to a real failure - so the one platform most likely to break
+    # was the one platform this gate could never actually check. A Windows
+    # packaged build with the @wayland connectors bundled measures ~69 minutes.
+    timeout-minutes: 120
     needs: capability-acceptance
     permissions:
       actions: read

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -272,7 +272,40 @@ jobs:
       # record. WAYLANDMCP_REF follows the WAYLAND_HUB_TAG named-constant
       # convention; tests/unit/scripts/waylandmcpSourcePin.test.ts holds the four
       # copies byte-identical so they cannot drift apart.
+      # windows-11-arm ONLY. actions/checkout's ssh-key mode cannot authenticate
+      # on this runner image: both @v4 and @v6 fail identically after three
+      # retries with "git@github.com: Permission denied (publickey)", proven on
+      # the runner itself before this step was written. Every other target
+      # authenticates fine, so the action below is left exactly as it was for
+      # them rather than swapping ten working jobs onto an untested mechanism.
+      # The difference is which ssh binary runs: the action invokes Windows
+      # native OpenSSH (C:\Windows\System32\OpenSSH\ssh.exe), which rejects the
+      # key the action writes, while the bash shell here uses Git's bundled
+      # OpenSSH (C:\Program Files\Git\usr\bin\ssh.exe), which accepts it. The
+      # clone lands the pinned commit as a detached HEAD, so the provenance
+      # assertion in the relocate step below is unchanged and still authoritative.
+      # The key is written under RUNNER_TEMP and removed on step exit, which is
+      # what persist-credentials:false buys on the other targets.
+      - name: Checkout @wayland MCP connector sources (windows-arm64)
+        if: runner.os == 'Windows' && runner.arch == 'ARM64'
+        shell: bash
+        env:
+          WAYLANDMCP_DEPLOY_KEY: ${{ secrets.WAYLANDMCP_DEPLOY_KEY }}
+        run: |
+          set -euo pipefail
+          key="$RUNNER_TEMP/waylandmcp_deploy_key"
+          trap 'rm -f "$key"' EXIT
+          printf '%s\n' "$WAYLANDMCP_DEPLOY_KEY" > "$key"
+          chmod 600 "$key"
+          export GIT_SSH_COMMAND="ssh -i $key -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
+          rm -rf waylandmcp
+          git clone --no-checkout git@github.com:FerroxLabs/waylandmcp.git waylandmcp
+          cd waylandmcp
+          git fetch --depth 1 origin "$WAYLANDMCP_REF"
+          git checkout --detach FETCH_HEAD
+
       - name: Checkout @wayland MCP connector sources
+        if: "!(runner.os == 'Windows' && runner.arch == 'ARM64')"
         uses: actions/checkout@v4
         with:
           repository: FerroxLabs/waylandmcp

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -293,8 +293,14 @@ jobs:
           WAYLANDMCP_DEPLOY_KEY: ${{ secrets.WAYLANDMCP_DEPLOY_KEY }}
         run: |
           set -euo pipefail
-          key="$RUNNER_TEMP/waylandmcp_deploy_key"
+          # $HOME, not $RUNNER_TEMP. Both name a real directory, but RUNNER_TEMP
+          # holds a WINDOWS path and ssh eats its backslashes as escapes when it
+          # is interpolated into GIT_SSH_COMMAND, so the key argument arrives as
+          # "C:a_temp/..." and ssh falls back to no identity. In Git bash $HOME
+          # is a POSIX path and survives the same interpolation intact.
+          key="$HOME/.ssh/waylandmcp_deploy_key"
           trap 'rm -f "$key"' EXIT
+          mkdir -p "$HOME/.ssh"
           printf '%s\n' "$WAYLANDMCP_DEPLOY_KEY" > "$key"
           chmod 600 "$key"
           export GIT_SSH_COMMAND="ssh -i $key -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"

--- a/tests/unit/scripts/waylandmcpSourcePin.test.ts
+++ b/tests/unit/scripts/waylandmcpSourcePin.test.ts
@@ -157,15 +157,16 @@ describe('@wayland MCP connector source pin (#940)', () => {
   // The arm64 clone is the one checkout that cannot express its pin through
   // `with.ref`, so it has to assert the same thing in shell. Without this it
   // could silently drift onto the default branch - the exact #940 failure.
-  it.each(
-    parsed.filter((entry) => entry.arm64Checkout).map((entry) => [entry.file, entry] as const)
-  )('%s pins the windows-arm64 clone to the same WAYLANDMCP_REF', (_file, entry) => {
-    const run = entry.arm64Checkout?.run ?? '';
-    expect(entry.arm64Checkout?.shell).toBe('bash');
-    expect(run).toContain('git fetch --depth 1 origin "$WAYLANDMCP_REF"');
-    expect(run).toContain('git checkout --detach FETCH_HEAD');
-    expect(run).toContain('FerroxLabs/waylandmcp.git');
-  });
+  it.each(parsed.filter((entry) => entry.arm64Checkout).map((entry) => [entry.file, entry] as const))(
+    '%s pins the windows-arm64 clone to the same WAYLANDMCP_REF',
+    (_file, entry) => {
+      const run = entry.arm64Checkout?.run ?? '';
+      expect(entry.arm64Checkout?.shell).toBe('bash');
+      expect(run).toContain('git fetch --depth 1 origin "$WAYLANDMCP_REF"');
+      expect(run).toContain('git checkout --detach FETCH_HEAD');
+      expect(run).toContain('FerroxLabs/waylandmcp.git');
+    }
+  );
 
   it('keeps the windows-arm64 clone bodies byte-identical', () => {
     const bodies = parsed.filter((entry) => entry.arm64Checkout).map((entry) => entry.arm64Checkout?.run);

--- a/tests/unit/scripts/waylandmcpSourcePin.test.ts
+++ b/tests/unit/scripts/waylandmcpSourcePin.test.ts
@@ -34,6 +34,12 @@ const WORKFLOWS = path.resolve(__dirname, '../../../.github/workflows');
  *  DERIVED from the files rather than hardcoded. */
 const CHECKOUT_STEP = 'Checkout @wayland MCP connector sources';
 const RELOCATE_STEP = 'Relocate and install @wayland MCP connector sources';
+/** windows-11-arm cannot authenticate actions/checkout's ssh-key mode, so that
+ *  one image clones explicitly instead. The pair below must stay a TOTAL and
+ *  MUTUALLY EXCLUSIVE split - see the skip-is-a-pass test at the bottom. */
+const ARM64_CHECKOUT_STEP = 'Checkout @wayland MCP connector sources (windows-arm64)';
+const ARM64_ONLY = "runner.os == 'Windows' && runner.arch == 'ARM64'";
+const NOT_ARM64 = `!(${ARM64_ONLY})`;
 
 type Step = {
   name?: string;
@@ -55,6 +61,7 @@ const parsed = ['_build-reusable.yml', 'build-and-release.yml', 'build-matrix.ym
     file,
     ref: doc.env?.WAYLANDMCP_REF,
     checkout: steps.find((step) => step.name === CHECKOUT_STEP),
+    arm64Checkout: steps.find((step) => step.name === ARM64_CHECKOUT_STEP),
     relocate: steps.find((step) => step.name === RELOCATE_STEP),
   };
 });
@@ -119,15 +126,50 @@ describe('@wayland MCP connector source pin (#940)', () => {
   );
 
   // SKIP-IS-A-PASS: on GitHub a skipped required check counts as a PASS, and a
-  // continue-on-error step reports success. Neither of these steps may acquire
+  // continue-on-error step reports success. No connector step may acquire
   // either - a #940 gate that can be skipped is not a gate.
+  //
+  // The checkout is allowed to exist as a PAIR, because windows-11-arm cannot
+  // authenticate actions/checkout's ssh-key mode and clones explicitly instead.
+  // That is only safe while the pair is TOTAL and MUTUALLY EXCLUSIVE: the two
+  // conditions must be exact complements, so every platform runs exactly one of
+  // them and none can fall through the gap into a connector-less build. Pinning
+  // the literal strings is deliberate - a third condition, a widened guard or a
+  // typo in either one all break the complement and fail here.
   it.each(withCheckout.map((entry) => [entry.file, entry] as const))(
-    '%s leaves both connector steps unconditional and fail-closed',
+    '%s runs exactly one connector checkout on every platform, fail-closed',
     (_file, entry) => {
-      for (const step of [entry.checkout, entry.relocate]) {
-        expect(step?.if).toBeUndefined();
-        expect(step?.['continue-on-error']).toBeUndefined();
+      if (entry.arm64Checkout) {
+        expect(entry.checkout?.if).toBe(NOT_ARM64);
+        expect(entry.arm64Checkout.if).toBe(ARM64_ONLY);
+      } else {
+        // No split in this workflow, so the single checkout must be unguarded.
+        expect(entry.checkout?.if).toBeUndefined();
+      }
+      // The relocate step consumes whichever checkout ran and is never guarded.
+      expect(entry.relocate?.if).toBeUndefined();
+      for (const step of [entry.checkout, entry.arm64Checkout, entry.relocate]) {
+        if (step) expect(step['continue-on-error']).toBeUndefined();
       }
     }
   );
+
+  // The arm64 clone is the one checkout that cannot express its pin through
+  // `with.ref`, so it has to assert the same thing in shell. Without this it
+  // could silently drift onto the default branch - the exact #940 failure.
+  it.each(
+    parsed.filter((entry) => entry.arm64Checkout).map((entry) => [entry.file, entry] as const)
+  )('%s pins the windows-arm64 clone to the same WAYLANDMCP_REF', (_file, entry) => {
+    const run = entry.arm64Checkout?.run ?? '';
+    expect(entry.arm64Checkout?.shell).toBe('bash');
+    expect(run).toContain('git fetch --depth 1 origin "$WAYLANDMCP_REF"');
+    expect(run).toContain('git checkout --detach FETCH_HEAD');
+    expect(run).toContain('FerroxLabs/waylandmcp.git');
+  });
+
+  it('keeps the windows-arm64 clone bodies byte-identical', () => {
+    const bodies = parsed.filter((entry) => entry.arm64Checkout).map((entry) => entry.arm64Checkout?.run);
+    expect(bodies.length).toBeGreaterThan(0);
+    expect(new Set(bodies).size).toBe(1);
+  });
 });


### PR DESCRIPTION
Blocks the 0.12.1 tag.

0.12.1 added the @wayland MCP connector checkout to the release path, and #1012 removed the WAYLAND_ALLOW_MISSING_MCP bypass that used to let a build proceed without it. The checkout is therefore mandatory on every release target for the first time, and it does not work on windows-11-arm.

On that image actions/checkout ssh-key mode fails with git@github.com: Permission denied (publickey) after all three of its internal retries, on @v4 (build-matrix) and @v6 (the release path) alike. The other ten targets pass the same step. v0.12.0 shipped a win-arm64 installer, so leaving this would fail the arm64 leg of the tag build and strip those users of the release.

Verified directly on windows-11-arm before the fix was written: both action versions leave an empty repository behind, and an explicit ssh clone lands the pinned commit 29a2538. The action invokes Windows native OpenSSH, which rejects the key file it writes; Git's bundled OpenSSH, which the bash shell uses, accepts it.

So the single image the action cannot serve gets an explicit clone, and every target that already works keeps the mechanism that works. The clone leaves the pinned commit checked out detached, so the provenance assertion in the relocate step remains the authority on what was bundled.

Full Build Matrix dispatched on this branch to prove all twelve targets.