### PR TITLE
fix: terminate the descendant walk, and stop two suites answering to the host

### DIFF
--- a/scripts/platform-package-smoke.mjs
+++ b/scripts/platform-package-smoke.mjs
@@ -967,17 +967,36 @@ function descendantsFromSnapshot(rootPid, snapshot) {
     children.push(record);
     childrenByParent.set(record.parentPid, children);
   }
-  // A process table is NOT guaranteed to be a tree, so this walk must not assume
-  // one. Windows recycles PIDs aggressively, and a surviving child whose parent
-  // slot has been reused can report a ppid that is itself inside this subtree -
-  // a cycle. Without the visited set below the queue refills forever and the
-  // only thing that stops it is `descendants.push` throwing
-  // "RangeError: Invalid array length" once the array reaches 2^32-1, which is
-  // what took down the windows-x64 leg of the v0.12.1 release AFTER a clean
-  // install and build. Marking a PID before enqueueing it makes the walk
-  // terminate on any graph, and bounds the result at one entry per process.
-  // rootPid is pre-seeded so a self-parent or a child pointing back at the root
-  // cannot re-enter either.
+  // A process table is NOT guaranteed to be a walkable tree, and this walk must
+  // terminate on whatever it is handed.
+  //
+  // Every record carries exactly ONE parentPid, so `childrenByParent` is an
+  // inverted functional graph: each node has a single in-edge. A node sitting on
+  // a cycle therefore has its only parent inside that cycle, so its ancestor
+  // chain never reaches rootPid and the walk cannot enter it. Only two shapes
+  // actually loop, and it is worth naming them precisely because the obvious
+  // guess - "some descendant's ppid points back into the subtree" - is exactly
+  // the unreachable case:
+  //
+  //   1. rootPid is ITSELF on the cycle. Its own children are seeded into the
+  //      queue, the walk comes back around to rootPid, and its children are
+  //      seeded again, forever. This is the physically realistic one: PID reuse
+  //      lets the root's ancestry re-enter its own subtree.
+  //   2. The snapshot contains two records with the SAME pid. Get-CimInstance
+  //      cannot emit that - PIDs are unique at an instant - so this is defence
+  //      against a malformed table rather than an observed shape.
+  //
+  // Untreated, shape 1 took down the windows-x64 leg of the v0.12.1 release
+  // AFTER a clean build and a successful install, with `descendants.push`
+  // refusing the array length. Marking a PID before expanding it makes the walk
+  // terminate on any graph and bounds the result at one entry per process.
+  // rootPid is pre-seeded so shape 1 cannot re-enter; nothing is lost by it,
+  // because the root's own children were already seeded into the queue.
+  //
+  // Keying by pid alone is deliberate and safe: PID reuse is a phenomenon across
+  // TIME and this walk only ever sees one instant. The kill path does not rely
+  // on this list being identity-unique either - `createProcessMonitor` and
+  // `terminateProcessTree` both re-key on `pid\0identity`.
   const descendants = [];
   const seen = new Set([rootPid]);
   const queue = [...(childrenByParent.get(rootPid) || [])];
@@ -986,6 +1005,15 @@ function descendantsFromSnapshot(rootPid, snapshot) {
     if (seen.has(record.pid)) continue;
     seen.add(record.pid);
     descendants.push(record);
+    // Belt and braces, and the reason a regression here FAILS instead of hanging.
+    // The result is provably bounded by the snapshot size, so this can never fire
+    // on a legitimate table. Without it, breaking the visited set does not raise a
+    // catchable error: it allocates until the process dies of a FATAL heap OOM,
+    // which in a test shard reads as a crashed or hung runner rather than a
+    // failing assertion.
+    if (descendants.length > snapshot.length) {
+      throw new Error(`${TAG} descendant walk did not terminate (rootPid=${rootPid})`);
+    }
     queue.push(...(childrenByParent.get(record.pid) || []));
   }
   return descendants;

