### PR TITLE
fix(release): repair the acceptance gate so it can actually run

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -742,6 +742,16 @@ jobs:
     name: Require protected exact-candidate final acceptance
     runs-on: ubuntu-latest
     needs: [assemble-raw-release-acceptance]
+    # `create-tag` is skipped on every tag build (it only runs on refs/heads/dev),
+    # and GitHub propagates that skip through the whole `needs` closure to any job
+    # that carries no status guard - even when its own direct dependency succeeded
+    # (actions/runner#2205). Without this guard the job never schedules, so the
+    # acceptance gate is never dispatched and `publish-release` never fires; that
+    # is why every other job in this chain already carries `always()`.
+    if: |
+      always() &&
+      needs.assemble-raw-release-acceptance.result == 'success' &&
+      startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-dev-')
     permissions:
       actions: write
       attestations: read

--- a/.github/workflows/release-acceptance-trust-root.yml
+++ b/.github/workflows/release-acceptance-trust-root.yml
@@ -207,7 +207,12 @@ jobs:
           [[ "$CANDIDATE_TREE" =~ ^[0-9a-f]{40,64}$ ]] || exit 1
           [[ "$ARTIFACT_RUN_ID" =~ ^[0-9]+$ ]] || exit 1
           [[ "$GATE_ARTIFACT_ID" =~ ^[0-9]+$ ]] || exit 1
