### PR TITLE
chore: bump desktop to 0.12.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Wayland",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "The local-first desktop AI agent that drives every AI CLI on your machine - Claude Code, Codex, Gemini and more, on your keys.",
   "keywords": [],
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Version bump only. One line in package.json; bun.lock carries no version field.

v0.12.2 is consumed. Its tag points at d3dc51d65, which predates the producer
bun pin (#1120), and the resource verifier ships INSIDE the artifacts, so
unblocking the Windows observer legs requires a rebuild under a new tag.

electron-builder names every asset from package.json, so the tag and this
version have to agree or the release would carry 0.12.2 assets under a v0.12.3
tag.

Tagging v0.12.3 on the merge of this PR is the next step.