### PR TITLE
test(conversation): wait for the focus-gated Space badge

### DIFF
--- a/tests/unit/renderer/conversation/PathBoundaryConfirmCard.dom.test.tsx
+++ b/tests/unit/renderer/conversation/PathBoundaryConfirmCard.dom.test.tsx
@@ -288,10 +288,18 @@ describe('#1099 folder-grant card', () => {
     renderCard();
     const card = await screen.findByTestId('path-boundary-card');
 
+    // The badge is FOCUS-GATED - the card renders `Space` on the focused row
+    // only, and focus arrives from an effect. `findByTestId` resolves as soon
+    // as the card exists, which is one state update too early, so asserting the
+    // badge straight off it is a race: green on an idle machine, red on a busy
+    // CI runner (it failed exactly one shard of twelve, ubuntu 2/4, on #1191 -
+    // a PR touching only the readme and a script). Wait for the badge, then
+    // assert the negatives on the settled text.
+    await waitFor(() => expect(card.textContent).toContain('Space'));
+
     // Enter / Esc / Y badges would be a promise the card does not keep.
     expect(card.textContent).not.toContain('Enter');
     expect(card.textContent).not.toContain('Esc');
-    expect(card.textContent).toContain('Space');
     expect(screen.getByTestId('path-boundary-grant').getAttribute('aria-keyshortcuts')).toBe('Space');
   });
 


### PR DESCRIPTION
## The defect

`PathBoundaryConfirmCard.tsx:291` renders the visible `Space` badge on the **focused row only**:

```tsx
{isFocused ? ACTIVATION_KEY_NAME : ''}
```

`focusedValue` is set by an `onFocus` handler, driven by a `useEffect` that focuses the refusal on mount. So the badge appears one state update *after* the card does.

The test asserted it off `findByTestId`, which resolves the moment the card exists:

```ts
const card = await screen.findByTestId('path-boundary-card');
expect(card.textContent).toContain('Space');   // ← one update too early
```

Green on an idle machine. Red on a loaded runner.

## Why it matters

This took down **exactly one shard of twelve** — `Unit Tests Shard (ubuntu-latest 2/4)` — on #1191, a PR touching only `readme.md`, two `package.json` files, a script and a workflow. macOS 2/4 and all ten other shards passed on the same commit.

A red shard reds out all three required `Unit Tests (<os>)` checks, so this blocks **every** PR, not just that one.

## Proof

Mutation, on the same component, run both ways:

| Component | Test | Result |
|---|---|---|
| focus deferred one tick | **old** assertion | ❌ `AssertionError: expected 'messages.confirmation.pathBoundaryTit…' to contain 'Space'` |
| focus deferred one tick | **new** assertion | ✅ 27 passed |
| unmodified | **new** assertion | ✅ 27 passed |

Row 1 is byte-identical to the CI failure. The component is not touched by this PR.

## The change

One `await waitFor` around the badge assertion, with the negatives (`Enter`, `Esc`) moved after it so they read the settled text. `aria-keyshortcuts` is still asserted exactly as before — the commitment under test is unchanged, it is just no longer read early.