### PR TITLE
fix(ci): admit any in-flight producer state, not only in_progress

### DIFF
--- a/.github/workflows/protected-platform-package-observer.yml
+++ b/.github/workflows/protected-platform-package-observer.yml
@@ -173,11 +173,28 @@ jobs:
           test "$actual_attempt" = "$PRODUCER_RUN_ATTEMPT"
           test "$(printf '%s' "$producer" | jq -r .head_sha)" = "$EXPECTED_COMMIT"
           test "$(printf '%s' "$producer" | jq -r .path)" = ".github/workflows/build-and-release.yml"
-          producer_state="$(printf '%s' "$producer" | jq -r '[.status, (.conclusion // "null")] | join(":")')"
-          case "$producer_state" in
-            in_progress:null|completed:success) ;;
-            *) echo "producer run is not an admissible exact build state: $producer_state" >&2; exit 1 ;;
-          esac
+          # The producer dispatches this observer and then WAITS on it, so while this
+          # job runs the producer is still in flight by definition. GitHub reports that
+          # in-flight state as queued, waiting, pending or requested as well as
+          # in_progress, depending on whether its remaining jobs have runners yet.
+          # Admitting only in_progress therefore made this gate a race: an observer leg
+          # that happened to start while the producer sat in `queued` failed for no
+          # reason at all. Measured on run 32153073848 - three of six platform legs and
+          # five of six updater legs died on exactly that, while the legs that started
+          # during an in_progress window passed.
+          #
+          # The property that actually matters is unchanged: never observe a producer
+          # that has already CONCLUDED as anything other than success.
+          producer_status="$(printf '%s' "$producer" | jq -r .status)"
+          producer_conclusion="$(printf '%s' "$producer" | jq -r '.conclusion // "null"')"
+          if [[ "$producer_status" == "completed" && "$producer_conclusion" != "success" ]]; then
+            echo "producer run concluded $producer_conclusion; refusing to observe it" >&2
+            exit 1
+          fi
+          if [[ "$producer_status" != "completed" && "$producer_conclusion" != "null" ]]; then
+            echo "producer run reports conclusion $producer_conclusion while $producer_status" >&2
+            exit 1
+          fi
           gh run download "$PRODUCER_RUN_ID" --repo "$GITHUB_REPOSITORY" --name "$ARTIFACT_NAME" --dir payload
 
       - name: Independently observe installed native package

--- a/.github/workflows/protected-updater-journey-observer.yml
+++ b/.github/workflows/protected-updater-journey-observer.yml
@@ -198,11 +198,28 @@ jobs:
           test "$(printf '%s' "$producer" | jq -r .run_attempt)" = "$PRODUCER_RUN_ATTEMPT"
           test "$(printf '%s' "$producer" | jq -r .head_sha)" = "$EXPECTED_COMMIT"
           test "$(printf '%s' "$producer" | jq -r .path)" = ".github/workflows/build-and-release.yml"
-          producer_state="$(printf '%s' "$producer" | jq -r '[.status, (.conclusion // "null")] | join(":")')"
-          case "$producer_state" in
-            in_progress:null|completed:success) ;;
-            *) echo "producer run is not an admissible exact build state: $producer_state" >&2; exit 1 ;;
-          esac
+          # The producer dispatches this observer and then WAITS on it, so while this
+          # job runs the producer is still in flight by definition. GitHub reports that
+          # in-flight state as queued, waiting, pending or requested as well as
+          # in_progress, depending on whether its remaining jobs have runners yet.
+          # Admitting only in_progress therefore made this gate a race: an observer leg
+          # that happened to start while the producer sat in `queued` failed for no
+          # reason at all. Measured on run 32153073848 - three of six platform legs and
+          # five of six updater legs died on exactly that, while the legs that started
+          # during an in_progress window passed.
+          #
+          # The property that actually matters is unchanged: never observe a producer
+          # that has already CONCLUDED as anything other than success.
+          producer_status="$(printf '%s' "$producer" | jq -r .status)"
+          producer_conclusion="$(printf '%s' "$producer" | jq -r '.conclusion // "null"')"
+          if [[ "$producer_status" == "completed" && "$producer_conclusion" != "success" ]]; then
+            echo "producer run concluded $producer_conclusion; refusing to observe it" >&2
+            exit 1
+          fi
+          if [[ "$producer_status" != "completed" && "$producer_conclusion" != "null" ]]; then
+            echo "producer run reports conclusion $producer_conclusion while $producer_status" >&2
+            exit 1
+          fi
           gh run download "$PRODUCER_RUN_ID" --repo "$GITHUB_REPOSITORY" --name "$ARTIFACT_NAME" --dir payload
 
       - name: Independently observe installed native package
