### PR TITLE
fix(release): make the release gate executable, and fix the eight blockers hiding in it

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -716,6 +716,19 @@ jobs:
   # Publish only after BOTH the macOS and Windows install gates pass. Keeping
   # publish in its own job (instead of inside the macOS gate) makes the draft ->
   # published flip depend on a green Windows signature too.
+  #
+  # `-rehearsal-` is the ONLY thing this job excludes beyond `-dev-`, and that is
+  # what makes this pipeline testable. Every acceptance job - both observers, the
+  # assembler and the final trust-root acceptance - runs only on a tag, so until
+  # now a defect in them could be discovered only by cutting a REAL release and
+  # burning two hours of six-platform matrix, which is why five separate blockers
+  # accumulated in code that had never executed. A `vX.Y.Z-rehearsal-N` tag runs
+  # the entire chain end to end - dispatch, OIDC, attestation, all six targets -
+  # and stops here, so it can prove the pipeline without shipping anything.
+  #
+  # It is deliberately NOT the `-dev-` marker: create-tag pushes `vX.Y.Z-dev-<sha>`
+  # on every dev-branch build, and admitting those would fire a second full build
+  # plus the whole acceptance matrix on every dev push.
   publish-release:
     name: Publish Release (both gates passed)
     runs-on: ubuntu-latest
@@ -725,7 +738,9 @@ jobs:
       needs.release-smoke-gate.result == 'success' &&
       needs.release-smoke-gate-windows.result == 'success' &&
       needs.final-release-acceptance.result == 'success' &&
-      startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-dev-')
+      startsWith(github.ref, 'refs/tags/') &&
+      !contains(github.ref, '-dev-') &&
+      !contains(github.ref, '-rehearsal-')
     steps:
       - name: Resolve tag
         id: tag

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -18,14 +18,107 @@ env:
   WAYLANDMCP_REF: '29a253804ccd3d7f1eb385cf610b0dc27a130478'
 
 jobs:
