### PR TITLE
docs(readme): name the sandbox we actually ship

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,7 +75,7 @@ You are not prompting a chatbot. You are coworking with a system that remembers 
 
 **One team, not isolated CLIs.** Your CLIs are brilliant strangers who never met. Each one forgets everything between sessions and lives in its own silo. Wayland is the command center that makes them one team: shared memory across every agent, one workflow from idea to ship, multi-AI cross-audit, and opt-in routing that sends each task to the best-fit model.
 
-**Your machine, not someone's cloud.** Chatbots run on someone else's servers, behind someone else's keys and retention policy. Wayland runs on your machine, reads and writes your files, and executes shell commands inside a native per-OS sandbox (Landlock, sandbox-exec, AppContainer). Go fully local with Ollama, or reach for a frontier cloud model when you want it.
+**Your machine, not someone's cloud.** Chatbots run on someone else's servers, behind someone else's keys and retention policy. Wayland runs on your machine, reads and writes your files, and executes shell commands inside a native per-OS sandbox (bubblewrap on Linux, sandbox-exec on macOS; on Windows a kill-on-close Job Object by default, with AppContainer available via `WAYLAND_SANDBOX=appcontainer`). Go fully local with Ollama, or reach for a frontier cloud model when you want it.
 
 **A system, not a prettier chat window.** Most are a nicer window onto one model, and they reset every time you close them. Wayland is a system that compounds: an engine that rewrites and re-scores its own skill prompts against an eval harness, a memory that persists across sessions (five SQLite-backed partitions), plus ready-made assistants, self-assembling teams, workflows, and schedules that run without you. It gets sharper the more you run it.
 
@@ -257,7 +257,7 @@ Wayland runs a four-step loop on every turn:
 - **Acts** through built-in tools (Read, Write, Edit, Bash, Grep, Glob, Spawn) and connectors for Git, databases, and the web, inside a native per-OS sandbox.
 - **Evolves**: a loop rewrites and scores your skill prompts against an eval harness, then promotes the winners back into your library.
 
-**Wayland-Core engine.** One Rust binary, around 47 MB, no Node or Python runtime to install. It ships every model provider, the built-in tools, the MCP client, the cognitive memory system, and the sandbox (Landlock on Linux, sandbox-exec on macOS, AppContainer on Windows) behind a single egress chokepoint. The same engine powers the standalone CLI and the desktop app: one codebase, two surfaces.
+**Wayland-Core engine.** One Rust binary, around 47 MB, no Node or Python runtime to install. It ships every model provider, the built-in tools, the MCP client, the cognitive memory system, and the sandbox (bubblewrap on Linux, sandbox-exec on macOS; on Windows a kill-on-close Job Object by default, AppContainer opt-in) behind a single egress chokepoint. The same engine powers the standalone CLI and the desktop app: one codebase, two surfaces.
 
 **Flux routing (optional).** Route a backend's traffic through Flux Router to send each task to the best-fit specialist across same-class models and run multi-AI cross-audit, lifting quality while cutting wasted tokens. Opt-in, bring your own key, off by default.
 

--- a/readme.md
+++ b/readme.md
@@ -255,7 +255,7 @@ Wayland runs a four-step loop on every turn:
 - **Perceives** your request and the state of your files, project, and memory.
 - **Reasons** with the best model for the task. A read-only Plan mode can write a structured plan before anything is touched.
 - **Acts** through built-in tools (Read, Write, Edit, Bash, Grep, Glob, Spawn) and connectors for Git, databases, and the web, inside a native per-OS sandbox.
-- **Evolves**: a loop rewrites and scores your skill prompts against an eval harness, then promotes the winners back into your library.
+- **Evolves**: a loop mutates and scores your skill prompts against an eval harness, keeping a variant only when it beats both the running best and the parent it came from. Winners persist across runs, so the next run starts from the last one's best. Nothing reaches your live library until you promote it.
 
 **Wayland-Core engine.** One Rust binary, around 47 MB, no Node or Python runtime to install. It ships every model provider, the built-in tools, the MCP client, the cognitive memory system, and the sandbox (bubblewrap on Linux, sandbox-exec on macOS; on Windows a kill-on-close Job Object by default, AppContainer opt-in) behind a single egress chokepoint. The same engine powers the standalone CLI and the desktop app: one codebase, two surfaces.
 