@@ -238,8 +255,13 @@ jobs:
           mkdir -p releases/initial releases/rollback
           gh release download v0.11.18 --repo "$GITHUB_REPOSITORY" --pattern "$INITIAL_ASSET" --dir releases/initial
           gh release download v0.11.8 --repo "$GITHUB_REPOSITORY" --pattern "$ROLLBACK_ASSET" --dir releases/rollback
-          test -f "releases/initial/$INITIAL_ASSET"
-          test -f "releases/rollback/$ROLLBACK_ASSET"
+          for expected in "releases/initial/$INITIAL_ASSET" "releases/rollback/$ROLLBACK_ASSET"; do
+            if [[ ! -f "$expected" ]]; then
+              echo "baseline asset $expected was not downloaded" >&2
+              find releases -type f -print >&2
+              exit 1
+            fi
+          done
 
       - name: Observe initial failure rollback and re-upgrade from protected code
         shell: bash
@@ -255,10 +277,22 @@ jobs:
           test -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
           test -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
           candidate_version="$(jq -er .version candidate/package.json)"
+          # These were bare `test` calls. Under `set -e` they exit 1 in silence, so a
+          # failing leg produced NO output at all and the reason had to be guessed from
+          # the surrounding log - the same blindness that made the packaged-resource
+          # failures unreadable. Say which assertion failed and show the evidence.
           installer_count="$(find payload -maxdepth 1 -type f -iname "*.$INSTALLER_EXTENSION" -print | wc -l | tr -d ' ')"
-          test "$installer_count" -eq 1
+          if [[ "$installer_count" -ne 1 ]]; then
+            echo "expected exactly one .$INSTALLER_EXTENSION in payload, found $installer_count:" >&2
+            find payload -maxdepth 1 -type f -print >&2
+            exit 1
+          fi
           installer="$(find payload -maxdepth 1 -type f -iname "*.$INSTALLER_EXTENSION" -print)"
-          test -f "payload/platform-package-smoke-$TARGET.json"
+          if [[ ! -f "payload/platform-package-smoke-$TARGET.json" ]]; then
+            echo "payload/platform-package-smoke-$TARGET.json is absent; payload holds:" >&2
+            find payload -maxdepth 2 -print >&2
+            exit 1
+          fi
           nonce="$(openssl rand -hex 32)"
           node trust/scripts/release-acceptance/produceNativeUpdaterObservation.mjs \
             --target "$TARGET" \