+  # Everything this job checks is a blocker this pipeline has ALREADY hit, and every
+  # one of them was discoverable in seconds but only ever surfaced two hours into a
+  # six-platform matrix - or worse, after the release had been cut. A stale trust
+  # root fails EVERY attestation at the very end; an observer workflow missing from
+  # the default branch 404s the dispatch, because that is where GitHub resolves
+  # workflow_dispatch by filename; a moved engine pin makes the acceptance assembler
+  # demand asset names that no download can match.
+  #
+  # It runs first and the build depends on it, so the answer to "are we ready?"
+  # arrives in a minute instead of after the whole matrix has been spent.
+  release-preflight:
+    name: Release Preflight
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-dev-')
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout exact candidate
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Assert every release precondition
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUST_ROOT_SHA: ${{ vars.WAYLAND_RELEASE_TRUST_ROOT_SHA }}
+        run: |
+          set -euo pipefail
+          failed=0
+          note() { echo "PREFLIGHT FAIL: $*" >&2; failed=1; }
+
+          # 1. The observers must be registered on the DEFAULT branch, or the
+          #    producer's `gh workflow run <file>` dies with a 404 mid-release.
+          for wf in protected-platform-package-observer.yml protected-updater-journey-observer.yml; do
+            if ! gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$wf" >/dev/null 2>&1; then
+              note "workflow $wf is not registered on the default branch; dispatch would 404"
+            fi
+          done
+
+          # 2. The trust root pin must match the protected verifier branch. A stale
+          #    pin fails `gh attestation verify --signer-digest` for all six targets
+          #    at the LAST step of the pipeline.
+          if [[ -z "${TRUST_ROOT_SHA:-}" ]]; then
+            note "WAYLAND_RELEASE_TRUST_ROOT_SHA is unset"
+          else
+            head="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/release-trust-v1" --jq .object.sha 2>/dev/null || true)"
+            if [[ -z "$head" ]]; then
+              note "release-trust-v1 does not exist"
+            elif [[ "$head" != "$TRUST_ROOT_SHA" ]]; then
+              note "trust root pin $TRUST_ROOT_SHA != release-trust-v1 head $head; every attestation would be rejected"
+            fi
+          fi
+
+          # 3. The engine tag is read from the bundle authority, and every asset the
+          #    acceptance assembler demands must actually exist upstream.
+          core_tag="$(node -p "require('./scripts/prepareWaylandCore').DEFAULT_WCORE_VERSION")"
+          if [[ ! "$core_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            note "engine pin is not a release tag: '$core_tag'"
+          else
+            available="$(gh release view "$core_tag" --repo FerroxLabs/wayland-core --json assets --jq '.assets[].name' 2>/dev/null || true)"
+            if [[ -z "$available" ]]; then
+              note "wayland-core $core_tag has no downloadable release"
+            else
+              while read -r asset; do
+                [[ -z "$asset" ]] && continue
+                grep -qxF "$asset" <<<"$available" || note "wayland-core $core_tag is missing $asset"
+              done < <(node -e "
+                const p=require('./scripts/prepareWaylandCore');
+                const m=require('./scripts/release-acceptance/verifyHardeningMatrix');
+                for (const t of m.TARGETS) { const [pl,ar]=t.split('-'); console.log(p.getAssetName(pl,ar,p.DEFAULT_WCORE_VERSION)); }
+              ")
+            fi
+          fi
+
+          if [[ "$failed" -ne 0 ]]; then
+            echo "Preflight refused the release. Nothing was built." >&2
+            exit 1
+          fi
+          echo "Preflight passed: observers registered, trust root current, engine $core_tag complete."
+
   build-pipeline:
     name: Build Pipeline
+    needs: [release-preflight]
     uses: ./.github/workflows/_build-reusable.yml
     permissions:
       actions: read
       contents: read
-    # dev 分支或正式 tag 触发构建（排除 -dev- tag，避免重复构建）
-    if: github.ref == 'refs/heads/dev' || (startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-dev-'))
+    # The dev branch, or a real tag (dev-branch auto tags are excluded to avoid a
+    # duplicate build). `always()` plus the explicit skipped check is required
+    # because preflight only runs for tags, and a skipped dependency would
+    # otherwise propagate and cancel every dev-branch build.
+    if: |
+      always() &&
+      (needs.release-preflight.result == 'success' || needs.release-preflight.result == 'skipped') &&
+      (github.ref == 'refs/heads/dev' || (startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-dev-')))
     with:
       matrix: >-
         {"include":[

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -598,6 +598,12 @@ jobs:
           echo "commit=$commit" >> "$GITHUB_OUTPUT"
           echo "tree=$tree" >> "$GITHUB_OUTPUT"
 
+      # The acceptance scripts below are release-critical and were running on
+      # whatever Node the runner image happened to ship.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
       - name: Download exact canonical build artifacts
         uses: actions/download-artifact@v7
         with:

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -603,15 +603,26 @@ jobs:
         with:
           path: canonical-artifacts
 
+      # The engine tag is READ from the bundle authority, never re-typed.
+      # assembleCanonicalRawAcceptance.js derives the asset names it demands from
+      # prepareWaylandCore.DEFAULT_WCORE_VERSION, so a literal tag here goes stale
+      # the moment the pin moves and nothing downloaded can ever match it - which
+      # is exactly what a hard-coded v0.12.25 did once the pin reached v0.13.0.
       - name: Download exact pinned Wayland Core publisher artifacts
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          mkdir -p canonical-artifacts/wayland-core-v0.12.25
-          gh release download v0.12.25 \
+          set -euo pipefail
+          core_tag="$(node -p "require('./scripts/prepareWaylandCore').DEFAULT_WCORE_VERSION")"
+          [[ "$core_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]] || {
+            echo "refusing to download an unpinned engine tag: '$core_tag'" >&2
+            exit 1
+          }
+          mkdir -p "canonical-artifacts/wayland-core-$core_tag"
+          gh release download "$core_tag" \
             --repo FerroxLabs/wayland-core \
-            --dir canonical-artifacts/wayland-core-v0.12.25 \
-            --pattern 'wayland-core-v0.12.25-*'
+            --dir "canonical-artifacts/wayland-core-$core_tag" \
+            --pattern "wayland-core-$core_tag-*"
 
       - name: Assemble complete raw acceptance source
         run: |

--- a/.github/workflows/protected-platform-package-observer.yml
+++ b/.github/workflows/protected-platform-package-observer.yml
@@ -168,7 +168,7 @@ jobs:
           EXPECTED_COMMIT: ${{ inputs.candidate_commit }}
         run: |
           set -euo pipefail
-          producer="$(gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$PRODUCER_RUN_ID")"
+          producer="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$PRODUCER_RUN_ID")"
           actual_attempt="$(printf '%s' "$producer" | jq -r .run_attempt)"
           test "$actual_attempt" = "$PRODUCER_RUN_ATTEMPT"
           test "$(printf '%s' "$producer" | jq -r .head_sha)" = "$EXPECTED_COMMIT"

--- a/.github/workflows/protected-updater-journey-observer.yml
+++ b/.github/workflows/protected-updater-journey-observer.yml
@@ -179,7 +179,7 @@ jobs:
           EXPECTED_COMMIT: ${{ inputs.candidate_commit }}
         run: |
           set -euo pipefail
-          producer="$(gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$PRODUCER_RUN_ID")"
+          producer="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$PRODUCER_RUN_ID")"
           test "$(printf '%s' "$producer" | jq -r .run_attempt)" = "$PRODUCER_RUN_ATTEMPT"
           test "$(printf '%s' "$producer" | jq -r .head_sha)" = "$EXPECTED_COMMIT"
           test "$(printf '%s' "$producer" | jq -r .path)" = ".github/workflows/build-and-release.yml"

--- a/.github/workflows/protected-updater-journey-observer.yml
+++ b/.github/workflows/protected-updater-journey-observer.yml
@@ -1,0 +1,347 @@
+name: Protected native updater journey observer
+run-name: protected-updater-observer candidate=${{ inputs.candidate_commit }} producer=${{ inputs.producer_run_id }} attempt=${{ inputs.producer_run_attempt }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_commit:
+        description: Exact candidate commit built by the producer run
+        required: true
+        type: string
+      candidate_tree:
+        description: Exact candidate tree built by the producer run
+        required: true
+        type: string
+      producer_run_id:
+        description: Exact build-and-release run containing the native installers
+        required: true
+        type: string
+      producer_run_attempt:
+        description: Exact producer run attempt
+        required: true
+        type: string
+      release_track:
+        description: Native package release track
+        required: true
+        default: stable
+        type: choice
+        options: [stable, preview]
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: protected-updater-observer-${{ inputs.candidate_commit }}-${{ inputs.producer_run_id }}-${{ inputs.producer_run_attempt }}
+  cancel-in-progress: false
+
+jobs:
+  observe:
+    name: Observe native updater journey (${{ matrix.target }})
+    if: github.ref == 'refs/heads/release-trust-v1'
+    permissions:
+      actions: read
+      contents: read
+    env:
+      # Candidate application bytes execute in this job. Keep OIDC capability absent
+      # even if a future caller broadens workflow-level permissions, and keep the
+      # forge tokens out of the default environment so only the steps that must talk
+      # to the API can.
+      ACTIONS_ID_TOKEN_REQUEST_TOKEN: ''
+      ACTIONS_ID_TOKEN_REQUEST_URL: ''
+      GH_TOKEN: ''
+      GITHUB_TOKEN: ''
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: darwin-arm64
+            os: macos-15
+            platform: darwin
+            arch: arm64
+            artifact: macos-build-arm64
+            extension: dmg
+            initial: Wayland-0.11.18-mac-arm64.dmg
+            rollback: Wayland-0.11.8-mac-arm64.zip
+          - target: darwin-x64
+            os: macos-15-intel
+            platform: darwin
+            arch: x64
+            artifact: macos-build-x64
+            extension: dmg
+            initial: Wayland-0.11.18-mac-x64.dmg
+            rollback: Wayland-0.11.8-mac-x64.zip
+          - target: win32-arm64
+            os: windows-11-arm
+            platform: win32
+            arch: arm64
+            artifact: windows-build-arm64
+            extension: exe
+            initial: Wayland-0.11.18-win-arm64.exe
+            rollback: Wayland-0.11.8-win-arm64.exe
+          - target: win32-x64
+            os: windows-2022
+            platform: win32
+            arch: x64
+            artifact: windows-build-x64
+            extension: exe
+            initial: Wayland-0.11.18-win-x64.exe
+            rollback: Wayland-0.11.8-win-x64.exe
+          - target: linux-arm64
+            os: ubuntu-24.04-arm
+            platform: linux
+            arch: arm64
+            artifact: linux-build-arm64
+            extension: deb
+            initial: Wayland-0.11.18-linux-arm64.deb
+            rollback: Wayland-0.11.8-linux-arm64.AppImage
+          - target: linux-x64
+            os: ubuntu-24.04
+            platform: linux
+            arch: x64
+            artifact: linux-build-x64
+            extension: deb
+            initial: Wayland-0.11.18-linux-amd64.deb
+            rollback: Wayland-0.11.8-linux-x86_64.AppImage
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    steps:
+      - name: Checkout pinned protected observer
+        uses: actions/checkout@v6
+        with:
+          ref: release-trust-v1
+          path: trust
+          persist-credentials: false
+
+      - name: Checkout exact candidate as data
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.candidate_commit }}
+          path: candidate
+          persist-credentials: false
+
+      - name: Verify protected and candidate identities
+        shell: bash
+        env:
+          EXPECTED_COMMIT: ${{ inputs.candidate_commit }}
+          EXPECTED_TREE: ${{ inputs.candidate_tree }}
+        run: |
+          set -euo pipefail
+          test -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
+          test -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
+          test "$(git -C trust rev-parse HEAD)" = "$GITHUB_SHA"
+          test "$(git -C candidate rev-parse HEAD)" = "$EXPECTED_COMMIT"
+          test "$(git -C candidate rev-parse HEAD^{tree})" = "$EXPECTED_TREE"
+          test -z "$(git -C candidate status --porcelain=v1 --untracked-files=all)"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.14'
+
+      - name: Install protected observer dependencies
+        working-directory: trust
+        run: bun install --frozen-lockfile
+
+      # Capture runs before anything is downloaded so the recorded prior digests are
+      # provably empty. The digest is published as a step output because a step cannot
+      # read its own outputs: `${{ steps.<id>.outputs.* }}` is expanded before the step
+      # body runs and would interpolate to the empty string.
+      - name: Capture empty pre-download package state
+        id: package-state
+        shell: bash
+        env:
+          TARGET_PLATFORM: ${{ matrix.platform }}
+          TARGET_ARCH: ${{ matrix.arch }}
+          RELEASE_TRACK: ${{ inputs.release_track }}
+        run: |
+          set -euo pipefail
+          mkdir payload
+          cd candidate
+          node ../trust/scripts/platform-package-smoke.mjs \
+            --out ../payload \
+            --target-platform "$TARGET_PLATFORM" \
+            --target-arch "$TARGET_ARCH" \
+            --release-track "$RELEASE_TRACK" \
+            --capture-state "$RUNNER_TEMP/protected-updater-package-state.json" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Authenticate producer and download exact candidate package
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PRODUCER_RUN_ID: ${{ inputs.producer_run_id }}
+          PRODUCER_RUN_ATTEMPT: ${{ inputs.producer_run_attempt }}
+          ARTIFACT_NAME: ${{ matrix.artifact }}
+          EXPECTED_COMMIT: ${{ inputs.candidate_commit }}
+        run: |
+          set -euo pipefail
+          producer="$(gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$PRODUCER_RUN_ID")"
+          test "$(printf '%s' "$producer" | jq -r .run_attempt)" = "$PRODUCER_RUN_ATTEMPT"
+          test "$(printf '%s' "$producer" | jq -r .head_sha)" = "$EXPECTED_COMMIT"
+          test "$(printf '%s' "$producer" | jq -r .path)" = ".github/workflows/build-and-release.yml"
+          producer_state="$(printf '%s' "$producer" | jq -r '[.status, (.conclusion // "null")] | join(":")')"
+          case "$producer_state" in
+            in_progress:null|completed:success) ;;
+            *) echo "producer run is not an admissible exact build state: $producer_state" >&2; exit 1 ;;
+          esac
+          gh run download "$PRODUCER_RUN_ID" --repo "$GITHUB_REPOSITORY" --name "$ARTIFACT_NAME" --dir payload
+
+      - name: Independently observe installed native package
+        shell: bash
+        env:
+          TARGET_PLATFORM: ${{ matrix.platform }}
+          TARGET_ARCH: ${{ matrix.arch }}
+          RELEASE_TRACK: ${{ inputs.release_track }}
+          CANDIDATE_STATE_DIGEST: ${{ steps.package-state.outputs.candidate_state_digest }}
+        run: |
+          set -euo pipefail
+          test -n "$CANDIDATE_STATE_DIGEST"
+          cd candidate
+          node ../trust/scripts/platform-package-smoke.mjs \
+            --out ../payload \
+            --target-platform "$TARGET_PLATFORM" \
+            --target-arch "$TARGET_ARCH" \
+            --release-track "$RELEASE_TRACK" \
+            --candidate-state-file "$RUNNER_TEMP/protected-updater-package-state.json" \
+            --candidate-state-digest "$CANDIDATE_STATE_DIGEST"
+
+      # Downloaded outside payload/ on purpose. The compiled v0.11.18 initial installer
+      # shares the candidate's extension on linux and windows, and the smoke step above
+      # scans payload/ for installers.
+      - name: Download exact compiled initial and rollback releases
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INITIAL_ASSET: ${{ matrix.initial }}
+          ROLLBACK_ASSET: ${{ matrix.rollback }}
+        run: |
+          set -euo pipefail
+          mkdir -p releases/initial releases/rollback
+          gh release download v0.11.18 --repo "$GITHUB_REPOSITORY" --pattern "$INITIAL_ASSET" --dir releases/initial
+          gh release download v0.11.8 --repo "$GITHUB_REPOSITORY" --pattern "$ROLLBACK_ASSET" --dir releases/rollback
+          test -f "releases/initial/$INITIAL_ASSET"
+          test -f "releases/rollback/$ROLLBACK_ASSET"
+
+      - name: Observe initial failure rollback and re-upgrade from protected code
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+          CANDIDATE_COMMIT: ${{ inputs.candidate_commit }}
+          CANDIDATE_TREE: ${{ inputs.candidate_tree }}
+          INITIAL_ASSET: ${{ matrix.initial }}
+          ROLLBACK_ASSET: ${{ matrix.rollback }}
+          INSTALLER_EXTENSION: ${{ matrix.extension }}
+        run: |
+          set -euo pipefail
+          test -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
+          test -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
+          candidate_version="$(jq -er .version candidate/package.json)"
+          installer_count="$(find payload -maxdepth 1 -type f -iname "*.$INSTALLER_EXTENSION" -print | wc -l | tr -d ' ')"
+          test "$installer_count" -eq 1
+          installer="$(find payload -maxdepth 1 -type f -iname "*.$INSTALLER_EXTENSION" -print)"
+          test -f "payload/platform-package-smoke-$TARGET.json"
+          nonce="$(openssl rand -hex 32)"
+          node trust/scripts/release-acceptance/produceNativeUpdaterObservation.mjs \
+            --target "$TARGET" \
+            --commit "$CANDIDATE_COMMIT" \
+            --tree "$CANDIDATE_TREE" \
+            --version "$candidate_version" \
+            --nonce "$nonce" \
+            --run-id "$GITHUB_RUN_ID" \
+            --initial "releases/initial/$INITIAL_ASSET" \
+            --candidate "$installer" \
+            --rollback "releases/rollback/$ROLLBACK_ASSET" \
+            --package-smoke "payload/platform-package-smoke-$TARGET.json" \
+            --out observation-bundle
+          test -f observation-bundle/observation.json
+
+      - name: Upload untrusted native execution bundle
+        uses: actions/upload-artifact@v6
+        with:
+          name: untrusted-updater-observation-${{ matrix.target }}-${{ inputs.candidate_commit }}
+          path: observation-bundle
+          if-no-files-found: error
+          retention-days: 14
+
+  sign:
+    name: Sign protected updater observation (${{ matrix.target }})
+    needs: observe
+    if: github.ref == 'refs/heads/release-trust-v1'
+    permissions:
+      actions: read
+      attestations: write
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [darwin-arm64, darwin-x64, win32-arm64, win32-x64, linux-arm64, linux-x64]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout pinned signing authority only
+        uses: actions/checkout@v6
+        with:
+          ref: release-trust-v1
+          path: trust
+          persist-credentials: false
+
+      - name: Verify signing authority identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git -C trust rev-parse HEAD)" = "$GITHUB_SHA"
+          test -z "$(git -C trust status --porcelain=v1 --untracked-files=all)"
+
+      - name: Download same-run inert observation bytes
+        uses: actions/download-artifact@v7
+        with:
+          name: untrusted-updater-observation-${{ matrix.target }}-${{ inputs.candidate_commit }}
+          path: bundle
+
+      - name: Validate exact bundle without executing candidate
+        id: validate
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+          CANDIDATE_COMMIT: ${{ inputs.candidate_commit }}
+          CANDIDATE_TREE: ${{ inputs.candidate_tree }}
+        run: |
+          set -euo pipefail
+          validation="$(node trust/scripts/release-acceptance/validateNativeUpdaterBundle.js \
+            --bundle bundle \
+            --commit "$CANDIDATE_COMMIT" \
+            --tree "$CANDIDATE_TREE" \
+            --target "$TARGET" \
+            --run-id "$GITHUB_RUN_ID")"
+          printf '%s\n' "$validation"
+          candidate_installer="$(printf '%s' "$validation" | jq -er .candidateArtifactFile)"
+          case "$candidate_installer" in
+            ''|*/*|*\\*|.|..) echo "candidate artifact reference is not a bundle-local basename" >&2; exit 1 ;;
+          esac
+          test -f "bundle/$candidate_installer"
+          echo "candidate_installer=$candidate_installer" >> "$GITHUB_OUTPUT"
+
+      # The observation receipt carries this workflow's identity for the trust root's
+      # `gh attestation verify --signer-workflow`. The candidate installer is attested
+      # by the same job because verifyUpdaterObservation demands provenance from this
+      # exact workflow for the linux candidate artifact; signing all six keeps the
+      # matrix uniform and costs one extra subject.
+      - name: Attest exact protected updater observation bytes
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            bundle/observation.json
+            bundle/${{ steps.validate.outputs.candidate_installer }}
+
+      - name: Publish protected updater observation bundle
+        uses: actions/upload-artifact@v6
+        with:
+          name: protected-updater-observation-${{ matrix.target }}-${{ inputs.candidate_commit }}
+          path: bundle
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/protected-updater-journey-observer.yml
+++ b/.github/workflows/protected-updater-journey-observer.yml
@@ -144,7 +144,22 @@ jobs:
 
       - name: Install protected observer dependencies
         working-directory: trust
-        run: bun install --frozen-lockfile
+        shell: bash
+        run: |
+          # Retry: package.json pins a GitHub git dependency, so install traffic hits
+          # api.github.com and an API 504 reds out this observer for reasons unrelated
+          # to the release. The sibling platform observer already retries for exactly
+          # this reason. It matters more here than it looks: once any observer job
+          # fails, the producer run concludes `failure`, and both observers refuse a
+          # producer that is not in-progress or successful - so a single transient
+          # install failure cannot be re-dispatched and costs a whole new tag run.
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then exit 0; fi
+            echo "bun install attempt $attempt of 3 failed" >&2
+            if [[ $attempt -lt 3 ]]; then sleep $(( attempt * 20 )); fi
+          done
+          echo "bun install failed after 3 attempts (GitHub API or registry unreachable)" >&2
+          exit 1
 
       # Capture runs before anything is downloaded so the recorded prior digests are
       # provably empty. The digest is published as a step output because a step cannot
@@ -296,6 +311,13 @@ jobs:
           set -euo pipefail
           test "$(git -C trust rev-parse HEAD)" = "$GITHUB_SHA"
           test -z "$(git -C trust status --porcelain=v1 --untracked-files=all)"
+
+      # Pinned like the observe job. This job runs the validator that IS the gate;
+      # inheriting whatever Node the runner image happens to ship puts a
+      # release-critical script on an unpinned toolchain.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
 
       - name: Download same-run inert observation bytes
         uses: actions/download-artifact@v7

--- a/.github/workflows/release-acceptance-trust-root.yml
+++ b/.github/workflows/release-acceptance-trust-root.yml
@@ -124,7 +124,12 @@ jobs:
               >> "$records"
           }
           run_gate tests 'bun run test'
-          run_gate typecheck 'bunx tsc --noEmit'
+          # `bun run typecheck`, not a raw `tsc`: package.json sets
+          # NODE_OPTIONS=--max-old-space-size=8192 for this project, and without it the
+          # check dies of heap exhaustion. Every other gate here already goes through
+          # its script; this one bypassed it and would have OOM'd the first time this
+          # job was reached - which has never happened.
+          run_gate typecheck 'bun run typecheck'
           run_gate lint 'bun run lint'
           run_gate build 'bun run build:renderer:web'
           bun audit --json > "$GATE_OUTPUT/dependency-audit.json" 2> "$GATE_OUTPUT/dependency-audit.stderr" || true

--- a/scripts/platform-package-smoke.mjs
+++ b/scripts/platform-package-smoke.mjs
@@ -1322,30 +1322,30 @@ export async function runSmoke(options, dependencies = {}) {
     try {
       verification = verifyResources({
         argv: [
-        'node',
-        'verify-packaged-resources.js',
-        '--out',
-        installed.installRoot,
-        '--target-platform',
-        options.targetPlatform,
-        '--target-arch',
-        options.targetArch,
-        '--resources-dir',
-        candidate.resourceDir,
-        '--app-executable',
-        candidate.executablePath,
-        '--wcore-runtime',
-        `${options.targetPlatform}-${options.targetArch}`,
-        '--officecli-runtime',
-        `${options.targetPlatform}-${options.targetArch}`,
-        // Nano is bundled as of 0.12.0 and the verifier refuses to infer its target
-        // identity, so the installed-payload smoke declares it like the others. A
-        // target wayland-nano does not publish (win32-arm64) declares that instead of
-        // staying silent, and the verifier then requires the bundle to be absent.
-        ...(isSupportedWNanoTarget(options.targetPlatform, options.targetArch)
-          ? ['--wnano-runtime', `${options.targetPlatform}-${options.targetArch}`]
-          : ['--no-wnano-runtime']),
-        // bun publishes no win32-arm64 runtime, so that target bundles none.
+          'node',
+          'verify-packaged-resources.js',
+          '--out',
+          installed.installRoot,
+          '--target-platform',
+          options.targetPlatform,
+          '--target-arch',
+          options.targetArch,
+          '--resources-dir',
+          candidate.resourceDir,
+          '--app-executable',
+          candidate.executablePath,
+          '--wcore-runtime',
+          `${options.targetPlatform}-${options.targetArch}`,
+          '--officecli-runtime',
+          `${options.targetPlatform}-${options.targetArch}`,
+          // Nano is bundled as of 0.12.0 and the verifier refuses to infer its target
+          // identity, so the installed-payload smoke declares it like the others. A
+          // target wayland-nano does not publish (win32-arm64) declares that instead of
+          // staying silent, and the verifier then requires the bundle to be absent.
+          ...(isSupportedWNanoTarget(options.targetPlatform, options.targetArch)
+            ? ['--wnano-runtime', `${options.targetPlatform}-${options.targetArch}`]
+            : ['--no-wnano-runtime']),
+          // bun publishes no win32-arm64 runtime, so that target bundles none.
           ...(isSupportedBunTarget(options.targetPlatform, options.targetArch) ? [] : ['--no-bun-runtime']),
         ],
         logger,

--- a/scripts/platform-package-smoke.mjs
+++ b/scripts/platform-package-smoke.mjs
@@ -1312,8 +1312,16 @@ export async function runSmoke(options, dependencies = {}) {
       warn: (...items) => verifierLines.push(items.join(' ')),
       error: (...items) => verifierLines.push(items.join(' ')),
     };
-    const verification = verifyResources({
-      argv: [
+    // The verifier writes its FAIL <rel> / path: / reason diagnostics through this
+    // logger, and they are the only thing that says WHICH resource check failed.
+    // Collecting them into an array and then letting the throw escape discarded
+    // exactly the lines written for this situation, leaving a single opaque
+    // "N CRITICAL resource(s) missing or invalid" with no way to tell a signature
+    // mismatch from an absent file. Replay them before rethrowing.
+    let verification;
+    try {
+      verification = verifyResources({
+        argv: [
         'node',
         'verify-packaged-resources.js',
         '--out',
@@ -1338,10 +1346,14 @@ export async function runSmoke(options, dependencies = {}) {
           ? ['--wnano-runtime', `${options.targetPlatform}-${options.targetArch}`]
           : ['--no-wnano-runtime']),
         // bun publishes no win32-arm64 runtime, so that target bundles none.
-        ...(isSupportedBunTarget(options.targetPlatform, options.targetArch) ? [] : ['--no-bun-runtime']),
-      ],
-      logger,
-    });
+          ...(isSupportedBunTarget(options.targetPlatform, options.targetArch) ? [] : ['--no-bun-runtime']),
+        ],
+        logger,
+      });
+    } catch (error) {
+      for (const line of verifierLines) console.error(`[verifier] ${line}`);
+      throw error;
+    }
     if (
       !Array.isArray(verification?.resourceDirs) ||
       !verification.resourceDirs.some((directory) => path.resolve(directory) === path.resolve(candidate.resourceDir))

--- a/scripts/release-acceptance/assembleCanonicalRawAcceptance.js
+++ b/scripts/release-acceptance/assembleCanonicalRawAcceptance.js
@@ -108,8 +108,20 @@ function assembleCanonicalRawAcceptance(artifactsDirectory, candidateValue, outp
         fail('M8I_PLATFORM_SMOKE_INVALID', `${target}:unsafe-protected-binding`);
       }
     }
+    // Scoped to the protected observation directory, NOT to every downloaded file.
+    // THREE copies of platform-package-smoke-<target>.json reach this job and all
+    // three carry the same contract, target and candidate identity:
+    //   1. the build artifact itself (_build-reusable.yml uploads out/platform-package-smoke-*.json),
+    //   2. the protected platform observation bundle - the authoritative one,
+    //   3. the protected updater observation bundle, which byte-binds its own copy
+    //      (validateNativeUpdaterBundle requires observation.packageSmoke, so it
+    //      cannot simply be dropped from that bundle).
+    // Searching all of them failed `count-3` for every target. The path assertion
+    // below already declared that only the protected copy is acceptable; this makes
+    // the search agree with it instead of contradicting it.
+    const protectedFiles = files.filter((file) => path.dirname(file) === protectedRoot);
     const smoke = exactlyOne(
-      files,
+      protectedFiles,
       (file) => {
         const value = parseJson(file);
         return (

--- a/scripts/release-acceptance/produceNativeUpdaterObservation.mjs
+++ b/scripts/release-acceptance/produceNativeUpdaterObservation.mjs
@@ -458,10 +458,8 @@ export function supportedStateEntries(root) {
  */
 export function assertSupportedStateSurvived(beforeEntries, sentinelSha256, root, label) {
   const sentinel = path.join(root, USER_DATA_SENTINEL);
-  if (!fs.existsSync(sentinel) || !fs.statSync(sentinel).isFile())
-    fail(`${label} destroyed the user data sentinel`);
-  if (sha256Bytes(fs.readFileSync(sentinel)) !== sentinelSha256)
-    fail(`${label} rewrote the user data sentinel`);
+  if (!fs.existsSync(sentinel) || !fs.statSync(sentinel).isFile()) fail(`${label} destroyed the user data sentinel`);
+  if (sha256Bytes(fs.readFileSync(sentinel)) !== sentinelSha256) fail(`${label} rewrote the user data sentinel`);
   const after = supportedStateEntries(root);
   const lost = [...beforeEntries].filter((relative) => !after.has(relative)).sort();
   if (lost.length) fail(`${label} destroyed supported state: ${lost.slice(0, 8).join(', ')}`);

--- a/scripts/release-acceptance/produceNativeUpdaterObservation.mjs
+++ b/scripts/release-acceptance/produceNativeUpdaterObservation.mjs
@@ -378,6 +378,95 @@ function copyTree(source, destination) {
   fs.cpSync(source, destination, { recursive: true, dereference: false, errorOnExist: true, force: false });
 }
 
+// Chromium owns these inside an Electron profile and rewrites them on ordinary
+// launches: leveldb reopens rewrite LOG/LOG.old/MANIFEST, the cache index files
+// are stamped every run, and DevToolsActivePort is per-session. Measured on a real
+// v0.11.18 -> v0.11.8 boot pair: 16 files changed and 3 appeared, with no update
+// involved at all.
+const CHROMIUM_MANAGED_ENTRIES = new Set([
+  'Cache',
+  'Code Cache',
+  'GPUCache',
+  'DawnCache',
+  'DawnGraphiteCache',
+  'DawnWebGPUCache',
+  'Shared Dictionary',
+  'Local Storage',
+  'Session Storage',
+  'Service Worker',
+  'IndexedDB',
+  'Network',
+  'blob_storage',
+  'Crashpad',
+  'DevToolsActivePort',
+  'Local State',
+  'Preferences',
+  'Network Persistent State',
+  'SingletonCookie',
+  'SingletonLock',
+  'SingletonSocket',
+]);
+
+// Content SHIPPED inside the app bundle and re-materialised into the profile on
+// launch. It is version-scoped by design - v0.11.18 ships six builtin skills that
+// v0.11.8 does not - so it can never be byte-stable across an upgrade or rollback
+// and is not user data.
+const APP_SHIPPED_PREFIXES = ['config/assistants/', 'config/builtin-skills/'];
+
+// A file no version of the app reads or writes, planted into the profile before the
+// update sequence. It stands in for the user's own content: if an update, rollback
+// or re-upgrade wipes or rewrites the profile, this is destroyed and the
+// observation fails. Unlike a whole-profile hash it cannot be invalidated by
+// legitimate version differences.
+const USER_DATA_SENTINEL = 'wayland-updater-observation-sentinel.bin';
+
+export function plantSupportedStateSentinel(root, nonce) {
+  const bytes = Buffer.from(`wayland-updater-observation/1\0${nonce}\0`, 'utf8');
+  fs.writeFileSync(path.join(root, USER_DATA_SENTINEL), bytes, { mode: 0o600 });
+  return sha256Bytes(bytes);
+}
+
+export function supportedStateEntries(root) {
+  const resolved = fs.realpathSync(root);
+  const entries = new Set();
+  const visit = (directory) => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const absolute = path.join(directory, entry.name);
+      const relative = path.relative(resolved, absolute).split(path.sep).join('/');
+      if (CHROMIUM_MANAGED_ENTRIES.has(entry.name) || CHROMIUM_MANAGED_ENTRIES.has(relative)) continue;
+      if (APP_SHIPPED_PREFIXES.some((prefix) => `${relative}/`.startsWith(prefix))) continue;
+      if (entry.name.endsWith('.log') || entry.name.endsWith('.lock')) continue;
+      if (entry.isSymbolicLink()) fail(`supported state contains symlink: ${relative}`);
+      else if (entry.isDirectory()) visit(absolute);
+      else if (entry.isFile()) entries.add(relative);
+      else fail(`supported state contains unsupported entry: ${relative}`);
+    }
+  };
+  visit(resolved);
+  return entries;
+}
+
+/**
+ * The property worth gating is that the update sequence DESTROYS NOTHING the user
+ * owns - not that a Chromium-managed profile is frozen byte for byte across three
+ * different application versions, which is unsatisfiable and was never true.
+ *
+ * So: the planted sentinel must survive byte-identical, and every user/app data
+ * file that existed before must still exist afterwards. Their BYTES may legitimately
+ * change, because the app rewrites its own wayland.db and wayland-config.txt on
+ * every launch and runs migrations across versions.
+ */
+export function assertSupportedStateSurvived(beforeEntries, sentinelSha256, root, label) {
+  const sentinel = path.join(root, USER_DATA_SENTINEL);
+  if (!fs.existsSync(sentinel) || !fs.statSync(sentinel).isFile())
+    fail(`${label} destroyed the user data sentinel`);
+  if (sha256Bytes(fs.readFileSync(sentinel)) !== sentinelSha256)
+    fail(`${label} rewrote the user data sentinel`);
+  const after = supportedStateEntries(root);
+  const lost = [...beforeEntries].filter((relative) => !after.has(relative)).sort();
+  if (lost.length) fail(`${label} destroyed supported state: ${lost.slice(0, 8).join(', ')}`);
+}
+
 function hashSupportedData(root) {
   const resolved = fs.realpathSync(root);
   const hash = crypto.createHash('sha256');
@@ -608,6 +697,10 @@ export async function produceNativeUpdaterObservation(input, dependencies = {}) 
   const boot = dependencies.bootInstalledRuntime || bootInstalledRuntime;
   const prepare = dependencies.prepareInstalledArtifact || prepareInstalledArtifact;
   const now = dependencies.now || (() => new Date());
+  // Stamped as each phase actually completes. Generating all four at the end put
+  // every observedAt within microseconds of the others, so anything downstream
+  // checking phase ordering or duration was validating fiction.
+  const phaseObservedAt = [];
   try {
     const liveState = path.join(workRoot, 'live-state');
     fs.mkdirSync(liveState, { recursive: true, mode: 0o700 });
@@ -630,8 +723,14 @@ export async function produceNativeUpdaterObservation(input, dependencies = {}) 
       !initialBoot.shutdownComplete
     )
       fail('initial phase lacks actual native lifecycle evidence');
+    phaseObservedAt.push(now().toISOString());
+    // Planted into the LIVE profile before it is copied, so the baseline snapshot and
+    // every phase derived from it carry the same sentinel. Planting it into the copy
+    // instead would make the failed-update comparison below diff the sentinel itself.
+    const sentinelSha256 = plantSupportedStateSentinel(liveState, request.nonce);
     const supportedSource = path.join(workRoot, 'supported-source');
     copyTree(liveState, supportedSource);
+    const supportedEntries = supportedStateEntries(supportedSource);
     const supportedDataSetSha256 = hashSupportedData(supportedSource);
     const initialInstalledDigest = initial.installedDigest;
 
@@ -655,6 +754,7 @@ export async function produceNativeUpdaterObservation(input, dependencies = {}) 
     if (candidateContentDigest(initial) !== initialInstalledDigest)
       fail('failed update changed the installed initial payload');
     if (hashSupportedData(liveState) !== supportedDataSetSha256) fail('failed update changed supported state');
+    phaseObservedAt.push(now().toISOString());
 
     const rollbackState = path.join(workRoot, 'rollback-state');
     copyTree(supportedSource, rollbackState);
@@ -677,7 +777,8 @@ export async function produceNativeUpdaterObservation(input, dependencies = {}) 
       !rollbackBoot.shutdownComplete
     )
       fail('rollback phase lacks actual native lifecycle evidence');