--- a/scripts/platform-package-smoke.mjs
+++ b/scripts/platform-package-smoke.mjs
@@ -967,10 +967,24 @@ function descendantsFromSnapshot(rootPid, snapshot) {
     children.push(record);
     childrenByParent.set(record.parentPid, children);
   }
+  // A process table is NOT guaranteed to be a tree, so this walk must not assume
+  // one. Windows recycles PIDs aggressively, and a surviving child whose parent
+  // slot has been reused can report a ppid that is itself inside this subtree -
+  // a cycle. Without the visited set below the queue refills forever and the
+  // only thing that stops it is `descendants.push` throwing
+  // "RangeError: Invalid array length" once the array reaches 2^32-1, which is
+  // what took down the windows-x64 leg of the v0.12.1 release AFTER a clean
+  // install and build. Marking a PID before enqueueing it makes the walk
+  // terminate on any graph, and bounds the result at one entry per process.
+  // rootPid is pre-seeded so a self-parent or a child pointing back at the root
+  // cannot re-enter either.
   const descendants = [];
+  const seen = new Set([rootPid]);
   const queue = [...(childrenByParent.get(rootPid) || [])];
   while (queue.length) {
     const record = queue.shift();
+    if (seen.has(record.pid)) continue;
+    seen.add(record.pid);
     descendants.push(record);
     queue.push(...(childrenByParent.get(record.pid) || []));
   }

--- a/tests/unit/process/agent/wcore/engineConfigRecovery.test.ts
+++ b/tests/unit/process/agent/wcore/engineConfigRecovery.test.ts
@@ -28,7 +28,29 @@ import { existsSync, readdirSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, sep } from 'node:path';
 import { parse } from 'smol-toml';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * Counts every TOML parse without changing what one does.
