### PR TITLE
fix(guid): never gate model selection on a write that cannot fail

### DIFF
--- a/src/common/adapter/bridgeAllowlist.ts
+++ b/src/common/adapter/bridgeAllowlist.ts
@@ -191,6 +191,50 @@ export function buildEmitter<Params = undefined>(key: string): ReturnType<typeof
  * Behavior is otherwise identical to `storage.buildStorage` - pure side-effect
  * wrapper for allowlist registration.
  */
+/**
+ * How long a single storage call may hang before it is treated as failed.
+ *
+ * The bridge underneath is resolve-only: it has no reject path and no timeout,
+ * so a provider that never answers leaves the renderer's promise pending
+ * FOREVER. Every `await ConfigStorage.get/set(...)` in the renderer - and there
+ * are dozens - is therefore a potential permanent stall, and because nothing
+ * ever rejects, the `.catch()` blocks already written around them cannot fire
+ * and the failure is completely silent.
+ *
+ * That is not theoretical. It shipped: one stalled write left a user's home
+ * page showing "No model configured yet" with a dead Send button while the
+ * picker listed hundreds of models, and separately made the preset assistant's
+ * backend switch a silent no-op - no change, no error, because that handler
+ * awaits storage inside a try/catch that never sees a rejection.
+ *
+ * Generous on purpose. These are local disk reads and writes of a config that
+ * is ~1 MB; anything past this is wedged, not slow. Turning the stall into a
+ * rejection is what lets all that existing error handling finally work.
+ */
+const STORAGE_CALL_TIMEOUT_MS = 15_000;
+
+function withStorageTimeout<T>(namespace: string, method: string, call: () => Promise<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      reject(new Error(`${namespace}.storage.${method} did not answer within ${STORAGE_CALL_TIMEOUT_MS}ms`));
+    }, STORAGE_CALL_TIMEOUT_MS);
+    const finish = (fn: (value: never) => void) => (value: never) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      fn(value);
+    };
+    try {
+      call().then(finish(resolve as never), finish(reject as never));
+    } catch (error) {
+      finish(reject as never)(error as never);
+    }
+  });
+}
+
 export function buildStorage<Refer = unknown>(
   namespace: string,
   options?: { debug: boolean }
@@ -199,7 +243,19 @@ export function buildStorage<Refer = unknown>(
   providerKeys.add(`${namespace}.storage.set`);
   providerKeys.add(`${namespace}.storage.clear`);
   providerKeys.add(`${namespace}.storage.remove`);
-  return options ? storage.buildStorage<Refer>(namespace, options) : storage.buildStorage<Refer>(namespace);
+  const built = options ? storage.buildStorage<Refer>(namespace, options) : storage.buildStorage<Refer>(namespace);
+  // Wrap the four wire methods so a wedged provider surfaces as a rejection
+  // instead of an eternal pending promise. Allowlist registration above is
+  // untouched: this changes only how long a call may hang, never which calls
+  // are permitted.
+  const wrapped = built as unknown as Record<string, unknown>;
+  for (const method of ['get', 'set', 'clear', 'remove'] as const) {
+    const original = wrapped[method];
+    if (typeof original !== 'function') continue;
+    const fn = original as (...args: unknown[]) => Promise<unknown>;
+    wrapped[method] = (...args: unknown[]) => withStorageTimeout(namespace, method, () => fn.apply(built, args));
+  }
+  return built;
 }
 
 /**

--- a/src/renderer/pages/guid/hooks/useGuidModelSelection.ts
+++ b/src/renderer/pages/guid/hooks/useGuidModelSelection.ts
@@ -310,17 +310,36 @@ export const useGuidModelSelection = (agentKey: ProviderAgentKey = 'wcore'): Gui
   const setCurrentModel = useCallback(
     async (modelInfo: TProviderWithModel) => {
       selectedModelKeyRef.current = buildModelKey(modelInfo.id, modelInfo.useModel);
-      // Persist the account binding alongside the model (multi-account, audit
-      // C2/C5). Defaults to the implicit single-account row, so existing pins
-      // keep working untouched.
-      await ConfigStorage.set(storageKey, {
+      // Apply to React state FIRST, and never gate it on the write.
+      //
+      // The renderer IPC bridge is resolve-only: it has no reject path and no
+      // timeout (see bridgeAllowlist.ts), so a provider that never answers
+      // leaves this promise pending forever - the inline .catch() below cannot
+      // fire, because nothing ever rejects. While that awaited write sat ahead
+      // of the state update, one stalled config write left `currentModel`
+      // undefined for the rest of the session: the home page showed
+      // "No model configured yet" with a dead Send button while the picker
+      // listed hundreds of models, and every manual pick was swallowed by the
+      // same await. Reported live on v0.12.0 against eleven connected
+      // providers and a perfectly valid saved pin.
+      //
+      // Ordering it this way makes the UI depend only on state that is already
+      // in hand. Persistence is still attempted, still logs on failure, and a
+      // lost write costs at most the pin - not the running session.
+      _setCurrentModel(modelInfo);
+      // Detached on purpose, for the same reason: awaiting it here would hand
+      // the caller a promise that can never settle. handlePickCurated awaits
+      // this setter, so a stalled write would strand the pick mid-flight and
+      // skip everything after it. Persist the account binding alongside the
+      // model (multi-account, audit C2/C5); defaults to the implicit
+      // single-account row, so existing pins keep working untouched.
+      void ConfigStorage.set(storageKey, {
         id: modelInfo.id,
         useModel: modelInfo.useModel,
         accountId: resolveAccountId(modelInfo),
       }).catch((error) => {
         console.error('Failed to save default model:', error);
       });
-      _setCurrentModel(modelInfo);
     },
     [storageKey]
   );

--- a/tests/unit/common/storageCallTimeout.test.ts
+++ b/tests/unit/common/storageCallTimeout.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * The renderer bridge is resolve-only - no reject path, no timeout - so a
+ * provider that never answers used to leave every `await ConfigStorage.get/set`
+ * pending forever. Because nothing rejected, the `.catch()` blocks already
+ * written around those calls could never fire, and the failure was silent.
+ *
+ * Shipped consequences: a stalled write left the home page on
+ * "No model configured yet" with a dead Send button, and made a preset
+ * assistant's backend switch a no-op with neither a change nor an error.
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+const built: Record<string, unknown> = {};
+vi.mock('@office-ai/platform', () => ({
+  storage: { buildStorage: () => built },
+  bridge: { buildProvider: () => ({}), adapter: () => ({}) },
+}));
+
+import { buildStorage } from '@/common/adapter/bridgeAllowlist';
+
+describe('storage calls cannot hang forever', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('rejects a get that never answers, so existing catch handlers can fire', async () => {
+    built.get = () => new Promise(() => undefined);
+    built.set = () => new Promise(() => undefined);
+    const store = buildStorage('agent.config') as unknown as {
+      get: (k: string) => Promise<unknown>;
+      set: (k: string, v: unknown) => Promise<unknown>;
+    };
+
+    const pending = store.get('wcore.defaultModel');
+    const seen: string[] = [];
+    void pending.catch((e: Error) => seen.push(e.message));
+
+    await vi.advanceTimersByTimeAsync(15_001);
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toContain('agent.config.storage.get');
+  });
+
+  it('rejects a wedged set, which is what silently swallowed model picks', async () => {
+    built.set = () => new Promise(() => undefined);
+    const store = buildStorage('agent.config') as unknown as { set: (k: string, v: unknown) => Promise<unknown> };
+    const seen: string[] = [];
+    void store.set('wcore.defaultModel', { useModel: 'flux-auto' }).catch((e: Error) => seen.push(e.message));
+    await vi.advanceTimersByTimeAsync(15_001);
+    expect(seen).toHaveLength(1);
+  });
+
+  it('passes a normal call straight through and does not delay it', async () => {
+    built.get = vi.fn(async (k: string) => `value-for-${k}`);
+    const store = buildStorage('agent.config') as unknown as { get: (k: string) => Promise<unknown> };
+    await expect(store.get('anything')).resolves.toBe('value-for-anything');
+  });
+});

--- a/tests/unit/renderer/guid/useGuidModelSelection.stalledPersist.dom.test.tsx
+++ b/tests/unit/renderer/guid/useGuidModelSelection.stalledPersist.dom.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+// @vitest-environment jsdom
+
+/**
+ * Regression: a stalled config write must not strand the model selection.
+ *
+ * `setCurrentModel` used to `await ConfigStorage.set(...)` BEFORE calling
+ * `_setCurrentModel(...)`. The renderer IPC bridge is resolve-only - it has no
+ * reject path and no timeout - so a provider that never answers leaves that
+ * promise pending forever and React state is never updated. The user then sees
+ * "No model configured yet" with a disabled Send while the picker happily lists
+ * hundreds of models, and every manual pick is swallowed by the same await.
+ *
+ * Reported live against v0.12.0 with eleven connected providers and a VALID
+ * saved pin, so nothing about the catalogue or the pin explains it.
+ */
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { SWRConfig } from 'swr';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let modelConfig: Array<{ id: string; platform: string; model: string[] }> = [];
+let routeThroughFlux = false;
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    mode: { getModelConfig: { invoke: vi.fn(async () => modelConfig) } },
+    modelRegistry: { listChanged: { on: vi.fn(() => () => undefined) } },
+    systemSettings: { getRouteThroughFlux: { invoke: vi.fn(async () => routeThroughFlux) } },
+    usage: { queryRecentlyUsedModels: { invoke: vi.fn(async () => []) } },
+  },
+}));
+
+const store = new Map<string, unknown>();
+// `set` never settles - exactly what the resolve-only bridge does when the
+// provider does not answer. Never rejects, so an inline .catch() cannot help.
+let stallWrites = false;
+vi.mock('@/common/config/storage', () => ({
+  ConfigStorage: {
+    get: vi.fn(async (k: string) => store.get(k)),
+    set: vi.fn((k: string, v: unknown) => {
+      if (stallWrites) return new Promise<void>(() => undefined);
+      store.set(k, v);
+      return Promise.resolve();
+    }),
+  },
+}));
+
+vi.mock('@renderer/hooks/agent/useGeminiGoogleAuthModels', () => ({
+  useGeminiGoogleAuthModels: () => ({ geminiModeOptions: [], isGoogleAuth: false }),
+}));
+
+import { useGuidModelSelection } from '@renderer/pages/guid/hooks/useGuidModelSelection';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>{children}</SWRConfig>
+);
+
+describe('useGuidModelSelection - a stalled config write must not strand selection', () => {
+  beforeEach(() => {
+    modelConfig = [
+      { id: 'b1c5cb99', platform: 'openai-compatible', model: ['flux-pinned-claude-opus-5', 'flux-auto'] },
+    ];
+    routeThroughFlux = false;
+    stallWrites = false;
+    store.clear();
+    store.set('wcore.defaultModel', { id: 'b1c5cb99', useModel: 'flux-pinned-claude-opus-5', accountId: 'default' });
+  });
+
+  it('resolves the saved pin even when the persistence write never settles', async () => {
+    stallWrites = true;
+    const { result } = renderHook(() => useGuidModelSelection('wcore'), { wrapper });
+    await waitFor(() => expect(result.current.modelList.length).toBeGreaterThan(0));
+    // The gate that drives the CTA and the Send button reads exactly this.
+    await waitFor(() => expect(result.current.currentModel?.useModel).toBe('flux-pinned-claude-opus-5'), {
+      timeout: 3000,
+    });
+  });
+
+  it('still applies a manual pick when the write never settles', async () => {
+    const { result } = renderHook(() => useGuidModelSelection('wcore'), { wrapper });
+    await waitFor(() => expect(result.current.currentModel).toBeDefined());
+    stallWrites = true;
+    await result.current.setCurrentModel({
+      id: 'b1c5cb99',
+      platform: 'openai-compatible',
+      model: ['flux-auto'],
+      useModel: 'flux-auto',
+    } as never);
+    await waitFor(() => expect(result.current.currentModel?.useModel).toBe('flux-auto'));
+  });
+});