--- a/tests/unit/scripts/observerProducerState.test.ts
+++ b/tests/unit/scripts/observerProducerState.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const OBSERVERS = [
+  '.github/workflows/protected-platform-package-observer.yml',
+  '.github/workflows/protected-updater-journey-observer.yml',
+];
+
+/**
+ * The producer dispatches these observers and then WAITS on them, so while an observer
+ * runs the producer is in flight by definition. GitHub reports that as queued, waiting,
+ * pending or requested as well as in_progress, depending on whether the producer's
+ * remaining jobs have runners yet.
+ *
+ * The original guard admitted only in_progress, which made these gates a race. Measured
+ * on run 32153073848: three of six platform legs and five of six updater legs failed with
+ * "not an admissible exact build state: queued:null", while the legs that happened to
+ * start during an in_progress window passed. Nothing about the candidate was wrong.
+ */
+describe('observer producer-state admissibility', () => {
+  it.each(OBSERVERS)('%s no longer admits only in_progress', (file) => {
+    const text = readFileSync(path.join(process.cwd(), file), 'utf8');
+    expect(text).not.toContain('in_progress:null|completed:success');
+  });
+
+  it.each(OBSERVERS)('%s rejects a producer that concluded anything but success', (file) => {
+    const text = readFileSync(path.join(process.cwd(), file), 'utf8');
+    // The security property: never observe a producer that has already concluded
+    // unsuccessfully. That must survive the widening above.
+    expect(text).toContain('"$producer_status" == "completed" && "$producer_conclusion" != "success"');
+    expect(text).toContain('refusing to observe it');
+  });
+
+  it.each(OBSERVERS)('%s rejects a conclusion reported while still in flight', (file) => {
+    const text = readFileSync(path.join(process.cwd(), file), 'utf8');
+    expect(text).toContain('"$producer_status" != "completed" && "$producer_conclusion" != "null"');
+  });
+});

--- a/tests/unit/scripts/releaseAcceptancePipeline.test.ts
+++ b/tests/unit/scripts/releaseAcceptancePipeline.test.ts
@@ -188,7 +188,18 @@ describe('protected release acceptance pipeline', () => {
     expect(observe.env.ACTIONS_ID_TOKEN_REQUEST_URL).toBe('');
     expect(observeText).toContain('platform-package-smoke.mjs');
     expect(observeText).toContain('.github/workflows/build-and-release.yml');
-    expect(observeText).toContain('in_progress:null|completed:success');
+    // The producer is IN FLIGHT while this observer runs - it dispatched this job and
+    // is waiting on it - and GitHub reports that as queued/waiting/pending/requested as
+    // well as in_progress. Admitting only in_progress made this gate a race on runner
+    // availability: three of six platform legs and five of six updater legs failed on
+    // `queued:null` in the first real rehearsal, with nothing wrong with the candidate.
+    // Both halves of the replacement are asserted, so the widening cannot silently
+    // become "admit anything".
+    // observeText is a JSON.stringify of the job, so quotes arrive escaped; match on the
+    // quote-free failure messages instead.
+    expect(observeText).toContain('producer_status');
+    expect(observeText).toContain('refusing to observe it');
+    expect(observeText).toContain('producer run reports conclusion');
     expect(observeText).not.toContain('attest-build-provenance');
     expect(observeText).not.toContain('createProtectedPlatformObservation.js');
 


### PR DESCRIPTION
First rehearsal (run 32153073848) result: **preflight, all six builds, Build Summary, Create Release and BOTH smoke gates green**. Both observers failed - and not because of the candidate.

The observers are dispatched by the producer, which then waits on them, so while an observer runs the producer is in flight by definition. GitHub reports that as `queued`, `waiting`, `pending` or `requested` as well as `in_progress`, depending on whether the producer's remaining jobs have runners yet. The guard admitted only `in_progress`, which made both gates a race on runner availability.

Measured: three of six platform legs and five of six updater legs died on `not an admissible exact build state: queued:null`. The legs that happened to start during an `in_progress` window passed - including **darwin-arm64, which proves the staged-signature fix from #1084 works in CI**.

The security property is unchanged and now stated directly: never observe a producer that has already concluded as anything other than success, and reject a producer that reports a conclusion while claiming to still run. Verified across queued/in_progress/waiting/pending/requested (admit), completed:success (admit), completed:failure|cancelled|timed_out (reject), and a malformed conclusion-while-queued (reject).

Also replaces the bare `test` calls in the updater observer with checks that report what failed and show the evidence. Under `set -e` those exited in silence, so a failing leg produced no output at all.