### PR TITLE
fix(wcore): retain auto-approved tool details

### DIFF
--- a/src/process/agent/wcore/index.ts
+++ b/src/process/agent/wcore/index.ts
@@ -1614,8 +1614,10 @@ export class WCoreAgent {
         break;
 
       case 'tool_request':
+      case 'call_announced':
         // #520: remember the request-time command so the later running/result
-        // frames (which the wire sends without it) can re-surface it.
+        // frames (which the wire sends without it) can re-surface it. #1189:
+        // auto-approved calls announce the same ToolInfo without a request.
         this.toolDescriptionByCallId.set(event.call_id, event.tool.description);
         // #746: the agent is now waiting — first on the human (this frame renders an
         // approve/deny card) and then on the tool itself. Neither is agent inactivity,
@@ -1628,7 +1630,7 @@ export class WCoreAgent {
               callId: event.call_id,
               name: event.tool.name,
               description: event.tool.description,
-              status: 'Confirming',
+              status: event.type === 'tool_request' ? 'Confirming' : 'Executing',
               renderOutputAsMarkdown: false,
               confirmationDetails: this.mapConfirmationDetails(event),
             },
@@ -2160,7 +2162,10 @@ export class WCoreAgent {
       // WCoreEvent is handled above; this branch only fires at runtime
       // when the engine ships a new variant before this host learns it).
       default: {
-        const unknownEvent = event as { type?: unknown };
+        // Adding a supported union member without handling it must fail tsc.
+        // Truly unknown runtime variants retain the forward-compatible warning.
+        const unhandled: never = event;
+        const unknownEvent = unhandled as { type?: unknown };
         const typeStr = typeof unknownEvent.type === 'string' ? unknownEvent.type : '<non-string>';
         console.warn(`[WCoreAgent] unknown event type "${typeStr}" - dropping`, event);
         break;
@@ -2186,9 +2191,10 @@ export class WCoreAgent {
   }
 
   /**
-   * Map wcore tool_request to wayland confirmation details format.
+   * Retain tool arguments in the existing display/confirmation format. Only a
+   * Confirming card asks for approval; announcements use this for display.
    */
-  private mapConfirmationDetails(event: WCoreEvent & { type: 'tool_request' }) {
+  private mapConfirmationDetails(event: WCoreEvent & { type: 'tool_request' | 'call_announced' }) {
     const { tool } = event;
 
     // #1099: the engine classified a filesystem boundary BEFORE running the

--- a/src/process/agent/wcore/protocol.ts
+++ b/src/process/agent/wcore/protocol.ts
@@ -277,6 +277,13 @@ export type WCoreEvent =
       tool: ToolInfo;
     }
   | {
+      /** Core has already approved this call; the host must not request approval again. */
+      type: 'call_announced';
+      msg_id: string;
+      call_id: string;
+      tool: ToolInfo;
+    }
+  | {
       type: 'tool_running';
       msg_id: string;
       call_id: string;

--- a/src/renderer/pages/conversation/Messages/components/MessageToolGroup.tsx
+++ b/src/renderer/pages/conversation/Messages/components/MessageToolGroup.tsx
@@ -225,18 +225,27 @@ const ConfirmationDetails: React.FC<{
   const [selected, setSelected] = useState<ToolConfirmationOutcome | null>(null);
 
   const isConfirm = content.status === 'Confirming';
+  const completedEditDiff =
+    !isConfirm &&
+    confirmationDetails.type === 'edit' &&
+    typeof content.resultDisplay === 'object' &&
+    content.resultDisplay !== null &&
+    'fileDiff' in content.resultDisplay
+      ? content.resultDisplay
+      : null;
 
   return (
     <div>
       {confirmationDetails.type === 'edit' ? (
         <EditConfirmationDiff
-          diff={confirmationDetails?.fileDiff || ''}
-          fileName={confirmationDetails.fileName}
+          diff={completedEditDiff?.fileDiff || confirmationDetails.fileDiff || ''}
+          fileName={completedEditDiff?.fileName || confirmationDetails.fileName}
           title={isConfirm ? confirmationDetails.title : content.description}
         />
       ) : (
         node
       )}
+      {!isConfirm && content.resultDisplay && !completedEditDiff && <ToolResultDisplay content={content} />}
       {content.status === 'Confirming' && confirmationDetails.type !== 'question' && (
         <>
           <div className='mt-10px text-t-primary'>{question}</div>

--- a/tests/unit/process/agent/wcore/toolCommandVisibility.test.ts
+++ b/tests/unit/process/agent/wcore/toolCommandVisibility.test.ts
@@ -16,9 +16,14 @@
  * per callId and re-attaches it, so the command stays visible for the whole
  * tool lifecycle.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import { WCoreAgent, type WCoreAgentOptions } from '@/process/agent/wcore';
 import type { WCoreEvent } from '@/process/agent/wcore/protocol';
+import { DesktopCoreV1Consumer } from '@/process/agent/wcore/desktopContractV1';
+import { composeMessage, transformMessage, type IMessageToolGroup, type TMessage } from '@/common/chat/chatLib';
+import type { IResponseMessage } from '@/common/adapter/ipcBridge';
 
 type Emitted = { type: string; data?: unknown; msg_id?: string };
 
@@ -92,6 +97,109 @@ describe('#520 wcore tool command visibility', () => {
     feed(request);
     feed(result); // terminal → cache entry for c1 cleared
     feed({ ...running }); // a stray later running frame for the same callId
+    expect(lastToolFrame(emitted).description).toBe('');
+  });
+});
+
+const fixture = (name: string): string =>
+  readFileSync(path.resolve('contracts/wayland-desktop-core/v1/events', `${name}.json`), 'utf8').trim();
+
+function projectedTools(emitted: Emitted[]): IMessageToolGroup['content'] {
+  let messages: TMessage[] = [];
+  for (const event of emitted.filter((entry) => entry.type === 'tool_group')) {
+    messages = composeMessage(
+      transformMessage({ ...event, conversation_id: 'announcement-test' } as IResponseMessage),
+      messages
+    );
+  }
+  // Exercise the stored-message JSON representation, not just a cached agent field.
+  const restored = JSON.parse(JSON.stringify(messages)) as TMessage[];
+  return restored.flatMap((message) => (message.type === 'tool_group' ? message.content : []));
+}
+
+describe('#1189 auto-approved tool announcements', () => {
+  it('decodes the shipped announcement and retains its command through a completed saved card', () => {
+    const { emitted, feed } = makeAgent();
+    const consumer = new DesktopCoreV1Consumer();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      for (const name of ['ready', 'stream_start', 'call_announced']) {
+        for (const decoded of consumer.consumeChunk(`${fixture(name)}\n`)) {
+          if (decoded.kind === 'event') feed(decoded.event);
+        }
+      }
+      feed({ type: 'tool_running', msg_id: 'msg-001', call_id: 'call-tool-002', tool_name: 'Bash' });
+      feed({
+        type: 'tool_result',
+        msg_id: 'msg-001',
+        call_id: 'call-tool-002',
+        tool_name: 'Bash',
+        status: 'success',
+        output: 'tests passed',
+        output_type: 'text',
+      });
+      const tools = projectedTools(emitted);
+      expect(tools).toHaveLength(1);
+      expect(tools[0]).toMatchObject({
+        name: 'Bash',
+        description: 'Run the test suite',
+        status: 'Success',
+        confirmationDetails: { type: 'exec', command: 'cargo test' },
+      });
+      expect(emitted.filter((event) => event.type === 'tool_group').flatMap((event) => event.data)).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ status: 'Confirming' })])
+      );
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('preserves the affected file for an auto-approved edit, without asking for approval', () => {
+    const { emitted, feed } = makeAgent();
+    feed({
+      type: 'call_announced',
+      msg_id: 'm1',
+      call_id: 'edit-1',
+      tool: {
+        name: 'Write',
+        category: 'edit',
+        args: { file_path: '/workspace/report.md' },
+        description: 'Write report',
+      },
+    } as WCoreEvent);
+    feed({ type: 'tool_running', msg_id: 'm1', call_id: 'edit-1', tool_name: 'Write' });
+    feed({
+      type: 'tool_result',
+      msg_id: 'm1',
+      call_id: 'edit-1',
+      tool_name: 'Write',
+      status: 'success',
+      output: 'saved',
+      output_type: 'text',
+    });
+    expect(projectedTools(emitted)[0]).toMatchObject({
+      status: 'Success',
+      description: 'Write report',
+      confirmationDetails: { type: 'edit', fileName: '/workspace/report.md' },
+    });
+  });
+
+  it('keeps concurrent announcements separate and releases the cancelled call cache', () => {
+    const { emitted, feed } = makeAgent();
+    feed({ ...request, type: 'call_announced' } as WCoreEvent);
+    feed({
+      ...request,
+      type: 'call_announced',
+      call_id: 'c2',
+      tool: { ...request.tool, description: 'second command' },
+    } as WCoreEvent);
+    feed({ ...running, call_id: 'c2' });
+    expect(lastToolFrame(emitted).description).toBe('second command');
+    feed(running);
+    expect(lastToolFrame(emitted).description).toBe('Execute: ls -la');
+    feed({ type: 'tool_cancelled', msg_id: 'm1', call_id: 'c1', reason: 'cancelled' });
+    feed(running);
     expect(lastToolFrame(emitted).description).toBe('');
   });
 });

--- a/tests/unit/renderer/conversation/Messages/components/MessageToolGroupPathBoundary.dom.test.tsx
+++ b/tests/unit/renderer/conversation/Messages/components/MessageToolGroupPathBoundary.dom.test.tsx
@@ -44,6 +44,14 @@ vi.mock('@/renderer/pages/conversation/Messages/MessageList', () => ({
   ImagePreviewContext: React.createContext({ inPreviewGroup: false }),
 }));
 
+vi.mock('@renderer/components/Markdown', () => ({
+  default: ({ children }: React.PropsWithChildren) => <pre>{children}</pre>,
+}));
+
+vi.mock('@renderer/components/chat/CollapsibleContent', () => ({
+  default: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+}));
+
 vi.mock('@arco-design/web-react', () => {
   const Radio = ({ value, children }: { value: string; children?: React.ReactNode }) => (
     <label data-testid='confirm-option' data-value={String(value)}>
@@ -133,4 +141,38 @@ describe('#1099 MessageToolGroup never renders a path boundary as an MCP prompt'
     expect(screen.getByText(MCP_LABEL_KEY)).toBeTruthy();
     expect(optionValues()).toEqual(['proceed_once', 'proceed_always_tool', 'proceed_always_server', 'cancel']);
   });
+});
+
+describe('#1189 announced tool cards retain inputs and outcomes', () => {
+  it.each(['Executing', 'Success', 'Error'] as const)(
+    'shows the command and available output for %s without offering approval',
+    (status) => {
+      const message: IMessageToolGroup = {
+        id: 'announcement-message',
+        conversation_id: 'announcement-conversation',
+        type: 'tool_group',
+        content: [
+          {
+            callId: 'announced-call',
+            name: 'Bash',
+            description: 'Run the command',
+            status,
+            renderOutputAsMarkdown: true,
+            resultDisplay: 'captured tool outcome',
+            confirmationDetails: {
+              type: 'exec',
+              title: 'Run the command',
+              command: 'printf reliable',
+              rootCommand: 'printf',
+            },
+          },
+        ],
+      };
+      render(<MessageToolGroup message={message} />);
+      expect(screen.getByText(/printf reliable/)).toBeTruthy();
+      expect(screen.getByText('captured tool outcome')).toBeTruthy();
+      expect(optionValues()).toEqual([]);
+      expect(screen.queryByRole('button', { name: 'messages.confirm' })).toBeNull();
+    }
+  );
 });


### PR DESCRIPTION
## Description

Auto-approved Core tool calls announce their inputs with `call_announced`, which Desktop previously dropped after contract validation. Handle the announcement as an executing tool card, retain its command/file details through completion, and keep results visible alongside those details. No additional approval is requested. The dispatcher now has a compile-time exhaustiveness check for its declared event union.

## Related Issues

- Refs #1189. Issue closure remains a release action.

## Type of Change

- [x] Bug fix

## Testing

- [x] macOS: focused adapter, message-merge and renderer tests; typecheck, lint and local `prek` checks.
- [x] Linux: complete `bun run test` on an isolated Ubuntu 24.04 VM as an unprivileged user: 21,466 Vitest tests passed, 53 skipped; 285 Bun-native tests passed. Typecheck passed.
- [x] Red controls recorded before the fix for missing announcement details and hidden renderer results.
- [x] Tested Git tree `d9f2dc7c3dc94cf162fdca5262b84428e3a6178b` matches the committed tree. Source remained unchanged during the Linux run.
- [x] i18n validation passed with existing warnings; full lint remained at the existing 3,017-warning baseline with zero errors.
- [ ] Windows CI and packaged real-engine verification pending.

## Additional Context

The renderer adjustment prevents retained input details from hiding tool output, including completed edit diffs. The existing path-boundary approval guard remains covered. This draft does not claim native installer, every approval-mode journey, or `/rewind` acceptance.