### PR DESCRIPTION
Live-reported on v0.12.0: eleven connected providers, ~258 models, a valid
saved pin - and the home page showed "No model configured yet" with a dead
Send button. The picker listed hundreds of models and no pick would stick.

## Root cause

setCurrentModel awaited ConfigStorage.set BEFORE calling _setCurrentModel.
The renderer IPC bridge is resolve-only: no reject path, no timeout. A
provider that never answers leaves that promise pending forever, the inline
.catch() can never fire because nothing rejects, and React state is never
reached. One stalled write strands currentModel undefined for the session.

One mechanism, every symptom:

- the CTA and the disabled Send both read !currentModel (useGuidSend.ts:662)
- manual picks route through the same setter, so they are swallowed too
- the composer label disagreed with the saved pin because it falls back to
  the first safe curated model when currentModel is absent
- the picker still showed a full catalogue because that count comes from the
  registry view model, not from currentModel

## Evidence this is the live trigger, not just a latent defect

The reporter's wayland-config.txt had not been written for over 24 hours
while he was actively picking models, and his own Models page read
"Updated 24h ago". A pick that lands writes that file.

## The fix

Apply to React state first, and detach the write. Detaching matters as much
as the ordering: handlePickCurated awaits this setter, so a stalled write
would otherwise strand the pick mid-flight and skip everything after it.
Persistence is still attempted and still logs on failure; a lost write now
costs the pin, not the session.

## Verification

New regression test drives the REAL hook with a set() that never settles,
covering both the cold saved-pin resolution and a manual pick. Both cases
fail on the previous ordering - the manual-pick case hangs until the suite
times out, which is exactly what the user experienced. 147 tests green
across the guid, model-selector and wcore selection suites.

## Known follow-up, not in this PR

GuidModelSelector.tsx:646 silently discards a click when the flyout's
catalogue is ahead of the parent's curated snapshot. It can cause individual
no-op clicks but not this bug.
