### PR TITLE
Bundle wayland-core v0.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ Two bugs that made a fully configured install look broken, and the engine everyo
 
 ### Changed
 
-- **Bundled engine moves to wayland-core v0.13.2.**
+- **Bundled engine moves to wayland-core v0.13.3.**
+- **You are told when a search leaves for a third party.** The keyless default web search sends queries to `parallel.ai`. The notice saying so was being written to the log file instead of shown to you, so in practice you never saw it. It now shows up where you are, once.
 
 ## [0.12.1] - 2026-08-18
 

--- a/installer/scripts/postinstall.mjs
+++ b/installer/scripts/postinstall.mjs
@@ -17,7 +17,7 @@ import { fileURLToPath } from 'node:url';
 
 // Kept in lockstep with scripts/prepareWaylandCore.js DEFAULT_WCORE_VERSION by
 // scripts/stage-wcore-bump.mjs. Do not hand-edit; run that tool so both move.
-const WCORE_VERSION = 'v0.13.2';
+const WCORE_VERSION = 'v0.13.3';
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PAYLOAD = resolve(HERE, '..', 'payload');
 

--- a/scripts/bundled-wcore-shasums.json
+++ b/scripts/bundled-wcore-shasums.json
@@ -1,5 +1,31 @@
 {
   "_comment": "Authoritative SHA-256 checksums for bundled wayland-core release archives (the downloaded .tar.gz / .zip assets), keyed by release tag then asset filename. Mirrors scripts/bundled-bun-shasums.json. Source of truth: the SHASUMS published alongside each signed FerroxLabs/wayland-core release. The downloaded archive is verified against this file BEFORE it is extracted, copied, or executed. Update this file in lockstep with DEFAULT_WCORE_VERSION in scripts/prepareWaylandCore.js and regenerate on every engine version bump.",
+  "v0.13.3": {
+    "wayland-core-v0.13.3-aarch64-apple-darwin.tar.gz": {
+      "archiveSha256": "sha256:c0877f8e7ef03463de37177a482e4adc779f200064d60387390c5a00d451af1f",
+      "binarySha256": "sha256:d2c4d15a0b4ebd9f9dd046f4cf563febcad88e7766727596461dd4fc49c530c0"
+    },
+    "wayland-core-v0.13.3-x86_64-apple-darwin.tar.gz": {
+      "archiveSha256": "sha256:4c18a3fea9123c75a0e1de5a805ec38de33bec7b2de4ab42eaa8cc2277eb2050",
+      "binarySha256": "sha256:cc853f9dbf3b7c335c6b4543d9aa9176504e13508458c4cd80eab82e894ca5b3"
+    },
+    "wayland-core-v0.13.3-aarch64-unknown-linux-gnu.tar.gz": {
+      "archiveSha256": "sha256:c3f1a93fe435ff46d8d452da74372d2975fc02e23db5dc45d536ba2dac4d9473",
+      "binarySha256": "sha256:7a72cc34decd0cd08d8f2df4505409124f1b4037ef1fdec88ee81c5da7635f32"
+    },
+    "wayland-core-v0.13.3-x86_64-unknown-linux-gnu.tar.gz": {
+      "archiveSha256": "sha256:2776471b4918a1c387dbe279a76acbadbf4040d38698bf5fce5d3fbf2e3c158d",
+      "binarySha256": "sha256:564093fdd07525ef4c80e803c16fde966d93b396ddbde997362b677221d9c836"
+    },
+    "wayland-core-v0.13.3-aarch64-pc-windows-msvc.zip": {
+      "archiveSha256": "sha256:9dda1343d5a87ee585f0aa5c8bb191e7a1e6d80e06105451ec2c416c85cbd260",
+      "binarySha256": "sha256:2f7bc5b5655d14de83755a9a0fccdc1d557b4d8386bc8e101c2ac3abba32b6e3"
+    },
+    "wayland-core-v0.13.3-x86_64-pc-windows-msvc.zip": {
+      "archiveSha256": "sha256:05727c7edd5660b745f936314f903919670124d0f9bfdd1fee6a5ebcf642c549",
+      "binarySha256": "sha256:a99a81b3bc895215fff3e3749d0553ebc4e0dddf751add4c8dcb09bf9b62f48b"
+    }
+  },
   "v0.13.2": {
     "wayland-core-v0.13.2-aarch64-apple-darwin.tar.gz": {
       "archiveSha256": "sha256:abcac1ca625522b5cb34455921fe6797df5bcef0dd5da3978bcdb347a72c71b6",

--- a/scripts/prepareWaylandCore.js
+++ b/scripts/prepareWaylandCore.js
@@ -240,7 +240,7 @@ function verifyArchiveChecksum(archivePath, expectedHex, assetName, tag) {
 // directory, and it gets tagged only once that verification passes. So this
 // branch is NOT shippable, the tag below stays where it is until then, and
 // `desktopContractV1.test.ts` holds the tripwire that says so.
-const DEFAULT_WCORE_VERSION = 'v0.13.2';
+const DEFAULT_WCORE_VERSION = 'v0.13.3';
 
 function getVersion() {
   return (process.env.WCORE_VERSION || DEFAULT_WCORE_VERSION).trim();

--- a/scripts/supply-chain/publisher-attestations.json
+++ b/scripts/supply-chain/publisher-attestations.json
@@ -39,7 +39,7 @@
     },
     {
       "id": "wayland-core-v0.13.2-release",
-      "status": "active",
+      "status": "superseded",
       "releaseTag": "v0.13.2",
       "repository": "FerroxLabs/wayland-core",
       "signerWorkflow": "FerroxLabs/wayland-core/.github/workflows/release.yml",
@@ -57,6 +57,18 @@
       "signerWorkflow": "FerroxLabs/wayland-nano/.github/workflows/release.yml",
       "sourceRef": "refs/tags/v0.1.1",
       "sourceDigest": "466f030db615038919d6f367e2b7f0354ac73f06",
+      "predicateType": "https://slsa.dev/provenance/v1",
+      "oidcIssuer": "https://token.actions.githubusercontent.com",
+      "runner": "github-hosted"
+    },
+    {
+      "id": "wayland-core-v0.13.3-release",
+      "status": "active",
+      "releaseTag": "v0.13.3",
+      "repository": "FerroxLabs/wayland-core",
+      "signerWorkflow": "FerroxLabs/wayland-core/.github/workflows/release.yml",
+      "sourceRef": "refs/heads/main",
+      "sourceDigest": "37edc24414def682c46d749fe84b369a091c286a",
       "predicateType": "https://slsa.dev/provenance/v1",
       "oidcIssuer": "https://token.actions.githubusercontent.com",
       "runner": "github-hosted"

--- a/tests/unit/process/agent/wcore/desktopContractV1.test.ts
+++ b/tests/unit/process/agent/wcore/desktopContractV1.test.ts
@@ -160,6 +160,12 @@ describe('Wayland Core Desktop v1 producer pin', () => {
     // changed, and exactly six vendored fixtures carry that stamp; every other
     // byte of the corpus is unchanged.
     //
+    // v0.13.2 -> v0.13.3 moved NOTHING in the contract: the released manifest
+    // carries byte-identical fixture, schema and source-inputs digests, the same
+    // gen/14 generator and the same seventeen capability statuses. Re-derived
+    // from that manifest, not assumed - the assertions above are what prove it,
+    // and they are unchanged because the bytes are.
+    //
     // That distinction is the whole risk. assertDescriptor fails closed on both
     // of those fields, so bumping the bundled tag WITHOUT re-vendoring them
     // would have handed users a build that dies at the handshake on every turn
@@ -170,7 +176,7 @@ describe('Wayland Core Desktop v1 producer pin', () => {
     // must be re-derived from the released manifest, not patched.
     expect(DESKTOP_CORE_V1_PIN.minor).toBe(14);
     expect(readFileSync(path.resolve(process.cwd(), 'scripts/prepareWaylandCore.js'), 'utf8')).toContain(
-      "const DEFAULT_WCORE_VERSION = 'v0.13.2'"
+      "const DEFAULT_WCORE_VERSION = 'v0.13.3'"
     );
   });
 

--- a/tests/unit/scripts/publisherAttestation.test.ts
+++ b/tests/unit/scripts/publisherAttestation.test.ts
@@ -12,13 +12,20 @@ const {
   verifyPublisherAttestation,
 } = require('../../../scripts/supply-chain/verifyPublisherAttestation');
 
-// Derived, never re-typed: the release-acceptance gate requires exactly ONE
-// active policy, so hard-coding a tag here breaks the day the engine is bumped.
-const ACTIVE = readPolicy().policies.find((entry: { status: string }) => entry.status === 'active') as {
-  releaseTag: string;
-  signerWorkflow: string;
-  sourceDigest: string;
-};
+// Derived, never re-typed: hard-coding a tag here breaks the day the engine is
+// bumped. Scoped to the ENGINE, because the document is not single-active: an
+// active wayland-nano policy sits alongside it, and taking the first active
+// entry made this depend on array order. It picked the engine only while the
+// engine entry happened to come first, and asserts a wayland-core signer
+// workflow, so the day the order changed it failed claiming the engine was
+// misconfigured.
+const ACTIVE_ENGINE_POLICIES = readPolicy().policies.filter(
+  (entry: { status: string; id: string }) => entry.status === 'active' && entry.id.startsWith('wayland-core-')
+) as { releaseTag: string; signerWorkflow: string; sourceDigest: string; id: string }[];
+if (ACTIVE_ENGINE_POLICIES.length !== 1) {
+  throw new Error(`expected exactly one active wayland-core publisher policy, found ${ACTIVE_ENGINE_POLICIES.length}`);
+}
+const ACTIVE = ACTIVE_ENGINE_POLICIES[0]!;
 
 const roots: string[] = [];
 afterEach(() => {

--- a/tests/unit/verifyPackagedResources.test.ts
+++ b/tests/unit/verifyPackagedResources.test.ts
@@ -56,13 +56,27 @@ const {
 // the real DEFAULT_WCORE_VERSION and the real attestation policy, so a
 // hard-coded tag here fails the day the engine is bumped and proves nothing in
 // between.
-const TEST_WCORE_ACTIVE_POLICY = (
+//
+// Selected by engine id, NOT by "the first active entry". The document also
+// carries an active wayland-nano policy, so position decided which product this
+// picked: while the active engine entry happened to precede nano it worked, and
+// appending v0.13.3 after nano silently handed these fixtures the NANO tag and
+// failed fifteen tests on a mismatch that had nothing to do with the engine.
+// The production selector keys off releaseTag and demands a unique match, so
+// only this test was ever order-dependent.
+const TEST_WCORE_ACTIVE_POLICIES = (
   require('../../scripts/supply-chain/verifyPublisherAttestation') as {
     readPolicy: () => { policies: Array<{ status: string; id: string; releaseTag: string; sourceDigest: string }> };
   }
 )
   .readPolicy()
-  .policies.find((entry) => entry.status === 'active')!;
+  .policies.filter((entry) => entry.status === 'active' && entry.id.startsWith('wayland-core-'));
+if (TEST_WCORE_ACTIVE_POLICIES.length !== 1) {
+  throw new Error(
+    `expected exactly one active wayland-core publisher policy, found ${TEST_WCORE_ACTIVE_POLICIES.length}`
+  );
+}
+const TEST_WCORE_ACTIVE_POLICY = TEST_WCORE_ACTIVE_POLICIES[0]!;
 const TEST_WCORE_RELEASE = TEST_WCORE_ACTIVE_POLICY.releaseTag;
 const TEST_WCORE_ARCHIVE_SHA = 'a'.repeat(64);
 const TEST_WCORE_BYTES = Buffer.from('deterministic-test-wayland-core');


### PR DESCRIPTION
v0.13.2 is the release that made the keyless default web search actually reach the network for the first time. Before it, every request was refused by the egress policy and quietly served by DuckDuckGo. The notice telling the user their queries go to `parallel.ai` was emitted into the log file rather than to the terminal, so in practice nobody saw it.

v0.13.3 is the release that shows it. Shipping 0.12.2 on v0.13.2 would ship the silent combination, so this is a trust fix, not version currency.

## Costs nothing in contract work

Unlike v0.13.0 to v0.13.2, this needs no re-vendoring. The released manifest carries:

| field | v0.13.2 | v0.13.3 |
| --- | --- | --- |
| generator | wcore-desktop-contract-gen/14 | identical |
| fixture_digest | sha256:8dd56f9a... | identical |
| schema_digest | sha256:306d83e1... | identical |
| source_inputs_digest | sha256:6db45f83... | identical |
| contract | major 1 / minor 14 | identical |
| capabilities | 17 statuses | identical |

So the compiled descriptor is already correct. The contract test asserts that against the released manifest rather than assuming it, and it passes unchanged.

## Attestation proved both ways

A publisher attestation policy entry is required or a verified prepare refuses the tag, which is exactly what happened on the v0.13.2 move. The new entry was checked against the real artifact:

- the v0.13.3 linux archive verifies under the `release.yml` signer at source digest `37edc244...` with `--deny-self-hosted-runners`
- a deliberately wrong source digest is rejected with `expected SourceRepositoryDigest to be 0000..., got 37edc244...`

Source digest convention confirmed against v0.13.2, whose policy digest equals its tag commit.

## Also

- `DEFAULT_WCORE_VERSION`, the bundled shasums block and the installer postinstall version all move together via `scripts/stage-wcore-bump.mjs`.
- Changelog and release notes gain the search-notice line, since it is user-facing.
