### PR TITLE
fix(release): survive an empty bun audit instead of dying on JSON.parse (v0.12.14)

### DIFF
--- a/.github/workflows/release-acceptance-trust-root.yml
+++ b/.github/workflows/release-acceptance-trust-root.yml
@@ -132,7 +132,29 @@ jobs:
           run_gate typecheck 'bun run typecheck'
           run_gate lint 'bun run lint'
           run_gate build 'bun run build:renderer:web'
-          bun audit --json > "$GATE_OUTPUT/dependency-audit.json" 2> "$GATE_OUTPUT/dependency-audit.stderr" || true
+          # `|| true` is REQUIRED here - `bun audit` exits non-zero whenever it
+          # FINDS advisories, which is the normal case - but it also swallows a
+          # registry 5xx/timeout, and that leaves the file EMPTY. The JSON.parse
+          # below then dies with "Unexpected end of JSON input" and takes down a
+          # 90-minute job for a reason that has nothing to do with the candidate.
+          # That is exactly how v0.12.13 died, after every gate above it had
+          # already passed and the renderer had finished building.
+          #
+          # So: retry like every other network op in this repo, and distinguish
+          # "found advisories, wrote JSON" from "call failed, wrote nothing" by
+          # requiring real bytes. A genuine audit failure still exits non-zero.
+          audit_ok=0
+          for attempt in 1 2 3; do
+            bun audit --json > "$GATE_OUTPUT/dependency-audit.json" 2> "$GATE_OUTPUT/dependency-audit.stderr" || true
+            if [[ -s "$GATE_OUTPUT/dependency-audit.json" ]]; then audit_ok=1; break; fi
+            echo "bun audit produced no output (attempt $attempt of 3); retrying" >&2
+            sleep $(( attempt * 15 ))
+          done
+          if [[ "$audit_ok" -ne 1 ]]; then
+            echo "::error title=dependency audit unavailable::bun audit returned no JSON after 3 attempts" >&2
+            cat "$GATE_OUTPUT/dependency-audit.stderr" >&2 || true
+            exit 1
+          fi
           node -e 'const fs=require("node:fs"); const value=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); if (!value || typeof value!=="object" || Array.isArray(value)) process.exit(1)' \
             "$GATE_OUTPUT/dependency-audit.json"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Wayland",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "The local-first desktop AI agent that drives every AI CLI on your machine - Claude Code, Codex, Gemini and more, on your keys.",
   "keywords": [],
   "license": "AGPL-3.0-or-later",

--- a/tests/integration/process/acp/waylandNanoProductionOwner.test.ts
+++ b/tests/integration/process/acp/waylandNanoProductionOwner.test.ts
@@ -10,6 +10,13 @@ import { promisify } from 'node:util';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import canonicalize from 'canonicalize';
 
+// Every case here builds a real fixture on disk: mkdtemp under LOCALAPPDATA, mode-0700
+// directories, a written executable, a KeyStore create and a BindingStore put, then a
+// recursive rm in teardown. That costs ~0.6s on a warm macOS checkout and comfortably
+// more than the 10s suite default on a windows-2022 runner with a scanner in the path.
+const CASE_TIMEOUT_MS = 60_000;
+const TEARDOWN_TIMEOUT_MS = 60_000;
+
 const connectorMocks = vi.hoisted(() => ({ spawnGenericBackend: vi.fn() }));
 const execFileAsync = promisify(execFile);
 const electronMocks = vi.hoisted(() => ({
@@ -95,15 +102,31 @@ const GRANT: WaylandNanoActivationGrant = Object.freeze({
   validityMs: 300_000,
 });
 
+// Teardown runs every step even if an earlier one throws. A case that times out mid-flight
+// used to abort this hook at the dispose() call, which left the process owner installed and
+// the temp roots on disk, so every later case in the file failed on state it never created.
 afterEach(async () => {
-  await disposeWaylandNanoActivationOwner();
+  const failures: unknown[] = [];
+  const attempt = async (step: () => Promise<unknown>) => {
+    try {
+      await step();
+    } catch (error) {
+      failures.push(error);
+    }
+  };
+
+  await attempt(() => disposeWaylandNanoActivationOwner());
   electronMocks.encryptionAvailable = true;
   electronMocks.backend = 'gnome_libsecret';
   electronMocks.userDataRoot = 'C:/test-user-data';
-  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
-});
+  await Promise.all(roots.splice(0).map((root) => attempt(() => rm(root, { recursive: true, force: true }))));
 
-describe('Wayland Nano production activation owner', () => {
+  if (failures.length > 0) {
+    throw new AggregateError(failures, 'teardown failed after restoring shared state');
+  }
+}, TEARDOWN_TIMEOUT_MS);
+
+describe('Wayland Nano production activation owner', { timeout: CASE_TIMEOUT_MS }, () => {
   it('resolves only an enrolled opaque binding and releases retries only for correlated child receipt metadata', async () => {
     const fixture = await ownerFixture();
     const resolved = await fixture.owner.load(fixture.binding.productSubjectId);


### PR DESCRIPTION
v0.12.13 passed every build, both smoke gates, all twelve protected observations and the raw assembler, then died in the untrusted candidate-gates job with SyntaxError: Unexpected end of JSON input, after the renderer had already finished building.

bun audit --json returned nothing, a registry hiccup, and the JSON.parse on the next line took down a 90-minute job for a reason that has nothing to do with the candidate.

The || true on that call is REQUIRED, because bun audit exits non-zero whenever it finds advisories, which is the normal case. But it also swallows a 5xx or a timeout, and those leave the file EMPTY. Nothing downstream could tell the two apart.

Fix: retry three times with backoff, matching how every other network op in this repo is already wrapped, and require real bytes before parsing. On genuine unavailability it fails with a named error plus the captured stderr instead of a bare stack trace. A real audit failure still exits non-zero.

This was flagged as a latent risk during a review of the never-executed corridor and then hit on the very next run.