### PR TITLE
fix(acp): restore taskkill /T where no exempt subtree is beneath it

### DIFF
--- a/src/process/agent/acp/utils.ts
+++ b/src/process/agent/acp/utils.ts
@@ -54,9 +54,9 @@ export async function killChild(child: ChildProcess, isDetached: boolean, sigter
   const pid = child.pid;
   if (process.platform === 'win32' && pid) {
     // Enumerate BEFORE killing anything, same reason as the POSIX path below.
-    let pruned: number[] | null = null;
+    let plan: Win32KillPlan | null = null;
     try {
-      pruned = await collectWin32DescendantPids(pid);
+      plan = await collectWin32KillPlan(pid);
     } catch {
       // DELIBERATE ASYMMETRY WITH POSIX, WHICH FAILS CLOSED HERE.
       // On POSIX, enumeration failure aborts because the group kill is
@@ -64,10 +64,10 @@ export async function killChild(child: ChildProcess, isDetached: boolean, sigter
       // behaviour, so failing closed would regress #139 (orphaned trees) on any
       // host where PowerShell is unavailable or blocked by policy. Falling back
       // costs the chart, never correctness.
-      pruned = null;
+      plan = null;
     }
 
-    if (pruned === null) {
+    if (plan === null) {
       try {
         await execFile('taskkill', ['/PID', String(pid), '/T', '/F'], { windowsHide: true, timeout: 5000 });
       } catch (forceError) {
@@ -76,25 +76,35 @@ export async function killChild(child: ChildProcess, isDetached: boolean, sigter
         });
       }
     } else {
-      // Deepest-first, root last, and NO /T: the whole point is that the tree
-      // walk is ours, so an exempt subtree is never handed to taskkill at all.
-      const targets = [...pruned].reverse();
-      targets.push(pid);
-      try {
-        await execFile('taskkill', ['/F', ...targets.flatMap((p) => ['/PID', String(p)])], {
-          windowsHide: true,
-          timeout: 5000,
-        });
-      } catch (forceError) {
-        // taskkill exits non-zero when ANY listed pid has already gone, which is
-        // routine during teardown. Liveness below is the proof, not exit status.
-        if (isProcessAlive(pid)) {
-          throw new Error(`ACP process-tree shutdown failed for PID ${pid}: ${decodeWindowsError(forceError)}`, {
-            cause: forceError,
-          });
+      // The tree walk is ours, so an exempt subtree is never handed to taskkill.
+      // But the walk is a SNAPSHOT, so anything spawned after it is in no list -
+      // `/T` is what kills those, and it is safe on any subtree proven
+      // exempt-free. Nodes on the path down to an exempt process get a bare
+      // `/F`, because `/T` there would take the chart with them.
+      const runTaskkill = async (args: string[]): Promise<void> => {
+        try {
+          await execFile('taskkill', args, { windowsHide: true, timeout: 5000 });
+        } catch (forceError) {
+          // taskkill exits non-zero when ANY listed pid has already gone, which
+          // is routine during teardown. Liveness below is the proof, not exit
+          // status.
+          if (isProcessAlive(pid)) {
+            throw new Error(`ACP process-tree shutdown failed for PID ${pid}: ${decodeWindowsError(forceError)}`, {
+              cause: forceError,
+            });
+          }
         }
+      };
+
+      if (plan.treeKill.length > 0) {
+        await runTaskkill(['/F', '/T', ...plan.treeKill.flatMap((p) => ['/PID', String(p)])]);
       }
-      for (const dpid of pruned) {
+      // Deepest-first, root last.
+      const rest = [...plan.single].reverse();
+      rest.push(pid);
+      await runTaskkill(['/F', ...rest.flatMap((p) => ['/PID', String(p)])]);
+
+      for (const dpid of plan.pruned) {
         await waitForProcessExit(dpid, 2000);
         if (isProcessAlive(dpid)) {
           throw new Error(`ACP descendant process ${dpid} is still alive after SIGKILL escalation`);
@@ -265,6 +275,100 @@ export function _collectDescendantPidsFromProcTable(
     }
   }
   return result;
+}
+
+/**
+ * What to hand taskkill, split by whether `/T` is safe.
+ *
+ * WHY THIS EXISTS. Dropping `/T` in favour of an explicit PID list made the kill
+ * a POINT-IN-TIME SNAPSHOT: anything spawned between `win32ProcessTable()` and
+ * the taskkill is in no list and nothing sweeps the tree, so it SURVIVES. The
+ * snapshot is shared with a 1s TTL (WIN32_TABLE_TTL_MS), so that window is up to
+ * a second wide. It shipped as "packaged app left descendant processes alive" on
+ * two Windows arches in the v0.12.6 release; v0.12.5 was clean.
+ *
+ * `/T` is what closes the window, and it is safe exactly where no exempt process
+ * sits beneath the target - taskkill's own tree walk cannot be told to skip one.
+ * So: `/T` every subtree that is exempt-free, and fall back to a bare `/F` for
+ * the few nodes on the path DOWN to an exempt process. With no chart running the
+ * exempt set is empty, nothing is tainted, and this is a plain tree-kill again.
+ */
+export interface Win32KillPlan {
+  /** Subtree roots proven exempt-free - `/T` here, so late spawns die too. */
+  treeKill: number[];
+  /** Ancestors of an exempt process - killed alone, or `/T` takes the chart. */
+  single: number[];
+  /** Every pid expected dead afterwards; the liveness proof still covers all. */
+  pruned: number[];
+}
+
+export function _win32KillPlanFromProcTable(
+  psStdout: string,
+  rootPid: number,
+  isExempt: (command: string) => boolean
+): Win32KillPlan {
+  const childMap = new Map<number, number[]>();
+  const commandOf = new Map<number, string>();
+  for (const line of psStdout.trim().split('\n')) {
+    const parts = line.trim().split(/\s+/);
+    if (parts.length < 2) continue;
+    const pid = parseInt(parts[0], 10);
+    const ppid = parseInt(parts[1], 10);
+    if (isNaN(pid) || isNaN(ppid)) continue;
+    commandOf.set(pid, parts.slice(2).join(' '));
+    if (!childMap.has(ppid)) childMap.set(ppid, []);
+    childMap.get(ppid)!.push(pid);
+  }
+
+  const exemptPid = (pid: number): boolean => isExempt(commandOf.get(pid) ?? '');
+
+  // Memoised: a process table has hundreds of rows and this is asked once per
+  // node, so the naive form is quadratic on the teardown path.
+  const taintCache = new Map<number, boolean>();
+  const hasExemptBelow = (pid: number): boolean => {
+    const cached = taintCache.get(pid);
+    if (cached !== undefined) return cached;
+    let tainted = false;
+    for (const child of childMap.get(pid) || []) {
+      if (exemptPid(child) || hasExemptBelow(child)) {
+        tainted = true;
+        break;
+      }
+    }
+    taintCache.set(pid, tainted);
+    return tainted;
+  };
+
+  const treeKill: number[] = [];
+  const single: number[] = [];
+  const pruned: number[] = [];
+
+  // Under a `/T` root everything dies with it, but the liveness proof still
+  // names each pid, so `pruned` stays exactly the old BFS result.
+  const collectSubtree = (pid: number): void => {
+    for (const child of childMap.get(pid) || []) {
+      if (exemptPid(child)) continue;
+      pruned.push(child);
+      collectSubtree(child);
+    }
+  };
+
+  const walk = (pid: number): void => {
+    for (const child of childMap.get(pid) || []) {
+      if (exemptPid(child)) continue; // spared, with its whole subtree
+      pruned.push(child);
+      if (hasExemptBelow(child)) {
+        single.push(child);
+        walk(child);
+      } else {
+        treeKill.push(child);
+        collectSubtree(child);
+      }
+    }
+  };
+  walk(rootPid);
+
+  return { treeKill, single, pruned };
 }
 
 /**
@@ -444,10 +548,10 @@ async function win32ProcessTable(now: number = Date.now()): Promise<string> {
   return stdout;
 }
 
-async function collectWin32DescendantPids(rootPid: number): Promise<number[]> {
+async function collectWin32KillPlan(rootPid: number): Promise<Win32KillPlan> {
   const stdout = await win32ProcessTable();
   const exempt = await _resolveWin32ExemptPaths(_win32TableCommands(stdout), process.env, verifyAuthenticode);
-  return _collectDescendantPidsFromProcTable(stdout, rootPid, (command) => {
+  return _win32KillPlanFromProcTable(stdout, rootPid, (command) => {
     const normalized = _normalizeWindowsPath(command);
     return normalized !== null && exempt.has(normalized);
   });

--- a/tests/unit/acpKillChild.test.ts
+++ b/tests/unit/acpKillChild.test.ts
@@ -106,7 +106,16 @@ describe('killChild on Windows (taskkill tree-kill)', () => {
     vi.restoreAllMocks();
   });
 
-  it('enumerates the tree, prunes it, and kills the survivors WITHOUT /T', async () => {
+  // REPOINTED, not relaxed. This test used to assert `killArgs` never contains
+  // `/T` at all. That over-stated the invariant: what must hold is that an
+  // EXEMPT SUBTREE IS NEVER HANDED TO TASKKILL, and a blanket no-/T rule is only
+  // one way to get there - a way that silently turned the kill into a
+  // point-in-time snapshot, so anything spawned after the (1s-TTL) enumeration
+  // survived. That shipped as "packaged app left descendant processes alive" on
+  // two Windows arches in v0.12.6. So the assertions below now pin the real
+  // invariant on both sides: `/T` IS used on the exempt-free subtree (4400), and
+  // the chart (5000/5001) appears in NO taskkill call, /T or otherwise.
+  it('tree-kills exempt-free subtrees with /T and never hands the chart to taskkill', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
 
     // pid ppid path - the same row shape as `ps -eo pid=,ppid=,comm=`, which is
@@ -156,20 +165,30 @@ describe('killChild on Windows (taskkill tree-kill)', () => {
     expect(enumArgs.join(' ')).toContain('Get-CimInstance Win32_Process');
     expect(enumArgs.join(' ')).not.toContain('wmic');
 
-    // Call 1 kills the pruned set. THIS is the load-bearing assertion: no /T,
-    // because the tree walk is ours and the chart must not be handed to taskkill.
-    const [killCmd, killArgs, killOpts] = execFileMock.mock.calls[1];
-    expect(killCmd).toBe('taskkill');
-    expect(killArgs).not.toContain('/T');
-    expect(killOpts).toMatchObject({ windowsHide: true, timeout: 5000 });
+    // 4300 is an ANCESTOR of the chart (5000 -> 5001), so it may never carry
+    // /T. 4400 has nothing exempt beneath it, so it MUST, or a process spawned
+    // after the snapshot outlives the app - the v0.12.6 regression.
+    const taskkillCalls = execFileMock.mock.calls.filter((c) => c[0] === 'taskkill');
+    expect(taskkillCalls).toHaveLength(2);
 
-    const killedPids = killArgs.filter((a: string) => /^[0-9]+$/.test(a));
-    expect(killedPids).toContain('4242'); // the engine root
-    expect(killedPids).toContain('4300'); // ordinary descendant
-    expect(killedPids).toContain('4400'); // ordinary descendant
-    expect(killedPids).not.toContain('5000'); // TradingView - spared
-    expect(killedPids).not.toContain('5001'); // its helper - spared
-    expect(killedPids).not.toContain('9999'); // outside the tree entirely
+    const [, treeArgs, treeOpts] = taskkillCalls[0];
+    expect(treeArgs).toContain('/T');
+    expect(treeOpts).toMatchObject({ windowsHide: true, timeout: 5000 });
+    expect(treeArgs.filter((a: string) => /^[0-9]+$/.test(a))).toEqual(['4400']);
+
+    const [, restArgs] = taskkillCalls[1];
+    expect(restArgs).not.toContain('/T');
+    // Deepest-first, root last: the chart's ancestor before the engine itself.
+    expect(restArgs.filter((a: string) => /^[0-9]+$/.test(a))).toEqual(['4300', '4242']);
+
+    // The load-bearing invariant, across EVERY taskkill call regardless of /T.
+    const allKilled = taskkillCalls.flatMap((c) => c[1].filter((a: string) => /^[0-9]+$/.test(a)));
+    expect(allKilled).toContain('4242'); // the engine root
+    expect(allKilled).toContain('4300'); // path to the chart
+    expect(allKilled).toContain('4400'); // ordinary descendant
+    expect(allKilled).not.toContain('5000'); // TradingView - spared
+    expect(allKilled).not.toContain('5001'); // its helper - spared
+    expect(allKilled).not.toContain('9999'); // outside the tree entirely
 
     // On Windows we never fall through to child.kill() / process-group signals.
     expect(kill).not.toHaveBeenCalled();


### PR DESCRIPTION
The Windows reaper stopped killing processes it used to kill, and the packaged-app
smoke caught it during the v0.12.6 release: "packaged app left descendant processes
alive" with 4 pids, on windows-arm64 AND win32-x64. v0.12.5 passed both observer sets.

## Root cause

Sparing the chart replaced taskkill /PID pid /T /F with an explicit PID list and NO /T,
which turned the kill into a POINT-IN-TIME SNAPSHOT. Anything spawned between the
enumeration and the taskkill is in no list, and without /T nothing sweeps the tree, so
it survives. The snapshot is shared with a 1s TTL, so the window is up to a second wide,
and the ACP detector is hammering PowerShell with 5s timeouts right through it
(AgentRegistry took 11-13s on both failing legs).

Eliminated by execution rather than by reading:

- safeExec.ts, AcpDetector.ts, AgentRegistry.ts are UNCHANGED since v0.12.5, so the
  probes are not the new variable.
- platform-package-smoke.mjs is UNCHANGED, so the check is not newly strict.
- acp/utils.ts is where the 404 lines moved.

## The fix

/T is what closes the window, and it is safe exactly where no exempt process sits
beneath the target, because taskkill's own tree walk cannot be told to skip one. So the
plan is split: /T every subtree proven exempt-free, a bare /F for the few nodes on the
path DOWN to an exempt process, and an exempt subtree is still never handed to taskkill
at all. With no chart running the exempt set is empty, nothing is tainted, and this is a
plain tree-kill again, which is every CI runner and most users.

## On the changed test

It asserted that killArgs never contains /T at all. That over-stated the invariant: what
must hold is that an exempt subtree is never handed to taskkill, and the blanket no-/T
rule was one way to satisfy it, the way that introduced this race. Repointed, not
relaxed, and it now pins both sides: /T IS used on the exempt-free subtree, and the
chart appears in NO taskkill call.

## Verification

- Mutation-proven both directions: dropping /T fails the test; disabling the taint check
  so the chart's ancestor would be /T'd also fails it.
- Typecheck clean.
- Full suite 21,317 passed. The only constant failures are main's two pre-existing
  waylandNano files; the other run-to-run failures differ every run and pass in isolation.

Not yet proven on real Windows hardware; that is the next step.