### PR TITLE
Pin the build job's bun so the observers can re-derive the bridge

### DIFF
--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -232,7 +232,29 @@ jobs:
       - name: Setup bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          # PINNED, and it must stay pinned. The tree that SHIPS as
+          # resources/whatsapp-bridge is built by prepareWhatsAppBridgeResources in
+          # scripts/build-with-builder.js: it deletes the bridge's node_modules and
+          # reinstalls it clean with `bun install --frozen-lockfile --os <platform>
+          # --cpu <arch>`, invoking whatever `bun` this step put on PATH. The
+          # protected observers then re-derive that tree with their OWN `bun install`
+          # and require a byte-identical inventory (verifySourceMirror). That only
+          # holds while both sides run the SAME bun.
+          #
+          # On Windows bun writes node_modules/.bin/* as real .exe launcher stubs,
+          # which sourceInventory hashes; on macOS and Linux they are symlinks,
+          # recorded as `link:<name>:<target>` with no bytes. So a bun version skew
+          # is invisible on POSIX and fails EVERY Windows leg.
+          #
+          # Measured on windows-2022, same tree, same lockfile: 1.3.14 twice is
+          # byte-identical; 1.3.14 vs 1.4.0 differs in exactly 16 files, all of them
+          # .bin/*.exe stubs (15872 -> 8192 bytes), nothing added or removed.
+          #
+          # `latest` is what broke v0.12.2: it resolved to 1.3.14 on 2026-08-19 and
+          # all six legs passed, then to 1.4.0 on 2026-08-24 and both Windows legs
+          # failed on an unchanged tree. The observers pin '1.3.14'; so does
+          # release-acceptance-trust-root.yml and the bundled-bun authority. Match them.
+          bun-version: '1.3.14'
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/tests/unit/scripts/producerObserverBunPin.test.ts
+++ b/tests/unit/scripts/producerObserverBunPin.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+/**
+ * THE PRODUCER AND THE OBSERVERS MUST INSTALL WITH THE SAME BUN.
+ *
+ * The tree that SHIPS as `resources/whatsapp-bridge` is built by
+ * `prepareWhatsAppBridgeResources` in scripts/build-with-builder.js. It deletes
+ * the bridge's node_modules and reinstalls it clean with `bun install
+ * --frozen-lockfile --os <platform> --cpu <arch>`, running whatever `bun` the
+ * build job put on PATH - so this pin is what decides those bytes. (The root
+ * postinstall also installs the bridge, but that tree is discarded first; do not
+ * mistake one for the other.) The protected observers then run their OWN
+ * `bun install` and require the two inventories to be byte-identical -
+ * `verifySourceMirror` in verify-packaged-resources.js. That is the whole point
+ * of an independent observer: it re-derives the tree rather than trusting it.
+ *
+ * Byte equality only survives if both sides run the same bun, because bun's
+ * output is not stable ACROSS versions. Measured on windows-2022 against this
+ * exact lockfile: two 1.3.14 installs are byte-identical, while 1.3.14 vs 1.4.0
+ * differ in exactly 16 files - every one a `node_modules/.bin/*.exe` launcher
+ * stub, 15872 bytes against 8192 - with nothing added or removed.
+ *
+ * WHY THIS IS INVISIBLE UNTIL IT REACHES WINDOWS. On macOS and Linux bun writes
+ * `.bin` entries as SYMLINKS, and `sourceInventory` records a symlink as
+ * `link:<relative>:<target>` - a name and a target, no bytes. On Windows there
+ * are no symlinks; bun writes real `.exe` stubs, which are hashed. So a bun
+ * version skew cannot fail a POSIX leg and always fails BOTH Windows legs.
+ *
+ * WHAT THIS GUARDS. `bun-version: latest` in the build job is what broke
+ * v0.12.2: it resolved to 1.3.14 on 2026-08-19 and all six observer legs passed,
+ * then to 1.4.0 on 2026-08-24 and both Windows legs failed on a tree that had
+ * not changed. Nothing in the repository moved - the toolchain did. A floating
+ * version is therefore not a convenience here, it is a live release blocker, and
+ * reverting this pin re-arms it. Bumping bun is still fine; it just has to be
+ * done on the producer and BOTH observers together, which is exactly what this
+ * test forces.
+ */
+
+const WORKFLOWS = join(__dirname, '../../../.github/workflows');
+
+type Step = { uses?: string; with?: Record<string, unknown> };
+type Job = { steps?: Step[] };
+
+function bunVersion(file: string, jobName: string): string {
+  const workflow = parse(readFileSync(join(WORKFLOWS, file), 'utf8')) as { jobs: Record<string, Job> };
+  const job = workflow.jobs[jobName];
+  expect(job, `${jobName} job must exist in ${file}`).toBeDefined();
+  const steps = (job.steps ?? []).filter((step) => step.uses?.startsWith('oven-sh/setup-bun@'));
+  // Exactly one: a second setup-bun step would silently decide the version by
+  // order, and this guard would then be reading the wrong one.
+  expect(steps, `${file}:${jobName} must set bun up exactly once`).toHaveLength(1);
+  const version = steps[0].with?.['bun-version'];
+  expect(typeof version, `${file}:${jobName} must declare bun-version`).toBe('string');
+  return String(version);
+}
+
+describe('producer and observer bun pin', () => {
+  const producer = () => bunVersion('_build-reusable.yml', 'build');
+
+  it('pins the artifact-producing build job to an exact bun version', () => {
+    const version = producer();
+    expect(version).not.toBe('latest');
+    // `1.3` is a floating minor and drifts exactly like `latest`, one patch at a time.
+    expect(version, 'bun-version must be an exact x.y.z pin').toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it.each([
+    ['protected-platform-package-observer.yml', 'observe'],
+    ['protected-updater-journey-observer.yml', 'observe'],
+  ])('installs with the same bun as %s', (file, jobName) => {
+    expect(bunVersion(file, jobName)).toBe(producer());
+  });
+});


### PR DESCRIPTION
## The blocker

v0.12.2 is built and sitting as a Draft because whatsapp-bridge reads
present-but-invalid on win32-x64 and win32-arm64, on BOTH protected observers.
Four legs, one cause. Publish is skipped, so no user can reach the release.

## Root cause, established by execution

The observers re-run bun install and require the shipped
resources/whatsapp-bridge to be inventory-identical to their own tree
(verifySourceMirror). The build job asked for bun-version: latest while both
observers pin 1.3.14.

From the run logs, not inference:

| date | producer bun | observer bun | win32-x64 leg |
| --- | --- | --- | --- |
| 2026-08-19 (producer 32200374609) | 1.3.14 | 1.3.14 | PASS |
| 2026-08-24 (producer 32751269643) | 1.4.0 | 1.3.14 | FAIL |

git diff over that range is empty for both src/process/channels/whatsapp-bridge
and scripts/verify-packaged-resources.js. Nothing in the repository moved. The
toolchain did, because latest is not a version.

## Why it is invisible until Windows

bun writes node_modules/.bin entries as SYMLINKS on macOS and Linux, and
sourceInventory records a symlink as link:name:target with no bytes. On Windows
there are no symlinks; bun writes real .exe launcher stubs, which it hashes. A
bun version skew therefore cannot fail a POSIX leg and always fails both
Windows legs.

Measured on windows-2022 against this exact lockfile, three installs:

- 1.3.14 vs 1.3.14: IDENTICAL, 9673 entries. bun is deterministic at a pin.
- 1.3.14 vs 1.4.0: 16 files differ, every one a .bin/*.exe stub, 15872 bytes
  against 8192. Zero files added, zero removed.

## The change

Pin the producer to the 1.3.14 that the observers, release-acceptance-trust-root
and the bundled-bun authority already name. Nothing is exempted and no check is
weakened: verifySourceMirror still demands a byte-identical inventory, and the
Windows legs have no reconciliation of any kind. The two sides simply agree on a
toolchain again, which is what an independent re-derivation requires.

The guard fails if the build job floats (latest, or a partial pin like '1.3'
that drifts one patch at a time) or drifts away from either observer. Bumping
bun stays possible; it has to happen on all three together.

Sabotage-verified: latest gives 3 red, '1.3' gives 3 red, an exact-but-mismatched
'1.4.0' gives 2 red and 1 green, and the restored file is byte-identical to its
backup.

## Verification

- Full unit suite 20,260 passed / 0 failed / 164 skipped
- tsc --noEmit clean, oxfmt clean on the touched file

## Follow-up worth knowing

The observers are the only check that inspects the INSTALLED tree; the build
only checks out/. Previously shipped Windows builds may carry the same
non-reproducible bundle without anyone noticing.