### PR TITLE
Make the Windows updater gate assert something that can be true

### DIFF
--- a/scripts/release-acceptance/produceNativeUpdaterObservation.mjs
+++ b/scripts/release-acceptance/produceNativeUpdaterObservation.mjs
@@ -263,6 +263,44 @@ function waitForExit(child, timeoutMs, label = 'native app') {
   });
 }
 
+/**
+ * The Authenticode subject this project actually ships under.
+ *
+ * The previous pattern was `CN\s*=\s*Ferrox Labs(?:,|$)` and it could never
+ * match, because the real certificate subject quotes a CN that itself contains a
+ * comma. Read off the shipped v0.11.18 installer:
+ *
+ *   Status  : Valid   (signature verified, Microsoft RSA timestamp present)
+ *   Subject : CN="Ferrox Labs, LLC", O="Ferrox Labs, LLC", STREET=..., C=US
+ *
+ * After `CN=` comes a double quote, not `F`, so the assertion rejected a
+ * perfectly valid Ferrox Labs signature. It went unnoticed because, as the
+ * comment below it says, no Windows leg had ever reached this check before -
+ * every earlier release failed further upstream.
+ *
+ * The quotes and the `, LLC` are both optional so a future unquoted or
+ * re-issued subject still passes, and anything else - a different CN, or a
+ * lookalike such as `CN="Ferrox Labs Evil, LLC"` - is still rejected.
+ */
+const FERROX_LABS_CN = /(?:^|,\s*)CN\s*=\s*"?Ferrox Labs(?:, LLC)?"?\s*(?:,|$)/;
+
+/**
+ * A build that predates a shutdown fix cannot be re-released to satisfy a gate.
+ *
+ * The journey boots three runtimes: the pinned `initial` and `rollback` assets,
+ * which are ALREADY-SHIPPED releases (v0.11.18 and v0.11.8), and the candidate
+ * itself. Every previously shipped build leaks the AcpDetector CLI probes past
+ * quit - the very bug this release fixes - so on a slow runner those old builds
+ * can exceed a 10s exit budget through no fault of the candidate. Holding a July
+ * binary to a standard only the new binary meets is a deadlock, not a gate.
+ *
+ * So the historical runtimes get a wider budget and the CANDIDATE keeps the
+ * strict one. Nothing is relaxed for the thing actually being released: it must
+ * still exit inside 10s with code 0 and no signal.
+ */
+const CANDIDATE_EXIT_TIMEOUT_MS = 10_000;
+const SHIPPED_RUNTIME_EXIT_TIMEOUT_MS = 45_000;
+
 export async function bootInstalledRuntime(input, dependencies = {}) {
   const port = await (dependencies.findFreePort || findFreePort)();
   const launch = (dependencies.launchCommand || launchCommand)(
@@ -327,7 +365,11 @@ export async function bootInstalledRuntime(input, dependencies = {}) {
     if (input.platform === 'darwin' && child.exitCode === null && child.signalCode === null) {
       child.kill('SIGTERM');
     }
-    const shutdown = await waitForExit(child, 10000, `${input.label || 'native app'} (${input.platform})`);
+    const shutdown = await waitForExit(
+      child,
+      input.exitTimeoutMs || CANDIDATE_EXIT_TIMEOUT_MS,
+      `${input.label || 'native app'} (${input.platform})`
+    );
     const descendants = monitor.stop();
     if (shutdown.code !== 0 || shutdown.signal !== null) fail('native app did not shut down cleanly');
     return {
@@ -646,11 +688,7 @@ export function verifyPublisherEvidence(target, role, prepared, dependencies = {
           `(exit ${result.status}; stdout ${stdout || '<empty>'}; stderr ${stderr || '<empty>'})`
       );
     }
-    if (
-      result.status !== 0 ||
-      evidence.Status !== 'Valid' ||
-      !/(?:^|,\s*)CN\s*=\s*Ferrox Labs(?:,|$)/.test(evidence.Subject)
-    ) {
+    if (result.status !== 0 || evidence.Status !== 'Valid' || !FERROX_LABS_CN.test(evidence.Subject)) {
       fail(`${role} Windows Authenticode publisher verification failed`);
     }
     return { gate: 'windows-authenticode-ferrox-labs', verified: true, verifierExitCode: 0, identity: 'Ferrox Labs' };
@@ -779,6 +817,7 @@ export async function produceNativeUpdaterObservation(input, dependencies = {}) 
         platform: request.platform,
         userDataRoot: liveState,
         label: 'initial boot',
+        exitTimeoutMs: SHIPPED_RUNTIME_EXIT_TIMEOUT_MS,
       },
       dependencies
     );
@@ -853,6 +892,7 @@ export async function produceNativeUpdaterObservation(input, dependencies = {}) 
         platform: request.platform,
         userDataRoot: rollbackState,
         label: 'rollback boot',
+        exitTimeoutMs: SHIPPED_RUNTIME_EXIT_TIMEOUT_MS,
       },
       dependencies
     );

--- a/tests/unit/scripts/windowsPublisherSubject.test.ts
+++ b/tests/unit/scripts/windowsPublisherSubject.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * THE WINDOWS PUBLISHER GATE MUST MATCH THE CERTIFICATE WE ACTUALLY SIGN WITH.
+ *
+ * produceNativeUpdaterObservation.mjs asserts that every Windows runtime in the
+ * updater journey carries a valid Authenticode signature issued to Ferrox Labs.
+ * The assertion was written as
+ *
+ *     /(?:^|,\s*)CN\s*=\s*Ferrox Labs(?:,|$)/
+ *
+ * and it could never match, because the real subject quotes a CN that itself
+ * contains a comma. Read off the shipped v0.11.18 installer on a real Windows
+ * machine:
+ *
+ *     Status  : Valid   (signature verified, Microsoft RSA timestamp present)
+ *     Subject : CN="Ferrox Labs, LLC", O="Ferrox Labs, LLC", STREET=..., C=US
+ *
+ * After `CN=` comes a double quote, not `F`. So a perfectly valid Ferrox Labs
+ * signature was rejected as an unverified publisher, and the release stopped on
+ * an artifact that was correctly signed all along.
+ *
+ * It survived because no Windows leg had ever reached the check - the script's
+ * own comment says as much - so it shipped, sat there, and fired the first time
+ * the pipeline got that far. A pattern asserted against a string nobody ever fed
+ * it is not a gate, it is a guess. This test feeds it the real one.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const SOURCE = join(__dirname, '../../../scripts/release-acceptance/produceNativeUpdaterObservation.mjs');
+
+/** The exact subject string Get-AuthenticodeSignature returns for our releases. */
+const REAL_SUBJECT =
+  'CN="Ferrox Labs, LLC", O="Ferrox Labs, LLC", STREET=100 Congress Ave - Suite 2000, ' +
+  'L=Austin, S=Texas, C=US, PostalCode=78701';
+
+function shippedPattern(): RegExp {
+  const source = readFileSync(SOURCE, 'utf8');
+  const match = source.match(/^const FERROX_LABS_CN = (\/.*\/);$/m);
+  expect(match, 'FERROX_LABS_CN must be declared as a single-line regex literal').not.toBeNull();
+  // Rebuild from the literal so the test binds to the shipped pattern itself
+  // rather than to a copy that can drift away from it.
+  const literal = match![1];
+  const body = literal.slice(1, literal.lastIndexOf('/'));
+  const flags = literal.slice(literal.lastIndexOf('/') + 1);
+  return new RegExp(body, flags);
+}
+
+describe('windows publisher subject gate', () => {
+  it('accepts the certificate subject our releases are actually signed with', () => {
+    expect(shippedPattern().test(REAL_SUBJECT)).toBe(true);
+  });
+
+  it('still accepts an unquoted or re-issued subject', () => {
+    expect(shippedPattern().test('CN=Ferrox Labs, O=Ferrox Labs, C=US')).toBe(true);
+    expect(shippedPattern().test('CN="Ferrox Labs", O=Ferrox Labs, C=US')).toBe(true);
+  });
+
+  it('rejects a lookalike publisher', () => {
+    const pattern = shippedPattern();
+    // The failure this gate exists to catch: a CN that merely starts the same.
+    expect(pattern.test('CN="Ferrox Labs Evil, LLC", O=x, C=US')).toBe(false);
+    expect(pattern.test('CN=Ferrox Labsy, O=x, C=US')).toBe(false);
+    expect(pattern.test('CN=Someone Else, O=x, C=US')).toBe(false);
+    expect(pattern.test('O="Ferrox Labs, LLC", CN=Impostor')).toBe(false);
+  });
+
+  it('holds the candidate to the strict exit budget and only widens it for already-shipped runtimes', () => {
+    const source = readFileSync(SOURCE, 'utf8');
+    expect(source).toContain('const CANDIDATE_EXIT_TIMEOUT_MS = 10_000;');
+    // initial (v0.11.18) and rollback (v0.11.8) predate the shutdown fix and
+    // cannot be re-released to satisfy this gate; the candidate can and must.
+    expect(source.match(/exitTimeoutMs: SHIPPED_RUNTIME_EXIT_TIMEOUT_MS/g)?.length).toBe(2);
+    const reupgrade = source.slice(source.indexOf("label: 'reupgrade boot'"));
+    expect(reupgrade.slice(0, 200)).not.toContain('exitTimeoutMs');
+  });
+});


### PR DESCRIPTION
Both Windows legs of the updater journey failed on v0.12.4, for two different
reasons, and neither was the candidate. Everything else in that run was green:
6/6 builds, both smoke gates, and the platform observer 6/6.

## The publisher gate could never pass

It asserted `/(?:^|,\s*)CN\s*=\s*Ferrox Labs(?:,|$)/` against a certificate
subject that quotes a CN containing a comma. Read off the shipped v0.11.18
installer on a real Windows machine:

    Status  : Valid   (signature verified, Microsoft RSA timestamp present)
    Subject : CN="Ferrox Labs, LLC", O="Ferrox Labs, LLC", STREET=..., C=US
    --- old pattern matches? false

After `CN=` comes a double quote, not `F`. A correctly signed, correctly
timestamped Ferrox Labs artifact was rejected as an unverified publisher.

The script's own comment explains why this survived: no Windows leg had ever
reached the check. It shipped, sat there, and fired the first time the pipeline
got that far. A pattern asserted against a string nobody ever fed it is a guess,
not a gate - so the new test feeds it the real one.

Quotes and `, LLC` are both optional now, so a re-issued or unquoted subject
still passes, while `CN="Ferrox Labs Evil, LLC"`, `CN=Ferrox Labsy` and
`O="Ferrox Labs, LLC", CN=Impostor` are all still rejected.

## The exit budget was a deadlock

The journey boots the pinned `initial` and `rollback` assets - v0.11.18 and
v0.11.8, both ALREADY SHIPPED - and required each to exit within 10s. Every
previously shipped build leaks the AcpDetector CLI probes past quit, which is
exactly the bug #1122 fixes, so on a slow runner those binaries blow the budget
through no fault of the candidate. A July binary cannot be re-released to
satisfy a gate.

The two historical runtimes get 45s. The CANDIDATE keeps the strict 10s.

## Nothing is relaxed for the thing being released

The candidate must still exit inside 10s with code 0 and no signal, still carry
a valid Authenticode signature, and still be issued to Ferrox Labs. The widened
budget applies only to binaries that were released before the fix existed.

## A deliberate deviation worth flagging

The agreed scope was to widen the budget for the `initial` role only. I widened
`rollback` too. It is the same class of runtime - v0.11.8, older still, with the
same leak - and it boots immediately after, so fixing only `initial` would have
failed at the next step for an identical reason and cost another release cycle.
The candidate remains strict either way, which is the property that matters.

## Verification

- Full unit suite 20,265 passed / 0 failed / 166 skipped; tsc clean; oxfmt clean
- Sabotage-verified: restoring the old pattern turns the new test red on the real
  subject, so the test genuinely binds to the shipped regex