### PR TITLE
chore: bump desktop to 0.12.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Wayland",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "The local-first desktop AI agent that drives every AI CLI on your machine - Claude Code, Codex, Gemini and more, on your keys.",
   "keywords": [],
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Version bump only. One line in package.json; bun.lock carries no version field.

v0.12.3 is consumed. Its tag points at a commit that predates both the
dependency-security fix and the before-quit reaper fix (#1122), and the resource
verifier ships INSIDE the artifacts, so unblocking the release requires a
rebuild under a new tag.

electron-builder names every asset from package.json, so the tag and this
version have to agree or the release would carry 0.12.3 assets under a v0.12.4
tag.

Tagging v0.12.4 on the merge of this PR is the next step.