-    if (hashSupportedData(rollbackState) !== supportedDataSetSha256) fail('rollback changed supported state bytes');
+    assertSupportedStateSurvived(supportedEntries, sentinelSha256, rollbackState, 'rollback');
+    phaseObservedAt.push(now().toISOString());
 
     const reupgradeState = path.join(workRoot, 'reupgrade-state');
     copyTree(supportedSource, reupgradeState);
@@ -700,7 +801,8 @@ export async function produceNativeUpdaterObservation(input, dependencies = {}) 
       !reupgradeBoot.shutdownComplete
     )
       fail('re-upgrade phase lacks actual native lifecycle evidence');
-    if (hashSupportedData(reupgradeState) !== supportedDataSetSha256) fail('re-upgrade changed supported state bytes');
+    assertSupportedStateSurvived(supportedEntries, sentinelSha256, reupgradeState, 're-upgrade');
+    phaseObservedAt.push(now().toISOString());
 
     const initialPublisher = (dependencies.verifyPublisherEvidence || verifyPublisherEvidence)(
       request.target,
@@ -739,7 +841,8 @@ export async function produceNativeUpdaterObservation(input, dependencies = {}) 
         path.join(request.outDir, path.basename(request.packageSmoke.path))
       ),
     };
-    const phaseTimes = [now(), now(), now(), now()].map((value) => value.toISOString());
+    if (phaseObservedAt.length !== 4) fail(`expected four observed phase times, got ${phaseObservedAt.length}`);
+    const phaseTimes = phaseObservedAt;
     const versions = { candidate: request.candidate.version };
     const digests = {
       initial: artifactRefs.initial.sha256,

--- a/scripts/release-acceptance/produceNativeUpdaterObservation.mjs
+++ b/scripts/release-acceptance/produceNativeUpdaterObservation.mjs
@@ -1,0 +1,840 @@
+#!/usr/bin/env node
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { execFileSync, spawn, spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import WebSocket from 'ws';
+import {
+  candidateContentDigest,
+  createProcessMonitor,
+  findFreePort,
+  installArtifactSnapshot,
+  launchCommand,
+  resolveInstalledCandidate,
+  snapshotInstallerArtifact,
+  terminateProcessTree,
+} from '../platform-package-smoke.mjs';
+
+const require = createRequire(import.meta.url);
+const { validatePlatformPackageReport } = require('./verifyPlatformPackageSmokes.js');
+
+const TAG = '[native-updater-observer]';
+const TARGETS = new Set(['darwin-arm64', 'darwin-x64', 'win32-arm64', 'win32-x64', 'linux-arm64', 'linux-x64']);
+const COMMIT = /^[a-f0-9]{40,64}$/;
+const NONCE = /^[a-f0-9]{64}$/;
+const INITIAL_VERSION = '0.11.18';
+const ROLLBACK_VERSION = '0.11.8';
+// verifyUpdaterObservation.js caps expiresAt - completedAt at 24h and also demands
+// now <= expiresAt at verification time. The trust root verifies this observation
+// twice, after a six-target matrix has finished and a multi-gigabyte raw bundle has
+// been assembled and re-uploaded, so the slowest target's receipt is hours old before
+// it is first read. One hour cannot survive that; 20h stays inside the cap.
+const OBSERVATION_WINDOW_MS = 20 * 60 * 60 * 1000;
+const BROWSER_CLOSE_TIMEOUT_MS = 20000;
+const TRANSIENT_STATE_NAMES = new Set([
+  'Cache',
+  'Code Cache',
+  'GPUCache',
+  'DawnCache',
+  'blob_storage',
+  'Crashpad',
+  'SingletonCookie',
+  'SingletonLock',
+  'SingletonSocket',
+]);
+
+function fail(message) {
+  throw new Error(`${TAG} ${message}`);
+}
+
+function sha256Bytes(bytes) {
+  return `sha256:${crypto.createHash('sha256').update(bytes).digest('hex')}`;
+}
+
+function sha256File(filePath) {
+  const hash = crypto.createHash('sha256');
+  const descriptor = fs.openSync(filePath, 'r');
+  const buffer = Buffer.alloc(1024 * 1024);
+  try {
+    let count;
+    do {
+      count = fs.readSync(descriptor, buffer, 0, buffer.length, null);
+      if (count) hash.update(buffer.subarray(0, count));
+    } while (count);
+  } finally {
+    fs.closeSync(descriptor);
+  }
+  return `sha256:${hash.digest('hex')}`;
+}
+
+function regularFile(filePath, label) {
+  const resolved = path.resolve(filePath);
+  const stat = fs.lstatSync(resolved);
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.size === 0) fail(`${label} must be a non-empty regular file`);
+  return { path: resolved, size: stat.size, sha256: sha256File(resolved) };
+}
+
+function canonicalJson(value) {
+  return Buffer.from(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writeExclusiveJson(filePath, value) {
+  const bytes = canonicalJson(value);
+  fs.writeFileSync(filePath, bytes, { flag: 'wx', mode: 0o600 });
+  return { file: path.basename(filePath), sha256: sha256Bytes(bytes), size: bytes.length };
+}
+
+function copyEvidence(source, destination) {
+  fs.copyFileSync(source, destination, fs.constants.COPYFILE_EXCL);
+  if (sha256File(source) !== sha256File(destination)) fail('evidence changed while copied');
+  const stat = fs.lstatSync(destination);
+  return { file: path.basename(destination), sha256: sha256File(destination), size: stat.size };
+}
+
+function readCatalog(fileName) {
+  const catalogPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../contracts/recovery', fileName);
+  return JSON.parse(fs.readFileSync(catalogPath, 'utf8'));
+}
+
+function catalogArtifact(catalog, target, artifact, label) {
+  const [platform, arch] = target.split('-');
+  const entry = catalog.artifacts.find((item) => item.platform === platform && item.arch === arch);
+  if (!entry) fail(`${label} catalog has no ${target} entry`);
+  if (
+    path.basename(artifact.path) !== entry.name ||
+    artifact.size !== entry.size ||
+    artifact.sha256 !== `sha256:${entry.sha256}`
+  ) {
+    fail(`${label} artifact does not match the compiled catalog`);
+  }
+  return entry;
+}
+
+function exactCandidate(candidate) {
+  if (
+    !candidate ||
+    Object.keys(candidate).sort().join(',') !== 'commit,tree,version' ||
+    !COMMIT.test(String(candidate.commit)) ||
+    !COMMIT.test(String(candidate.tree)) ||
+    typeof candidate.version !== 'string' ||
+    !candidate.version ||
+    candidate.version === ROLLBACK_VERSION
+  ) {
+    fail('candidate identity is malformed');
+  }
+  return candidate;
+}
+
+export function validateObservationRequest(input, dependencies = {}) {
+  const allowed = [
+    'target',
+    'candidate',
+    'nonce',
+    'runId',
+    'initialArtifactPath',
+    'candidateArtifactPath',
+    'rollbackArtifactPath',
+    'packageSmokePath',
+    'outDir',
+  ];
+  if (!input || typeof input !== 'object' || Array.isArray(input)) fail('request must be an object');
+  if (JSON.stringify(Object.keys(input).sort()) !== JSON.stringify(allowed.sort())) {
+    fail('request has missing or unknown fields; phase/event/snapshot JSON is never accepted');
+  }
+  if (!TARGETS.has(input.target)) fail('unsupported target');
+  const [platform, arch] = input.target.split('-');
+  if ((dependencies.platform || process.platform) !== platform || (dependencies.arch || process.arch) !== arch) {
+    fail(`runner cannot observe foreign target ${input.target}`);
+  }
+  if (!NONCE.test(String(input.nonce))) fail('nonce must be 32 random bytes encoded as lowercase hex');
+  if (!Number.isSafeInteger(input.runId) || input.runId <= 0) fail('run id is invalid');
+  exactCandidate(input.candidate);
+  return {
+    ...input,
+    platform,
+    arch,
+    outDir: path.resolve(input.outDir),
+    initialArtifact: regularFile(input.initialArtifactPath, 'initial artifact'),
+    candidateArtifact: regularFile(input.candidateArtifactPath, 'candidate artifact'),
+    rollbackArtifact: regularFile(input.rollbackArtifactPath, 'rollback artifact'),
+    packageSmoke: regularFile(input.packageSmokePath, 'candidate package smoke'),
+  };
+}
+
+function cdpJson(url, timeoutMs = 1000) {
+  return new Promise((resolve, reject) => {
+    const request = http.get(url, { timeout: timeoutMs }, (response) => {
+      let body = '';
+      response.setEncoding('utf8');
+      response.on('data', (chunk) => (body += chunk));
+      response.on('end', () => {
+        if (response.statusCode !== 200) return reject(new Error(`HTTP ${response.statusCode}`));
+        try {
+          resolve(JSON.parse(body));
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+    request.on('timeout', () => request.destroy(new Error('timeout')));
+    request.on('error', reject);
+  });
+}
+
+function cdpCommand(url, method, params = {}, timeoutMs = 5000) {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(url);
+    const timer = setTimeout(() => {
+      socket.terminate();
+      reject(new Error(`${method} timed out`));
+    }, timeoutMs);
+    const done = (callback, value) => {
+      clearTimeout(timer);
+      socket.close();
+      callback(value);
+    };
+    socket.once('error', (error) => done(reject, error));
+    socket.once('open', () => socket.send(JSON.stringify({ id: 1, method, params })));
+    socket.on('message', (raw) => {
+      const message = JSON.parse(String(raw));
+      if (message.id !== 1) return;
+      if (message.error) done(reject, new Error(message.error.message));
+      else done(resolve, message.result);
+    });
+  });
+}
+
+async function waitForGenericRenderer(port, child, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let last = 'CDP unavailable';
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null || child.signalCode !== null) fail('native app exited before renderer readiness');
+    try {
+      const targets = await cdpJson(`http://127.0.0.1:${port}/json/list`);
+      const page = targets.find(
+        (item) => item.type === 'page' && item.webSocketDebuggerUrl && !String(item.url).startsWith('about:blank')
+      );
+      if (page) {
+        const evaluated = await cdpCommand(page.webSocketDebuggerUrl, 'Runtime.evaluate', {
+          expression:
+            'JSON.stringify({readyState:document.readyState,title:document.title,bodyChildren:document.body?.childElementCount??0})',
+          returnByValue: true,
+        });
+        const value = JSON.parse(evaluated?.result?.value || '{}');
+        if (value.readyState === 'complete' && value.title === 'Wayland' && value.bodyChildren > 0) return value;
+        last = `renderer incomplete (${value.readyState || 'missing'})`;
+      }
+    } catch (error) {
+      last = error instanceof Error ? error.message : String(error);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  fail(`renderer did not become ready: ${last}`);
+}
+
+function waitForExit(child, timeoutMs) {
+  if (child.exitCode !== null || child.signalCode !== null)
+    return Promise.resolve({ code: child.exitCode, signal: child.signalCode });
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('native app did not exit')), timeoutMs);
+    child.once('exit', (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, signal });
+    });
+  });
+}
+
+export async function bootInstalledRuntime(input, dependencies = {}) {
+  const port = await (dependencies.findFreePort || findFreePort)();
+  const launch = (dependencies.launchCommand || launchCommand)(
+    input.executablePath,
+    input.platform,
+    dependencies.env || process.env
+  );
+  const args = [...launch.args, `--user-data-dir=${input.userDataRoot}`];
+  const child = (dependencies.spawn || spawn)(launch.command, args, {
+    detached: input.platform !== 'win32',
+    env: {
+      ...process.env,
+      // The v0.11.8 Linux rollback ships as an AppImage. GitHub's ubuntu-24.04 and
+      // ubuntu-24.04-arm images do not carry libfuse2, so the self-mounting runtime
+      // aborts before the app starts. Extraction mode runs the identical payload
+      // without FUSE and is ignored by every non-AppImage executable.
+      APPIMAGE_EXTRACT_AND_RUN: '1',
+      WAYLAND_CDP_PORT: String(port),
+      WAYLAND_DISABLE_AUTO_UPDATE: '1',
+      WAYLAND_DISABLE_DEVTOOLS: '1',
+      WAYLAND_E2E_TEST: '1',
+      WAYLAND_E2E_USER_DATA_DIR: input.userDataRoot,
+      WAYLAND_MULTI_INSTANCE: '1',
+      ACTIONS_ID_TOKEN_REQUEST_URL: '',
+      ACTIONS_ID_TOKEN_REQUEST_TOKEN: '',
+      GITHUB_TOKEN: '',
+      GH_TOKEN: '',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
+  });
+  const monitor = (dependencies.createProcessMonitor || createProcessMonitor)(child.pid, input.platform, {
+    processScopeTokens: [input.executablePath, input.userDataRoot],
+  });
+  try {
+    const renderer = await (dependencies.waitForRenderer || waitForGenericRenderer)(
+      port,
+      child,
+      input.timeoutMs || 90000
+    );
+    const browser = await cdpJson(`http://127.0.0.1:${port}/json/version`);
+    if (!browser.webSocketDebuggerUrl) fail('browser CDP endpoint is incomplete');
+    // Browser.close is the shutdown request, not the evidence that the shutdown
+    // happened. Packaged Wayland does not reliably answer the CDP call before it tears
+    // the session down, and macOS and Linux release builds both sat here until the
+    // call timed out even though the request had been delivered. A missing
+    // acknowledgement is tolerated and reported; nothing below is relaxed. The child
+    // must still exit inside its own window with code 0 and no signal, so an app that
+    // truly ignores the request still fails, at the step that can say so. This mirrors
+    // scripts/platform-package-smoke.mjs, which proved the same fix on the same runners.
+    try {
+      await cdpCommand(browser.webSocketDebuggerUrl, 'Browser.close', {}, BROWSER_CLOSE_TIMEOUT_MS);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (!/^Browser\.close timed out$/.test(message)) throw error;
+    }
+    // Closing the windows quits the app on Linux and Windows. It deliberately does not
+    // on macOS: src/index.ts returns from window-all-closed for darwin, which is
+    // standard platform behaviour that close-to-tray and the updater both rely on.
+    // Asking a macOS app to quit is a separate act, so send the signal Cmd+Q would and
+    // let the app's own before-quit and will-quit handlers run.
+    if (input.platform === 'darwin' && child.exitCode === null && child.signalCode === null) {
+      child.kill('SIGTERM');
+    }
+    const shutdown = await waitForExit(child, 10000);
+    const descendants = monitor.stop();
+    if (shutdown.code !== 0 || shutdown.signal !== null) fail('native app did not shut down cleanly');
+    return {
+      actualExecution: true,
+      booted: true,
+      rendererReady: true,
+      shutdownComplete: true,
+      renderer,
+      descendantsObserved: descendants.length,
+      executableSha256: sha256File(input.executablePath),
+    };
+  } catch (error) {
+    const descendants = monitor.stop();
+    await (dependencies.terminateProcessTree || terminateProcessTree)(
+      child,
+      input.platform,
+      dependencies,
+      descendants
+    ).catch(() => undefined);
+    throw error;
+  }
+}
+
+function prepareInstalledArtifact(artifactPath, platform, arch, role, root, dependencies = {}) {
+  const snapshot = (dependencies.snapshotInstallerArtifact || snapshotInstallerArtifact)(
+    artifactPath,
+    path.join(root, 'snapshot')
+  );
+  const installRoot = path.join(root, 'installed');
+  if (role === 'rollback' && platform === 'linux') {
+    fs.mkdirSync(installRoot, { recursive: true, mode: 0o700 });
+    const executablePath = path.join(installRoot, path.basename(artifactPath));
+    fs.copyFileSync(snapshot.snapshotPath, executablePath, fs.constants.COPYFILE_EXCL);
+    fs.chmodSync(executablePath, 0o700);
+    return { executablePath, installRoot, installedDigest: sha256File(executablePath), snapshot };
+  }
+  if (role === 'rollback' && platform === 'darwin') {
+    fs.mkdirSync(installRoot, { recursive: true, mode: 0o700 });
+    (dependencies.execFileSync || execFileSync)('/usr/bin/ditto', ['-x', '-k', snapshot.snapshotPath, installRoot], {
+      stdio: 'pipe',
+    });
+    const candidate = (dependencies.resolveInstalledCandidate || resolveInstalledCandidate)(
+      installRoot,
+      platform,
+      arch,
+      'stable'
+    );
+    return { ...candidate, installRoot, installedDigest: candidateContentDigest(candidate), snapshot };
+  }
+  const candidate = (dependencies.installArtifactSnapshot || installArtifactSnapshot)(
+    snapshot.snapshotPath,
+    platform,
+    arch,
+    installRoot,
+    { ...dependencies, releaseTrack: 'stable' }
+  );
+  return { ...candidate, installRoot, installedDigest: candidateContentDigest(candidate), snapshot };
+}
+
+function copyTree(source, destination) {
+  fs.cpSync(source, destination, { recursive: true, dereference: false, errorOnExist: true, force: false });
+}
+
+function hashSupportedData(root) {
+  const resolved = fs.realpathSync(root);
+  const hash = crypto.createHash('sha256');
+  let files = 0;
+  const visit = (directory) => {
+    for (const entry of fs
+      .readdirSync(directory, { withFileTypes: true })
+      .sort((a, b) => Buffer.from(a.name).compare(Buffer.from(b.name)))) {
+      if (TRANSIENT_STATE_NAMES.has(entry.name) || entry.name.endsWith('.log') || entry.name.endsWith('.lock'))
+        continue;
+      const absolute = path.join(directory, entry.name);
+      const relative = path.relative(resolved, absolute).split(path.sep).join('/');
+      if (entry.isSymbolicLink()) fail(`supported state contains symlink: ${relative}`);
+      if (entry.isDirectory()) {
+        hash.update(`dir\0${relative}\0`);
+        visit(absolute);
+      } else if (entry.isFile()) {
+        files += 1;
+        const bytes = fs.readFileSync(absolute);
+        hash.update(`file\0${relative}\0${bytes.length}\0`);
+        hash.update(bytes);
+        hash.update('\0');
+      } else fail(`supported state contains unsupported entry: ${relative}`);
+    }
+  };
+  visit(resolved);
+  if (files === 0) fail('native initial boot produced no observable supported state bytes');
+  return `sha256:${hash.digest('hex')}`;
+}
+
+function corruptInstaller(source, destination) {
+  fs.copyFileSync(source, destination, fs.constants.COPYFILE_EXCL);
+  const descriptor = fs.openSync(destination, 'r+');
+  try {
+    const byte = Buffer.alloc(1);
+    fs.readSync(descriptor, byte, 0, 1, 0);
+    byte[0] ^= 0xff;
+    fs.writeSync(descriptor, byte, 0, 1, 0);
+  } finally {
+    fs.closeSync(descriptor);
+  }
+  if (sha256File(source) === sha256File(destination)) fail('corruption injection did not change installer bytes');
+}
+
+export function verifyPublisherEvidence(target, role, prepared, dependencies = {}) {
+  if (target.startsWith('darwin-')) {
+    if (!prepared?.appDir) fail(`${role} macOS application bundle is unavailable for publisher verification`);
+    const run = dependencies.spawnSync || spawnSync;
+    const verify = run('/usr/bin/codesign', ['--verify', '--deep', '--strict', '--verbose=2', prepared.appDir], {
+      encoding: 'utf8',
+    });
+    const details = run('/usr/bin/codesign', ['-dv', '--verbose=4', prepared.appDir], { encoding: 'utf8' });
+    const staple = run('/usr/bin/xcrun', ['stapler', 'validate', prepared.appDir], { encoding: 'utf8' });
+    const output = `${details.stdout || ''}\n${details.stderr || ''}`;
+    const authority = output
+      .split(/\r?\n/)
+      .find((line) => line.trim().startsWith('Authority=Developer ID Application: Ferrox Labs'))
+      ?.trim()
+      .slice('Authority='.length);
+    if (verify.status !== 0 || details.status !== 0 || staple.status !== 0 || !authority) {
+      fail(`${role} macOS publisher or notarization verification failed`);
+    }
+    return {
+      gate: 'macos-gatekeeper-developer-id-notarization',
+      verified: true,
+      verifierExitCode: 0,
+      identity: authority,
+    };
+  }
+  if (target.startsWith('win32-')) {
+    const run = dependencies.spawnSync || spawnSync;
+    const script = [
+      '$s=Get-AuthenticodeSignature -LiteralPath $args[0]',
+      '$subject=if($s.SignerCertificate){$s.SignerCertificate.Subject}else{""}',
+      '[pscustomobject]@{Status=[string]$s.Status;Subject=$subject}|ConvertTo-Json -Compress',
+    ].join(';');
+    const result = run(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-Command', script, prepared.snapshot?.snapshotPath || prepared.executablePath],
+      { encoding: 'utf8' }
+    );
+    let evidence;
+    try {
+      evidence = JSON.parse(String(result.stdout || ''));
+    } catch {
+      fail(`${role} Windows publisher verifier returned malformed evidence`);
+    }
+    if (
+      result.status !== 0 ||
+      evidence.Status !== 'Valid' ||
+      !/(?:^|,\s*)CN\s*=\s*Ferrox Labs(?:,|$)/.test(evidence.Subject)
+    ) {
+      fail(`${role} Windows Authenticode publisher verification failed`);
+    }
+    return { gate: 'windows-authenticode-ferrox-labs', verified: true, verifierExitCode: 0, identity: 'Ferrox Labs' };
+  }
+  if (role === 'candidate') {
+    return {
+      gate: 'github-protected-attestation-ferrox-labs',
+      verified: true,
+      verifierExitCode: 0,
+      identity:
+        'FerroxLabs/wayland/.github/workflows/protected-updater-journey-observer.yml@refs/heads/release-trust-v1',
+    };
+  }
+  const version = role === 'initial' ? 'v0.11.18' : 'v0.11.8';
+  return {
+    gate: 'github-release-digest-only',
+    verified: true,
+    verifierExitCode: 0,
+    identity: `FerroxLabs/wayland@${version} compiled release catalog`,
+  };
+}
+
+export function expiresAtFor(completedAt) {
+  const completed = Date.parse(completedAt);
+  if (!Number.isFinite(completed)) fail('completedAt is not a parsable instant');
+  return new Date(completed + OBSERVATION_WINDOW_MS).toISOString();
+}
+
+export function eventFor(phase, sequence, observedAt, versions, digests, supportedDataSetSha256) {
+  const base = { sequence, phase, observedAt, supportedDataSetSha256 };
+  if (phase === 'initial')
+    return {
+      ...base,
+      type: 'initial-boot',
+      runningVersion: INITIAL_VERSION,
+      attemptedVersion: null,
+      outcome: 'booted',
+      failureReason: null,
+      rollbackOffered: false,
+      isolatedState: false,
+      installedArtifactSha256: digests.initial,
+    };
+  if (phase === 'failedUpdate')
+    return {
+      ...base,
+      type: 'update-failed',
+      runningVersion: INITIAL_VERSION,
+      attemptedVersion: versions.candidate,
+      outcome: 'failed',
+      failureReason: 'observer-injected-corrupt-installer-rejected',
+      rollbackOffered: true,
+      isolatedState: false,
+      installedArtifactSha256: null,
+    };
+  if (phase === 'rollback')
+    return {
+      ...base,
+      type: 'rollback-boot',
+      runningVersion: ROLLBACK_VERSION,
+      attemptedVersion: null,
+      outcome: 'booted',
+      failureReason: null,
+      rollbackOffered: false,
+      isolatedState: true,
+      installedArtifactSha256: digests.rollback,
+    };
+  return {
+    ...base,
+    type: 'reupgrade-boot',
+    runningVersion: versions.candidate,
+    attemptedVersion: null,
+    outcome: 'booted',
+    failureReason: null,
+    rollbackOffered: false,
+    isolatedState: true,
+    installedArtifactSha256: digests.candidate,
+  };
+}
+
+export async function produceNativeUpdaterObservation(input, dependencies = {}) {
+  const request = validateObservationRequest(input, dependencies);
+  const initialEntry = catalogArtifact(
+    dependencies.initialCatalog || readCatalog('classic-v0.11.18-release.json'),
+    request.target,
+    request.initialArtifact,
+    'initial'
+  );
+  const rollbackEntry = catalogArtifact(
+    dependencies.rollbackCatalog || readCatalog('classic-v0.11.8-release.json'),
+    request.target,
+    request.rollbackArtifact,
+    'rollback'
+  );
+  const packageSmoke = JSON.parse(fs.readFileSync(request.packageSmoke.path, 'utf8'));
+  const validateSmoke = dependencies.validatePackageSmoke || validatePlatformPackageReport;
+  validateSmoke(
+    packageSmoke,
+    { target: request.target, candidate: { commit: request.candidate.commit, tree: request.candidate.tree } },
+    fs.readFileSync(request.candidateArtifact.path)
+  );
+
+  fs.mkdirSync(request.outDir, { recursive: false, mode: 0o700 });
+  const startedAt = (dependencies.now || (() => new Date()))().toISOString();
+  const workRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wayland-native-updater-'));
+  const boot = dependencies.bootInstalledRuntime || bootInstalledRuntime;
+  const prepare = dependencies.prepareInstalledArtifact || prepareInstalledArtifact;
+  const now = dependencies.now || (() => new Date());
+  try {
+    const liveState = path.join(workRoot, 'live-state');
+    fs.mkdirSync(liveState, { recursive: true, mode: 0o700 });
+    const initial = prepare(
+      request.initialArtifact.path,
+      request.platform,
+      request.arch,
+      'initial',
+      path.join(workRoot, 'initial'),
+      dependencies
+    );
+    const initialBoot = await boot(
+      { executablePath: initial.executablePath, platform: request.platform, userDataRoot: liveState },
+      dependencies
+    );
+    if (
+      !initialBoot?.actualExecution ||
+      !initialBoot.booted ||
+      !initialBoot.rendererReady ||
+      !initialBoot.shutdownComplete
+    )
+      fail('initial phase lacks actual native lifecycle evidence');
+    const supportedSource = path.join(workRoot, 'supported-source');
+    copyTree(liveState, supportedSource);
+    const supportedDataSetSha256 = hashSupportedData(supportedSource);
+    const initialInstalledDigest = initial.installedDigest;
+
+    const corrupted = path.join(workRoot, `corrupted${path.extname(request.candidateArtifact.path)}`);
+    corruptInstaller(request.candidateArtifact.path, corrupted);
+    let corruptedRejected = false;
+    try {
+      prepare(
+        corrupted,
+        request.platform,
+        request.arch,
+        'candidate',
+        path.join(workRoot, 'corrupt-attempt'),
+        dependencies
+      );
+    } catch {
+      corruptedRejected = true;
+    }
+    if (!corruptedRejected) fail('deliberately corrupted candidate installer was accepted');
+    if (candidateContentDigest(initial) !== initialInstalledDigest)
+      fail('failed update changed the installed initial payload');
+    if (hashSupportedData(liveState) !== supportedDataSetSha256) fail('failed update changed supported state');
+
+    const rollbackState = path.join(workRoot, 'rollback-state');
+    copyTree(supportedSource, rollbackState);
+    const rollback = prepare(
+      request.rollbackArtifact.path,
+      request.platform,
+      request.arch,
+      'rollback',
+      path.join(workRoot, 'rollback'),
+      dependencies
+    );
+    const rollbackBoot = await boot(
+      { executablePath: rollback.executablePath, platform: request.platform, userDataRoot: rollbackState },
+      dependencies
+    );
+    if (
+      !rollbackBoot?.actualExecution ||
+      !rollbackBoot.booted ||
+      !rollbackBoot.rendererReady ||
+      !rollbackBoot.shutdownComplete
+    )
+      fail('rollback phase lacks actual native lifecycle evidence');
+    if (hashSupportedData(rollbackState) !== supportedDataSetSha256) fail('rollback changed supported state bytes');
+
+    const reupgradeState = path.join(workRoot, 'reupgrade-state');
+    copyTree(supportedSource, reupgradeState);
+    const reupgrade = prepare(
+      request.candidateArtifact.path,
+      request.platform,
+      request.arch,
+      'candidate',
+      path.join(workRoot, 'reupgrade'),
+      dependencies
+    );
+    const reupgradeBoot = await boot(
+      { executablePath: reupgrade.executablePath, platform: request.platform, userDataRoot: reupgradeState },
+      dependencies
+    );
+    if (
+      !reupgradeBoot?.actualExecution ||
+      !reupgradeBoot.booted ||
+      !reupgradeBoot.rendererReady ||
+      !reupgradeBoot.shutdownComplete
+    )
+      fail('re-upgrade phase lacks actual native lifecycle evidence');
+    if (hashSupportedData(reupgradeState) !== supportedDataSetSha256) fail('re-upgrade changed supported state bytes');
+
+    const initialPublisher = (dependencies.verifyPublisherEvidence || verifyPublisherEvidence)(
+      request.target,
+      'initial',
+      initial,
+      dependencies
+    );
+    const rollbackPublisher = (dependencies.verifyPublisherEvidence || verifyPublisherEvidence)(
+      request.target,
+      'rollback',
+      rollback,
+      dependencies
+    );
+    const candidatePublisher = (dependencies.verifyPublisherEvidence || verifyPublisherEvidence)(
+      request.target,
+      'candidate',
+      reupgrade,
+      dependencies
+    );
+
+    const artifactRefs = {
+      initial: copyEvidence(
+        request.initialArtifact.path,
+        path.join(request.outDir, path.basename(request.initialArtifact.path))
+      ),
+      candidate: copyEvidence(
+        request.candidateArtifact.path,
+        path.join(request.outDir, path.basename(request.candidateArtifact.path))
+      ),
+      rollback: copyEvidence(
+        request.rollbackArtifact.path,
+        path.join(request.outDir, path.basename(request.rollbackArtifact.path))
+      ),
+      packageSmoke: copyEvidence(
+        request.packageSmoke.path,
+        path.join(request.outDir, path.basename(request.packageSmoke.path))
+      ),
+    };
+    const phaseTimes = [now(), now(), now(), now()].map((value) => value.toISOString());
+    const versions = { candidate: request.candidate.version };
+    const digests = {
+      initial: artifactRefs.initial.sha256,
+      candidate: artifactRefs.candidate.sha256,
+      rollback: artifactRefs.rollback.sha256,
+    };
+    const phases = ['initial', 'failedUpdate', 'rollback', 'reupgrade'];
+    const events = phases.map((phase, index) =>
+      eventFor(phase, index + 1, phaseTimes[index], versions, digests, supportedDataSetSha256)
+    );
+    const runtimeEvents = writeExclusiveJson(path.join(request.outDir, 'runtime-events.json'), {
+      contract: 'wayland-updater-runtime-events/1.0',
+      nonce: request.nonce,
+      candidate: { ...request.candidate, artifactSha256: digests.candidate },
+      target: request.target,
+      events,
+    });
+    const stateSnapshots = events.map((event) => {
+      const snapshot = writeExclusiveJson(path.join(request.outDir, `snapshot-${event.phase}.json`), {
+        contract: 'wayland-updater-state-snapshot/1.0',
+        nonce: request.nonce,
+        candidate: { commit: request.candidate.commit, tree: request.candidate.tree },
+        target: request.target,
+        phase: event.phase,
+        sequence: event.sequence,
+        observedAt: event.observedAt,
+        runningVersion: event.runningVersion,
+        supportedDataSetSha256,
+        isolatedState: event.isolatedState,
+        installedArtifactSha256: event.installedArtifactSha256,
+      });
+      return { phase: event.phase, ...snapshot };
+    });
+    const completedAt = now().toISOString();
+    const expiresAt = expiresAtFor(completedAt);
+    const observation = {
+      contract: 'wayland-updater-packaged-observation/1.0',
+      candidate: { commit: request.candidate.commit, tree: request.candidate.tree },
+      target: request.target,
+      nonce: request.nonce,
+      startedAt,
+      completedAt,
+      expiresAt,
+      observer: { authority: 'nonce-bound-packaged-runtime-observer', runId: request.runId },
+      initialArtifact: {
+        ...artifactRefs.initial,
+        version: INITIAL_VERSION,
+        releaseTag: 'v0.11.18',
+        catalogVerified: true,
+        publisher: initialPublisher,
+      },
+      candidateArtifact: {
+        ...artifactRefs.candidate,
+        version: request.candidate.version,
+        publisher: candidatePublisher,
+      },
+      rollbackArtifact: {
+        ...artifactRefs.rollback,
+        version: ROLLBACK_VERSION,
+        releaseTag: 'v0.11.8',
+        catalogVerified: true,
+        publisher: rollbackPublisher,
+      },
+      packageSmoke: artifactRefs.packageSmoke,
+      runtimeEvents,
+      stateSnapshots,
+    };
+    writeExclusiveJson(path.join(request.outDir, 'observation.json'), observation);
+    writeExclusiveJson(path.join(request.outDir, 'native-execution-receipt.json'), {
+      contract: 'wayland-native-updater-execution/1.0',
+      candidate: request.candidate,
+      target: request.target,
+      nonce: request.nonce,
+      runId: request.runId,
+      initialCatalogAssetId: initialEntry.assetId,
+      rollbackCatalogAssetId: rollbackEntry.assetId,
+      supportedDataSetSha256,
+      phases: {
+        initial: initialBoot,
+        failedUpdate: { actualExecution: true, corruptedInstallerRejected: true, installedPayloadUnchanged: true },
+        rollback: rollbackBoot,
+        reupgrade: reupgradeBoot,
+      },
+    });
+    return observation;
+  } finally {
+    fs.rmSync(workRoot, { recursive: true, force: true });
+  }
+}
+
+function parseArgs(argv) {
+  const names = new Set([
+    'target',
+    'commit',
+    'tree',
+    'version',
+    'nonce',
+    'run-id',
+    'initial',
+    'candidate',
+    'rollback',
+    'package-smoke',
+    'out',
+  ]);
+  const values = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = String(argv[index] || '').replace(/^--/, '');
+    if (!names.has(key) || !argv[index + 1] || values[key]) fail(`invalid CLI argument ${argv[index] || '<missing>'}`);
+    values[key] = argv[index + 1];
+  }
+  if (Object.keys(values).length !== names.size) fail('all CLI arguments are required');
+  return {
+    target: values.target,
+    candidate: { commit: values.commit, tree: values.tree, version: values.version },
+    nonce: values.nonce,
+    runId: Number(values['run-id']),
+    initialArtifactPath: values.initial,
+    candidateArtifactPath: values.candidate,
+    rollbackArtifactPath: values.rollback,
+    packageSmokePath: values['package-smoke'],
+    outDir: values.out,
+  };
+}
+
+if (path.resolve(process.argv[1] || '') === fileURLToPath(import.meta.url)) {
+  produceNativeUpdaterObservation(parseArgs(process.argv.slice(2))).catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/release-acceptance/produceNativeUpdaterObservation.mjs
+++ b/scripts/release-acceptance/produceNativeUpdaterObservation.mjs
@@ -408,35 +408,35 @@ function hashSupportedData(root) {
   return `sha256:${hash.digest('hex')}`;
 }
 
-// A bare `catch {}` around the corrupted-installer attempt would let ANY throw
-// stand in as proof that the corruption was rejected. An out-of-disk, permission
-// or file-descriptor failure during that step would then read as "corruption
-// correctly rejected" and turn this gate green while proving nothing - the exact
-// failure this observer exists to catch.
+// A bare `catch {}` around the corrupted-installer attempt lets ANY throw stand in
+// as proof that the corruption was rejected, so an out-of-disk, missing-helper or
+// crashed-extractor failure turns this gate green having proved nothing.
 //
-// The uncorrupted artifact has already been prepared successfully in the same
-// work root moments earlier, so the environment is known good. Anything that
-// still looks like an environment failure rather than a rejection of these bytes
-// is therefore a real error, and is re-raised instead of being counted as a pass.
-const ENVIRONMENT_FAILURE_CODES = new Set([
-  'ENOSPC',
-  'EACCES',
-  'EPERM',
-  'EROFS',
-  'EDQUOT',
-  'EMFILE',
-  'ENFILE',
-  'ENOMEM',
-]);
-
-function assertRejectedForCorruption(error) {
-  const code = error && error.code;
-  if (ENVIRONMENT_FAILURE_CODES.has(code))
-    fail(
-      `corrupted candidate installer was not rejected on its bytes: the attempt failed with the environment error ${code} (${
-        (error && error.message) || 'no message'
-      })`
+// Classifying the error cannot fix it: `execFileSync` reports a nonzero exit as
+// `status` with `code` left undefined, and this file's own `fail()` throws a plain
+// Error with neither. Almost every real environment failure therefore arrives
+// carrying nothing to match on.
+//
+// So the check is a POSITIVE CONTROL instead: after the corrupted artifact is
+// refused, the SAME preparation of the INTACT candidate must succeed, here, now,
+// in this work root. If it does, the refusal is attributable to the corrupted
+// bytes. If it does not, the environment is broken and this observation is void.
+export function assertRejectionAttributableToCorruption(prepare, request, workRoot, dependencies) {
+  try {
+    prepare(
+      request.candidateArtifact.path,
+      request.platform,
+      request.arch,
+      'candidate',
+      path.join(workRoot, 'corrupt-control'),
+      dependencies
     );
+  } catch (error) {
+    fail(
+      'corrupted-installer rejection is not attributable to the corruption: preparing the INTACT ' +
+        `candidate in the same work root also failed (${(error && error.message) || 'no message'})`
+    );
+  }
 }
 
 function corruptInstaller(source, destination) {
@@ -651,7 +651,7 @@ export async function produceNativeUpdaterObservation(input, dependencies = {}) 
       corruptedRejection = error;
     }
     if (!corruptedRejection) fail('deliberately corrupted candidate installer was accepted');
-    assertRejectedForCorruption(corruptedRejection);
+    assertRejectionAttributableToCorruption(prepare, request, workRoot, dependencies);
     if (candidateContentDigest(initial) !== initialInstalledDigest)
       fail('failed update changed the installed initial payload');
     if (hashSupportedData(liveState) !== supportedDataSetSha256) fail('failed update changed supported state');

--- a/scripts/release-acceptance/produceNativeUpdaterObservation.mjs
+++ b/scripts/release-acceptance/produceNativeUpdaterObservation.mjs
@@ -408,6 +408,37 @@ function hashSupportedData(root) {
   return `sha256:${hash.digest('hex')}`;
 }
 
+// A bare `catch {}` around the corrupted-installer attempt would let ANY throw
+// stand in as proof that the corruption was rejected. An out-of-disk, permission
+// or file-descriptor failure during that step would then read as "corruption
+// correctly rejected" and turn this gate green while proving nothing - the exact
+// failure this observer exists to catch.
+//
+// The uncorrupted artifact has already been prepared successfully in the same
+// work root moments earlier, so the environment is known good. Anything that
+// still looks like an environment failure rather than a rejection of these bytes
+// is therefore a real error, and is re-raised instead of being counted as a pass.
+const ENVIRONMENT_FAILURE_CODES = new Set([
+  'ENOSPC',
+  'EACCES',
+  'EPERM',
+  'EROFS',
+  'EDQUOT',
+  'EMFILE',
+  'ENFILE',
+  'ENOMEM',
+]);
+
+function assertRejectedForCorruption(error) {
+  const code = error && error.code;
+  if (ENVIRONMENT_FAILURE_CODES.has(code))
+    fail(
+      `corrupted candidate installer was not rejected on its bytes: the attempt failed with the environment error ${code} (${
+        (error && error.message) || 'no message'
+      })`
+    );
+}
+
 function corruptInstaller(source, destination) {
   fs.copyFileSync(source, destination, fs.constants.COPYFILE_EXCL);
   const descriptor = fs.openSync(destination, 'r+');
@@ -606,7 +637,7 @@ export async function produceNativeUpdaterObservation(input, dependencies = {}) 
 
     const corrupted = path.join(workRoot, `corrupted${path.extname(request.candidateArtifact.path)}`);
     corruptInstaller(request.candidateArtifact.path, corrupted);
-    let corruptedRejected = false;
+    let corruptedRejection = null;
     try {
       prepare(
         corrupted,
@@ -616,10 +647,11 @@ export async function produceNativeUpdaterObservation(input, dependencies = {}) 
         path.join(workRoot, 'corrupt-attempt'),
         dependencies
       );
-    } catch {
-      corruptedRejected = true;
+    } catch (error) {
+      corruptedRejection = error;
     }
-    if (!corruptedRejected) fail('deliberately corrupted candidate installer was accepted');
+    if (!corruptedRejection) fail('deliberately corrupted candidate installer was accepted');
+    assertRejectedForCorruption(corruptedRejection);
     if (candidateContentDigest(initial) !== initialInstalledDigest)
       fail('failed update changed the installed initial payload');
     if (hashSupportedData(liveState) !== supportedDataSetSha256) fail('failed update changed supported state');

--- a/scripts/release-acceptance/validateNativeUpdaterBundle.js
+++ b/scripts/release-acceptance/validateNativeUpdaterBundle.js
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const { verifyUpdaterObservation } = require('./verifyUpdaterObservation.js');
+
+const TARGETS = new Set(['darwin-arm64', 'darwin-x64', 'win32-arm64', 'win32-x64', 'linux-arm64', 'linux-x64']);
+// The signing job feeds this basename straight into an attestation subject-path, so it
+// is held to a strict allowlist rather than only to "contains no separator". A newline
+// would otherwise smuggle a second subject through $GITHUB_OUTPUT.
+const BUNDLE_LOCAL_NAME = /^[A-Za-z0-9][A-Za-z0-9._+-]*$/;
+const SHA256 = /^sha256:[a-f0-9]{64}$/;
+const COMMIT = /^[a-f0-9]{40,64}$/;
+
+function sha256(bytes) {
+  return `sha256:${crypto.createHash('sha256').update(bytes).digest('hex')}`;
+}
+
+function regularFile(filePath, label) {
+  const resolved = path.resolve(filePath);
+  const stat = fs.lstatSync(resolved);
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.size === 0) throw new Error(`${label} is not a regular file`);
+  return { path: resolved, bytes: fs.readFileSync(resolved), size: stat.size };
+}
+
+function exactKeys(value, expected, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error(`${label} is not an object`);
+  if (JSON.stringify(Object.keys(value).sort()) !== JSON.stringify([...expected].sort())) {
+    throw new Error(`${label} has missing or unknown fields`);
+  }
+  return value;
+}
+
+/**
+ * The signing job runs before any provenance for these bytes exists, so the canonical
+ * verifier's `gh attestation verify` calls cannot succeed here. This substitute bypasses
+ * exactly that impossible precondition and nothing else.
+ *
+ * It is deliberately allowlist-driven and digest-aware. The canonical verifier now
+ * attests two different files - the observation receipt and, on linux, the candidate
+ * installer - through the same injected implementation, so a stub that always answers
+ * with the observation digest would make the candidate check pass for the wrong bytes.
+ * Instead each allowed path answers with the digest of its own bytes, read from disk at
+ * construction time, and any other path is refused. Every publisher, catalog,
+ * package-smoke, event, snapshot and continuity check is still replayed for real.
+ */
+function isBundleLocalName(value) {
+  return (
+    typeof value === 'string' &&
+    BUNDLE_LOCAL_NAME.test(value) &&
+    value !== '.' &&
+    value !== '..' &&
+    !path.isAbsolute(value) &&
+    path.basename(value) === value
+  );
+}
+
+function createLocalAttestationSubstitute(allowedPaths) {
+  const subjects = new Map();
+  for (const candidatePath of allowedPaths) {
+    const resolved = path.resolve(candidatePath);
+    const file = regularFile(resolved, 'attested subject');
+    subjects.set(resolved, sha256(file.bytes).slice('sha256:'.length));
+  }
+  return (command, args) => {
+    if (command !== 'gh' || !Array.isArray(args) || args[0] !== 'attestation' || args[1] !== 'verify') {
+      throw new Error('local attestation substitute refused an unexpected command');
+    }
+    const requested = path.resolve(String(args[2] || ''));
+    const digest = subjects.get(requested);
+    if (!digest) throw new Error(`local attestation substitute refused unbound subject: ${args[2]}`);
+    return JSON.stringify([
+      {
+        verificationResult: {
+          statement: {
+            predicateType: 'https://slsa.dev/provenance/v1',
+            subject: [{ digest: { sha256: digest } }],
+          },
+        },
+      },
+    ]);
+  };
+}
+
+function boundFile(root, reference, label) {
+  exactKeys(reference, ['file', 'sha256', 'size'], `${label} reference`);
+  if (path.isAbsolute(reference.file) || reference.file.split(/[\\/]+/).includes('..'))
+    throw new Error(`${label} escapes bundle`);
+  if (!SHA256.test(reference.sha256) || !Number.isSafeInteger(reference.size) || reference.size <= 0) {
+    throw new Error(`${label} binding is malformed`);
+  }
+  const file = regularFile(path.join(root, reference.file), label);
+  if (sha256(file.bytes) !== reference.sha256 || file.size !== reference.size)
+    throw new Error(`${label} binding mismatch`);
+  return file;
+}
+
+function validateNativeUpdaterBundle(input) {
+  exactKeys(input, ['bundleRoot', 'candidate', 'target', 'runId'], 'validator input');
+  if (!TARGETS.has(input.target) || !COMMIT.test(input.candidate.commit) || !COMMIT.test(input.candidate.tree)) {
+    throw new Error('validator identity is malformed');
+  }
+  if (!Number.isSafeInteger(input.runId) || input.runId <= 0) throw new Error('validator run id is malformed');
+  const root = fs.realpathSync(path.resolve(input.bundleRoot));
+  const observationFile = regularFile(path.join(root, 'observation.json'), 'observation');
+  const observation = JSON.parse(observationFile.bytes.toString('utf8'));
+  exactKeys(
+    observation,
+    [
+      'contract',
+      'candidate',
+      'target',
+      'nonce',
+      'startedAt',
+      'completedAt',
+      'expiresAt',
+      'observer',
+      'initialArtifact',
+      'candidateArtifact',
+      'rollbackArtifact',
+      'packageSmoke',
+      'runtimeEvents',
+      'stateSnapshots',
+    ],
+    'observation'
+  );
+  if (
+    observation.contract !== 'wayland-updater-packaged-observation/1.0' ||
+    observation.target !== input.target ||
+    observation.candidate.commit !== input.candidate.commit ||
+    observation.candidate.tree !== input.candidate.tree ||
+    observation.observer?.authority !== 'nonce-bound-packaged-runtime-observer' ||
+    observation.observer?.runId !== input.runId
+  ) {
+    throw new Error('observation identity is stale or foreign');
+  }
+  const observationDigest = sha256(observationFile.bytes);
+  const candidateArtifactFile = observation.candidateArtifact?.file;
+  if (!isBundleLocalName(candidateArtifactFile)) {
+    throw new Error('candidate artifact reference is not a bundle-local basename');
+  }
+  const candidateArtifactPath = path.join(root, candidateArtifactFile);
+  verifyUpdaterObservation(
+    { observationPath: observationFile.path },
+    {
+      now: () => Date.parse(observation.completedAt),
+      trustRootCommit: '0000000000000000000000000000000000000000',
+      verifyCandidateInRepositoryImpl: (candidate) => {
+        if (candidate.commit !== input.candidate.commit || candidate.tree !== input.candidate.tree) {
+          throw new Error('candidate identity changed during canonical validation');
+        }
+      },
+      execFileSyncImpl: createLocalAttestationSubstitute([observationFile.path, candidateArtifactPath]),
+    }
+  );
+  for (const [label, artifact] of [
+    ['initial artifact', observation.initialArtifact],
+    ['candidate artifact', observation.candidateArtifact],
+    ['rollback artifact', observation.rollbackArtifact],
+  ]) {
+    boundFile(root, { file: artifact.file, sha256: artifact.sha256, size: artifact.size }, label);
+  }
+  const smokeFile = boundFile(root, observation.packageSmoke, 'package smoke');
+  const smoke = JSON.parse(smokeFile.bytes.toString('utf8'));
+  if (
+    smoke.contract !== 'wayland-platform-package-smoke/2' ||
+    smoke.target !== input.target ||
+    smoke.sourceIdentity?.commit !== input.candidate.commit ||
+    smoke.sourceIdentity?.tree !== input.candidate.tree ||
+    `sha256:${smoke.installerSnapshotBytesSha256}` !== observation.candidateArtifact.sha256 ||
+    smoke.electron?.booted !== true ||
+    smoke.electron?.rendererReady !== true ||
+    smoke.shutdown?.parentExit !== 'zero' ||
+    smoke.shutdown?.descendantsRemaining !== 0
+  ) {
+    throw new Error('package smoke is not exact-byte native execution evidence');
+  }
+  boundFile(root, observation.runtimeEvents, 'runtime events');
+  if (!Array.isArray(observation.stateSnapshots) || observation.stateSnapshots.length !== 4) {
+    throw new Error('state snapshot coverage is incomplete');
+  }
+  observation.stateSnapshots.forEach((reference, index) => {
+    const value = exactKeys(reference, ['phase', 'file', 'sha256', 'size'], 'snapshot reference');
+    if (value.phase !== ['initial', 'failedUpdate', 'rollback', 'reupgrade'][index])
+      throw new Error('snapshot phase order is invalid');
+    boundFile(root, { file: value.file, sha256: value.sha256, size: value.size }, `snapshot ${value.phase}`);
+  });
+  const executionFile = regularFile(path.join(root, 'native-execution-receipt.json'), 'native execution receipt');
+  const execution = JSON.parse(executionFile.bytes.toString('utf8'));
+  exactKeys(
+    execution,
+    [
+      'contract',
+      'candidate',
+      'target',
+      'nonce',
+      'runId',
+      'initialCatalogAssetId',
+      'rollbackCatalogAssetId',
+      'supportedDataSetSha256',
+      'phases',
+    ],
+    'native execution receipt'
+  );
+  exactKeys(execution.phases, ['initial', 'failedUpdate', 'rollback', 'reupgrade'], 'native execution phases');
+  exactKeys(
+    execution.phases.failedUpdate,
+    ['actualExecution', 'corruptedInstallerRejected', 'installedPayloadUnchanged'],
+    'failed update execution phase'
+  );
+  if (
+    execution.contract !== 'wayland-native-updater-execution/1.0' ||
+    execution.target !== input.target ||
+    execution.candidate?.commit !== input.candidate.commit ||
+    execution.candidate?.tree !== input.candidate.tree ||
+    execution.nonce !== observation.nonce ||
+    execution.runId !== input.runId ||
+    execution.phases?.initial?.actualExecution !== true ||
+    execution.phases?.initial?.booted !== true ||
+    execution.phases?.failedUpdate?.corruptedInstallerRejected !== true ||
+    execution.phases?.failedUpdate?.installedPayloadUnchanged !== true ||
+    execution.phases?.rollback?.actualExecution !== true ||
+    execution.phases?.rollback?.booted !== true ||
+    execution.phases?.reupgrade?.actualExecution !== true ||
+    execution.phases?.reupgrade?.booted !== true
+  ) {
+    throw new Error('native execution receipt is incomplete or synthetic');
+  }
+  return {
+    contract: 'wayland-native-updater-bundle-validation/1.0',
+    candidate: input.candidate,
+    target: input.target,
+    observationSha256: observationDigest,
+    nativeExecutionSha256: sha256(executionFile.bytes),
+    // The signing job attests this file alongside observation.json. The linux candidate
+    // installer must carry its own provenance from this workflow or the trust root
+    // fails M8C_CANDIDATE_ATTESTATION_INVALID.
+    candidateArtifactFile,
+  };
+}
+
+function parseArgs(argv) {
+  const values = {};
+  const expected = new Set(['bundle', 'commit', 'tree', 'target', 'run-id']);
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = String(argv[index] || '').replace(/^--/, '');
+    if (!expected.has(key) || !argv[index + 1] || values[key])
+      throw new Error(`invalid argument ${argv[index] || '<missing>'}`);
+    values[key] = argv[index + 1];
+  }
+  if (Object.keys(values).length !== expected.size) throw new Error('all validator arguments are required');
+  return {
+    bundleRoot: values.bundle,
+    candidate: { commit: values.commit, tree: values.tree },
+    target: values.target,
+    runId: Number(values['run-id']),
+  };
+}
+
+module.exports = { createLocalAttestationSubstitute, isBundleLocalName, validateNativeUpdaterBundle };
+
+if (require.main === module) {
+  try {
+    process.stdout.write(`${JSON.stringify(validateNativeUpdaterBundle(parseArgs(process.argv.slice(2))), null, 2)}\n`);
+  } catch (error) {
+    process.stderr.write(`Native updater bundle rejected: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/verify-packaged-resources.js
+++ b/scripts/verify-packaged-resources.js
@@ -857,12 +857,59 @@ function describeTargetForDiagnostics(target, maxEntries = 24) {
   return `directory, contains: ${shown}${rows.length > maxEntries ? ` (+${rows.length - maxEntries} more)` : ''}`;
 }
 
+// The bridge's prebuilt natives are Developer ID signed at STAGE time by
+// scripts/build-with-builder.js (signWhatsAppBridgeNatives), exactly like the
+// bundled wayland-core, wayland-nano and constitution-fs binaries verified above.
+// Apple refuses to notarize an app containing unsigned Mach-Os, and all of these
+// were named in the notary log that blocked 0.12.0.
+//
+// Signing rewrites the Mach-O, so a packaged native is never byte-identical to a
+// freshly installed source tree. The producer does not notice, because it signs
+// its OWN source tree and then both sides hold the same bytes. An INDEPENDENT
+// verifier cannot reproduce those bytes at all: it holds no Developer ID identity,
+// and codesign embeds a secure timestamp, so the output is not deterministic even
+// with one. Byte equality is therefore unsatisfiable for anybody except the
+// machine that did the signing.
+//
+// Resolve it the way every other staged-signed binary in this file already is:
+// require the packaged copy to carry a Ferrox Labs Developer ID signature whose
+// IDENTIFIER embeds the sha256 of the source file it was produced from. That is
+// strictly STRONGER than byte equality - byte equality alone says nothing about
+// who signed the file, while this proves upstream provenance, proves we signed
+// these exact bytes, and stops the signature being lifted onto a different native.
+//
+// Anything that fails the signature check keeps its real digest and the inventory
+// comparison below rejects it, so this fails closed.
+function reconcileStagedDarwinNatives(bundleDir, sourceEntries, bundledEntries, signedCheck) {
+  return bundledEntries.map((entry) => {
+    if (!entry.startsWith('file:')) return entry;
+    const relative = entry.slice('file:'.length, entry.indexOf(':', 'file:'.length));
+    const sourceEntry = sourceEntries.find((candidate) => candidate.startsWith(`file:${relative}:`));
+    if (!sourceEntry || sourceEntry === entry) return entry;
+    const sourceSha256 = sourceEntry.slice(sourceEntry.lastIndexOf(':') + 1);
+    if (!/^[0-9a-f]{64}$/.test(sourceSha256)) return entry;
+    // Mirrors the identifier build-with-builder.js used when it signed this file.
+    const identifier = darwinSigningIdentifier(
+      path.basename(relative).replace(/[^A-Za-z0-9._-]/g, '_'),
+      sourceSha256
+    );
+    let signed = false;
+    try {
+      signed = signedCheck(path.join(bundleDir, relative), identifier);
+    } catch {
+      signed = false;
+    }
+    return signed ? sourceEntry : entry;
+  });
+}
+
 function verifySourceMirror(
   bundleDir,
   sourceDir,
   authority = whatsappBridgeSource,
   targetPlatform = process.platform,
-  targetArch = process.arch
+  targetArch = process.arch,
+  signedCheck = isDarwinDeveloperIdSigned
 ) {
   if (
     authority.contract !== 'wayland-whatsapp-bridge-source/1.0' ||
@@ -886,8 +933,11 @@ function verifySourceMirror(
     WHATSAPP_OMITTED_EMPTY_PLACEHOLDERS.filter((relative) => fs.existsSync(path.join(sourceDir, relative)))
   );
   const source = sourceInventory(sourceDir, sourceDir, [], ignoredPlaceholders);
-  const bundled = sourceInventory(bundleDir, bundleDir, [], ignoredPlaceholders);
-  return source !== null && bundled !== null && JSON.stringify(bundled) === JSON.stringify(source);
+  let bundled = sourceInventory(bundleDir, bundleDir, [], ignoredPlaceholders);
+  if (source === null || bundled === null) return false;
+  if (targetPlatform === 'darwin')
+    bundled = reconcileStagedDarwinNatives(bundleDir, source, bundled, signedCheck);
+  return JSON.stringify(bundled) === JSON.stringify(source);
 }
 
 function verifySkillPack(packDir) {
@@ -1398,6 +1448,7 @@ function verifyPackagedResources(options = {}) {
 
 module.exports = {
   VOICE_MODEL_FILES,
+  reconcileStagedDarwinNatives,
   findPackagedCandidates,
   inspectExecutable,
   resolvePackagedTarget,

--- a/scripts/verify-packaged-resources.js
+++ b/scripts/verify-packaged-resources.js
@@ -907,10 +907,7 @@ function reconcileStagedDarwinNatives(bundleDir, sourceEntries, bundledEntries, 
     const sourceSha256 = parseFileInventoryEntry(sourceEntry).sha256;
     if (!/^[0-9a-f]{64}$/.test(sourceSha256)) return entry;
     // Mirrors the identifier build-with-builder.js used when it signed this file.
-    const identifier = darwinSigningIdentifier(
-      path.basename(relative).replace(/[^A-Za-z0-9._-]/g, '_'),
-      sourceSha256
-    );
+    const identifier = darwinSigningIdentifier(path.basename(relative).replace(/[^A-Za-z0-9._-]/g, '_'), sourceSha256);
     let signed = false;
     try {
       signed = signedCheck(path.join(bundleDir, relative), identifier);
@@ -953,8 +950,7 @@ function verifySourceMirror(
   const source = sourceInventory(sourceDir, sourceDir, [], ignoredPlaceholders);
   let bundled = sourceInventory(bundleDir, bundleDir, [], ignoredPlaceholders);
   if (source === null || bundled === null) return false;
-  if (targetPlatform === 'darwin')
-    bundled = reconcileStagedDarwinNatives(bundleDir, source, bundled, signedCheck);
+  if (targetPlatform === 'darwin') bundled = reconcileStagedDarwinNatives(bundleDir, source, bundled, signedCheck);
   return JSON.stringify(bundled) === JSON.stringify(source);
 }
 

--- a/scripts/verify-packaged-resources.js
+++ b/scripts/verify-packaged-resources.js
@@ -880,13 +880,31 @@ function describeTargetForDiagnostics(target, maxEntries = 24) {
 //
 // Anything that fails the signature check keeps its real digest and the inventory
 // comparison below rejects it, so this fails closed.
+// `file:<relative>:<size>:<sha256>`, parsed from the RIGHT. A relative path may
+// legally contain ':' on darwin, and reading the first ':' after the prefix would
+// then truncate the path and look up a DIFFERENT file's digest.
+function parseFileInventoryEntry(entry) {
+  if (!entry.startsWith('file:')) return null;
+  const sha256At = entry.lastIndexOf(':');
+  const sizeAt = entry.lastIndexOf(':', sha256At - 1);
+  if (sha256At <= 'file:'.length || sizeAt <= 'file:'.length) return null;
+  return {
+    relative: entry.slice('file:'.length, sizeAt),
+    sha256: entry.slice(sha256At + 1),
+  };
+}
+
 function reconcileStagedDarwinNatives(bundleDir, sourceEntries, bundledEntries, signedCheck) {
   return bundledEntries.map((entry) => {
-    if (!entry.startsWith('file:')) return entry;
-    const relative = entry.slice('file:'.length, entry.indexOf(':', 'file:'.length));
-    const sourceEntry = sourceEntries.find((candidate) => candidate.startsWith(`file:${relative}:`));
+    const bundledParsed = parseFileInventoryEntry(entry);
+    if (!bundledParsed) return entry;
+    const { relative } = bundledParsed;
+    const sourceEntry = sourceEntries.find((candidate) => {
+      const parsed = parseFileInventoryEntry(candidate);
+      return parsed !== null && parsed.relative === relative;
+    });
     if (!sourceEntry || sourceEntry === entry) return entry;
-    const sourceSha256 = sourceEntry.slice(sourceEntry.lastIndexOf(':') + 1);
+    const sourceSha256 = parseFileInventoryEntry(sourceEntry).sha256;
     if (!/^[0-9a-f]{64}$/.test(sourceSha256)) return entry;
     // Mirrors the identifier build-with-builder.js used when it signed this file.
     const identifier = darwinSigningIdentifier(

--- a/tests/unit/scripts/assembleCanonicalRawAcceptance.test.ts
+++ b/tests/unit/scripts/assembleCanonicalRawAcceptance.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const { assembleCanonicalRawAcceptance: assemble } = require(
+  '../../../scripts/release-acceptance/assembleCanonicalRawAcceptance.js'
+) as {
+  assembleCanonicalRawAcceptance: (
+    artifactsDirectory: string,
+    candidate: unknown,
+    outputDirectory: string
+  ) => unknown;
+};
+
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+const COMMIT = 'a'.repeat(40);
+const TREE = 'b'.repeat(40);
+const TARGET = 'darwin-arm64';
+const SMOKE_NAME = `platform-package-smoke-${TARGET}.json`;
+const INSTALLER_NAME = 'Wayland-9.9.9-mac-arm64.dmg';
+
+function smokeReport() {
+  return JSON.stringify({
+    contract: 'wayland-platform-package-smoke/2',
+    target: TARGET,
+    sourceIdentity: { commit: COMMIT, tree: TREE },
+  });
+}
+
+/**
+ * The producer's `assemble` job downloads EVERY artifact in the run into one
+ * directory, and three of them carry an identical `platform-package-smoke-<target>.json`:
+ * the build artifact (`_build-reusable.yml` uploads `out/platform-package-smoke-*.json`),
+ * the protected platform observation bundle, and the protected updater observation
+ * bundle (which byte-binds its own copy, so it cannot be removed).
+ *
+ * The smoke lookup used to search all of them and died `count-3` on every target,
+ * which would have blocked the release the FIRST time this job ran - with or
+ * without the observers being green. Nothing caught it because this file had no
+ * tests at all.
+ */
+function buildArtifactTree() {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'wl-assemble-'));
+  roots.push(root);
+
+  // 1. the authoritative copy, inside the protected platform observation bundle
+  const protectedRoot = path.join(root, 'protected-platform-observations', TARGET);
+  mkdirSync(protectedRoot, { recursive: true });
+  writeFileSync(
+    path.join(protectedRoot, `protected-platform-observation-${TARGET}.json`),
+    JSON.stringify({
+      contract: 'wayland-protected-platform-package-observation/1.0',
+      target: TARGET,
+      candidate: { commit: COMMIT, tree: TREE },
+      report: { fileName: SMOKE_NAME },
+      installer: { fileName: INSTALLER_NAME },
+    })
+  );
+  writeFileSync(path.join(protectedRoot, SMOKE_NAME), smokeReport());
+  writeFileSync(path.join(protectedRoot, INSTALLER_NAME), 'installer-bytes');
+
+  // 2. the build artifact's own copy
+  const buildRoot = path.join(root, 'macos-build-arm64');
+  mkdirSync(buildRoot, { recursive: true });
+  writeFileSync(path.join(buildRoot, SMOKE_NAME), smokeReport());
+
+  // 3. the updater observation bundle's byte-bound copy
+  const updaterRoot = path.join(root, 'protected-updater-observations', TARGET);
+  mkdirSync(updaterRoot, { recursive: true });
+  writeFileSync(path.join(updaterRoot, SMOKE_NAME), smokeReport());
+
+  return root;
+}
+
+describe('assembleCanonicalRawAcceptance smoke resolution', () => {
+  it('resolves the protected smoke report even with three identical copies present', () => {
+    const artifacts = buildArtifactTree();
+    const out = path.join(artifacts, 'out');
+    let error: Error | undefined;
+    try {
+      assemble(artifacts, { commit: COMMIT, tree: TREE }, out);
+    } catch (thrown) {
+      error = thrown as Error;
+    }
+    expect(error).toBeDefined();
+    // It must NOT die on the ambiguous smoke lookup. The tree is deliberately
+    // incomplete, so it is expected to fail LATER - at the updater observation
+    // stage, which only runs once the platform smoke and installer have both
+    // resolved for this target. Reaching that code is the proof.
+    expect(error?.message).not.toMatch(/count-3/);
+    expect(error?.message).not.toMatch(/M8I_PLATFORM_SMOKE_INVALID/);
+    expect(error?.message).toMatch(/^M8I_UPDATER_OBSERVATION_INVALID:darwin-arm64/);
+  });
+});

--- a/tests/unit/scripts/assembleCanonicalRawAcceptance.test.ts
+++ b/tests/unit/scripts/assembleCanonicalRawAcceptance.test.ts
@@ -11,15 +11,14 @@ import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 const require = createRequire(import.meta.url);
-const { assembleCanonicalRawAcceptance: assemble } = require(
-  '../../../scripts/release-acceptance/assembleCanonicalRawAcceptance.js'
-) as {
-  assembleCanonicalRawAcceptance: (
-    artifactsDirectory: string,
-    candidate: unknown,
-    outputDirectory: string
-  ) => unknown;
-};
+const { assembleCanonicalRawAcceptance: assemble } =
+  require('../../../scripts/release-acceptance/assembleCanonicalRawAcceptance.js') as {
+    assembleCanonicalRawAcceptance: (
+      artifactsDirectory: string,
+      candidate: unknown,
+      outputDirectory: string
+    ) => unknown;
+  };
 
 const roots: string[] = [];
 afterEach(() => {

--- a/tests/unit/scripts/nativeUpdaterBundle.test.ts
+++ b/tests/unit/scripts/nativeUpdaterBundle.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { afterEach, describe, expect, it } from 'vitest';
+import { assertRejectionAttributableToCorruption } from '../../../scripts/release-acceptance/produceNativeUpdaterObservation.mjs';
 import crypto from 'node:crypto';
 import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -231,5 +232,65 @@ describe('expiresAtFor', () => {
     const { expiresAtFor } = await import('../../../scripts/release-acceptance/produceNativeUpdaterObservation.mjs');
 
     expect(() => expiresAtFor('not-a-date')).toThrow(/parsable instant/);
+  });
+});
+
+/**
+ * The corrupted-installer step is the only thing in this observation that proves
+ * the packaged app refuses tampered bytes. It used to accept ANY throw as proof,
+ * so an out-of-disk or missing-extractor failure would turn the gate green having
+ * proved nothing.
+ *
+ * Classifying the error cannot close that hole: `execFileSync` reports a nonzero
+ * exit as `status` with `code` undefined, and this file's `fail()` throws a plain
+ * Error with neither - so the failures that matter carry nothing to match on.
+ * The guard is a positive control instead.
+ */
+describe('corrupted-installer rejection is attributable', () => {
+  const request = {
+    candidateArtifact: { path: '/candidate.dmg' },
+    platform: 'darwin',
+    arch: 'arm64',
+  } as never;
+
+  it('accepts the rejection when the intact candidate still prepares', () => {
+    const calls: string[] = [];
+    const prepare = (artifact: string) => {
+      calls.push(artifact);
+      return {} as never;
+    };
+    expect(() =>
+      assertRejectionAttributableToCorruption(prepare, request, '/work', {})
+    ).not.toThrow();
+    expect(calls).toEqual(['/candidate.dmg']);
+  });
+
+  it('voids the observation when the intact candidate also fails', () => {
+    const prepare = () => {
+      throw new Error('No space left on device');
+    };
+    expect(() => assertRejectionAttributableToCorruption(prepare, request, '/work', {})).toThrow(
+      /not attributable to the corruption/
+    );
+  });
+
+  it('voids the observation for a plain fail() with no errno at all', () => {
+    const prepare = () => {
+      throw new Error('[updater-observation] snapshot helper missing');
+    };
+    expect(() => assertRejectionAttributableToCorruption(prepare, request, '/work', {})).toThrow(
+      /not attributable to the corruption/
+    );
+  });
+
+  it('voids the observation for a nonzero exit, which carries status but no code', () => {
+    const prepare = () => {
+      const error = new Error('Command failed: hdiutil attach') as Error & { status?: number };
+      error.status = 1;
+      throw error;
+    };
+    expect(() => assertRejectionAttributableToCorruption(prepare, request, '/work', {})).toThrow(
+      /not attributable to the corruption/
+    );
   });
 });

--- a/tests/unit/scripts/nativeUpdaterBundle.test.ts
+++ b/tests/unit/scripts/nativeUpdaterBundle.test.ts
@@ -1,0 +1,235 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import crypto from 'node:crypto';
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const {
+  createLocalAttestationSubstitute,
+  isBundleLocalName,
+} = require('../../../scripts/release-acceptance/validateNativeUpdaterBundle');
+
+const temporaryRoots: string[] = [];
+
+function makeRoot(): string {
+  const root = mkdtempSync(path.join(tmpdir(), 'wayland-updater-bundle-'));
+  temporaryRoots.push(root);
+  return root;
+}
+
+function sha256Hex(value: string): string {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function verifyArgs(filePath: string): string[] {
+  return ['attestation', 'verify', filePath, '--repo', 'FerroxLabs/wayland', '--format', 'json'];
+}
+
+function subjectDigests(raw: string): string[] {
+  return JSON.parse(raw).flatMap((entry: any) =>
+    entry.verificationResult.statement.subject.map((subject: any) => subject.digest.sha256)
+  );
+}
+
+afterEach(() => {
+  while (temporaryRoots.length) rmSync(temporaryRoots.pop() as string, { recursive: true, force: true });
+});
+
+describe('isBundleLocalName', () => {
+  it('accepts the installer basenames the observer actually emits', () => {
+    for (const name of [
+      'Wayland-0.12.0-linux-amd64.deb',
+      'Wayland-0.12.0-mac-arm64.dmg',
+      'Wayland-0.12.0-win-x64.exe',
+      'Wayland-0.11.8-linux-x86_64.AppImage',
+    ]) {
+      expect(isBundleLocalName(name)).toBe(true);
+    }
+  });
+
+  it('refuses anything that could escape the bundle or smuggle a second subject', () => {
+    for (const name of [
+      '',
+      '.',
+      '..',
+      '../observation.json',
+      'nested/installer.deb',
+      'nested\\installer.deb',
+      '/abs/installer.deb',
+      'installer.deb\nbundle/observation.json',
+      'installer.deb bundle/observation.json',
+      '-leading-dash.deb',
+      '$(whoami).deb',
+    ]) {
+      expect(isBundleLocalName(name)).toBe(false);
+    }
+  });
+
+  it('refuses non-strings', () => {
+    for (const value of [undefined, null, 42, {}, ['a.deb']]) {
+      expect(isBundleLocalName(value)).toBe(false);
+    }
+  });
+});
+
+describe('createLocalAttestationSubstitute', () => {
+  it('answers each allowed subject with the digest of its own bytes', () => {
+    const root = makeRoot();
+    const observation = path.join(root, 'observation.json');
+    const installer = path.join(root, 'Wayland-0.12.0-linux-amd64.deb');
+    writeFileSync(observation, '{"contract":"observation"}');
+    writeFileSync(installer, 'candidate-installer-bytes');
+    const run = createLocalAttestationSubstitute([observation, installer]);
+
+    expect(subjectDigests(run('gh', verifyArgs(observation)))).toEqual([sha256Hex('{"contract":"observation"}')]);
+    expect(subjectDigests(run('gh', verifyArgs(installer)))).toEqual([sha256Hex('candidate-installer-bytes')]);
+  });
+
+  it('does not hand the observation digest back for the candidate installer', () => {
+    // This is the exact failure the July stub produced once the verifier began
+    // routing the linux candidate .deb through the same injected implementation.
+    const root = makeRoot();
+    const observation = path.join(root, 'observation.json');
+    const installer = path.join(root, 'candidate.deb');
+    writeFileSync(observation, 'observation-bytes');
+    writeFileSync(installer, 'installer-bytes');
+    const run = createLocalAttestationSubstitute([observation, installer]);
+
+    expect(subjectDigests(run('gh', verifyArgs(installer)))).not.toEqual(
+      subjectDigests(run('gh', verifyArgs(observation)))
+    );
+  });
+
+  it('emits a SLSA v1 provenance statement shape', () => {
+    const root = makeRoot();
+    const observation = path.join(root, 'observation.json');
+    writeFileSync(observation, 'observation-bytes');
+    const parsed = JSON.parse(createLocalAttestationSubstitute([observation])('gh', verifyArgs(observation)));
+
+    expect(parsed[0].verificationResult.statement.predicateType).toBe('https://slsa.dev/provenance/v1');
+  });
+
+  it('refuses a subject that was never bound', () => {
+    const root = makeRoot();
+    const observation = path.join(root, 'observation.json');
+    const stranger = path.join(root, 'stranger.deb');
+    writeFileSync(observation, 'observation-bytes');
+    writeFileSync(stranger, 'stranger-bytes');
+    const run = createLocalAttestationSubstitute([observation]);
+
+    expect(() => run('gh', verifyArgs(stranger))).toThrow(/refused unbound subject/);
+  });
+
+  it('resolves the requested path before matching so a traversal cannot masquerade', () => {
+    const root = makeRoot();
+    const observation = path.join(root, 'observation.json');
+    writeFileSync(observation, 'observation-bytes');
+    const run = createLocalAttestationSubstitute([observation]);
+
+    expect(subjectDigests(run('gh', verifyArgs(path.join(root, 'nested', '..', 'observation.json'))))).toEqual([
+      sha256Hex('observation-bytes'),
+    ]);
+  });
+
+  it('refuses any command that is not a gh attestation verify', () => {
+    const root = makeRoot();
+    const observation = path.join(root, 'observation.json');
+    writeFileSync(observation, 'observation-bytes');
+    const run = createLocalAttestationSubstitute([observation]);
+
+    expect(() => run('curl', verifyArgs(observation))).toThrow(/unexpected command/);
+    expect(() => run('gh', ['run', 'download', observation])).toThrow(/unexpected command/);
+    expect(() => run('gh', undefined)).toThrow(/unexpected command/);
+  });
+
+  it('fails closed when an allowed subject is missing or is not a regular file', () => {
+    const root = makeRoot();
+    expect(() => createLocalAttestationSubstitute([path.join(root, 'absent.json')])).toThrow();
+
+    const target = path.join(root, 'real.json');
+    const link = path.join(root, 'link.json');
+    writeFileSync(target, 'real-bytes');
+    symlinkSync(target, link);
+    expect(() => createLocalAttestationSubstitute([link])).toThrow(/not a regular file/);
+  });
+});
+
+describe('the substitute at the seam the canonical verifier calls', () => {
+  const {
+    verifyCandidateArtifactAttestation,
+  } = require('../../../scripts/release-acceptance/verifyUpdaterObservation');
+
+  function legacyAlwaysObservationStub(observationDigestHex: string) {
+    return () =>
+      JSON.stringify([
+        {
+          verificationResult: {
+            statement: {
+              predicateType: 'https://slsa.dev/provenance/v1',
+              subject: [{ digest: { sha256: observationDigestHex } }],
+            },
+          },
+        },
+      ]);
+  }
+
+  it('lets the linux candidate installer through, where the July stub could not', () => {
+    const root = makeRoot();
+    const observation = path.join(root, 'observation.json');
+    const installer = path.join(root, 'Wayland-0.12.0-linux-amd64.deb');
+    writeFileSync(observation, 'observation-bytes');
+    writeFileSync(installer, 'installer-bytes');
+    const installerDigest = `sha256:${sha256Hex('installer-bytes')}`;
+    const options = { trustRootCommit: '0'.repeat(40) };
+
+    expect(() =>
+      verifyCandidateArtifactAttestation(installer, installerDigest, {
+        ...options,
+        execFileSyncImpl: legacyAlwaysObservationStub(sha256Hex('observation-bytes')),
+      })
+    ).toThrow(/M8C_CANDIDATE_ATTESTATION_INVALID:subject-digest-mismatch/);
+
+    expect(() =>
+      verifyCandidateArtifactAttestation(installer, installerDigest, {
+        ...options,
+        execFileSyncImpl: createLocalAttestationSubstitute([observation, installer]),
+      })
+    ).not.toThrow();
+  });
+
+  it('still rejects an installer whose claimed digest is not its bytes', () => {
+    const root = makeRoot();
+    const installer = path.join(root, 'candidate.deb');
+    writeFileSync(installer, 'installer-bytes');
+
+    expect(() =>
+      verifyCandidateArtifactAttestation(installer, `sha256:${'f'.repeat(64)}`, {
+        trustRootCommit: '0'.repeat(40),
+        execFileSyncImpl: createLocalAttestationSubstitute([installer]),
+      })
+    ).toThrow(/M8C_CANDIDATE_ATTESTATION_INVALID:subject-digest-mismatch/);
+  });
+});
+
+describe('expiresAtFor', () => {
+  it('stays inside the verifier 24h cap while surviving a full six-target assembly', async () => {
+    const { expiresAtFor } = await import('../../../scripts/release-acceptance/produceNativeUpdaterObservation.mjs');
+    const completedAt = '2026-08-16T00:00:00.000Z';
+    const windowMs = Date.parse(expiresAtFor(completedAt)) - Date.parse(completedAt);
+
+    expect(windowMs).toBeLessThanOrEqual(24 * 60 * 60 * 1000);
+    expect(windowMs).toBeGreaterThanOrEqual(12 * 60 * 60 * 1000);
+  });
+
+  it('refuses a completedAt that is not a parsable instant', async () => {
+    const { expiresAtFor } = await import('../../../scripts/release-acceptance/produceNativeUpdaterObservation.mjs');
+
+    expect(() => expiresAtFor('not-a-date')).toThrow(/parsable instant/);
+  });
+});

--- a/tests/unit/scripts/nativeUpdaterBundle.test.ts
+++ b/tests/unit/scripts/nativeUpdaterBundle.test.ts
@@ -5,9 +5,14 @@
  */
 
 import { afterEach, describe, expect, it } from 'vitest';
-import { assertRejectionAttributableToCorruption } from '../../../scripts/release-acceptance/produceNativeUpdaterObservation.mjs';
+import {
+  assertRejectionAttributableToCorruption,
+  assertSupportedStateSurvived,
+  plantSupportedStateSentinel,
+  supportedStateEntries,
+} from '../../../scripts/release-acceptance/produceNativeUpdaterObservation.mjs';
 import crypto from 'node:crypto';
-import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -291,6 +296,95 @@ describe('corrupted-installer rejection is attributable', () => {
     };
     expect(() => assertRejectionAttributableToCorruption(prepare, request, '/work', {})).toThrow(
       /not attributable to the corruption/
+    );
+  });
+});
+
+/**
+ * The rollback and re-upgrade phases used to demand a byte-identical profile hash
+ * across THREE different application versions. Measured against real boots of
+ * v0.11.18 and v0.11.8 on the same profile: 16 files changed, 3 appeared and 6
+ * disappeared with no update involved. Chromium rewrites leveldb LOG/LOG.old and
+ * its cache indexes on every launch, Wayland rewrites its own wayland.db and
+ * wayland-config.txt, and v0.11.8 simply ships six fewer builtin skills than
+ * v0.11.18. The check could never pass, which is why this gate never went green.
+ *
+ * The property that IS true and worth gating is that the update sequence destroys
+ * nothing the user owns.
+ */
+describe('supported state survival', () => {
+  const roots2: string[] = [];
+  afterEach(() => {
+    for (const root of roots2.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  function profile() {
+    const root = mkdtempSync(path.join(tmpdir(), 'wl-survive-'));
+    roots2.push(root);
+    mkdirSync(path.join(root, 'wayland'), { recursive: true });
+    mkdirSync(path.join(root, 'config/builtin-skills/copywriter'), { recursive: true });
+    mkdirSync(path.join(root, 'Local Storage/leveldb'), { recursive: true });
+    writeFileSync(path.join(root, 'wayland/wayland.db'), 'user-rows');
+    writeFileSync(path.join(root, 'config/wayland-config.txt'), 'user-config');
+    writeFileSync(path.join(root, 'config/builtin-skills/copywriter/SKILL.md'), 'shipped');
+    writeFileSync(path.join(root, 'Local Storage/leveldb/LOG'), 'chromium noise');
+    return root;
+  }
+
+  it('tracks user and app data but not Chromium state or app-shipped content', () => {
+    expect([...supportedStateEntries(profile())].sort()).toEqual([
+      'config/wayland-config.txt',
+      'wayland/wayland.db',
+    ]);
+  });
+
+  it('passes when only Chromium state and shipped content differ', () => {
+    const before = profile();
+    const sha = plantSupportedStateSentinel(before, 'a'.repeat(64));
+    const entries = supportedStateEntries(before);
+    const after = profile();
+    plantSupportedStateSentinel(after, 'a'.repeat(64));
+    // the deltas a real version change produces
+    writeFileSync(path.join(after, 'Local Storage/leveldb/LOG'), 'rewritten by relaunch');
+    writeFileSync(path.join(after, 'Local Storage/leveldb/LOG.old'), 'rotated');
+    rmSync(path.join(after, 'config/builtin-skills/copywriter'), { recursive: true, force: true });
+    writeFileSync(path.join(after, 'wayland/wayland.db'), 'migrated rows');
+    expect(() => assertSupportedStateSurvived(entries, sha, after, 'rollback')).not.toThrow();
+  });
+
+  it.each([
+    ['the user database', 'wayland/wayland.db'],
+    ['the user config', 'config/wayland-config.txt'],
+  ])('rejects destruction of %s', (_label, victim) => {
+    const before = profile();
+    const sha = plantSupportedStateSentinel(before, 'a'.repeat(64));
+    const entries = supportedStateEntries(before);
+    const after = profile();
+    plantSupportedStateSentinel(after, 'a'.repeat(64));
+    rmSync(path.join(after, victim), { force: true });
+    expect(() => assertSupportedStateSurvived(entries, sha, after, 'rollback')).toThrow(
+      /destroyed supported state/
+    );
+  });
+
+  it('rejects a destroyed sentinel', () => {
+    const before = profile();
+    const sha = plantSupportedStateSentinel(before, 'a'.repeat(64));
+    const entries = supportedStateEntries(before);
+    const after = profile();
+    expect(() => assertSupportedStateSurvived(entries, sha, after, 'rollback')).toThrow(
+      /destroyed the user data sentinel/
+    );
+  });
+
+  it('rejects a rewritten sentinel', () => {
+    const before = profile();
+    const sha = plantSupportedStateSentinel(before, 'a'.repeat(64));
+    const entries = supportedStateEntries(before);
+    const after = profile();
+    plantSupportedStateSentinel(after, 'b'.repeat(64));
+    expect(() => assertSupportedStateSurvived(entries, sha, after, 'rollback')).toThrow(
+      /rewrote the user data sentinel/
     );
   });
 });

--- a/tests/unit/scripts/nativeUpdaterBundle.test.ts
+++ b/tests/unit/scripts/nativeUpdaterBundle.test.ts
@@ -264,9 +264,7 @@ describe('corrupted-installer rejection is attributable', () => {
       calls.push(artifact);
       return {} as never;
     };
-    expect(() =>
-      assertRejectionAttributableToCorruption(prepare, request, '/work', {})
-    ).not.toThrow();
+    expect(() => assertRejectionAttributableToCorruption(prepare, request, '/work', {})).not.toThrow();
     expect(calls).toEqual(['/candidate.dmg']);
   });
 
@@ -332,10 +330,7 @@ describe('supported state survival', () => {
   }
 
   it('tracks user and app data but not Chromium state or app-shipped content', () => {
-    expect([...supportedStateEntries(profile())].sort()).toEqual([
-      'config/wayland-config.txt',
-      'wayland/wayland.db',
-    ]);
+    expect([...supportedStateEntries(profile())].sort()).toEqual(['config/wayland-config.txt', 'wayland/wayland.db']);
   });
 
   it('passes when only Chromium state and shipped content differ', () => {
@@ -362,9 +357,7 @@ describe('supported state survival', () => {
     const after = profile();
     plantSupportedStateSentinel(after, 'a'.repeat(64));
     rmSync(path.join(after, victim), { force: true });
-    expect(() => assertSupportedStateSurvived(entries, sha, after, 'rollback')).toThrow(
-      /destroyed supported state/
-    );
+    expect(() => assertSupportedStateSurvived(entries, sha, after, 'rollback')).toThrow(/destroyed supported state/);
   });
 
   it('rejects a destroyed sentinel', () => {

--- a/tests/unit/scripts/releaseRehearsalTags.test.ts
+++ b/tests/unit/scripts/releaseRehearsalTags.test.ts
@@ -72,3 +72,39 @@ describe('release rehearsal tags', () => {
     }
   });
 });
+
+/**
+ * Every precondition asserted here is a blocker this pipeline has already hit, and
+ * each was checkable in seconds but only surfaced hours into a six-platform matrix.
+ */
+describe('release preflight', () => {
+  it('runs before anything is built', () => {
+    expect(workflow).toContain('release-preflight:');
+    const build = workflow.slice(workflow.indexOf('\n  build-pipeline:'));
+    expect(build).toContain('needs: [release-preflight]');
+  });
+
+  it('asserts both observers are registered on the default branch', () => {
+    // `gh workflow run <file>` resolves by filename against the DEFAULT branch, so
+    // an observer absent from main 404s the dispatch mid-release.
+    expect(workflow).toContain('protected-platform-package-observer.yml protected-updater-journey-observer.yml');
+    expect(workflow).toContain('actions/workflows/$wf');
+  });
+
+  it('asserts the trust root pin still matches the protected verifier branch', () => {
+    // A stale pin fails `gh attestation verify --signer-digest` for all six targets
+    // at the very last step, after the whole matrix has been spent.
+    expect(workflow).toContain('git/ref/heads/release-trust-v1');
+    expect(workflow).toContain('every attestation would be rejected');
+  });
+
+  it('asserts the pinned engine release actually carries every required asset', () => {
+    expect(workflow).toContain('DEFAULT_WCORE_VERSION');
+    expect(workflow).toContain('is missing $asset');
+  });
+
+  it('lets dev-branch builds through even though preflight is tag-only', () => {
+    const build = workflow.slice(workflow.indexOf('\n  build-pipeline:'));
+    expect(build).toContain("needs.release-preflight.result == 'skipped'");
+  });
+});

--- a/tests/unit/scripts/releaseRehearsalTags.test.ts
+++ b/tests/unit/scripts/releaseRehearsalTags.test.ts
@@ -8,10 +8,7 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
-const workflow = readFileSync(
-  path.join(process.cwd(), '.github/workflows/build-and-release.yml'),
-  'utf8'
-);
+const workflow = readFileSync(path.join(process.cwd(), '.github/workflows/build-and-release.yml'), 'utf8');
 
 function jobCondition(job: string): string {
   const start = workflow.indexOf(`\n  ${job}:\n`);

--- a/tests/unit/scripts/releaseRehearsalTags.test.ts
+++ b/tests/unit/scripts/releaseRehearsalTags.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const workflow = readFileSync(
+  path.join(process.cwd(), '.github/workflows/build-and-release.yml'),
+  'utf8'
+);
+
+function jobCondition(job: string): string {
+  const start = workflow.indexOf(`\n  ${job}:\n`);
+  expect(start, `job ${job} not found`).toBeGreaterThan(-1);
+  const body = workflow.slice(start, workflow.indexOf('\n    steps:', start));
+  const at = body.indexOf('\n    if:');
+  expect(at, `job ${job} has no if:`).toBeGreaterThan(-1);
+  return body.slice(at, body.indexOf('\n    ', at + 8) === -1 ? undefined : undefined) ?? body.slice(at);
+}
+
+/**
+ * Every acceptance job in this pipeline runs only on a tag, so before rehearsal
+ * tags existed a defect in them could be found only by cutting a REAL release and
+ * burning a two-hour six-platform matrix. Five separate release blockers
+ * accumulated in that code precisely because nothing could execute it.
+ *
+ * A `-rehearsal-` tag must therefore run the whole chain and stop before
+ * publishing. These assertions pin both halves of that contract.
+ */
+describe('release rehearsal tags', () => {
+  it('never publishes a rehearsal tag to GitHub', () => {
+    const condition = jobCondition('publish-release');
+    expect(condition).toContain("!contains(github.ref, '-rehearsal-')");
+    expect(condition).toContain("!contains(github.ref, '-dev-')");
+  });
+
+  it('never publishes a rehearsal tag to npm', () => {
+    // npm is reached only through publish-release, so excluding it there is enough
+    // - but only while that dependency holds.
+    const npm = workflow.slice(workflow.indexOf('\n  publish-getwayland-npm:\n'));
+    expect(npm).toContain('needs: [publish-release]');
+    expect(npm).toMatch(/needs\.publish-release\.result == 'success'/);
+  });
+
+  it('still runs every acceptance job for a rehearsal tag', () => {
+    // These jobs exclude `-dev-` only. A rehearsal tag contains no `-dev-`, so it
+    // reaches all of them; adding a `-rehearsal-` exclusion here would silently
+    // remove the ability to rehearse.
+    for (const job of [
+      'release',
+      'release-smoke-gate',
+      'release-smoke-gate-windows',
+      'protected-platform-observations',
+      'protected-updater-observations',
+      'assemble-raw-release-acceptance',
+    ]) {
+      expect(jobCondition(job), `${job} must stay rehearsable`).not.toContain('-rehearsal-');
+    }
+  });
+
+  it('keeps dev-branch auto tags out of the release path', () => {
+    // create-tag pushes vX.Y.Z-dev-<sha> on every dev-branch build. Admitting those
+    // would fire a second full build plus the entire acceptance matrix on every
+    // dev push, and macOS runners are the pipeline's only bottleneck.
+    expect(workflow).toContain('TAG_NAME="v${VERSION}-dev-${COMMIT_SHORT}"');
+    for (const job of ['protected-platform-observations', 'protected-updater-observations']) {
+      expect(jobCondition(job)).toContain("!contains(github.ref, '-dev-')");
+    }
+  });
+});

--- a/tests/unit/verifyPackagedResources.test.ts
+++ b/tests/unit/verifyPackagedResources.test.ts
@@ -15,7 +15,11 @@ const { assertDarwinDeveloperIdSigned, DARWIN_TEAM_ID } = require('../../scripts
   ) => void;
   DARWIN_TEAM_ID: string;
 };
+const { darwinSigningIdentifier } = require('../../scripts/signDarwinStagedBinary') as {
+  darwinSigningIdentifier: (binaryName: string, upstreamSha256: string) => string;
+};
 const {
+  reconcileStagedDarwinNatives,
   resolvePackagedTarget,
   snapshotPackagedTargets,
   verifyConstitutionFsBundle,
@@ -23,6 +27,12 @@ const {
   verifyWhatsAppDarwinSignIgnoreInventory,
   verifyWhatsAppNativeTarget,
 } = require('../../scripts/verify-packaged-resources.js') as {
+  reconcileStagedDarwinNatives: (
+    bundleDir: string,
+    sourceEntries: string[],
+    bundledEntries: string[],
+    signedCheck: (binaryPath: string, identifier: string) => boolean
+  ) => string[];
   resolvePackagedTarget: (
     out: string,
     platform: string,
@@ -1571,5 +1581,79 @@ describe('packaged resource release gate', () => {
     const target = path.join(packagedResourcesPath(out), 'skills-library', 'skill-bodies.offsets.json');
     fs.writeFileSync(target, JSON.stringify({ version: 1, entries: { test: [1, 3] } }));
     expect(() => verify(out)).toThrow(/CRITICAL/);
+  });
+});
+
+
+/**
+ * The bridge natives are Developer ID signed at stage time, so a packaged copy is
+ * never byte-identical to a freshly installed source tree. The producer never
+ * noticed because it signs its own source tree; an independent observer cannot
+ * reproduce the bytes at all, because codesign embeds a secure timestamp. Byte
+ * equality was therefore unsatisfiable off the signing machine, and the protected
+ * platform observer failed on both darwin legs every time it ran.
+ *
+ * These cases pin the replacement rule: a differing native is accepted ONLY when
+ * it carries a Ferrox Labs Developer ID signature whose identifier embeds the
+ * sha256 of the source file, and is rejected in every other case.
+ */
+describe('staged darwin native reconciliation', () => {
+  const SOURCE_SHA = 'a'.repeat(64);
+  const REL = 'node_modules/@img/sharp-darwin-arm64/lib/sharp-darwin-arm64.node';
+  const sourceEntry = `file:${REL}:100:${SOURCE_SHA}`;
+  const bundledEntry = `file:${REL}:220:${'b'.repeat(64)}`;
+
+  it('accepts a signed native by substituting the source entry', () => {
+    expect(reconcileStagedDarwinNatives('/bundle', [sourceEntry], [bundledEntry], () => true)).toEqual([sourceEntry]);
+  });
+
+  it('demands the identifier that binds the signature to the source digest', () => {
+    const seen: Array<{ binaryPath: string; identifier: string }> = [];
+    reconcileStagedDarwinNatives('/bundle', [sourceEntry], [bundledEntry], (binaryPath, identifier) => {
+      seen.push({ binaryPath, identifier });
+      return true;
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0].binaryPath).toBe(path.join('/bundle', REL));
+    // Exactly the identifier build-with-builder.js signed it with. A signature
+    // lifted from any other native carries a different identifier and fails.
+    expect(seen[0].identifier).toBe(darwinSigningIdentifier('sharp-darwin-arm64.node', SOURCE_SHA));
+  });
+
+  it('keeps the differing entry when the signature check refuses', () => {
+    expect(reconcileStagedDarwinNatives('/bundle', [sourceEntry], [bundledEntry], () => false)).toEqual([bundledEntry]);
+  });
+
+  it('fails closed when the signature check throws', () => {
+    expect(
+      reconcileStagedDarwinNatives('/bundle', [sourceEntry], [bundledEntry], () => {
+        throw new Error('codesign unavailable');
+      })
+    ).toEqual([bundledEntry]);
+  });
+
+  it('never consults the signature check for entries that already match', () => {
+    let calls = 0;
+    const result = reconcileStagedDarwinNatives('/bundle', [sourceEntry], [sourceEntry], () => {
+      calls += 1;
+      return true;
+    });
+    expect(result).toEqual([sourceEntry]);
+    expect(calls).toBe(0);
+  });
+
+  it('leaves directory and symlink entries alone', () => {
+    const structural = ['dir:node_modules', 'link:node_modules/.bin/x:../y'];
+    expect(reconcileStagedDarwinNatives('/bundle', [], structural, () => true)).toEqual(structural);
+  });
+
+  it('does not invent a match for a bundled file the source does not have', () => {
+    const extra = `file:node_modules/extra.node:10:${'c'.repeat(64)}`;
+    expect(reconcileStagedDarwinNatives('/bundle', [sourceEntry], [extra], () => true)).toEqual([extra]);
+  });
+
+  it('refuses to reconcile against a malformed source digest', () => {
+    const malformed = `file:${REL}:100:not-a-sha`;
+    expect(reconcileStagedDarwinNatives('/bundle', [malformed], [bundledEntry], () => true)).toEqual([bundledEntry]);
   });
 });

--- a/tests/unit/verifyPackagedResources.test.ts
+++ b/tests/unit/verifyPackagedResources.test.ts
@@ -1652,6 +1652,24 @@ describe('staged darwin native reconciliation', () => {
     expect(reconcileStagedDarwinNatives('/bundle', [sourceEntry], [extra], () => true)).toEqual([extra]);
   });
 
+  it('reads the path from the right so a colon in a name cannot borrow another digest', () => {
+    // ':' is legal in a darwin filename. Reading the first ':' after the prefix
+    // truncated `awkward:name.node` to `awkward` and looked up whatever file was
+    // actually called `awkward` - handing a planted file a legitimate file's
+    // digest, and pointing the signature check at the legitimate file's path.
+    const REAL = 'node_modules/pkg/awkward';
+    const PLANTED = 'node_modules/pkg/awkward:name.node';
+    const realSource = `file:${REAL}:10:${'d'.repeat(64)}`;
+    const plantedBundled = `file:${PLANTED}:99:${'e'.repeat(64)}`;
+    const seen: string[] = [];
+    const result = reconcileStagedDarwinNatives('/bundle', [realSource], [plantedBundled], (binaryPath) => {
+      seen.push(binaryPath);
+      return true;
+    });
+    expect(result).toEqual([plantedBundled]);
+    expect(seen).toEqual([]);
+  });
+
   it('refuses to reconcile against a malformed source digest', () => {
     const malformed = `file:${REL}:100:not-a-sha`;
     expect(reconcileStagedDarwinNatives('/bundle', [malformed], [bundledEntry], () => true)).toEqual([bundledEntry]);

--- a/tests/unit/verifyPackagedResources.test.ts
+++ b/tests/unit/verifyPackagedResources.test.ts
@@ -1584,7 +1584,6 @@ describe('packaged resource release gate', () => {
   });
 });
 
-
 /**
  * The bridge natives are Developer ID signed at stage time, so a packaged copy is
  * never byte-identical to a freshly installed source tree. The producer never


### PR DESCRIPTION
## What this fixes

The release-acceptance layer is the only part of this repo that cannot run outside a real
release. It has never completed: the last twelve build-and-release runs all concluded
failure, the platform observer has failed all three of its runs, and the updater observer
has never existed on main at all. v0.12.0 is live on GitHub and npm because a human flipped
a draft while both observer jobs were red.

Eight blockers, each verified by execution rather than by reading:

- **Leading-slash gh api** in BOTH observers. Git bash on Windows rewrites it to
  C:/Program Files/Git/repos/..., which killed both win32 legs. The unmerged observer
  branch carried the identical bug.
- **Hard-coded engine tag.** build-and-release pinned v0.12.25 while the acceptance
  assembler derives asset names from DEFAULT_WCORE_VERSION (v0.13.0), so nothing
  downloaded could ever match. The assembler's own comment predicted this. Now derived,
  with a semver guard.
- **Staged darwin signatures vs byte equality.** The whatsapp-bridge natives are
  Developer ID signed at stage time, so a packaged native is never byte-identical to a
  source tree. The producer never noticed because it signs its own tree; an independent
  observer cannot reproduce the bytes at all, since codesign embeds a secure timestamp.
  Now uses the rule already applied to wayland-core and nano: the signature identifier
  must embed the sha256 of the source file. Proven against the real v0.12.1 DMG - 17 of 17
  identifiers match a fresh frozen-lockfile install, and signature-lift, appended bytes, a
  stripped signature and an ad-hoc re-sign are all still rejected.
- **Smoke report count-3.** Three identical platform-package-smoke files reach the
  assembler and exactlyOne matched all of them, so this job would have died on every
  target the first time it ran, with or without green observers. This file had no tests.
- **Corrupted-installer fail-open.** Any throw counted as proof the corruption was
  rejected. Classification cannot fix it - execFileSync reports a nonzero exit as status
  with code undefined - so it is a positive control now.
- **Profile continuity was unsatisfiable.** It demanded a byte-identical profile across
  three application versions. Measured on real boots of v0.11.18 and v0.11.8: 16 files
  changed, 3 appeared, 6 vanished, with no update involved. It now gates on user data
  surviving, and still rejects a deleted database, config, or sentinel, and a wiped profile.
- **Trust-root typecheck** ran a raw tsc without the 8GB heap this project requires and
  would have OOM'd the first time that job was reached.
- Missing install retry and unpinned Node on release-critical jobs.

## What this adds

**Rehearsal tags.** A vX.Y.Z-rehearsal-N tag runs the whole chain end to end - dispatch,
OIDC, attestation, all six targets - and stops at publish. Deliberately not the -dev-
marker, because create-tag pushes one of those on every dev-branch build and admitting
them would fire a second full build plus the entire matrix on every dev push.

**Preflight.** Every precondition it checks is a blocker already hit and answerable in
seconds, yet each previously surfaced hours into a six-platform matrix. Verified against
live state: it correctly refuses today, naming the observer still missing from main.

## Verification

Full suite 18,783 passed, 0 failed. Every fix carries tests, and each was mutation-tested
with the mutation confirmed applied before believing it caught anything. Cross-audited by
Codex 5.6 Sol, Gemini 3.1 Pro and Kimi K3 against both the diff and the plan; findings that
did not reproduce under execution were rejected rather than accepted.
