### PR TITLE
diag(smoke): name surviving descendants instead of printing bare pids

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Wayland",
-  "version": "0.12.6",
+  "version": "0.12.9",
   "description": "The local-first desktop AI agent that drives every AI CLI on your machine - Claude Code, Codex, Gemini and more, on your keys.",
   "keywords": [],
   "license": "AGPL-3.0-or-later",

--- a/scripts/platform-package-smoke.mjs
+++ b/scripts/platform-package-smoke.mjs
@@ -907,6 +907,11 @@ function parseWindowsProcesses(raw) {
     parentPid: Number(entry.ParentProcessId),
     identity: `${entry.CreationDate || '<unknown>'}\0${entry.ExecutablePath || entry.Name || '<unknown>'}`,
     scopeText: `${entry.ExecutablePath || entry.Name || ''}\0${entry.CommandLine || ''}`,
+    // Kept for DIAGNOSIS ONLY - never for identity or liveness comparison.
+    // The survivor assertion used to print bare pids, which cost three sessions
+    // of guessing at a leak whose process names were in this record all along.
+    exePath: entry.ExecutablePath || entry.Name || '<unknown>',
+    commandLine: entry.CommandLine || '',
   }));
 }
 
@@ -925,6 +930,9 @@ function parsePosixProcesses(raw) {
       // same live process compares equal in both lightweight and final sweeps.
       identity: `${match[3]}\0${command.trim().split(/\s+/, 1)[0] || '<unknown>'}`,
       scopeText: command,
+      // Diagnosis only - see the note in `parseWindowsProcesses`.
+      exePath: command.trim().split(/\s+/, 1)[0] || '<unknown>',
+      commandLine: command,
     });
   }
   return records;
