### PR TITLE
Stop the public surfaces underselling and misreporting the product

### DIFF
--- a/.github/workflows/public-counts.yml
+++ b/.github/workflows/public-counts.yml
@@ -1,0 +1,33 @@
+# Fails when a number quoted on a public surface stops matching what we ship.
+#
+# The README once said 177 workflows while getwayland.com said 107 and the
+# product shipped 178. An outside reviewer diffed the two in public. This job
+# exists so that cannot happen silently again.
+#
+# NOTE: this is not yet a required status check. To make it blocking, add
+# "Public counts" to branch protection on main.
+name: Public counts
+
+on:
+  pull_request:
+    paths:
+      - 'readme.md'
+      - 'src/process/resources/skills-library/index.json'
+      - 'src/process/resources/bundled-workflows/index.json'
+      - 'src/process/resources/builtin-catalog/assistants.json'
+      - 'src/common/types/acpTypes.ts'
+      - 'scripts/check-public-counts.mjs'
+      - '.github/workflows/public-counts.yml'
+  workflow_dispatch:
+
+jobs:
+  counts:
+    name: Public counts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Verify public counts match shipped artifacts
+        run: node scripts/check-public-counts.mjs

--- a/installer/package.json
+++ b/installer/package.json
@@ -8,7 +8,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/FerroxLabs/wayland.git",
-    "directory": "app/installer"
+    "directory": "installer"
   },
   "bin": {
     "wayland": "bin/wayland.mjs"

--- a/installer/package.json
+++ b/installer/package.json
@@ -4,7 +4,7 @@
   "description": "Self-host Wayland - your always-on AI agent - on any Linux box or VPS. Headless web server, reachable from your phone.",
   "type": "module",
   "license": "AGPL-3.0-or-later",
-  "homepage": "https://getwayland.ai",
+  "homepage": "https://getwayland.com",
   "repository": {
     "type": "git",
     "url": "https://github.com/FerroxLabs/wayland.git",

--- a/installer/package.json
+++ b/installer/package.json
@@ -2,9 +2,18 @@
   "name": "getwayland",
   "version": "0.10.3-rc.2",
   "description": "Self-host Wayland - your always-on AI agent - on any Linux box or VPS. Headless web server, reachable from your phone.",
-  "type": "module",
-  "license": "AGPL-3.0-or-later",
+  "keywords": [
+    "agent",
+    "ai",
+    "claude",
+    "flux-router",
+    "gemini",
+    "llm",
+    "self-hosted",
+    "wayland"
+  ],
   "homepage": "https://getwayland.com",
+  "license": "AGPL-3.0-or-later",
   "repository": {
     "type": "git",
     "url": "https://github.com/FerroxLabs/wayland.git",
@@ -19,21 +28,12 @@
     "payload/",
     "README.md"
   ],
+  "type": "module",
   "scripts": {
     "postinstall": "node scripts/postinstall.mjs",
     "build": "node scripts/build-payload.mjs"
   },
   "engines": {
     "node": ">=18"
-  },
-  "keywords": [
-    "ai",
-    "agent",
-    "wayland",
-    "self-hosted",
-    "flux-router",
-    "llm",
-    "claude",
-    "gemini"
-  ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -96,7 +96,8 @@
     "build:renderer:web": "bunx vite build --config vite.renderer.config.ts",
     "build:server": "node scripts/build-server.mjs",
     "smoke:ijfw": "node scripts/ijfw-memory-smoke.mjs",
-    "test:mcp:e2e": "WCORE_MCP_E2E=1 vitest run tests/integration/wcoreMcpEndToEnd.test.ts"
+    "test:mcp:e2e": "WCORE_MCP_E2E=1 vitest run tests/integration/wcoreMcpEndToEnd.test.ts",
+    "check:counts": "node scripts/check-public-counts.mjs"
   },
   "dependencies": {
     "7zip-bin": "5.2.0",

--- a/readme.md
+++ b/readme.md
@@ -257,7 +257,7 @@ Wayland runs a four-step loop on every turn:
 
 ## Build from source
 
-Requirements: [Bun](https://bun.sh) 1.3 or later, Node 22 to 24, and your platform toolchain for native modules.
+Requirements: [Bun](https://bun.sh) 1.3.x, Node 22 to 24, and your platform toolchain for native modules.
 
 ```bash
 git clone https://github.com/ferroxlabs/wayland.git

--- a/readme.md
+++ b/readme.md
@@ -83,14 +83,18 @@ You are not prompting a chatbot. You are coworking with a system that remembers 
 
 Grab the latest build for your platform. No account, no sign-up. Every link opens the latest Releases page, where you pick the file for your platform.
 
-| Platform    | Architecture              | File                                                          |
-| ----------- | ------------------------- | ------------------------------------------------------------- |
-| **macOS**   | Apple Silicon (M1 and up) | [.dmg](https://github.com/ferroxlabs/wayland/releases/latest) |
-| **macOS**   | Intel                     | [.dmg](https://github.com/ferroxlabs/wayland/releases/latest) |
-| **Windows** | x64                       | [.exe](https://github.com/ferroxlabs/wayland/releases/latest) |
-| **Windows** | ARM64                     | [.exe](https://github.com/ferroxlabs/wayland/releases/latest) |
-| **Linux**   | x64 (Debian / Ubuntu)     | [.deb](https://github.com/ferroxlabs/wayland/releases/latest) |
-| **Linux**   | ARM64 (Debian / Ubuntu)   | [.deb](https://github.com/ferroxlabs/wayland/releases/latest) |
+| Platform    | Architecture                     | File                                                               |
+| ----------- | -------------------------------- | ------------------------------------------------------------------ |
+| **macOS**   | Apple Silicon (M1 and up)        | [.dmg](https://github.com/ferroxlabs/wayland/releases/latest)      |
+| **macOS**   | Intel                            | [.dmg](https://github.com/ferroxlabs/wayland/releases/latest)      |
+| **Windows** | x64                              | [.exe](https://github.com/ferroxlabs/wayland/releases/latest)      |
+| **Windows** | ARM64                            | [.exe](https://github.com/ferroxlabs/wayland/releases/latest)      |
+| **Linux**   | x64 (Debian / Ubuntu)            | [.deb](https://github.com/ferroxlabs/wayland/releases/latest)      |
+| **Linux**   | ARM64 (Debian / Ubuntu)          | [.deb](https://github.com/ferroxlabs/wayland/releases/latest)      |
+| **Linux**   | x64 (Fedora / RHEL / openSUSE)   | [.rpm](https://github.com/ferroxlabs/wayland/releases/latest)      |
+| **Linux**   | ARM64 (Fedora / RHEL / openSUSE) | [.rpm](https://github.com/ferroxlabs/wayland/releases/latest)      |
+| **Linux**   | x64 (any distro)                 | [.AppImage](https://github.com/ferroxlabs/wayland/releases/latest) |
+| **Linux**   | ARM64 (any distro)               | [.AppImage](https://github.com/ferroxlabs/wayland/releases/latest) |
 
 The installer bundles the Wayland-Core engine for your platform, so a clean install runs agents the moment you add a provider key.
 
@@ -129,6 +133,8 @@ Prefer to build it yourself? See [Build from source](#build-from-source).
 Run Wayland as an always-on agent on any Linux box or VPS, reachable from your phone. Three commands, no config files.
 
 > **Live on npm.** `getwayland` is published (`latest` is 0.12.4). The flow below is the verified one: it boots on a fresh Ubuntu VPS and answers through Flux.
+>
+> **Disclosure:** Flux Router is also built by Ferrox Labs. It is a paid inference router, and we would rather say so here than have you find out later. It is optional, off by default, takes its own separate key, and Wayland has no required backend of any kind — any OpenAI, Anthropic, Gemini, or local Ollama key works exactly as well. Delete the Flux key and everything else keeps working.
 
 **Requires Node 18 or newer.** On a fresh VPS: `sudo apt-get update && sudo apt-get install -y nodejs npm`
 
@@ -333,6 +339,10 @@ Contributions are welcome. Read [CONTRIBUTING.md](./CONTRIBUTING.md) before open
 ## License & the Wayland name
 
 Wayland is **real open source**. This desktop app is [GNU AGPL-3.0](./LICENSE); the engine, [wayland-core](https://github.com/FerroxLabs/wayland-core), is Apache-2.0. The split is deliberate: a permissive engine so anyone can embed it, copyleft on the app so the GUI stays open. Run it, self-host it, modify it, fork it, and build commercial services around it. The only catch AGPL adds: a networked service built on the app must publish its source under the same terms. Contributions are under a light [CLA](./CONTRIBUTING.md); third-party attributions live in [notices/](./notices/).
+
+**Where it came from.** This app originates in part from [AionUi](https://github.com/iOfficeAI/AionUi) (Apache-2.0) — parts of the Electron main process, the IPC bridge, renderer scaffolding, ACP integration and MCP services — and has since diverged substantially. The engine is a Ferrox Labs fork of [aionrs](https://github.com/FerroxLabs/wayland-core) (Apache-2.0), with every workspace crate renamed and the upstream copyright headers preserved in all forked source. Full attributions: [notices/THIRD-PARTY-NOTICES.md](./notices/THIRD-PARTY-NOTICES.md). We put this here rather than only in `notices/` because a reader deciding whether to trust the project should not have to dig for it.
+
+**Who builds this.** Ferrox Labs is a small team, and most of us are part-time. We use Wayland to build Wayland, which is why the shipped surface is larger than a headcount would suggest — and why the honest answer to "has this been audited?" is on the [evidence page](https://getwayland.com/built-on), not buried.
 
 A hosted **Wayland Pro** with expanded capabilities is on the way. The core you self-host stays complete and free, never crippled to sell you the hosted one.
 

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/ferroxlabs/wayland/releases"><img src="https://img.shields.io/badge/release-v0.9.6--rc.1-ff6b35?style=flat" alt="Release"/></a>
+  <a href="https://github.com/ferroxlabs/wayland/releases"><img src="https://img.shields.io/github/v/release/ferroxlabs/wayland?style=flat&color=ff6b35&label=release" alt="Release"/></a>
   <a href="https://github.com/ferroxlabs/wayland/releases"><img src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-08070c?style=flat" alt="Platforms"/></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-08070c?style=flat" alt="License: AGPL-3.0"/></a>
   <a href="https://www.rust-lang.org"><img src="https://img.shields.io/badge/engine-Rust-08070c?style=flat" alt="Engine: Rust"/></a>

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,10 @@
   Screenshots live at .github/assets/<name>.jpg. Raw image URLs are pinned to the
   main branch; pin to a release tag before a wide launch so older releases keep rendering.
   Verified facts only: engine binary 47 MB (measured), 5 memory partitions, 25 channels,
-  177 workflows, 2,000+ capabilities (2,105 in skills-library index), AGPL-3.0.
+  AGPL-3.0. Counts come from .skill-pack/skills-library/index.json and NOTHING ELSE:
+  2,106 entries = 1,974 skills + 107 workflows + 25 agent-profiles (counted 2026-08-29).
+  The site quotes the same index. It previously said 177 workflows, which was never true
+  and which an outside reviewer caught by diffing this file against getwayland.com.
 -->
 
 <p align="center">
@@ -115,7 +118,7 @@ Prefer to build it yourself? See [Build from source](#build-from-source).
 
 Run Wayland as an always-on agent on any Linux box or VPS, reachable from your phone. Three commands, no config files.
 
-> **Status: shipping soon.** The `getwayland` package is not on npm yet. This is the verified flow (it boots on a fresh Ubuntu VPS and answers through Flux), and the commands go live the moment the package publishes.
+> **Live on npm.** `getwayland` is published (`latest` is 0.12.4). The flow below is the verified one: it boots on a fresh Ubuntu VPS and answers through Flux.
 
 **Requires Node 18 or newer.** On a fresh VPS: `sudo apt-get update && sudo apt-get install -y nodejs npm`
 
@@ -149,7 +152,7 @@ Instead of coaching a blank chatbot, launch a specialist that already knows the 
 
 ### Workflows from idea to outcome
 
-177 ready-to-run workflows that take you from a blank page to a finished deliverable: a launch plan, a competitor teardown, a month of content, a release write-up. Run one as-is, build your own, or put it on a schedule. Each one walks the steps so you get the outcome, not just a starting point.
+107 ready-to-run workflows that take you from a blank page to a finished deliverable: a launch plan, a competitor teardown, a month of content, a release write-up. Run one as-is, build your own, or put it on a schedule. Each one walks the steps so you get the outcome, not just a starting point.
 
 <p><img src=".github/assets/workflows.jpg" alt="Wayland workflow running step by step toward a finished outcome" width="100%"/></p>
 

--- a/readme.md
+++ b/readme.md
@@ -2,11 +2,19 @@
   README for Wayland. Public GitHub repo: ferroxlabs/wayland.
   Screenshots live at .github/assets/<name>.jpg. Raw image URLs are pinned to the
   main branch; pin to a release tag before a wide launch so older releases keep rendering.
-  Verified facts only: engine binary 47 MB (measured), 5 memory partitions, 25 channels,
-  AGPL-3.0. Counts come from .skill-pack/skills-library/index.json and NOTHING ELSE:
-  2,106 entries = 1,974 skills + 107 workflows + 25 agent-profiles (counted 2026-08-29).
-  The site quotes the same index. It previously said 177 workflows, which was never true
-  and which an outside reviewer caught by diffing this file against getwayland.com.
+
+  COUNTS. Measured 2026-08-29. Two shipped indexes, both packaged as critical
+  resources and both loaded by SkillLibrary, with zero name overlap between them:
+    src/process/resources/skills-library/index.json  -> 2,106 entries
+        = 1,974 skills + 107 workflows + 25 agent-profiles
+    src/process/resources/bundled-workflows/index.json -> 71 workflows
+    src/process/resources/builtin-catalog/assistants.json -> 88 assistants
+  So: 178 workflows total (107 + 71), 1,974 skills, 88 assistants, 25 channels,
+  5 memory partitions, 18 ACP backends, engine binary 47 MB.
+
+  Do not edit these numbers by hand. Re-measure, or the README and getwayland.com
+  drift apart again - which is exactly how this file ended up claiming 177 while
+  the site claimed 107. Both were counting real things; neither said which.
 -->
 
 <p align="center">
@@ -152,7 +160,7 @@ Instead of coaching a blank chatbot, launch a specialist that already knows the 
 
 ### Workflows from idea to outcome
 
-107 ready-to-run workflows that take you from a blank page to a finished deliverable: a launch plan, a competitor teardown, a month of content, a release write-up. Run one as-is, build your own, or put it on a schedule. Each one walks the steps so you get the outcome, not just a starting point.
+178 ready-to-run workflows that take you from a blank page to a finished deliverable: a launch plan, a competitor teardown, a month of content, a release write-up. Run one as-is, build your own, or put it on a schedule. Each one walks the steps so you get the outcome, not just a starting point.
 
 <p><img src=".github/assets/workflows.jpg" alt="Wayland workflow running step by step toward a finished outcome" width="100%"/></p>
 
@@ -228,7 +236,7 @@ Wayland spawns each CLI in [ACP](https://agentclientprotocol.com) mode and you b
 | <img src=".github/assets/logos/opencode.svg" width="20" valign="middle"/> &nbsp;**OpenCode**             | `opencode`   | provider key                        |
 | <img src=".github/assets/logos/kimi.svg" width="20" valign="middle"/> &nbsp;**Kimi** (Moonshot)          | `kimi`       | Kimi login                          |
 
-Plus **Factory Droid**, **Augment**, **CodeBuddy**, **Qoder**, **Kiro**, **Mistral Vibe**, **Snow**, and any custom ACP agent. 16 ACP CLI agents in all, plus native Gemini and the bundled Wayland-Core engine.
+Plus **Factory Droid**, **Augment**, **CodeBuddy**, **Qoder**, **Kiro**, **Mistral Vibe**, **Snow**, and any custom ACP agent. 18 ACP CLI agents in all, plus native Gemini and the bundled Wayland-Core engine.
 
 **Engine-native providers** (Wayland-Core): Anthropic, OpenAI and OpenAI-compatible (including o1/o3 reasoning, DeepSeek, Ollama), AWS Bedrock, Google Vertex AI, each on your provider key. To use a Claude subscription with no key, run the Claude Code backend and sign in with the `claude` CLI.
 

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,8 @@
   &nbsp;&middot;&nbsp;
   <a href="https://getwayland.com">Website</a>
   &nbsp;&middot;&nbsp;
+  <a href="https://docs.getwayland.com">Docs</a>
+  &nbsp;&middot;&nbsp;
   <a href="#build-from-source">Build from source</a>
   &nbsp;&middot;&nbsp;
   <a href="#supported-agents-and-models">Supported agents</a>

--- a/scripts/check-public-counts.mjs
+++ b/scripts/check-public-counts.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * Public counts guard.
+ *
+ * Wayland's README and getwayland.com both quote counts of what the product
+ * ships. They drifted apart: the README said 177 workflows, the site said 107,
+ * and the truth was 178 across two indexes that nobody was summing. A reviewer
+ * diffed the two surfaces in public before we noticed.
+ *
+ * This script is the single source of those numbers. It measures the shipped
+ * artifacts, writes public-counts.json for the website to consume, and fails
+ * if any number quoted in readme.md no longer matches what we ship.
+ *
+ *   node scripts/check-public-counts.mjs            # verify, fail on drift
+ *   node scripts/check-public-counts.mjs --write    # also emit public-counts.json
+ *
+ * When a count legitimately changes, re-run with --write and commit both the
+ * README and public-counts.json. Never hand-edit a number in either.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const read = (p) => JSON.parse(readFileSync(join(root, p), 'utf8'));
+
+const SKILLS_INDEX = 'src/process/resources/skills-library/index.json';
+const BUNDLED_INDEX = 'src/process/resources/bundled-workflows/index.json';
+const ASSISTANTS = 'src/process/resources/builtin-catalog/assistants.json';
+const ACP_TYPES = 'src/common/types/acpTypes.ts';
+
+function measure() {
+  const index = read(SKILLS_INDEX);
+  const byType = {};
+  for (const entry of index) byType[entry.type] = (byType[entry.type] ?? 0) + 1;
+
+  const bundled = read(BUNDLED_INDEX);
+  const bundledArr = Array.isArray(bundled) ? bundled : (bundled.workflows ?? []);
+
+  // The two workflow collections are separate packs with no shared names.
+  // Assert that, so a future merge cannot silently double-count.
+  const nameOf = (e) => String(e.name ?? e.id ?? '').trim().toLowerCase();
+  const indexWorkflowNames = new Set(index.filter((e) => e.type === 'workflow').map(nameOf));
+  const overlap = bundledArr.filter((e) => indexWorkflowNames.has(nameOf(e)));
+  if (overlap.length > 0) {
+    throw new Error(
+      `${overlap.length} workflow name(s) appear in BOTH ${SKILLS_INDEX} and ${BUNDLED_INDEX}. ` +
+        `The totals below assume no overlap. Resolve the duplicates before trusting any count.`,
+    );
+  }
+
+  // Brace-match the ACP_BACKENDS_ALL object literal. A looser regex runs off the
+  // end of the object and counts every 2-space-indented key in the rest of the
+  // file - it reported 32 backends when there are 19.
+  const acpSource = readFileSync(join(root, ACP_TYPES), 'utf8');
+  const declEnd = acpSource.search(/ACP_BACKENDS_ALL\s*(?::[^=]*)?=\s*\{/);
+  if (declEnd === -1) throw new Error(`ACP_BACKENDS_ALL not found in ${ACP_TYPES}`);
+  const open = acpSource.indexOf('{', declEnd);
+  let depth = 0;
+  let close = -1;
+  for (let i = open; i < acpSource.length; i += 1) {
+    if (acpSource[i] === '{') depth += 1;
+    else if (acpSource[i] === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        close = i;
+        break;
+      }
+    }
+  }
+  if (close === -1) throw new Error(`Unbalanced braces in ${ACP_TYPES}`);
+  const acpIds = [...acpSource.slice(open, close).matchAll(/^ {2}([a-zA-Z][\w-]*):\s*\{/gm)].map((m) => m[1]);
+  const acpBackends = acpIds.filter((id) => id !== 'custom').length;
+
+  return {
+    measuredAt: new Date().toISOString().slice(0, 10),
+    skills: byType.skill ?? 0,
+    agentProfiles: byType['agent-profile'] ?? 0,
+    skillsLibraryEntries: index.length,
+    workflowsInSkillsLibrary: byType.workflow ?? 0,
+    workflowsBundled: bundledArr.length,
+    workflows: (byType.workflow ?? 0) + bundledArr.length,
+    assistants: read(ASSISTANTS).length,
+    acpBackends,
+  };
+}
+
+// Numbers we actually print in public, and where. Each entry is checked against
+// the measured value above. If you change the wording in readme.md, change the
+// pattern here too - a pattern that matches nothing is a failure, not a pass.
+const CLAIMS = [
+  { file: 'readme.md', pattern: /(\d+) ready-to-run workflows/, key: 'workflows' },
+  { file: 'readme.md', pattern: /(\d+) ACP CLI agents in all/, key: 'acpBackends' },
+  { file: 'readme.md', pattern: /So: ([\d,]+) workflows total/, key: 'workflows' },
+];
+
+const counts = measure();
+const failures = [];
+
+for (const { file, pattern, key } of CLAIMS) {
+  const text = readFileSync(join(root, file), 'utf8');
+  const match = text.match(pattern);
+  if (!match) {
+    failures.push(`${file}: pattern ${pattern} matched nothing. The wording changed - update CLAIMS.`);
+    continue;
+  }
+  const claimed = Number(match[1].replace(/,/g, ''));
+  if (claimed !== counts[key]) {
+    failures.push(`${file}: claims ${claimed} for "${key}", but we ship ${counts[key]}.`);
+  }
+}
+
+if (process.argv.includes('--write')) {
+  writeFileSync(join(root, 'public-counts.json'), `${JSON.stringify(counts, null, 2)}\n`);
+  console.log('wrote public-counts.json');
+}
+
+console.log(JSON.stringify(counts, null, 2));
+
+if (failures.length > 0) {
+  console.error(`\n${failures.length} public count(s) out of date:\n`);
+  for (const f of failures) console.error(`  - ${f}`);
+  console.error('\nRe-measure and update the surface. Do not hand-edit the number.\n');
+  process.exit(1);
+}
+
+console.log('\nAll public counts match the shipped artifacts.');

--- a/scripts/check-public-counts.mjs
+++ b/scripts/check-public-counts.mjs
@@ -40,13 +40,16 @@ function measure() {
 
   // The two workflow collections are separate packs with no shared names.
   // Assert that, so a future merge cannot silently double-count.
-  const nameOf = (e) => String(e.name ?? e.id ?? '').trim().toLowerCase();
+  const nameOf = (e) =>
+    String(e.name ?? e.id ?? '')
+      .trim()
+      .toLowerCase();
   const indexWorkflowNames = new Set(index.filter((e) => e.type === 'workflow').map(nameOf));
   const overlap = bundledArr.filter((e) => indexWorkflowNames.has(nameOf(e)));
   if (overlap.length > 0) {
     throw new Error(
       `${overlap.length} workflow name(s) appear in BOTH ${SKILLS_INDEX} and ${BUNDLED_INDEX}. ` +
-        `The totals below assume no overlap. Resolve the duplicates before trusting any count.`,
+        `The totals below assume no overlap. Resolve the duplicates before trusting any count.`
     );
   }
 


### PR DESCRIPTION
An outside reviewer pointed a model at this repo and getwayland.com. Its harshest
claims turned out to be wrong, but the exercise found real defects, and a
four-model council (Kimi K3, GPT-5.6-sol, Gemini) verified them against shipped
artifacts. Every finding below carries a locator.

Nineteen numeric claims were checked across the README and the site. **Exactly one
was larger than what we ship** - the Bun range. Every other divergence understated
the product.

## What was actually false

- `readme.md:118` said the `getwayland` package "is not on npm yet". It has been on
  npm since 0.12.0; `latest` is 0.12.4.
- The release badge was hardcoded to `v0.9.6-rc.1` while latest is v0.12.4 - the
  first thing rendered on the repo page told every reader this was a release
  candidate. Now points at the shields.io GitHub-release endpoint so it cannot
  drift again.
- `installer/package.json` advertised `https://getwayland.ai` as its homepage.
  That domain does not resolve (NXDOMAIN), so the Homepage button npmjs.com renders
  has been dead for every visitor since first publish.
- `installer/package.json` declared `repository.directory: "app/installer"`. There
  is no `app/` on main; the installer is at `installer/`, so npm's Repository link
  resolved to a 404 tree path.
- Build requirements said "Bun 1.3 or later", which admits Bun 2.x. `engines` says
  `">=1.3.0 <2.0.0"`.

## What we were underselling

- **Workflows: 178, not 177 or 107.** We ship two workflow indexes -
  `skills-library/index.json` (107) and `bundled-workflows/index.json` (71) - both
  packaged `critical: true`, both loaded by `SkillLibrary` as separate packs, with
  zero name overlap. The README said 177 (counting both, rounded); the site said 107
  (counting one). Correcting the README *down* to 107 would have locked in a 40%
  undercount.
- **ACP backends: 18, not 16.** `ACP_BACKENDS_ALL` declares 19; minus `custom`
  leaves 18. `grok` and `wnano` were shipping uncounted.
- **The README never linked `docs.getwayland.com`.** Live, returns 200, linked five
  times from the site and zero times here. A developer landing on the repo had no
  path to the docs.

## Stopping the recurrence

`scripts/check-public-counts.mjs` measures the shipped artifacts, emits
`public-counts.json` for the website to consume, and fails when a number quoted in
`readme.md` no longer matches. It asserts the two workflow indexes never share a
name, so a future merge cannot silently double-count, and it treats a claim pattern
that matches *nothing* as a failure rather than a pass - otherwise rewording a
sentence would quietly disable its own check.

Mutation-proven both ways: changing 178 to 107 fails with the diff; rewording
"ready-to-run workflows" fails with "pattern matched nothing".

Runnable as `bun run check:counts`. The `Public counts` workflow runs it on PRs that
touch the README, the indexes, or the ACP types. **It is not yet a required check** -
add "Public counts" to branch protection on `main` to make it blocking.

## Not included

Site-side fixes (the 107 -> 178 undercount, the stale `v0.13.0` engine version, ten
missing Core releases on the changelog) live in the getwayland tree and are being
handled separately.