### PR TITLE
fix(governance): bind final check receipts

### DIFF
--- a/scripts/verify-phase2-pr-governance.ts
+++ b/scripts/verify-phase2-pr-governance.ts
@@ -394,7 +394,7 @@ export function verifyGovernanceSnapshot(
     fail('GitHub repository/default branch mismatch');
   }
   if (
-    !snapshot.issue_open ||
+    (!finalReceipt && !snapshot.issue_open) ||
     snapshot.issue_assignee !== manifest.issue.assignee ||
     JSON.stringify([...snapshot.issue_labels].sort()) !== JSON.stringify([...manifest.issue.labels].sort())
   )
@@ -607,6 +607,12 @@ function checkManifestArtifacts(manifest: PremergeManifest): void {
   equalIdentity(manifest.implementation_input, implementation, 'implementation input');
 }
 
+export function findCheckRun(checkRuns: JsonObject[], name: string, expectedId?: number): JsonObject | undefined {
+  return checkRuns.find(
+    (candidate) => candidate.name === name && (expectedId === undefined || Number(candidate.id) === expectedId)
+  );
+}
+
 function fetchSnapshot(manifest: PremergeManifest, finalReceipt?: FinalReceipt): GovernanceSnapshot {
   const repository = ghApi(`repos/${manifest.repository}`) as JsonObject;
   const issue = ghApi(`repos/${manifest.repository}/issues/${manifest.issue.number}`) as JsonObject;
@@ -644,13 +650,21 @@ function fetchSnapshot(manifest: PremergeManifest, finalReceipt?: FinalReceipt):
   const checkRuns = (runsResponse.check_runs as JsonObject[]) ?? [];
   const checks: GovernanceSnapshot['checks'] = {};
   for (const name of REQUIRED_CHECKS) {
-    const check = checkRuns.find((candidate) => candidate.name === name);
+    const expectedId = finalReceipt?.check_run_ids[name];
+    const candidates = expectedId
+      ? [ghApi(`repos/${manifest.repository}/check-runs/${expectedId}`) as JsonObject]
+      : checkRuns;
+    const check = findCheckRun(candidates, name, expectedId);
     if (check)
       checks[name] = { conclusion: String(check.conclusion), head_sha: String(check.head_sha), id: Number(check.id) };
   }
   const artifactChecks: NonNullable<GovernanceSnapshot['artifact_checks']> = {};
   for (const name of manifest.artifact.workflow_checks) {
-    const check = checkRuns.find((candidate) => candidate.name === name);
+    const expectedId = finalReceipt?.artifact_check_run_ids[name];
+    const candidates = expectedId
+      ? [ghApi(`repos/${manifest.repository}/check-runs/${expectedId}`) as JsonObject]
+      : checkRuns;
+    const check = findCheckRun(candidates, name, expectedId);
     if (check)
       artifactChecks[name] = {
         conclusion: String(check.conclusion),
@@ -681,8 +695,8 @@ function fetchSnapshot(manifest: PremergeManifest, finalReceipt?: FinalReceipt):
     merge_sha: pr.merge_commit_sha,
     merge_parent_count: mergeParents.length,
     bypassed: false,
-    reviewedIdentity,
-    mergeIdentity,
+    reviewed_identity: reviewedIdentity,
+    merge_identity: mergeIdentity,
     nano_merge_time: finalReceipt.nano.merged_at,
     nano_fixture_helper_merge_time: finalReceipt.nano_fixture_helper.merged_at,
     desktop_merge_time: String(pr.merged_at),

--- a/tests/unit/scripts/phase2PrGovernance.test.ts
+++ b/tests/unit/scripts/phase2PrGovernance.test.ts
@@ -11,6 +11,7 @@ import {
   type FinalReceipt,
   type GovernanceSnapshot,
   type PremergeManifest,
+  findCheckRun,
   verifyGovernanceSnapshot,
 } from '../../../scripts/verify-phase2-pr-governance';
 
@@ -172,6 +173,38 @@ const snapshot = (): GovernanceSnapshot => ({
 });
 
 describe('Phase 2 squash governance', () => {
+  it('selects the receipt-frozen check when a newer skipped run has the same name', () => {
+    const runs = [
+      { id: 999, name: 'Code Quality', conclusion: 'skipped' },
+      { id: 10, name: 'Code Quality', conclusion: 'success' },
+    ];
+    expect(findCheckRun(runs, 'Code Quality', 10)?.id).toBe(10);
+    expect(findCheckRun(runs, 'Code Quality', 11)).toBeUndefined();
+  });
+
+  it('requires the tracked issue open premerge but permits it closed postmerge', () => {
+    const state = snapshot();
+    state.issue_open = false;
+    expect(() => verifyGovernanceSnapshot(manifest(), state)).toThrow(/issue 1201 is stale\/unclaimed/);
+    expect(() => verifyGovernanceSnapshot(manifest(), state, finalReceipt())).not.toThrow();
+  });
+
+  it.each([
+    ['assignee', (state: GovernanceSnapshot) => (state.issue_assignee = 'wrong-owner')],
+    ['labels', (state: GovernanceSnapshot) => (state.issue_labels = ['wrong-label'])],
+  ])('retains postmerge issue %s governance', (_name, mutate) => {
+    const state = snapshot();
+    state.issue_open = false;
+    mutate(state);
+    expect(() => verifyGovernanceSnapshot(manifest(), state, finalReceipt())).toThrow(/issue 1201 is stale\/unclaimed/);
+  });
+
+  it('rejects a successful check whose run ID differs from the final receipt', () => {
+    const state = snapshot();
+    state.checks!['Code Quality'].id = 999;
+    expect(() => verifyGovernanceSnapshot(manifest(), state, finalReceipt())).toThrow(/required check Code Quality/);
+  });
+
   it('accepts exact change identity without requiring reviewed-head ancestry', () => {
     expect(() => verifyGovernanceSnapshot(manifest(), snapshot(), finalReceipt())).not.toThrow();
   });


### PR DESCRIPTION
Phase 2 governance follow-up only.\n\n- resolve post-merge duplicate check names by frozen receipt IDs\n- preserve premerge/postmerge issue lifecycle semantics\n- populate the governed snake_case identity fields\n- add focused regression coverage\n\nReviewed with same-human multi-account disclosure; TradeCanyon remains the independent account-of-record for approval and merge.