@@ -1068,7 +1076,16 @@ function isSameProcessAlive(record, targetPlatform, dependencies = {}) {
  * (`exitCode=0`, complete event ledger) and EXACTLY FOUR descendants were still
  * alive at the instant of the check - on windows-arm64 and win32-x64 alike, with
  * probe timeouts anywhere from 0 to 22, so nothing about the app's own work
- * predicted it. It is teardown lag, not a leak.
+ * predicted it.
+ *
+ * THIS DRAIN DID NOT FIX THAT, AND THE ORIGINAL NOTE HERE WAS WRONG. It claimed
+ * the survivors were teardown lag. On the first release leg to run with the
+ * drain in place, four processes were still alive at the FULL 15,000ms deadline,
+ * which no amount of waiting can explain. The app's own before-quit sequence
+ * takes ~55ms end to end and logs no `cleanup-failed` event, so it is not a
+ * shutdown budget being missed either. WHAT the four processes are is still
+ * open - `describeProcessRecord` exists to answer that on the next occurrence
+ * rather than by inference. Do not add a sixth theory here without the names.
  *
  * THIS CANNOT HIDE A REAL LEAK. It only waits; the assertion is unchanged and
  * still authoritative. A genuinely orphaned process is still alive at the
@@ -1087,6 +1104,81 @@ export async function drainDescendants(records, targetPlatform, dependencies = {
   }
 }
 
+/**
+ * Render one process record for a human reading CI output.
+ *
+ * WHY THIS EXISTS. The survivor assertion printed bare pids. A pid is useless
+ * after the fact - the process is gone by the time anyone reads the log - so
+ * five separate failures were diagnosed by guesswork, and three different root
+ * causes were proposed and refuted in turn. Every one of those records already
+ * carried its executable path, creation time and command line. Print them.
+ *
+ * `identity` is `CreationDate\0ExecutablePath`; the creation time is the half a
+ * reader cannot get anywhere else, so it is surfaced as `started`.
+ */
+export function describeProcessRecord(record) {
+  // `identity` is the one field EVERY record carries, including the ones built
+  // by `terminateProcessTree` callers that never went through a parser, so the
+  // executable is derived from it whenever the parsed field is absent.
+  const [createdAt = '<unknown>', exeFromIdentity = '<unknown>'] = String(record.identity ?? '').split('\0');
+  return [
+    `pid=${record.pid}`,
+    `ppid=${record.parentPid}`,
+    `matchedBy=${record.matchedBy ?? '<unknown>'}`,
+    `started=${createdAt}`,
+    `exe=${redactHighEntropyRuns(record.exePath ?? exeFromIdentity)}`,
+    `role=${chromiumRoleFromCommandLine(record.commandLine)}`,
+  ].join(' ');
+}
+
+/**
+ * THIS REPO IS PUBLIC, SO CI LOGS ARE PUBLIC.
+ *
+ * The obvious diagnostic - dump each survivor's full `CommandLine` - cannot ship
+ * here. A Windows command line carries whatever arguments a process was spawned
+ * with, which for this app's CLI backends can include API keys, and the smoke
+ * marker is in there BY CONSTRUCTION because scope matching works by searching
+ * command lines for it. Printing it would publish a secret to a public log.
+ *
+ * So only Chromium's own role flags are extracted. They are the single most
+ * diagnostic tokens for "what are these four processes" (`gpu-process`,
+ * `renderer`, `utility` + its sub-type, `crashpad-handler`), they are internal
+ * to Chromium, and they can never carry a credential. Anything else is dropped.
+ */
+export function chromiumRoleFromCommandLine(commandLine) {
+  const text = String(commandLine ?? '');
+  const type = text.match(/--type=([A-Za-z0-9_-]{1,40})/);
+  if (!type) return '<none>';
+  const subType = text.match(/--utility-sub-type=([A-Za-z0-9_.-]{1,60})/);
+  return subType ? `${type[1]}:${subType[1]}` : type[1];
+}
+
+/**
+ * Blank out any run that looks like a token or hash before it reaches a public
+ * log. Executable paths are normally boring, but the installed tree lives under
+ * a randomised temp directory and defence in depth is cheaper than a leak.
+ */
+export function redactHighEntropyRuns(value) {
+  return String(value ?? '<unknown>').replace(/[A-Fa-f0-9]{32,}|[A-Za-z0-9+/]{40,}={0,2}/g, '<redacted>');
+}
+
+/**
+ * Inventory line for the population the survivors are drawn from.
+ *
+ * BOUNDED ON PURPOSE. The monitor polls every 25ms for the whole session and
+ * keeps every unique pid+identity it ever saw, so on Windows - where a CLI
+ * detector spawns a `where.exe` or `powershell.exe` per probe - this list runs
+ * to hundreds. Printing it whole would bury the survivor report that matters
+ * and bloat a public log, so it is capped and the remainder is counted.
+ */
+export function formatDescendantInventory(records, limit = 60) {
+  if (!records.length) return `${TAG} observed 0 descendant record(s) before shutdown`;
+  const shown = records.slice(0, limit).map((record) => `  ${describeProcessRecord(record)}`);
+  const omitted = records.length - shown.length;
+  if (omitted > 0) shown.push(`  …and ${omitted} more record(s) not shown`);
+  return `${TAG} observed ${records.length} descendant record(s) before shutdown:\n${shown.join('\n')}`;
+}
+
 export function createProcessMonitor(rootPid, targetPlatform, dependencies = {}) {
   const records = new Map();
   const collect = (includeEnvironment = false) => {
@@ -1098,9 +1190,24 @@ export function createProcessMonitor(rootPid, targetPlatform, dependencies = {})
           (record) => record.pid !== process.pid && scopeTokens.some((token) => record.scopeText.includes(token))
         )
       : [];
-    for (const record of [...descendants, ...scoped]) {
+    // WHY `matchedBy`. A record reaches this map two ways: it is a transitive
+    // child of the root (ancestry), or its path/command line contains a scope
+    // token (scope). Those have VERY different meanings when one survives -
+    // ancestry means the app truly orphaned it, while scope can capture a
+    // process that was never ours. The survivor assertion could not tell them
+    // apart, so every past investigation had to guess which it was.
+    for (const [record, how] of [
+      ...descendants.map((entry) => [entry, 'ancestry']),
+      ...scoped.map((entry) => [entry, 'scope']),
+    ]) {
       if (record.pid === rootPid) continue;
-      records.set(`${record.pid}\0${record.identity}`, record);
+      const key = `${record.pid}\0${record.identity}`;
+      const seen = records.get(key);
+      if (seen) {
+        if (!seen.matchedBy.includes(how)) seen.matchedBy = `${seen.matchedBy}+${how}`;
+        continue;
+      }
+      records.set(key, { ...record, matchedBy: how });
     }
   };
   collect();
@@ -1227,7 +1334,9 @@ export function verifyShutdownEvidence({
   );
   if (survivingDescendants.length) {
     throw new Error(
-      `${TAG} packaged app left descendant processes alive: ${survivingDescendants.map((record) => record.pid).join(',')}`
+      `${TAG} packaged app left descendant processes alive:\n${survivingDescendants
+        .map((record) => `  ${describeProcessRecord(record)}`)
+        .join('\n')}`
     );
   }
   return {
@@ -1533,9 +1642,16 @@ export async function runSmoke(options, dependencies = {}) {
       await new Promise((resolve) => setTimeout(resolve, dependencies.shutdownSettleMs ?? 250));
       const descendantRecords = processMonitor.stop();
       processMonitor = null;
-      // The flat settle above is a floor, not a guarantee: Windows reaps
-      // Electron's helpers asynchronously. Drain to a deadline before asserting,
-      // so teardown lag stops reading as a leaked process tree.
+      // ALWAYS-ON, NOT FAILURE-ONLY. The survivor set is load-dependent and does
+      // not reproduce on demand, so a passing run has to carry evidence too: this
+      // prints the population the survivors are drawn from. Without it the only
+      // way to learn what the harness tracks is to catch a red run in the act,
+      // which is exactly the trap that made this a three-session hunt.
+      console.log(formatDescendantInventory(descendantRecords));
+      // The flat settle above is a floor, not a guarantee. Drain to a deadline
+      // before asserting so mere teardown lag does not read as a leaked tree.
+      // NOTE: a drain cannot fix a process that never exits - five failures had
+      // four survivors still alive at the FULL deadline. This bounds lag only.
       await drainDescendants(descendantRecords, options.targetPlatform, dependencies);
       const events = (dependencies.readPackageSmokeEventLedger || readPackageSmokeEventLedger)(eventFile);
       const shutdownEvidence = (dependencies.verifyShutdownEvidence || verifyShutdownEvidence)({

--- a/tests/unit/platformPackageSmoke.test.ts
+++ b/tests/unit/platformPackageSmoke.test.ts
@@ -17,6 +17,10 @@ import {
   candidateContentDigest,
   captureCandidateState,
   createProcessMonitor,
+  describeProcessRecord,
+  chromiumRoleFromCommandLine,
+  redactHighEntropyRuns,
+  formatDescendantInventory,
   currentSourceIdentity,
   drainDescendants,
   expectedReleaseIdentity,
@@ -1092,7 +1096,7 @@ describe('real installer extraction and lifecycle evidence', () => {
           targetPlatform: 'linux',
           processRecordAlive: () => true,
         })
-      ).toThrow('left descendant processes alive: 99');
+      ).toThrow(/left descendant processes alive[\s\S]*pid=99/);
     });
   });
 
@@ -1147,9 +1151,25 @@ describe('real installer extraction and lifecycle evidence', () => {
         processRecordAlive: (record: typeof original) => record.identity === 'boot-b\0unrelated-process',
       }).descendantsRemaining
     ).toBe(0);
-    expect(() => verifyShutdownEvidence({ ...base, processRecordAlive: () => true })).toThrow(
-      'left descendant processes alive: 99'
-    );
+    // REPOINTED, NOT RELAXED. This used to assert the bare-pid message
+    // ('...alive: 99'). A pid alone is unusable after the fact - the process is
+    // gone by the time anyone reads CI - and that cost three sessions of guessing
+    // at five real failures. The assertion is now STRICTER: it must still name
+    // the pid, and must additionally carry the executable and how the record was
+    // matched, so the next occurrence is diagnosed from the log itself.
+    const thrown = (() => {
+      try {
+        verifyShutdownEvidence({ ...base, processRecordAlive: () => true });
+        return null;
+      } catch (error) {
+        return error instanceof Error ? error.message : String(error);
+      }
+    })();
+    expect(thrown).toContain('left descendant processes alive');
+    expect(thrown).toContain('pid=99');
+    expect(thrown).toContain('exe=wayland-helper');
+    expect(thrown).toContain('started=boot-a');
+    expect(thrown).toContain('matchedBy=');
   });
 
   it('does not mistake a post-kill PID reuse for a surviving descendant', async () => {
@@ -1203,6 +1223,86 @@ describe('real installer extraction and lifecycle evidence', () => {
       'ps',
       ['eww', '-axo', 'pid=,ppid=,lstart=,command='],
       expect.objectContaining({ maxBuffer: 64 * 1024 * 1024 })
+    );
+  });
+
+  it('records HOW each descendant was matched, so a survivor is not ambiguous', () => {
+    // A record reaches the monitor two ways, and they mean different things when
+    // one survives: `ancestry` proves the app orphaned it, `scope` can capture a
+    // process that was never ours. Five real failures could not be told apart
+    // because the survivor message carried neither.
+    const token = 'scope-token-not-user-controlled';
+    const childOfRoot = '101 8123 Mon Jul 18 20:00:00 2026 /opt/Wayland/wayland-core';
+    const strangerWithToken = `202 1 Mon Jul 18 20:00:01 2026 /usr/bin/unrelated --dir=${token}`;
+    const bothWays = `303 8123 Mon Jul 18 20:00:02 2026 /opt/Wayland/helper --dir=${token}`;
+    const execFileSync = vi.fn(() => `${childOfRoot}\n${strangerWithToken}\n${bothWays}\n`);
+    const monitor = createProcessMonitor(8123, 'linux', {
+      execFileSync,
+      processScopeTokens: [token],
+      processMonitorIntervalMs: 60_000,
+    });
+    const byPid = new Map(monitor.stop().map((record) => [record.pid, record.matchedBy]));
+    expect(byPid.get(101)).toBe('ancestry');
+    expect(byPid.get(202)).toBe('scope');
+    expect(byPid.get(303)).toBe('ancestry+scope');
+  });
+
+  it('renders the fields a reader needs and NEVER publishes command-line arguments', () => {
+    // This repo is public, so CI logs are public. A Windows command line can
+    // carry API keys, and it carries the smoke marker by construction (scope
+    // matching searches command lines for it). Only Chromium role flags escape.
+    const secret = 'sk-live-DEADBEEFdeadbeef0123456789abcdefTOPSECRET';
+    const rendered = describeProcessRecord({
+      pid: 6780,
+      parentPid: 4242,
+      identity: 'Wed Sep 3 08:00:00 2026\0C:\\Program Files\\Wayland\\Wayland.exe',
+      matchedBy: 'scope',
+      exePath: 'C:\\Program Files\\Wayland\\Wayland.exe',
+      commandLine: `Wayland.exe --type=utility --utility-sub-type=network.mojom.NetworkService --api-key=${secret}`,
+    });
+    expect(rendered).toContain('pid=6780');
+    expect(rendered).toContain('ppid=4242');
+    expect(rendered).toContain('matchedBy=scope');
+    expect(rendered).toContain('started=Wed Sep 3 08:00:00 2026');
+    expect(rendered).toContain('exe=C:\\Program Files\\Wayland\\Wayland.exe');
+    // The role is what identifies the process...
+    expect(rendered).toContain('role=utility:network.mojom.NetworkService');
+    // ...and nothing else from the command line survives.
+    expect(rendered).not.toContain(secret);
+    expect(rendered).not.toContain('--api-key');
+  });
+
+  it('reduces each Chromium role to a non-secret token, and reports none when absent', () => {
+    expect(chromiumRoleFromCommandLine('Wayland.exe --type=gpu-process --foo')).toBe('gpu-process');
+    expect(chromiumRoleFromCommandLine('Wayland.exe --type=renderer')).toBe('renderer');
+    expect(chromiumRoleFromCommandLine('crashpad_handler.exe --type=crashpad-handler')).toBe('crashpad-handler');
+    expect(chromiumRoleFromCommandLine('wayland-core.exe --json-stream')).toBe('<none>');
+    expect(chromiumRoleFromCommandLine(undefined)).toBe('<none>');
+  });
+
+  it('bounds the descendant inventory so a huge population cannot bury the survivors', () => {
+    const rec = (pid: number) => ({
+      pid,
+      parentPid: 1,
+      identity: `boot\0/usr/bin/probe-${pid}`,
+      matchedBy: 'scope',
+    });
+    expect(formatDescendantInventory([])).toContain('observed 0 descendant record(s)');
+    const many = formatDescendantInventory(Array.from({ length: 250 }, (_, index) => rec(index + 1)), 60);
+    expect(many).toContain('observed 250 descendant record(s)');
+    expect(many).toContain('pid=1 ');
+    expect(many).toContain('…and 190 more record(s) not shown');
+    // 60 shown + header + the elision line, never all 250.
+    expect(many.split('\n')).toHaveLength(62);
+    expect(many).not.toContain('probe-250');
+  });
+
+  it('redacts a token-shaped run from an executable path before it reaches a public log', () => {
+    const marker = 'a'.repeat(64);
+    expect(redactHighEntropyRuns(`C:\\Temp\\wayland-smoke-${marker}\\Wayland.exe`)).not.toContain(marker);
+    expect(redactHighEntropyRuns(`C:\\Temp\\wayland-smoke-${marker}\\Wayland.exe`)).toContain('<redacted>');
+    expect(redactHighEntropyRuns('C:\\Program Files\\Wayland\\Wayland.exe')).toBe(
+      'C:\\Program Files\\Wayland\\Wayland.exe'
     );
   });
 

--- a/tests/unit/platformPackageSmoke.test.ts
+++ b/tests/unit/platformPackageSmoke.test.ts
@@ -1288,7 +1288,10 @@ describe('real installer extraction and lifecycle evidence', () => {
       matchedBy: 'scope',
     });
     expect(formatDescendantInventory([])).toContain('observed 0 descendant record(s)');
-    const many = formatDescendantInventory(Array.from({ length: 250 }, (_, index) => rec(index + 1)), 60);
+    const many = formatDescendantInventory(
+      Array.from({ length: 250 }, (_, index) => rec(index + 1)),
+      60
+    );
     expect(many).toContain('observed 250 descendant record(s)');
     expect(many).toContain('pid=1 ');
     expect(many).toContain('…and 190 more record(s) not shown');


### PR DESCRIPTION
Five release legs failed with "packaged app left descendant processes alive" and EXACTLY four survivors, while the AcpDetector probe-timeout count ranged 0..22. Three root causes were proposed and refuted in turn, and a fourth was refuted before it was written.

The reason every investigation had to guess is that the assertion printed a bare pid. The record already carried the executable path, the creation time and the command line.

What changes:

- survivors report pid/ppid/matchedBy/started/exe/role
- matchedBy separates a true orphan (ancestry) from a scope-token match that may never have been ours
- an always-on, 60-record-capped inventory, because the fault is load-dependent and a passing run must carry evidence too

No command-line arguments are printed. This repo is public, so its CI logs are public, and scope matching puts the smoke marker into command lines by construction. Only Chromium role flags escape, plus a high-entropy redaction on the executable path.

The gate is unchanged: same records, same processRecordAlive filter, same throw. This adds evidence, not leniency.

Cross-audited by Codex 5.6 Sol (FIX-FIRST; both findings fixed before this PR) and Gemini 3.1 Pro (GO). Kimi K3 was unavailable (npm-side 403 quota).

🤖 Generated with [Claude Code](https://claude.com/claude-code)