### PR TITLE
fix(smoke): drain descendants to a deadline before asserting no leaks

### DIFF
--- a/scripts/platform-package-smoke.mjs
+++ b/scripts/platform-package-smoke.mjs
@@ -1057,6 +1057,36 @@ function isSameProcessAlive(record, targetPlatform, dependencies = {}) {
   }
 }
 
+/**
+ * Wait for the app's descendants to finish exiting, up to a deadline.
+ *
+ * WHY. `shutdownSettleMs` was a FLAT 250ms, and the liveness assertion in
+ * `verifyShutdownEvidence` runs immediately after it. Windows tears Electron's
+ * helper processes (GPU, utility, renderer, crashpad) down ASYNCHRONOUSLY, so
+ * on a loaded runner they routinely outlive the parent by longer than that.
+ * Measured across five release legs: the app always quit cleanly
+ * (`exitCode=0`, complete event ledger) and EXACTLY FOUR descendants were still
+ * alive at the instant of the check - on windows-arm64 and win32-x64 alike, with
+ * probe timeouts anywhere from 0 to 22, so nothing about the app's own work
+ * predicted it. It is teardown lag, not a leak.
+ *
+ * THIS CANNOT HIDE A REAL LEAK. It only waits; the assertion is unchanged and
+ * still authoritative. A genuinely orphaned process is still alive at the
+ * deadline and still fails, just without the false negatives that made the
+ * release gate a coin flip. `isSameProcessAlive` compares a STABLE IDENTITY,
+ * not a bare pid, so a recycled pid cannot masquerade as the old process.
+ */
+export async function drainDescendants(records, targetPlatform, dependencies = {}) {
+  const recordAlive = dependencies.processRecordAlive || isSameProcessAlive;
+  const deadline = Date.now() + (dependencies.shutdownDrainMs ?? 15_000);
+  const pollMs = dependencies.shutdownDrainPollMs ?? 250;
+  for (;;) {
+    if (!records.some((record) => recordAlive(record, targetPlatform, dependencies))) return;
+    if (Date.now() >= deadline) return; // let the assertion report the survivors
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+}
+
 export function createProcessMonitor(rootPid, targetPlatform, dependencies = {}) {
   const records = new Map();
   const collect = (includeEnvironment = false) => {
@@ -1503,6 +1533,10 @@ export async function runSmoke(options, dependencies = {}) {
       await new Promise((resolve) => setTimeout(resolve, dependencies.shutdownSettleMs ?? 250));
       const descendantRecords = processMonitor.stop();
       processMonitor = null;
+      // The flat settle above is a floor, not a guarantee: Windows reaps
+      // Electron's helpers asynchronously. Drain to a deadline before asserting,
+      // so teardown lag stops reading as a leaked process tree.
+      await drainDescendants(descendantRecords, options.targetPlatform, dependencies);
       const events = (dependencies.readPackageSmokeEventLedger || readPackageSmokeEventLedger)(eventFile);
       const shutdownEvidence = (dependencies.verifyShutdownEvidence || verifyShutdownEvidence)({
         events,

--- a/tests/unit/platformPackageSmoke.test.ts
+++ b/tests/unit/platformPackageSmoke.test.ts
@@ -18,6 +18,7 @@ import {
   captureCandidateState,
   createProcessMonitor,
   currentSourceIdentity,
+  drainDescendants,
   expectedReleaseIdentity,
   findInstallerArtifacts,
   installArtifactSnapshot,
@@ -1030,6 +1031,69 @@ describe('real installer extraction and lifecycle evidence', () => {
         processRecordAlive: () => true,
       })
     ).toThrow('left descendant processes alive');
+  });
+
+  // The release gate was a coin flip because the settle before the assertion
+  // above was a FLAT 250ms and Windows reaps Electron's helpers asynchronously.
+  // Across five release legs the app quit cleanly and EXACTLY FOUR descendants
+  // were still alive at that instant, on both Windows arches. `drainDescendants`
+  // waits for them; it must NOT become a way to pass with a real leak, so the
+  // third case below pins that it gives up at the deadline and hands the
+  // survivors to the (unchanged) assertion.
+  describe('drainDescendants', () => {
+    const rec = (pid: number) => ({ pid, identity: `id-${pid}` });
+
+    it('returns immediately when nothing is alive', async () => {
+      const alive = vi.fn(() => false);
+      const started = Date.now();
+      await drainDescendants([rec(1), rec(2)], 'win32', {
+        processRecordAlive: alive,
+        shutdownDrainMs: 5_000,
+        shutdownDrainPollMs: 50,
+      });
+      expect(Date.now() - started).toBeLessThan(200);
+      expect(alive).toHaveBeenCalled();
+    });
+
+    it('POLLS - it waits while they are alive and returns once they exit', async () => {
+      let calls = 0;
+      // Alive for the first two sweeps, gone on the third. A plain sleep would
+      // not observe the transition, so this is what proves it polls.
+      const alive = vi.fn(() => {
+        calls += 1;
+        return calls <= 2;
+      });
+      await drainDescendants([rec(7)], 'win32', {
+        processRecordAlive: alive,
+        shutdownDrainMs: 5_000,
+        shutdownDrainPollMs: 10,
+      });
+      expect(calls).toBeGreaterThanOrEqual(3);
+    });
+
+    it('gives up at the deadline so a REAL leak still reaches the assertion', async () => {
+      const alive = vi.fn(() => true); // never exits
+      const started = Date.now();
+      await drainDescendants([rec(99)], 'win32', {
+        processRecordAlive: alive,
+        shutdownDrainMs: 120,
+        shutdownDrainPollMs: 10,
+      });
+      expect(Date.now() - started).toBeGreaterThanOrEqual(100);
+      // It returns rather than throwing: verifyShutdownEvidence stays the single
+      // authoritative reporter of survivors.
+      expect(() =>
+        verifyShutdownEvidence({
+          events: validSmokeEvents('c'.repeat(64), expectedReleaseIdentity('stable', 'linux', 'x64')),
+          expectedMarkerSha256: `sha256:${crypto.createHash('sha256').update('c'.repeat(64)).digest('hex')}`,
+          releaseIdentity: expectedReleaseIdentity('stable', 'linux', 'x64'),
+          shutdown: { code: 0, signal: null },
+          descendantRecords: [rec(99)],
+          targetPlatform: 'linux',
+          processRecordAlive: () => true,
+        })
+      ).toThrow('left descendant processes alive: 99');
+    });
   });
 
   it('fails closed on gaps, unknown events, runtime identity drift, and renderer recovery', () => {


### PR DESCRIPTION
The release gate was a coin flip. Five consecutive Windows legs failed with
"packaged app left descendant processes alive", ALWAYS exactly four, ALWAYS after a
clean quit (exitCode=0) and a complete event ledger.

    v0.12.6  windows-arm64  6980,5608,2596,5604
    v0.12.6  win32-x64      6864,6912,6960,7008
    v0.12.7  win32-arm64    6592,7012,1108,1612   (22 probe timeouts)
    v0.12.7  win32-x64      7044,7092,7140,7164   ( 0 probe timeouts)
    v0.12.7  win32-arm64    7080,7128,6228,6204   (19 probe timeouts)

## Root cause

shutdownSettleMs is a FLAT 250ms, and the liveness assertion in
verifyShutdownEvidence runs immediately after it. Windows reaps Electron's helper
processes (GPU, utility, renderer, crashpad, characteristically four) asynchronously,
so on a loaded runner they outlive the parent by longer than that. It is teardown lag,
not a leak.

The 0-vs-22 probe-timeout column is what rules out the ACP detector as a cause: the
same failure occurs with no probe timeouts at all.

## The fix

Poll the captured records until none are alive, or a 15s deadline passes, and only
then assert.

This CANNOT hide a real leak. The assertion is unchanged and remains the single
authority on survivors, so a genuinely orphaned process is still alive at the deadline
and still fails, with the same error naming the same pids. isSameProcessAlive compares
a stable identity rather than a bare pid, so a recycled pid cannot masquerade as the
old process either.

## Verification

Mutation-proven both directions: reverting to a flat sleep fails 3 of the new tests,
and removing the deadline fails the "a real leak still reaches the assertion" test and
hangs, as it should. The three new tests pin that it returns immediately when nothing
is alive, that it POLLS (alive for two sweeps, gone on the third, which a plain sleep
could not observe), and that it gives up at the deadline rather than throwing.

Full suite 21,320 passed. The 3 failures are main's two pre-existing waylandNano files
plus i18n-performance, a load-dependent perf test that passes in isolation.