### PR TITLE
diag(updater): name the boot and the exit on a dirty shutdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Wayland",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "description": "The local-first desktop AI agent that drives every AI CLI on your machine - Claude Code, Codex, Gemini and more, on your keys.",
   "keywords": [],
   "license": "AGPL-3.0-or-later",

--- a/scripts/release-acceptance/produceNativeUpdaterObservation.mjs
+++ b/scripts/release-acceptance/produceNativeUpdaterObservation.mjs
@@ -301,6 +301,20 @@ const FERROX_LABS_CN = /(?:^|,\s*)CN\s*=\s*"?Ferrox Labs(?:, LLC)?"?\s*(?:,|$)/;
 const CANDIDATE_EXIT_TIMEOUT_MS = 10_000;
 const SHIPPED_RUNTIME_EXIT_TIMEOUT_MS = 45_000;
 
+/**
+ * Message for a boot that exited dirty.
+ *
+ * Extracted so it can be tested: the assertion itself sits inside
+ * `bootInstalledRuntime`, which reaches the network through non-injectable
+ * `cdpJson`/`cdpCommand` and so cannot be driven from a unit test.
+ */
+export function describeDirtyShutdown(input, shutdown, descendantCount) {
+  return (
+    `${input.label || 'native app'} (${input.platform}) did not shut down cleanly: ` +
+    `exitCode=${shutdown.code} signal=${shutdown.signal} descendantsObserved=${descendantCount}`
+  );
+}
+
 export async function bootInstalledRuntime(input, dependencies = {}) {
   const port = await (dependencies.findFreePort || findFreePort)();
   const launch = (dependencies.launchCommand || launchCommand)(
@@ -371,7 +385,21 @@ export async function bootInstalledRuntime(input, dependencies = {}) {
       `${input.label || 'native app'} (${input.platform})`
     );
     const descendants = monitor.stop();
-    if (shutdown.code !== 0 || shutdown.signal !== null) fail('native app did not shut down cleanly');
+    // NAME THE BOOT AND THE EXIT. This used to throw the fixed string 'native
+    // app did not shut down cleanly', which discarded three things it was
+    // holding: WHICH of the three boots it was (every call site passes a
+    // `label` - initial, rollback, reupgrade - and the message ignored it), and
+    // the exit code and signal that say HOW the app exited dirty.
+    //
+    // It cost a whole release. v0.12.9 died here on win32-arm64 with all six
+    // builds green, both smoke gates green and the package observer 6/6, and
+    // the log could not say whether the offending process was the 0.11.18
+    // initial install, the 0.11.8 rollback or the candidate re-upgrade - let
+    // alone what its exit code was. The sibling timeout path in `waitForExit`
+    // already learned this lesson and names its phase and budget.
+    if (shutdown.code !== 0 || shutdown.signal !== null) {
+      fail(describeDirtyShutdown(input, shutdown, descendants.length));
+    }
     return {
       actualExecution: true,
       booted: true,

--- a/tests/unit/scripts/updaterDirtyShutdownEvidence.test.ts
+++ b/tests/unit/scripts/updaterDirtyShutdownEvidence.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error - plain .mjs release-acceptance script, no type declarations
+import { describeDirtyShutdown } from '../../../scripts/release-acceptance/produceNativeUpdaterObservation.mjs';
+
+/**
+ * v0.12.9 died on this assertion on win32-arm64 with all six builds green,
+ * both smoke gates green and the package observer 6/6. The message was the
+ * fixed string 'native app did not shut down cleanly', so the log could not
+ * say which of the three boots it was - initial 0.11.18, 0.11.8 rollback, or
+ * the candidate re-upgrade - nor how the process actually exited.
+ *
+ * Every call site already passes a distinct `label`, and the exit code and
+ * signal are both in hand at the throw. These assertions pin all of it.
+ */
+describe('updater observation - dirty shutdown evidence', () => {
+  it('names which boot failed, not a generic label', () => {
+    const message = describeDirtyShutdown({ label: 'initial boot', platform: 'win32' }, { code: 1, signal: null }, 4);
+    expect(message).toContain('initial boot');
+    expect(message).toContain('(win32)');
+    // The old fixed string must not come back.
+    expect(message).not.toBe('native app did not shut down cleanly');
+  });
+
+  it('reports the exit code and the signal, so the failure mode is readable', () => {
+    expect(
+      describeDirtyShutdown({ label: 'rollback boot', platform: 'win32' }, { code: 3221225477, signal: null }, 0)
+    ).toContain('exitCode=3221225477');
+    expect(
+      describeDirtyShutdown({ label: 'reupgrade boot', platform: 'darwin' }, { code: null, signal: 'SIGKILL' }, 2)
+    ).toContain('signal=SIGKILL');
+  });
+
+  it('reports how many descendants were observed, to separate a dirty exit from a leak', () => {
+    // A dirty exit with survivors is a different bug from a dirty exit with
+    // none, and the two had been indistinguishable in CI.
+    expect(describeDirtyShutdown({ label: 'initial boot', platform: 'win32' }, { code: 1, signal: null }, 4)).toContain(
+      'descendantsObserved=4'
+    );
+    expect(describeDirtyShutdown({ label: 'initial boot', platform: 'win32' }, { code: 1, signal: null }, 0)).toContain(
+      'descendantsObserved=0'
+    );
+  });
+
+  it('falls back to a generic label only when a call site supplies none', () => {
+    expect(describeDirtyShutdown({ platform: 'linux' }, { code: 1, signal: null }, 0)).toContain('native app (linux)');
+  });
+});


### PR DESCRIPTION
v0.12.9 died on one line on win32-arm64 with everything else green: all six platform builds, both release smoke gates, Create Release, and the package observer 6/6 (the four-survivor leak gate did not fire once).

    if (shutdown.code !== 0 || shutdown.signal !== null)
      fail('native app did not shut down cleanly');

That fixed string threw away three things it already held: WHICH boot (every call site passes a distinct label - initial boot, rollback boot, reupgrade boot - and the message ignored them), and the exit code and signal that say how the process exited dirty. A whole release cycle produced one unusable sentence.

The sibling timeout path in waitForExit already names its phase and budget. This brings the dirty-exit path level with it and adds the observed descendant count, so a dirty exit is distinguishable from the separate four-survivor leak.

describeDirtyShutdown is extracted only so it can be tested - the assertion sits inside bootInstalledRuntime, which reaches the network via non-injectable cdpJson/cdpCommand. The condition is unchanged. Tests are mutation-proven: restoring the old fixed string fails all four.

Evidence, not leniency. Also bumps to 0.12.10, since the release names artifacts and publishes npm from package.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)