### PR TITLE
fix(smoke): reject PID-reuse ancestry in the descendant walk (v0.12.11)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Wayland",
-  "version": "0.12.10",
+  "version": "0.12.11",
   "description": "The local-first desktop AI agent that drives every AI CLI on your machine - Claude Code, Codex, Gemini and more, on your keys.",
   "keywords": [],
   "license": "AGPL-3.0-or-later",

--- a/scripts/platform-package-smoke.mjs
+++ b/scripts/platform-package-smoke.mjs
@@ -983,8 +983,70 @@ function processSnapshot(targetPlatform, dependencies = {}, includeEnvironment =
   }
 }
 
+/**
+ * Creation time of a process record, in epoch ms, or null when it cannot be
+ * read. `identity` is `CreationDate\0ExecutablePath`, so the time is already in
+ * hand on every record from either parser - no extra collection.
+ *
+ * Two wire formats reach this:
+ *   - Windows: `Get-CimInstance | ConvertTo-Json` serialises CreationDate as
+ *     `/Date(1788452728209)/`. Date.parse() does NOT understand that form.
+ *   - POSIX: `ps` `lstart`, e.g. `Wed Sep  3 16:25:28 2026`, which it does.
+ *
+ * Returns null rather than NaN or 0 so callers can distinguish "older" from
+ * "unknown" - the guard below must never treat unknown as a violation.
+ */
+export function processCreationTimeMs(record) {
+  const [createdAt = ''] = String(record?.identity ?? '').split('\0');
+  const dotNet = createdAt.match(/^\/Date\((-?\d+)\)\/$/);
+  if (dotNet) {
+    const ms = Number(dotNet[1]);
+    return Number.isFinite(ms) ? ms : null;
+  }
+  const parsed = Date.parse(createdAt);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 function descendantsFromSnapshot(rootPid, snapshot) {
   if (!Number.isInteger(rootPid) || rootPid <= 0) return [];
+  // THE PID-REUSE GUARD. A child records its parent's PID at birth and Windows
+  // NEVER clears that field, so a long-lived process keeps pointing at a PID
+  // that the OS has since recycled. When the recycled PID lands on the app, an
+  // ancestry walk over one instant adopts a stranger and everything below it.
+  //
+  // This is not hypothetical and it is not rare. On the win32-arm64 leg of
+  // v0.12.10 the walk claimed csrss.exe, winlogon.exe, fontdrvhost.exe and
+  // dwm.exe - the Windows session host - as descendants of the packaged app.
+  // They were created at 16:25:28; the app's own children were created at
+  // 16:46:56, twenty-one minutes later. Those four never exit, so every run
+  // burned the full 15,000ms drain deadline and then failed the survivor
+  // assertion, which is precisely the "still alive at the FULL deadline"
+  // evidence that refuted a teardown-lag explanation. Five tags were spent on
+  // four theories, and all four assumed the survivors were ours.
+  //
+  // The comment this replaces argued that keying by pid alone was safe because
+  // "PID reuse is a phenomenon across TIME and this walk only ever sees one
+  // instant". The snapshot is one instant; the ParentProcessId values inside it
+  // are not. They are historical, and that is the whole bug.
+  //
+  // A process cannot predate the process that created it, so a true descendant
+  // of the root cannot be older than the root. Excluding a provably-older
+  // candidate can only ever remove an impossible edge. Comparison is against
+  // the ROOT rather than the immediate parent deliberately: it is the weaker
+  // claim of the two, and it stays correct even where an intermediate record is
+  // missing from the snapshot.
+  const rootRecord = snapshot.find((record) => record.pid === rootPid);
+  const rootCreatedMs = rootRecord ? processCreationTimeMs(rootRecord) : null;
+  const predatesRoot = (record) => {
+    // FAIL OPEN, DELIBERATELY. An unknown time on either side must keep the
+    // record: dropping a real orphan would silently weaken the leak gate, which
+    // is the opposite of what this guard is for. It excludes only what it can
+    // PROVE impossible.
+    if (rootCreatedMs === null) return false;
+    const createdMs = processCreationTimeMs(record);
+    if (createdMs === null) return false;
+    return createdMs < rootCreatedMs;
+  };
   const childrenByParent = new Map();
   for (const record of snapshot) {
     if (!Number.isInteger(record.pid) || !Number.isInteger(record.parentPid)) continue;
@@ -1029,6 +1091,10 @@ function descendantsFromSnapshot(rootPid, snapshot) {
     const record = queue.shift();
     if (seen.has(record.pid)) continue;
     seen.add(record.pid);
+    // Skip BEFORE expanding, not just before recording. A stranger adopted by a
+    // recycled PID drags its own subtree in behind it - winlogon brought dwm and
+    // fontdrvhost - so refusing the node has to refuse its children too.
+    if (predatesRoot(record)) continue;
     descendants.push(record);
     // Belt and braces, and the reason a regression here FAILS instead of hanging.
     // The result is provably bounded by the snapshot size, so this can never fire

--- a/tests/unit/platformPackageSmoke.test.ts
+++ b/tests/unit/platformPackageSmoke.test.ts
@@ -28,7 +28,9 @@ import {
   installArtifactSnapshot,
   isReadyRendererState,
   launchCommand,
+  listDescendantProcessRecords,
   parseArgs,
+  processCreationTimeMs,
   parseOptionalCapabilityStates,
   prepareInstalledCandidate,
   redactSmokeMarkerFromUrl,
@@ -1705,5 +1707,141 @@ describe('platform workflows cannot silently skip installed-package smoke', () =
     expect(
       targetAssignments.map((target: Record<string, string>) => `${target.target_platform}-${target.arch}@${target.os}`)
     ).toEqual(expected);
+  });
+});
+
+/**
+ * PID REUSE FABRICATES ANCESTRY.
+ *
+ * A child records its parent's PID at birth and Windows never clears that
+ * field. When the OS recycles that PID onto the packaged app, a walk over a
+ * single process-table instant adopts a stranger and its whole subtree.
+ *
+ * This is the v0.12.10 win32-arm64 failure, reproduced from its real records:
+ * the walk claimed csrss.exe, winlogon.exe, fontdrvhost.exe and dwm.exe as
+ * descendants of the app. Those four were created at 16:25:28 and the app's own
+ * children at 16:46:56 - twenty-one minutes apart. They never exit, so the drain
+ * burned its full deadline and the survivor assertion failed the release.
+ *
+ * The invariant is simply that a process cannot predate the process that
+ * created it.
+ */
+describe('platform-package-smoke - PID-reuse ancestry guard', () => {
+  // Real values from the failing win32-arm64 leg.
+  const APP_STARTED = 1788454000000; // 16:46:40, the packaged app
+  const PROBE_STARTED = 1788454016936; // 16:46:56, a genuine child of the app
+  const SESSION_STARTED = 1788452728224; // 16:25:28, the Windows session host
+
+  const winEntry = (
+    pid: number,
+    parentPid: number,
+    createdMs: number | string,
+    exe: string
+  ): Record<string, unknown> => ({
+    ProcessId: pid,
+    ParentProcessId: parentPid,
+    CreationDate: typeof createdMs === 'number' ? `/Date(${createdMs})/` : createdMs,
+    ExecutablePath: exe,
+    Name: exe,
+    CommandLine: exe,
+  });
+
+  const windowsWalk = (entries: Record<string, unknown>[], rootPid = 9000) =>
+    listDescendantProcessRecords(rootPid, 'win32', {
+      execFileSync: vi.fn(() => JSON.stringify(entries)),
+    });
+
+  it('reads the creation time out of both wire formats, and only those', () => {
+    // Windows: ConvertTo-Json emits /Date(ms)/, which Date.parse cannot read.
+    expect(processCreationTimeMs({ identity: `/Date(${SESSION_STARTED})/\u0000C:\\x.exe` })).toBe(SESSION_STARTED);
+    // POSIX: `ps` lstart, which it can.
+    expect(processCreationTimeMs({ identity: 'Mon Jul 18 20:00:00 2026\u0000/opt/Wayland/app' })).toBe(
+      Date.parse('Mon Jul 18 20:00:00 2026')
+    );
+    // Unknown must be null, NOT NaN and NOT 0 - the guard has to be able to
+    // tell "older" apart from "unreadable", because it fails open on unreadable.
+    expect(processCreationTimeMs({ identity: '<unknown>\u0000C:\\x.exe' })).toBeNull();
+    expect(processCreationTimeMs({ identity: '' })).toBeNull();
+    expect(processCreationTimeMs({})).toBeNull();
+  });
+
+  it('refuses a stranger adopted through a recycled PID, and its whole subtree', () => {
+    const records = windowsWalk([
+      winEntry(9000, 1, APP_STARTED, 'C:\\Wayland\\Wayland.exe'),
+      // Genuine: created after the app.
+      winEntry(5356, 9000, PROBE_STARTED, 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'),
+      // Stranger: the Windows session host, pointing at the app's recycled PID.
+      winEntry(6176, 9000, SESSION_STARTED, 'C:\\Windows\\system32\\winlogon.exe'),
+      // The stranger's real children. Refusing winlogon must refuse these too,
+      // or the walk keeps the subtree it was dragged in with.
+      winEntry(7016, 6176, SESSION_STARTED + 55, 'C:\\Windows\\system32\\dwm.exe'),
+      winEntry(5804, 6176, SESSION_STARTED + 51, 'C:\\Windows\\system32\\fontdrvhost.exe'),
+    ]);
+
+    expect(records.map((record) => record.pid)).toEqual([5356]);
+    const executables = records.map((record) => record.exePath).join(' ');
+    expect(executables).not.toMatch(/winlogon|dwm|fontdrvhost|csrss/);
+  });
+
+  it('keeps every genuine descendant, including deep ones', () => {
+    // The guard must not become a leak-hiding filter: anything created after
+    // the root is still tracked, at any depth.
+    const records = windowsWalk([
+      winEntry(9000, 1, APP_STARTED, 'C:\\Wayland\\Wayland.exe'),
+      winEntry(5356, 9000, APP_STARTED + 1, 'C:\\Windows\\system32\\cmd.exe'),
+      winEntry(4432, 5356, APP_STARTED + 2, 'C:\\Windows\\system32\\conhost.exe'),
+      winEntry(11692, 4432, APP_STARTED + 3, 'C:\\Windows\\system32\\where.exe'),
+    ]);
+    expect(records.map((record) => record.pid).sort((a, b) => a - b)).toEqual([4432, 5356, 11692]);
+  });
+
+  it('keeps a descendant created in the same instant as the root', () => {
+    // POSIX lstart has one-second resolution, so a child spawned immediately
+    // shares the root's timestamp. Only a STRICTLY older record is impossible;
+    // an equal one is the common case and must survive.
+    const records = windowsWalk([
+      winEntry(9000, 1, APP_STARTED, 'C:\\Wayland\\Wayland.exe'),
+      winEntry(5356, 9000, APP_STARTED, 'C:\\Wayland\\helper.exe'),
+    ]);
+    expect(records.map((record) => record.pid)).toEqual([5356]);
+  });
+
+  it('fails OPEN when either creation time is unreadable', () => {
+    // Dropping a record we cannot time would silently weaken the leak gate.
+    // Unknown root time: filter nothing.
+    expect(
+      windowsWalk([
+        winEntry(9000, 1, '<unknown>', 'C:\\Wayland\\Wayland.exe'),
+        winEntry(6176, 9000, SESSION_STARTED, 'C:\\Windows\\system32\\winlogon.exe'),
+      ]).map((record) => record.pid)
+    ).toEqual([6176]);
+
+    // Unknown candidate time: keep the candidate.
+    expect(
+      windowsWalk([
+        winEntry(9000, 1, APP_STARTED, 'C:\\Wayland\\Wayland.exe'),
+        winEntry(6176, 9000, '<unknown>', 'C:\\Wayland\\orphan.exe'),
+      ]).map((record) => record.pid)
+    ).toEqual([6176]);
+
+    // Root absent from the snapshot entirely: filter nothing.
+    expect(
+      windowsWalk([winEntry(6176, 9000, SESSION_STARTED, 'C:\\Windows\\system32\\winlogon.exe')]).map(
+        (record) => record.pid
+      )
+    ).toEqual([6176]);
+  });
+
+  it('applies the same guard on POSIX, not just Windows', () => {
+    // `ps` lstart, the other wire format. Same invariant, same outcome.
+    const snapshot = [
+      '9000 1 Mon Jul 18 20:00:00 2026 /opt/Wayland/wayland',
+      '9100 9000 Mon Jul 18 20:00:05 2026 /opt/Wayland/wayland-helper',
+      '6176 9000 Mon Jul 18 19:30:00 2026 /usr/lib/systemd/systemd-logind',
+    ].join('\n');
+    const records = listDescendantProcessRecords(9000, 'linux', {
+      execFileSync: vi.fn(() => `${snapshot}\n`),
+    });
+    expect(records.map((record) => record.pid)).toEqual([9100]);
   });
 });


### PR DESCRIPTION
The win32-arm64 leg of v0.12.10 failed the survivor assertion with four leaked descendants: csrss.exe, winlogon.exe, fontdrvhost.exe and dwm.exe. Those are the Windows session host. They were created at 16:25:28 and the packaged app's own children at 16:46:56, twenty-one minutes later, so they were never its descendants.

A child records its parent's PID at birth and Windows never clears that field. When the OS recycles that PID onto the app, a walk over a single process-table instant adopts a stranger and everything beneath it. Because those four never exit, every affected run burned the full 15,000ms drain deadline and then failed, which is exactly the still-alive-at-the-full-deadline evidence that refuted a teardown-lag explanation. Five tags went to four theories, all of which assumed the survivors were ours.

The fix: a process cannot predate the process that created it, so a descendant of the root cannot be older than the root. The creation time is already carried on every record in identity, so no new collection is needed. It skips before expanding, so a stranger cannot drag its subtree in behind it.

The guard fails OPEN when either time is unreadable. That is load-bearing: two pre-existing tests build snapshots that omit the root, and a fail-closed guard would drop real orphans and gut the leak gate.

produceNativeUpdaterObservation.mjs imports createProcessMonitor from this module, so both observer legs are covered.

Verification: 65 passed in tests/unit/platformPackageSmoke.test.ts, up from 59. Mutation-proven on two independent mutants. Disabling the comparison fails the two behavioural tests; making it fail closed on an unknown root time fails the new fail-open test plus two pre-existing tests.

Also bumps package.json to 0.12.11, since the release derives its version from package.json rather than the tag.