@@ -340,7 +340,7 @@ Contributions are welcome. Read [CONTRIBUTING.md](./CONTRIBUTING.md) before open
 
 Wayland is **real open source**. This desktop app is [GNU AGPL-3.0](./LICENSE); the engine, [wayland-core](https://github.com/FerroxLabs/wayland-core), is Apache-2.0. The split is deliberate: a permissive engine so anyone can embed it, copyleft on the app so the GUI stays open. Run it, self-host it, modify it, fork it, and build commercial services around it. The only catch AGPL adds: a networked service built on the app must publish its source under the same terms. Contributions are under a light [CLA](./CONTRIBUTING.md); third-party attributions live in [notices/](./notices/).
 
-**Where it came from.** This app originates in part from [AionUi](https://github.com/iOfficeAI/AionUi) (Apache-2.0) — parts of the Electron main process, the IPC bridge, renderer scaffolding, ACP integration and MCP services — and has since diverged substantially. The engine is a Ferrox Labs fork of [aionrs](https://github.com/FerroxLabs/wayland-core) (Apache-2.0), with every workspace crate renamed and the upstream copyright headers preserved in all forked source. Full attributions: [notices/THIRD-PARTY-NOTICES.md](./notices/THIRD-PARTY-NOTICES.md). We put this here rather than only in `notices/` because a reader deciding whether to trust the project should not have to dig for it.
+**Where it came from.** This app originates in part from [AionUi](https://github.com/iOfficeAI/AionUi) (Apache-2.0) — parts of the Electron main process, the IPC bridge, renderer scaffolding, ACP integration and MCP services — and has since diverged substantially. The engine is a Ferrox Labs fork of [aionrs](https://github.com/FerroxLabs/wayland-core) (Apache-2.0), with every workspace crate renamed and the upstream copyright headers preserved in all forked source. Full attributions: [notices/THIRD-PARTY-NOTICES.md](./notices/THIRD-PARTY-NOTICES.md).
 
 **Who builds this.** Ferrox Labs is a small team, and most of us are part-time. We use Wayland to build Wayland, which is why the shipped surface is larger than a headcount would suggest — and why the honest answer to "has this been audited?" is on the [evidence page](https://getwayland.com/built-on), not buried.
 


### PR DESCRIPTION
Two independent external reviewers checked the readme's sandbox claim against `wayland-core` source. Both found it wrong, in the same two places. Verified here against the shipped **v0.13.11** tag.

## Windows

The readme said **AppContainer**. It isn't, by default.

`crates/wcore-sandbox/src/lib.rs:797-802`:

```rust
fn windows_candidate(strict: bool) -> Box<dyn backends::SandboxBackend> {
    if strict {
        Box::new(backends::appcontainer::AppContainerBackend::new())
    } else {
        Box::new(backends::windows_job_object::WindowsJobObjectBackend::new())
    }
}
```

The doc comment immediately above states it plainly:

> `strict == false` is the shipping default and must yield a backend whose `enforces_read_deny()` is the trait default `false`; `strict == true` is the operator's explicit opt-in back to AppContainer.

And `announce_windows_posture` logs `posture = "relaxed"` at `warn!` on every Windows start.

A Job Object bounds process lifetime and resource use. It does **not** confine the filesystem. AppContainer is reachable via `WAYLAND_SANDBOX=appcontainer`, and is opt-in because the strict profile could not reliably launch a usable shell.

## Linux

The readme said **Landlock**. `backends/bwrap.rs:663`:

> NOTE: Landlock is deliberately NOT applied around the bwrap backend.

`landlock` is a cargo feature and the crate's `default = []`. Containment comes from bubblewrap's mount namespace — which that same comment argues is a superset of any Landlock allowlist built from the same paths. **The design is sound; the label was wrong.**

## Why this one matters more than a normal doc fix

This is a security claim, on the page a reader checks before granting an agent filesystem access. `wayland-core`'s own readme already describes the AppContainer opt-in correctly, so the two readmes disagreed and the desktop one was the wrong half.

The site (`/built-on`, `/core`) has been corrected in the same pass, and `/built-on` now states explicitly that it previously said otherwise.

## Not changed here

Neither reviewer's other major finding is touched by this PR — `FULL_AUTO_MODE` in `src/common/types/agentModes.ts` maps every backend except `claude` to `'yolo'`, and workflows/cron inherit it. That's a product decision, not a docs fix, and it needs its own issue.