+ *
+ * The two halves of the repair budget - bytes and wall clock - mask each other:
+ * with both live, deleting either still yields "gave up", so a result-only
+ * assertion cannot tell them apart and a mutant that removes the byte cap
+ * survives. Parses are the unit the byte budget is actually spent in, so
+ * counting them lets the byte cap be asserted directly, with the clock frozen
+ * so it cannot be what stopped the work.
+ */
+const parseCalls = vi.hoisted(() => ({ n: 0 }));
+vi.mock('smol-toml', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('smol-toml')>();
+  return {
+    ...actual,
+    parse: (...args: Parameters<typeof actual.parse>) => {
+      parseCalls.n += 1;
+      return actual.parse(...args);
+    },
+  };
+});
 import {
   EngineConfigBackupError,
   createVerifiedBackup,
@@ -406,19 +428,79 @@ describe('planLineBreakRepair', () => {
     expect(Date.now() - started).toBeLessThan(500);
   });
 
-  it('still repairs a normal-sized config that needs several breaks (known positive)', () => {
-    // The budget must not have made the feature useless. 20 KB of real tables plus
-    // a glued line needing 4 breaks - the shape a user actually has.
+  /** 20 KB of real tables plus a glued line needing 4 breaks - the shape a user
+   *  actually has. Shared so the two clock cases below argue about the SAME
+   *  document and differ only in what time does. */
+  function normalSizedGluedConfig(): string {
     let doc = '';
     for (let t = 0; doc.length < 20000; t += 1) {
       doc += `[section_${t}]\nname = "value-${t}"\nnote = "padpadpadpadpadpadpadpadpadpad"\n\n`;
     }
-    doc += `[tail]\n${Array.from({ length: 5 }, (_, i) => `k${i} = 1`).join('')}\n`;
+    return doc + `[tail]\n${Array.from({ length: 5 }, (_, i) => `k${i} = 1`).join('')}\n`;
+  }
 
-    const repair = planLineBreakRepair(doc);
-    expect(repair).not.toBeNull();
-    expect(repair?.plan.lineBreaks).toBe(4);
-    expect(() => parse(repair!.repaired)).not.toThrow();
+  it('still repairs a normal-sized config that needs several breaks (known positive)', () => {
+    // The BYTE budget must not have made the feature useless. Time is frozen so
+    // the separate WALL-CLOCK bound cannot decide this case: with a real clock
+    // the 250ms deadline races the test, and on a loaded machine it wins and
+    // turns a statement about the byte budget into a statement about the load
+    // average. The deadline gets its own test below rather than being asserted
+    // here by accident.
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    try {
+      const repair = planLineBreakRepair(normalSizedGluedConfig());
+      expect(repair).not.toBeNull();
+      expect(repair?.plan.lineBreaks).toBe(4);
+      expect(() => parse(repair!.repaired)).not.toThrow();
+    } finally {
+      now.mockRestore();
+    }
+  });
+
+  it('bounds PARSES by the byte budget alone, with the clock frozen', () => {
+    // The byte half of the budget, asserted where the clock cannot reach it.
+    // Same pathological document as the cost-product test above: 852 parses
+    // totalling 417 MB before the budget existed, 4 parses and 1.96 MB after.
+    // Frozen time means only the byte cap can stop this, and a count rather
+    // than a stopwatch means a loaded machine cannot change the answer.
+    const alpha = 'abcdefghijklmnopqrstuvwxyz';
+    const pairs = Array.from({ length: 40 }, (_, i) => `${alpha[i % 26]}${alpha[Math.floor(i / 26)]}q = "v"`);
+    const commentLine = `# ${'f'.repeat(120)}\n`;
+    const tail = `[tail]\n${pairs.join(' ')}\n`;
+    let doc = '';
+    while (Buffer.byteLength(doc, 'utf-8') + commentLine.length <= 513852 - Buffer.byteLength(tail, 'utf-8')) {
+      doc += commentLine;
+    }
+    doc += tail;
+
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    parseCalls.n = 0;
+    try {
+      expect(planLineBreakRepair(doc)).toBeNull();
+    } finally {
+      now.mockRestore();
+    }
+    // 4 parses with the budget; 852 without. Anything in between still fails.
+    expect(parseCalls.n).toBeLessThan(20);
+  });
+
+  it('gives up on that SAME config once the wall-clock deadline passes', () => {
+    // The deadline half of the budget, which nothing covered while it was only
+    // ever exercised by accident. A clock that jumps 200ms per reading passes
+    // MAX_REPAIR_MILLIS partway through, so the planner must abandon a document
+    // it just proved it can repair - and abandon it whole, returning null rather
+    // than a partial plan.
+    let t = 1_000_000;
+    const now = vi.spyOn(Date, 'now').mockImplementation(() => {
+      const value = t;
+      t += 200;
+      return value;
+    });
+    try {
+      expect(planLineBreakRepair(normalSizedGluedConfig())).toBeNull();
+    } finally {
+      now.mockRestore();
+    }
   });
 });
 

--- a/tests/unit/process/agent/wcore/engineConfigRecovery.test.ts
+++ b/tests/unit/process/agent/wcore/engineConfigRecovery.test.ts
@@ -447,6 +447,7 @@ describe('planLineBreakRepair', () => {
     // average. The deadline gets its own test below rather than being asserted
     // here by accident.
     const now = vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    parseCalls.n = 0;
     try {
       const repair = planLineBreakRepair(normalSizedGluedConfig());
       expect(repair).not.toBeNull();
@@ -455,6 +456,13 @@ describe('planLineBreakRepair', () => {
     } finally {
       now.mockRestore();
     }
+    // Freezing the clock removed something real: with a live clock this
+    // assertion transitively proved a realistic repair FINISHES inside
+    // MAX_REPAIR_MILLIS on actual hardware. Make somebody making this planner
+    // quadratic fail here, deterministically, instead of shipping a feature that
+    // silently stops being offered to every user because it now blows the
+    // deadline. A work bound, not a stopwatch.
+    expect(parseCalls.n).toBe(40);
   });
 
   it('bounds PARSES by the byte budget alone, with the clock frozen', () => {
@@ -480,8 +488,12 @@ describe('planLineBreakRepair', () => {
     } finally {
       now.mockRestore();
     }
-    // 4 parses with the budget; 852 without. Anything in between still fails.
-    expect(parseCalls.n).toBeLessThan(20);
+    // EXACT, not a range. `< 20` tolerated MAX_REPAIR_PARSE_BYTES growing from
+    // 2 MB to ~10 MB - a 5x increase in the main-thread freeze this budget
+    // exists to prevent - while still passing green. The count is fully
+    // deterministic here: frozen clock, fixed ASCII document, integer budget
+    // arithmetic. 4 parses with the budget, 852 without.
+    expect(parseCalls.n).toBe(4);
   });
 
   it('gives up on that SAME config once the wall-clock deadline passes', () => {

--- a/tests/unit/process/task/acpAgentManagerNpmFallback.test.ts
+++ b/tests/unit/process/task/acpAgentManagerNpmFallback.test.ts
@@ -20,13 +20,24 @@
  */
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 
-const { mockGet, mockIsCliAvailable } = vi.hoisted(() => ({
+const { mockGet, mockIsCliAvailable, mockResolveWNanoBinary } = vi.hoisted(() => ({
   mockGet: vi.fn(),
   mockIsCliAvailable: vi.fn(),
+  mockResolveWNanoBinary: vi.fn(),
 }));
 
 vi.mock('@process/agent/acp/AcpDetector', () => ({
   acpDetector: { isCliAvailable: mockIsCliAvailable },
+}));
+// `resolveWNanoBinary` probes the REAL filesystem (userData override, bundled
+// resource, dev resources) and runs BEFORE the PATH probe below, so leaving it
+// unmocked made every assertion here depend on whether the machine happened to
+// have Nano installed: green in CI, three failures on any developer box with a
+// copy at ~/.local/bin/wayland-nano. The default is null - "no verified binary
+// present" - which is the precondition the npm-fallback cases are about; the
+// case that DOES have one sets it explicitly.
+vi.mock('@process/agent/wnano/binaryResolver', () => ({
+  resolveWNanoBinary: mockResolveWNanoBinary,
 }));
 vi.mock('@process/services/cron/CronBusyGuard', () => ({
   cronBusyGuard: { setProcessing: vi.fn(), isProcessing: vi.fn(() => false) },
@@ -106,6 +117,8 @@ describe('resolveBuiltinBackendConfig — npm fallback for builtins', () => {
     mockGet.mockReset();
     mockGet.mockResolvedValue(undefined);
     mockIsCliAvailable.mockReset();
+    mockResolveWNanoBinary.mockReset();
+    mockResolveWNanoBinary.mockReturnValue(null);
   });
 
   it('falls back to the pinned npm package when wayland-nano is NOT on PATH', async () => {
@@ -126,6 +139,30 @@ describe('resolveBuiltinBackendConfig — npm fallback for builtins', () => {
 
     expect(res.cliPath).toBe('wayland-nano');
     expect(res.cliPath).not.toContain('npx');
+  });
+
+  it('prefers a verified bundled binary over BOTH the npm pin and a bare PATH name', async () => {
+    // The ordering this file exists to pin, and the branch the unmocked
+    // filesystem was silently exercising: a resolved binary outranks the npm
+    // fallback even when PATH cannot serve the bare command.
+    mockIsCliAvailable.mockReturnValue(false);
+    mockResolveWNanoBinary.mockReturnValue('/opt/wayland/resources/wayland-nano');
+
+    const res = await resolveBuiltin('wnano')({ backend: 'wnano' });
+
+    expect(res.cliPath).toBe('/opt/wayland/resources/wayland-nano');
+    expect(res.cliPath).not.toContain('npx');
+  });
+
+  it('quotes a resolved binary path that contains whitespace', async () => {
+    // macOS userData lives under "Application Support"; an unquoted path would
+    // be split into two tokens by the spawn config.
+    mockIsCliAvailable.mockReturnValue(false);
+    mockResolveWNanoBinary.mockReturnValue('/Users/x/Application Support/wayland-nano');
+
+    const res = await resolveBuiltin('wnano')({ backend: 'wnano' });
+
+    expect(res.cliPath).toBe('"/Users/x/Application Support/wayland-nano"');
   });
 
   it('never overrides an explicitly configured cliPath, and does not even probe PATH', async () => {

--- a/tests/unit/process/task/acpAgentManagerNpmFallback.test.ts
+++ b/tests/unit/process/task/acpAgentManagerNpmFallback.test.ts
@@ -154,6 +154,20 @@ describe('resolveBuiltinBackendConfig — npm fallback for builtins', () => {
     expect(res.cliPath).not.toContain('npx');
   });
 
+  it('prefers the resolved binary even when the bare command IS on PATH', async () => {
+    // The other half of the headline claim, and the half that matters: an
+    // in-app-accepted update under userData has to supersede an older copy that
+    // happens to be on PATH. Asserting this only with the PATH probe returning
+    // false proved the resolved binary beats the npm pin and nothing more.
+    mockIsCliAvailable.mockReturnValue(true);
+    mockResolveWNanoBinary.mockReturnValue('/opt/wayland/resources/wayland-nano');
+
+    const res = await resolveBuiltin('wnano')({ backend: 'wnano' });
+
+    expect(res.cliPath).toBe('/opt/wayland/resources/wayland-nano');
+    expect(res.cliPath).not.toBe('wayland-nano');
+  });
+
   it('quotes a resolved binary path that contains whitespace', async () => {
     // macOS userData lives under "Application Support"; an unquoted path would
     // be split into two tokens by the spawn config.
@@ -167,6 +181,10 @@ describe('resolveBuiltinBackendConfig — npm fallback for builtins', () => {
 
   it('never overrides an explicitly configured cliPath, and does not even probe PATH', async () => {
     mockIsCliAvailable.mockReturnValue(false);
+    // A bundled binary must be PRESENT here, or the `!cliPath` half of the guard
+    // is unpinned: delete it and the resolver would clobber a path the user
+    // deliberately configured, and every assertion would still pass.
+    mockResolveWNanoBinary.mockReturnValue('/opt/bundled/wayland-nano');
 
     const res = await resolveBuiltin('wnano')({ backend: 'wnano', cliPath: '/opt/custom/wayland-nano' });
 

--- a/tests/unit/scripts/platformPackageSmokeDescendants.test.ts
+++ b/tests/unit/scripts/platformPackageSmokeDescendants.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * The descendant walk in `platform-package-smoke.mjs` had no coverage at all,
+ * and it assumed the process table is a tree. It is not: Windows recycles PIDs,
+ * so a surviving child whose parent slot was reused can report a ppid that is
+ * itself inside the subtree being walked. That is a cycle, and the walk refilled
+ * its queue forever until `Array.push` hit the 2^32-1 limit and threw
+ * "RangeError: Invalid array length".
+ *
+ * It took down the windows-x64 leg of the v0.12.1 release AFTER a clean build
+ * and a successful 181s silent install, and the identical windows-arm64 leg
+ * passed - which is what a data-dependent defect looks like from the outside.
+ */
+import { describe, expect, it } from 'vitest';
+import { listDescendantPids, listDescendantProcessRecords } from '../../../scripts/platform-package-smoke.mjs';
+
+/** Feed the real win32 parser a synthetic Get-CimInstance payload. */
+function winSnapshot(rows: Array<{ pid: number; ppid: number; name?: string }>) {
+  const payload = JSON.stringify(
+    rows.map((r) => ({
+      ProcessId: r.pid,
+      ParentProcessId: r.ppid,
+      CreationDate: '20260818000000.000000+000',
+      ExecutablePath: `C:\\\\p\\\\${r.name || `p${r.pid}`}.exe`,
+      Name: `${r.name || `p${r.pid}`}.exe`,
+      CommandLine: `${r.name || `p${r.pid}`}.exe`,
+    }))
+  );
+  return { execFileSync: () => payload };
+}
+
+describe('descendant walk over a process table that is not a tree', () => {
+  it('returns every descendant of a normal tree, depth first from the root (known positive)', () => {
+    // Without this the cycle cases below could pass by returning nothing.
+    const deps = winSnapshot([
+      { pid: 100, ppid: 1 },
+      { pid: 200, ppid: 100 },
+      { pid: 300, ppid: 100 },
+      { pid: 400, ppid: 200 },
+      { pid: 999, ppid: 1 }, // unrelated, must NOT appear
+    ]);
+
+    expect(listDescendantPids(100, 'win32', deps).sort()).toEqual([200, 300, 400]);
+  });
+
+  it('TERMINATES when a descendant claims a parent inside the subtree (PID reuse)', () => {
+    // 400's parent slot was recycled and now points back at 200, closing a loop
+    // 200 -> 400 -> 200. Before the visited set this never returned: it grew the
+    // result array until push threw RangeError.
+    const deps = winSnapshot([
+      { pid: 100, ppid: 1 },
+      { pid: 200, ppid: 100 },
+      { pid: 400, ppid: 200 },
+      { pid: 200, ppid: 400 },
+    ]);
+
+    const pids = listDescendantPids(100, 'win32', deps);
+    expect(pids).toContain(200);
+    expect(pids).toContain(400);
+    // One entry per process, however many parents claim it.
+    expect(new Set(pids).size).toBe(pids.length);
+  });
+
+  it('TERMINATES when a process is its own parent', () => {
+    const deps = winSnapshot([
+      { pid: 100, ppid: 1 },
+      { pid: 250, ppid: 100 },
+      { pid: 250, ppid: 250 },
+    ]);
+
+    expect(listDescendantPids(100, 'win32', deps)).toEqual([250]);
+  });
+
+  it('TERMINATES when a child points back at the root itself', () => {
+    const deps = winSnapshot([
+      { pid: 100, ppid: 500 },
+      { pid: 500, ppid: 100 },
+    ]);
+
+    expect(listDescendantPids(100, 'win32', deps)).toEqual([500]);
+  });
+
+  it('carries the full record through, not just the pid', () => {
+    const deps = winSnapshot([
+      { pid: 100, ppid: 1 },
+      { pid: 200, ppid: 100, name: 'Wayland' },
+    ]);
+
+    const [record] = listDescendantProcessRecords(100, 'win32', deps);
+    expect(record.pid).toBe(200);
+    expect(record.scopeText).toContain('Wayland');
+    expect(record.identity).toContain('20260818000000');
+  });
+});

--- a/tests/unit/scripts/platformPackageSmokeDescendants.test.ts
+++ b/tests/unit/scripts/platformPackageSmokeDescendants.test.ts
@@ -6,11 +6,16 @@
 
 /**
  * The descendant walk in `platform-package-smoke.mjs` had no coverage at all,
- * and it assumed the process table is a tree. It is not: Windows recycles PIDs,
- * so a surviving child whose parent slot was reused can report a ppid that is
- * itself inside the subtree being walked. That is a cycle, and the walk refilled
- * its queue forever until `Array.push` hit the 2^32-1 limit and threw
- * "RangeError: Invalid array length".
+ * and it assumed the process table is a walkable tree. It is not.
+ *
+ * Be precise about WHICH shape loops, because the obvious guess is wrong. Every
+ * record carries one parentPid, so the child index is an inverted functional
+ * graph and a node on a cycle has its only parent inside that cycle - its
+ * ancestor chain never reaches the root, so the walk cannot enter it. Only two
+ * shapes actually loop: the ROOT itself sitting on a cycle (realistic - PID
+ * reuse lets the root's ancestry re-enter its own subtree), and a snapshot
+ * carrying two records with the same pid (which Get-CimInstance cannot emit, so
+ * it is defence against a malformed table, not an observed shape).
  *
  * It took down the windows-x64 leg of the v0.12.1 release AFTER a clean build
  * and a successful 181s silent install, and the identical windows-arm64 leg
@@ -35,7 +40,7 @@ function winSnapshot(rows: Array<{ pid: number; ppid: number; name?: string }>) 
 }
 
 describe('descendant walk over a process table that is not a tree', () => {
-  it('returns every descendant of a normal tree, depth first from the root (known positive)', () => {
+  it('returns every descendant of a normal tree (known positive)', () => {
     // Without this the cycle cases below could pass by returning nothing.
     const deps = winSnapshot([
       { pid: 100, ppid: 1 },
@@ -48,10 +53,10 @@ describe('descendant walk over a process table that is not a tree', () => {
     expect(listDescendantPids(100, 'win32', deps).sort()).toEqual([200, 300, 400]);
   });
 
-  it('TERMINATES when a descendant claims a parent inside the subtree (PID reuse)', () => {
-    // 400's parent slot was recycled and now points back at 200, closing a loop
-    // 200 -> 400 -> 200. Before the visited set this never returned: it grew the
-    // result array until push threw RangeError.
+  it('TERMINATES on a malformed table that repeats a pid with a different parent', () => {
+    // DEFENSIVE, not observed: a real snapshot has one row per pid. Kept because
+    // the walk consumes whatever the parser produces and must not be able to
+    // spin on bad input.
     const deps = winSnapshot([
       { pid: 100, ppid: 1 },
       { pid: 200, ppid: 100 },
@@ -66,7 +71,7 @@ describe('descendant walk over a process table that is not a tree', () => {
     expect(new Set(pids).size).toBe(pids.length);
   });
 
-  it('TERMINATES when a process is its own parent', () => {
+  it('TERMINATES on a malformed table where a process is its own parent', () => {
     const deps = winSnapshot([
       { pid: 100, ppid: 1 },
       { pid: 250, ppid: 100 },
@@ -76,7 +81,9 @@ describe('descendant walk over a process table that is not a tree', () => {
     expect(listDescendantPids(100, 'win32', deps)).toEqual([250]);
   });
 
-  it('TERMINATES when a child points back at the root itself', () => {
+  it('TERMINATES when the ROOT is on the cycle (the realistic reproduction)', () => {
+    // This is the shape that actually failed the release: the root's own
+    // ancestry re-enters its subtree, so its children are re-seeded forever.
     const deps = winSnapshot([
       { pid: 100, ppid: 500 },
       { pid: 500, ppid: 100 },


### PR DESCRIPTION
Contains the v0.12.1 release blocker.

**The blocker.** The windows-x64 leg of the v0.12.1 tag build failed AFTER a clean build and a successful 181s silent install, with RangeError: Invalid array length at platform-package-smoke.mjs descendants.push(record). The descendant walk assumed the process table is a tree. It is not: Windows recycles PIDs, so a surviving child whose parent slot has been reused can report a ppid that is itself inside the subtree, closing a cycle. The queue refills forever and only stops when push hits the 2^32-1 array limit. Marking a PID before enqueueing terminates the walk on any graph. Pre-existing (same shape in v0.12.0) and latent, which is why the identical windows-arm64 leg passed in the same run. It had no test coverage at all; five added, and bypassing the visited set fails three of them and reproduces the RangeError.

Nothing was published: the release pipeline is fail-closed, so every downstream job skipped.

**The two host-dependent suites.** Both passed in CI and failed on a developer machine, which is the worst shape a test can have because it trains you to ignore red.

acpAgentManagerNpmFallback mocked the PATH probe but not resolveWNanoBinary, which reads the real filesystem and runs before the probe, so any machine with a copy at ~/.local/bin/wayland-nano resolved that instead. Now mocked, with real coverage for the branch the leak had been silently exercising.

engineConfigRecovery's known-positive raced the planner's 250ms wall-clock deadline, so under load a statement about the byte budget became a statement about the load average. Time is frozen there now and the deadline gets its own case. That exposed the more valuable finding: the two halves of the budget mask each other, so a mutant removing the byte cap survived. The new case counts TOML parses with the clock frozen, 4 with the budget against 852 without.

Full suite on the machine that used to report 3 failures: 18,745 passed, 0 failed.