-          [[ "$GATE_ARTIFACT_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]] || exit 1
+          # actions/upload-artifact emits `artifact-digest` as bare SHA-256 hex, while
+          # the REST artifacts API returns the same digest as "sha256:<hex>". This
+          # asserted the API's form against the producer's value, so it could never
+          # match and this job has never once run past this line. Assert each surface
+          # in its own documented form and compare the hex, below.
+          [[ "$GATE_ARTIFACT_DIGEST" =~ ^[0-9a-f]{64}$ ]] || exit 1
 
       - name: Checkout pinned trust-root authority code
         uses: actions/checkout@v6
@@ -260,7 +265,13 @@ jobs:
           [[ "$(jq -r '.expired' <<<"$artifact")" == "false" ]] || exit 1
           [[ "$(jq -r '.workflow_run.id | tostring' <<<"$artifact")" == "$GITHUB_RUN_ID" ]] || exit 1
           [[ "$(jq -r '.workflow_run.head_sha' <<<"$artifact")" == "$TRUST_ROOT_SHA" ]] || exit 1
-          [[ "$(jq -r '.digest' <<<"$artifact")" == "$GATE_ARTIFACT_DIGEST" ]] || exit 1
+          # The API returns "sha256:<hex>"; GATE_ARTIFACT_DIGEST is the producer's bare
+          # hex. Require the API's prefixed form explicitly - so a future change of
+          # digest algorithm fails closed rather than silently comparing something
+          # else - then compare the exact 64 hex characters.
+          api_digest="$(jq -r '.digest' <<<"$artifact")"
+          [[ "$api_digest" =~ ^sha256:[0-9a-f]{64}$ ]] || exit 1
+          [[ "${api_digest#sha256:}" == "$GATE_ARTIFACT_DIGEST" ]] || exit 1
 
       - name: Download exact same-run candidate gate outputs
         uses: actions/download-artifact@v7
@@ -342,6 +353,11 @@ jobs:
         env:
           RAW_ROOT: ${{ steps.raw.outputs.path }}
           GH_TOKEN: ${{ github.token }}
+          # writeCapabilitySeal is called without `verifyAttestedFile` and without
+          # `candidateClaim`, so verifyCandidateCapabilitySeal resolves the trust root
+          # from this env var and throws without it. The two later steps that run the
+          # same code already set it; this step was missed.
+          WAYLAND_RELEASE_TRUST_ROOT_SHA: ${{ env.TRUST_ROOT_SHA }}
         run: |
           node <<'NODE'
           const path = require('node:path');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Wayland",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "description": "The local-first desktop AI agent that drives every AI CLI on your machine - Claude Code, Codex, Gemini and more, on your keys.",
   "keywords": [],
   "license": "AGPL-3.0-or-later",

--- a/scripts/release-acceptance/verifyFinalAcceptance.js
+++ b/scripts/release-acceptance/verifyFinalAcceptance.js
@@ -192,7 +192,14 @@ function defaultVerifyReleaseBlockers(input, context) {
 function defaultExpectedPublisherAssets() {
   const { readPolicy } = require('../supply-chain/verifyPublisherAttestation');
   const policy = readPolicy();
-  const active = policy.policies.filter((entry) => entry.status === 'active');
+  // Scope to wayland-core. This ledger also carries wayland-nano policies, and nano
+  // legitimately has more than one active release, so an unscoped filter counts them
+  // toward the "exactly one active Core release" rule and fails every run. The assets
+  // resolved immediately below come from bundled-wcore-shasums.json, so Core is the
+  // only family this rule was ever about.
+  const active = policy.policies.filter(
+    (entry) => entry.status === 'active' && entry.repository === 'FerroxLabs/wayland-core'
+  );
   if (active.length !== 1) fail('M8A_PUBLISHER_ATTESTATION_INVALID', 'no-unique-active-core-release');
   const shasums = JSON.parse(
     fs.readFileSync(path.join(productionCandidateRoot(), 'scripts', 'bundled-wcore-shasums.json'), 'utf8')

--- a/tests/unit/scripts/finalAcceptanceController.test.ts
+++ b/tests/unit/scripts/finalAcceptanceController.test.ts
@@ -514,9 +514,9 @@ describe('M8-A final acceptance controller', () => {
 // the existing suite - which injects its own fixtures where production reads real
 // files - could not see any of them. These tests read the real files instead.
 describe('release acceptance gate invariants', () => {
-  const policy = JSON.parse(
-    readFileSync('scripts/supply-chain/publisher-attestations.json', 'utf8')
-  ) as { policies: Array<{ status: string; repository: string; releaseTag: string }> };
+  const policy = JSON.parse(readFileSync('scripts/supply-chain/publisher-attestations.json', 'utf8')) as {
+    policies: Array<{ status: string; repository: string; releaseTag: string }>;
+  };
   const CORE = 'FerroxLabs/wayland-core';
   const trustRoot = readFileSync('.github/workflows/release-acceptance-trust-root.yml', 'utf8');
 
@@ -550,9 +550,11 @@ describe('release acceptance gate invariants', () => {
   // Every step invoking the capability-seal code must supply the trust root, or it
   // throws before doing any work.
   it('gives every capability-seal and acceptance step the trust root', () => {
-    const steps = trustRoot.split(/^      - name: /m).filter((s) =>
-      /verifyCandidateCapabilitySeal|produceProtectedAcceptanceEvidence|verifyFinalAcceptance\.js/.test(s)
-    );
+    const steps = trustRoot
+      .split(/^      - name: /m)
+      .filter((s) =>
+        /verifyCandidateCapabilitySeal|produceProtectedAcceptanceEvidence|verifyFinalAcceptance\.js/.test(s)
+      );
     expect(steps.length).toBeGreaterThanOrEqual(3);
     for (const step of steps) expect(step).toContain('WAYLAND_RELEASE_TRUST_ROOT_SHA');
   });

--- a/tests/unit/scripts/finalAcceptanceController.test.ts
+++ b/tests/unit/scripts/finalAcceptanceController.test.ts
@@ -508,3 +508,64 @@ describe('M8-A final acceptance controller', () => {
     expect(workflow).not.toMatch(/gh release edit|softprops\/action-gh-release|kubectl|fly deploy/i);
   });
 });
+
+// Regression cover for four defects that made the trust-root acceptance gate
+// impossible to pass. Every one of them lived in code that had never executed, so
+// the existing suite - which injects its own fixtures where production reads real
+// files - could not see any of them. These tests read the real files instead.
+describe('release acceptance gate invariants', () => {
+  const policy = JSON.parse(
+    readFileSync('scripts/supply-chain/publisher-attestations.json', 'utf8')
+  ) as { policies: Array<{ status: string; repository: string; releaseTag: string }> };
+  const CORE = 'FerroxLabs/wayland-core';
+  const trustRoot = readFileSync('.github/workflows/release-acceptance-trust-root.yml', 'utf8');
+
+  // The ledger also carries wayland-nano, which legitimately has more than one
+  // active release. An unscoped count made the controller fail every run.
+  it('has exactly one active Core publisher policy, ignoring other product lines', () => {
+    const activeCore = policy.policies.filter((e) => e.status === 'active' && e.repository === CORE);
+    expect(activeCore).toHaveLength(1);
+    expect(policy.policies.some((e) => e.status === 'active' && e.repository !== CORE)).toBe(true);
+  });
+
+  // publisher-attestations.json is the fifth coupled edit of an engine bump. If a
+  // bump adds a policy without superseding the previous one, the gate breaks.
+  it('pins the active Core policy to the bundled engine version', () => {
+    const activeCore = policy.policies.find((e) => e.status === 'active' && e.repository === CORE);
+    const { DEFAULT_WCORE_VERSION } = require('../../../scripts/prepareWaylandCore') as {
+      DEFAULT_WCORE_VERSION: string;
+    };
+    expect(activeCore?.releaseTag).toBe(DEFAULT_WCORE_VERSION);
+  });
+
+  // actions/upload-artifact emits bare hex; the REST API returns "sha256:<hex>".
+  // Asserting either surface in the other's form can never match.
+  it('asserts each digest surface in its own documented form', () => {
+    expect(trustRoot).toContain('[[ "$GATE_ARTIFACT_DIGEST" =~ ^[0-9a-f]{64}$ ]]');
+    expect(trustRoot).toContain('[[ "$api_digest" =~ ^sha256:[0-9a-f]{64}$ ]]');
+    expect(trustRoot).toContain('[[ "${api_digest#sha256:}" == "$GATE_ARTIFACT_DIGEST" ]]');
+    expect(trustRoot).not.toContain('[[ "$GATE_ARTIFACT_DIGEST" =~ ^sha256:');
+  });
+
+  // Every step invoking the capability-seal code must supply the trust root, or it
+  // throws before doing any work.
+  it('gives every capability-seal and acceptance step the trust root', () => {
+    const steps = trustRoot.split(/^      - name: /m).filter((s) =>
+      /verifyCandidateCapabilitySeal|produceProtectedAcceptanceEvidence|verifyFinalAcceptance\.js/.test(s)
+    );
+    expect(steps.length).toBeGreaterThanOrEqual(3);
+    for (const step of steps) expect(step).toContain('WAYLAND_RELEASE_TRUST_ROOT_SHA');
+  });
+
+  // create-tag is dev-only and therefore skipped on every tag build; GitHub
+  // propagates that skip through the needs closure to any job without a status
+  // guard, so this job never scheduled on v0.12.4 or v0.12.5.
+  it('guards final-release-acceptance so a skipped upstream cannot skip it', () => {
+    const release = readFileSync('.github/workflows/build-and-release.yml', 'utf8');
+    const job = release.slice(release.indexOf('  final-release-acceptance:'));
+    const guard = job.slice(0, job.indexOf('    steps:'));
+    expect(guard).toMatch(/if:/);
+    expect(guard).toContain('always()');
+    expect(guard).toContain("needs.assemble-raw-release-acceptance.result == 'success'");
+  });
+});


### PR DESCRIPTION
## What this fixes

The release acceptance trust gate has **never once passed**. It has run exactly twice
(32825163441 on 2026-08-25, 33036347832 on 2026-08-27) and died both times on the *first*
bash assertion of its sealing job. Everything after that line - attestation, capability seal
recreation, the final acceptance controller - had never executed a single time.

Meanwhile publish-release is literally named "Publish Release (both gates passed)" and is
gated on that job. So the gate occupied the authorising position while being incapable of
authorising anything, and releases went out by hand instead.

Four independent defects, found by cross-audit (Codex 5.6 Sol, Kimi K3, and an internal
adversarial swarm), each verified by execution rather than by reading:

**1. Digest representation could never match.**
actions/upload-artifact emits artifact-digest as bare sha256 hex; the REST artifacts API
returns the same digest prefixed with "sha256:". Line 210 asserted the API form against the
producer value, and line 263 then compared the two forms to each other. Both had to move -
relaxing only the regex shifts the failure twenty lines downstream. Each surface is now
asserted in its own documented form and the hex compared, which is strictly stronger than
before: a future digest-algorithm change now fails closed.

**2. final-release-acceptance never scheduled.**
It was the only job in its chain with no status guard, so it defaulted to success().
create-tag is dev-branch-only and is therefore skipped on every tag build, and GitHub
propagates that skip through the entire needs closure to any dependent lacking always()
(actions/runner#2205). It skipped with steps=0 on both v0.12.4 and v0.12.5. A transitive
sweep of every workflow in the repo confirms this was the only job affected.

**3. Capability-seal step was missing the trust root.**
It passes neither verifyAttestedFile nor candidateClaim, so verifyCandidateCapabilitySeal
resolves the trust root from WAYLAND_RELEASE_TRUST_ROOT_SHA and throws "Release acceptance
trust root is unavailable." without it. The job-level env defines TRUST_ROOT_SHA, a different
name. The two later steps running the same code already set it; this one was missed.

**4. Publisher policy uniqueness was unscoped.**
defaultExpectedPublisherAssets demanded exactly one active policy across the whole ledger.
Executing the real reader returns three: wayland-nano v0.1.1, wayland-nano v0.2.0, and
wayland-core v0.13.8. The rule was always about Core - its error string says so, and the very
next line indexes the Core shasums - so it is now scoped to the Core repository.

The nano entries were deliberately **not** marked superseded. That would be editing the ledger
to satisfy a broken check, and it would falsify a live product line's provenance.

## Why the tests did not catch this

finalAcceptanceController.test.ts builds its own policy fixture; production reads the real
ledger. Every one of these defects sat in code that had never executed, so a green suite was
never evidence about any of them.

## Why the version bump is in this commit

The trust root and the tagged candidate must be the same commit, and electron-builder derives
asset names and updater metadata from package.json rather than from the tag. Splitting the
bump into a later commit would leave the trust root and the candidate on different commits.

## After merge

Re-pinning WAYLAND_RELEASE_TRUST_ROOT_SHA invalidates the already-green observer attestations
for v0.12.5, because the observer verifiers pass the trust root as both signer-digest and
source-digest. A tagged release therefore cannot be retro-blessed by a trust root that did not
exist when its observers ran. Sequence is: merge, fast-forward release-trust-v1, re-pin and
read back the variable, prove with a rehearsal tag (publish-release excludes rehearsal refs),
then tag for real.

## Known and deliberately deferred

The artifact name binds github.run_attempt at creation while the consumer re-derives it from
its own attempt number, so "Re-run failed jobs" can never pass and every retry costs a full
candidate-gates run. Real, but a retry-ergonomics issue rather than a correctness one, and not
worth widening this diff on a protected sealing path. Tracked separately.
