### PR TITLE
fix(release): bind target-gate evidence by resolved path, not raw string (v0.12.13)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Wayland",
-  "version": "0.12.12",
+  "version": "0.12.13",
   "description": "The local-first desktop AI agent that drives every AI CLI on your machine - Claude Code, Codex, Gemini and more, on your keys.",
   "keywords": [],
   "license": "AGPL-3.0-or-later",

--- a/scripts/release-acceptance/verifyFinalAcceptance.js
+++ b/scripts/release-acceptance/verifyFinalAcceptance.js
@@ -572,13 +572,40 @@ function verifyTargetGateReceiptSet(receipt, candidate, requirements) {
     }
     digest(file.sha256, 'M8A_TARGET_GATE_RECEIPT_INVALID');
     const evidenceFile = exactKeys(verified.evidenceFile, ['path', 'sha256'], 'M8A_TARGET_GATE_RECEIPT_INVALID');
-    if (
-      typeof verified.evidencePath !== 'string' ||
-      verified.evidencePath.length === 0 ||
-      evidenceFile.path !== verified.evidencePath ||
-      evidenceFile.sha256 !== verified.evidenceSha256
-    ) {
-      fail('M8A_TARGET_GATE_RECEIPT_INVALID', 'evidence-file-does-not-bind-receipt-claim');
+    // THE TWO SIDES ARE IN DIFFERENT PATH FORMS AND NEVER COULD MATCH.
+    //
+    // `verified.evidencePath` is a RELATIVE posix path, written by
+    // generateTrustRootAcceptance.js as `evidence/<target>/<gate>.json`.
+    // `evidenceFile.path` is an ABSOLUTE native path: verifyHardeningMatrix.js
+    // returns `path.resolve(receiptsDirectory, receipt.evidencePath)` from
+    // verifyTargetEvidence(). Comparing them with `!==` therefore rejected every
+    // release, which is what `M8A_TARGET_GATE_RECEIPT_INVALID:
+    // evidence-file-does-not-bind-receipt-claim` was on v0.12.12 - the fourth
+    // instance in this pipeline of an equality between two different encodings
+    // of the same value (see the `sha256:`-prefix and report-filename fixes).
+    //
+    // The binding is the DIGEST, and it is unchanged below. verifyTargetEvidence
+    // has additionally already proven this exact file hashes to
+    // `evidenceSha256` AND that it does not escape the receipt root, so
+    // requiring the absolute path to end at the claimed relative path keeps the
+    // claim honest without demanding two incompatible encodings be identical.
+    const claimedEvidencePath = typeof verified.evidencePath === 'string' ? verified.evidencePath : '';
+    const observedEvidencePath = String(evidenceFile.path || '')
+      .split(path.sep)
+      .join('/');
+    const evidencePathBinds =
+      claimedEvidencePath.length > 0 &&
+      (observedEvidencePath === claimedEvidencePath || observedEvidencePath.endsWith(`/${claimedEvidencePath}`));
+    if (!evidencePathBinds || evidenceFile.sha256 !== verified.evidenceSha256) {
+      // SAY WHICH SIDE FAILED AND WITH WHAT. The previous message was a fixed
+      // string, so a red release could not tell a path-form mismatch from a
+      // genuine digest mismatch without re-running the whole pipeline.
+      fail(
+        'M8A_TARGET_GATE_RECEIPT_INVALID',
+        `evidence-file-does-not-bind-receipt-claim:${requirement.receiptId}:` +
+          `claimedPath=${claimedEvidencePath || '<empty>'} observedPath=${observedEvidencePath || '<empty>'} ` +
+          `pathBinds=${evidencePathBinds} digestBinds=${evidenceFile.sha256 === verified.evidenceSha256}`
+      );
     }
     if (file.path === evidenceFile.path) {
       fail('M8A_TARGET_GATE_RECEIPT_INVALID', 'receipt-and-evidence-path-collide');

--- a/tests/unit/scripts/finalAcceptanceController.test.ts
+++ b/tests/unit/scripts/finalAcceptanceController.test.ts
@@ -372,6 +372,80 @@ describe('M8-A final acceptance controller', () => {
     expect(() => verifyFinalAcceptance(request(), hostile)).toThrow(/foreign-or-misbound:M8-F:linux-x64:re-upgrade/);
   });
 
+  /**
+   * THE PRODUCTION SHAPE, WHICH NO FIXTURE HERE EVER BUILT.
+   *
+   * `generateTrustRootAcceptance.js:119` writes `evidencePath` as a RELATIVE
+   * posix path (`evidence/<target>/<gate>.json`), while
+   * `verifyHardeningMatrix.js` returns `evidenceFile.path` as an ABSOLUTE
+   * native path (`path.resolve(receiptsDirectory, receipt.evidencePath)`).
+   * The controller compared them with `!==`, so v0.12.12 died with
+   * M8A_TARGET_GATE_RECEIPT_INVALID:evidence-file-does-not-bind-receipt-claim
+   * after the entire six-platform matrix and all twelve observations passed.
+   *
+   * Every fixture above sets BOTH sides to the same absolute string, so the
+   * equality always held and this could never be caught here.
+   */
+  it('accepts the real relative-claim / absolute-file pairing the pipeline emits', () => {
+    const real = verifiers();
+    const receipts = verifiedTargetGateReceipts().map((receipt) => ({
+      ...receipt,
+      // exactly what generateTrustRootAcceptance.js writes
+      evidencePath: `evidence/${receipt.target}/${receipt.gate}.json`,
+      // exactly what verifyHardeningMatrix.js resolves it to
+      evidenceFile: {
+        path: `/runner/_work/wayland/receipts/evidence/${receipt.target}/${receipt.gate}.json`,
+        sha256: receipt.evidenceFile.sha256,
+      },
+    }));
+    real.verifyTargetGateReceiptFiles = () => ({
+      ...verifiers().verifyTargetGateReceiptFiles(),
+      receipts,
+    });
+
+    expect(() => verifyFinalAcceptance(request(), real)).not.toThrow();
+  });
+
+  it('still rejects a relative claim the absolute evidence file does not end at', () => {
+    // Accepting the resolved form must not accept a DIFFERENT file: the path
+    // still has to be the claimed one, and the digest still binds the bytes.
+    const hostile = verifiers();
+    const receipts = verifiedTargetGateReceipts().map((receipt) => ({
+      ...receipt,
+      evidencePath: `evidence/${receipt.target}/${receipt.gate}.json`,
+      evidenceFile: {
+        path: `/runner/_work/wayland/receipts/evidence/${receipt.target}/somewhere-else.json`,
+        sha256: receipt.evidenceFile.sha256,
+      },
+    }));
+    hostile.verifyTargetGateReceiptFiles = () => ({
+      ...verifiers().verifyTargetGateReceiptFiles(),
+      receipts,
+    });
+
+    expect(() => verifyFinalAcceptance(request(), hostile)).toThrow(/evidence-file-does-not-bind-receipt-claim/);
+  });
+
+  it('names which side failed, so a red release is diagnosable', () => {
+    const hostile = verifiers();
+    const receipts = verifiedTargetGateReceipts().map((receipt) => ({
+      ...receipt,
+      evidencePath: `evidence/${receipt.target}/${receipt.gate}.json`,
+      evidenceFile: {
+        path: `/runner/_work/wayland/receipts/evidence/${receipt.target}/${receipt.gate}.json`,
+        sha256: `sha256:${'e'.repeat(64)}`,
+      },
+    }));
+    hostile.verifyTargetGateReceiptFiles = () => ({
+      ...verifiers().verifyTargetGateReceiptFiles(),
+      receipts,
+    });
+
+    // The old message was a fixed string and could not distinguish a path-form
+    // mismatch from a genuine digest mismatch.
+    expect(() => verifyFinalAcceptance(request(), hostile)).toThrow(/pathBinds=true digestBinds=false/);
+  });
+
   it('rejects a target gate receipt for a stale candidate', () => {
     const hostile = verifiers();
     const receipts = verifiedTargetGateReceipts();


### PR DESCRIPTION
v0.12.12 reached step 21 of 24 in the protected seal, the furthest any release has ever got, and died with M8A_TARGET_GATE_RECEIPT_INVALID:evidence-file-does-not-bind-receipt-claim, after all six builds, both smoke gates, all twelve protected observations and the raw assembler had passed.

The two sides are different encodings of the same value and could never match:

- generateTrustRootAcceptance.js:119 writes evidencePath as a RELATIVE posix path, evidence/TARGET/GATE.json
- verifyHardeningMatrix.js returns evidenceFile.path as an ABSOLUTE native path, path.resolve(receiptsDirectory, evidencePath)

This is the fourth instance of this family in this pipeline, after the sha256-prefix mismatch, the artifact-digest form mismatch, and the platform smoke report filename. Every one sat in code no green run had ever reached.

The digest is the binding and is unchanged. verifyTargetEvidence has already proven this exact file hashes to evidenceSha256 and does not escape the receipt root, so requiring the absolute path to END AT the claimed relative path keeps the claim honest without demanding two incompatible encodings be byte-identical.

The failure message now names which side failed and with what values. The old one was a fixed string, so a red release could not distinguish a path-form mismatch from a genuine digest mismatch without re-running two hours of CI.

Why no test caught it: every fixture in finalAcceptanceController.test.ts sets BOTH evidencePath and evidenceFile.path to the same absolute string, so the equality always held.

Verification: 28 passed. Mutation-proven, restoring the strict compare fails the production-shape test and the diagnosability test. Two further tests prove a non-matching absolute path is still refused and that the digest still binds.