### PR TITLE
fix(release): validate the smoke marker digest in the format it is written

### DIFF
--- a/scripts/release-acceptance/verifyPlatformPackageSmokes.js
+++ b/scripts/release-acceptance/verifyPlatformPackageSmokes.js
@@ -203,7 +203,12 @@ function verifySemanticRuntime(report, platform, arch) {
     'platform smoke electron evidence'
   );
   safeRelativePath(electron.expectedRendererPath, 'platform smoke expected renderer path');
-  hexDigest(electron.markerSha256, 'platform smoke marker digest');
+  // `sha256:`-prefixed, not bare. platform-package-smoke.mjs builds this one with
+  // sha256Bytes(), which prefixes, while executableSha256 and appAsarSha256 come from
+  // sha256File(), which does not. Validating this field as bare hex could therefore
+  // never accept a genuine report on any platform - it failed all six updater legs
+  // identically the first time this validator was ever reached.
+  digest(electron.markerSha256, 'platform smoke marker digest');
   if (
     electron.booted !== true ||
     electron.rendererReady !== true ||

--- a/tests/unit/scripts/platformPackageSmokeAuthority.test.ts
+++ b/tests/unit/scripts/platformPackageSmokeAuthority.test.ts
@@ -73,7 +73,12 @@ function report(target = 'linux-x64') {
       booted: true,
       rendererReady: true,
       expectedRendererPath: 'resources/app.asar/out/renderer/index.html',
-      markerSha256: '7'.repeat(64),
+      // `sha256:`-prefixed, because platform-package-smoke.mjs builds this field with
+      // sha256Bytes(), which prefixes - unlike executableSha256/appAsarSha256, which come
+      // from sha256File() and are bare. This fixture used the bare form, so it agreed with
+      // a validator that no real report could ever satisfy, and the whole updater observer
+      // failed on all six targets the first time it was reached.
+      markerSha256: `sha256:${'7'.repeat(64)}`,
       readyState: 'complete',
       title: 'Wayland',
       url: 'file:///resources/app.asar/out/renderer/index.html',

--- a/tests/unit/scripts/updaterObservationAuthority.test.ts
+++ b/tests/unit/scripts/updaterObservationAuthority.test.ts
@@ -101,7 +101,12 @@ function platformPackageSmoke(candidate: { file: string; sha256: string }) {
       booted: true,
       rendererReady: true,
       expectedRendererPath: 'resources/app.asar/out/renderer/index.html',
-      markerSha256: '7'.repeat(64),
+      // `sha256:`-prefixed, because platform-package-smoke.mjs builds this field with
+      // sha256Bytes(), which prefixes - unlike executableSha256/appAsarSha256, which come
+      // from sha256File() and are bare. This fixture used the bare form, so it agreed with
+      // a validator that no real report could ever satisfy, and the whole updater observer
+      // failed on all six targets the first time it was reached.
+      markerSha256: `sha256:${'7'.repeat(64)}`,
       readyState: 'complete',
       title: 'Wayland',
       url: 'file:///resources/app.asar/out/renderer/index.html',


### PR DESCRIPTION
Rehearsal 2 (run 32163019072) result: **the platform observer went 6/6 green including all six signing jobs - the first complete pass in this repo's history**. Preflight, all six builds, both smoke gates and Create Release were green too.

All six updater observer legs then failed identically:

```
platform smoke marker digest is not a SHA-256 hex digest
```

`platform-package-smoke.mjs` builds `electron.markerSha256` with `sha256Bytes()`, which prefixes with `sha256:`. `verifyPlatformPackageSmokes.js` validated it with `hexDigest()`, which requires bare hex. Those have never agreed, so this validator could not accept a genuine report on any platform - it only surfaced now because the producer-state fix in #1086 let the updater legs reach it for the first time.

**The fixtures hid it.** Both authority tests set `markerSha256` to bare hex, agreeing with the broken validator rather than the producer, while the producer's own test (`platformPackageSmoke.test.ts:153`) uses the prefixed form. The two halves of the suite disagreed and nothing caught it, because this validator had never run against a real report.

Fixtures corrected to what production writes; the validator stays strict and uses the prefixed matcher already defined in the file for this purpose. Mutation-checked: restoring the bare-hex check fails 6 tests that previously passed.