### PR TITLE
Add Dependabot version updates (conservative)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+# Dependabot version updates.
+#
+# Security updates are enabled separately in repo settings and are NOT governed
+# by this file - a vulnerable dependency raises a PR regardless of the schedule
+# below. This file only controls ROUTINE version bumps.
+#
+# Deliberately conservative: monthly, grouped, and capped. A small team drowning
+# in bot PRs stops reading them, which is worse than updating a month later.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    groups:
+      # One PR for all patch/minor bumps. Majors still come in separately so
+      # they get read.
+      routine:
+        update-types: [minor, patch]
+    commit-message:
+      prefix: chore(deps)
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+    groups:
+      actions:
+        patterns: ['*']
+    commit-message:
+      prefix: chore(ci)


### PR DESCRIPTION
Security updates are now enabled in repo settings on both repos and are **not** governed by this file — a vulnerable dependency raises a PR regardless of the schedule here. This only controls routine version bumps.

Deliberately conservative: **monthly, grouped, capped at 5 open PRs**, minor and patch collapsed into one PR, majors kept separate so they get read. A small team buried in bot PRs stops reading them, which is worse than updating a month later. Also covers `github-actions`, monthly, grouped.

### On the alert this surfaced
Enabling security updates immediately re-reported `sharp < 0.35.0` (GHSA-f88m-g3jw-g9cj, inherited libvips CVEs) as 1 high alert on `main`.

**This is not a new finding.** It is already triaged and accepted in `scripts/supply-chain/accepted-dependency-advisories.json` with the same GHSA and the same `<0.35.0` range. No app code imports sharp; it ships via the WhatsApp bridge (`Resources/whatsapp-bridge/node_modules/sharp`), so the exposure is confined to inbound bridge media. Slated for a version bump in an upcoming release.

The value of these settings is a standing automated second opinion plus secret scanning and push protection, not this particular alert.