### PR TITLE
Fix the clone-and-build path in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -267,7 +267,7 @@ Requirements: [Bun](https://bun.sh) 1.3.x, Node 22 to 24, and your platform tool
 
 ```bash
 git clone https://github.com/ferroxlabs/wayland.git
-cd wayland/app
+cd wayland
 bun install
 
 # Run the desktop app in dev


### PR DESCRIPTION
The build instructions said `cd wayland/app`. There is no top-level `app` directory in this repository — `package.json`, `src/` and the build config are all at the root, so **the very first command an external reviewer runs fails**.

Caught by an outside evaluator, who noted it weakens "clone it and verify everything yourself" more than its size suggests. One line.