### PR TITLE
Fix the last two updater observer blockers found by rehearsal 7

### DIFF
--- a/scripts/release-acceptance/produceNativeUpdaterObservation.mjs
+++ b/scripts/release-acceptance/produceNativeUpdaterObservation.mjs
@@ -473,6 +473,15 @@ export function supportedStateEntries(root) {
       if (CHROMIUM_MANAGED_ENTRIES.has(entry.name) || CHROMIUM_MANAGED_ENTRIES.has(relative)) continue;
       if (APP_SHIPPED_PREFIXES.some((prefix) => `${relative}/`.startsWith(prefix))) continue;
       if (entry.name.endsWith('.log') || entry.name.endsWith('.lock')) continue;
+      // SQLite write-ahead sidecars. A clean shutdown checkpoints the WAL into its
+      // database and DELETES both sidecars, so their absence afterwards is the
+      // library working, not user data being destroyed. Whether the baseline even
+      // contains one depends on whether that boot happened to exit mid-transaction,
+      // which made this a coin toss: rehearsal 7 lost `DIPS-wal` on darwin-arm64 and
+      // reported it as destroyed state, having passed the identical check before.
+      // The databases themselves stay tracked, so real loss is still reported - the
+      // durable bytes live in the main file once the checkpoint completes.
+      if (entry.name.endsWith('-wal') || entry.name.endsWith('-shm')) continue;
       if (entry.isSymbolicLink()) fail(`supported state contains symlink: ${relative}`);
       else if (entry.isDirectory()) visit(absolute);
       else if (entry.isFile()) entries.add(relative);
@@ -605,20 +614,37 @@ export function verifyPublisherEvidence(target, role, prepared, dependencies = {
   if (target.startsWith('win32-')) {
     const run = dependencies.spawnSync || spawnSync;
     const script = [
-      '$s=Get-AuthenticodeSignature -LiteralPath $args[0]',
+      '$s=Get-AuthenticodeSignature -LiteralPath $env:WAYLAND_PUBLISHER_SUBJECT',
       '$subject=if($s.SignerCertificate){$s.SignerCertificate.Subject}else{""}',
       '[pscustomobject]@{Status=[string]$s.Status;Subject=$subject}|ConvertTo-Json -Compress',
     ].join(';');
-    const result = run(
-      'powershell.exe',
-      ['-NoProfile', '-NonInteractive', '-Command', script, prepared.snapshot?.snapshotPath || prepared.executablePath],
-      { encoding: 'utf8' }
-    );
+    // The path travels in the ENVIRONMENT, not as a trailing argument. `-Command`
+    // consumes the rest of the command line AS COMMAND TEXT, so a path appended
+    // after the script never reaches `$args[0]`: it was being parsed as a
+    // positional argument to ConvertTo-Json, which binds nothing, writes nothing to
+    // stdout and made JSON.parse('') the reported failure. This is the first
+    // release where the Windows legs got far enough to run this at all.
+    const subjectPath = prepared.snapshot?.snapshotPath || prepared.executablePath;
+    const result = run('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', script], {
+      encoding: 'utf8',
+      env: { ...process.env, WAYLAND_PUBLISHER_SUBJECT: subjectPath },
+    });
     let evidence;
     try {
       evidence = JSON.parse(String(result.stdout || ''));
     } catch {
-      fail(`${role} Windows publisher verifier returned malformed evidence`);
+      // Say what the verifier actually did. A bare 'malformed evidence' cost a
+      // whole release rehearsal to attribute.
+      const stderr = String(result.stderr || '')
+        .trim()
+        .slice(0, 400);
+      const stdout = String(result.stdout || '')
+        .trim()
+        .slice(0, 200);
+      fail(
+        `${role} Windows publisher verifier returned malformed evidence for ${subjectPath} ` +
+          `(exit ${result.status}; stdout ${stdout || '<empty>'}; stderr ${stderr || '<empty>'})`
+      );
     }
     if (
       result.status !== 0 ||


### PR DESCRIPTION
Rehearsal 7 reached further than any run in this arc: all six builds, both smoke gates, all six platform observations, and both Linux updater legs green. Two failures remain, both in code those legs had never reached before.

## darwin: a checkpointed WAL read as destroyed user data

`supportedStateEntries` tracked SQLite write-ahead sidecars. A clean shutdown checkpoints the WAL into its database and deletes the sidecar, so its absence afterwards is the library working correctly, not the updater destroying state.

Whether the baseline contains a sidecar at all depends on whether that boot happened to exit mid-transaction, which made this a coin toss. Rehearsal 7 proves it: `darwin-arm64` failed on `DIPS-wal` while `darwin-x64` passed the identical check in the same run.

Sidecars are excluded now. The databases themselves stay tracked, so genuine loss is still reported: the durable bytes live in the main file once the checkpoint completes.

## win32: the publisher verifier could never have worked

It invoked:

```
powershell.exe -NoProfile -NonInteractive -Command "<script>" <path>
```

`-Command` consumes the rest of the command line as command text, so the path never reached `$args[0]`. It bound as a positional argument to `ConvertTo-Json`, which takes none, so PowerShell wrote nothing to stdout and the reported failure was `JSON.parse('')` throwing as "malformed evidence".

The subject path travels in the environment now. This is the first release where the Windows legs got far enough to execute this code at all, which is why a defect this total survived.

The failure message also names the subject path, exit code, stdout and stderr, because a bare "malformed evidence" cost a full rehearsal to attribute.

## Not weakened

No budget raised, no assertion removed. Same publisher proofs, same state comparisons, same artifacts.
