### PR TITLE
fix(nano): retain staged image until child exits

### DIFF
--- a/src/process/agent/acp/acpConnectors.ts
+++ b/src/process/agent/acp/acpConnectors.ts
@@ -739,15 +739,48 @@ export async function spawnGenericBackend(
     cleanEnv as Record<string, string>,
     launch
   );
-  const launchChild = (command: string): ChildProcess =>
-    spawn(command, config.args, {
+  const cleanupOwners = new WeakSet<ChildProcess>();
+  const retainStageUntilTerminal = (launched: ChildProcess): void => {
+    if (!verifiedWaylandNanoBinary || cleanupOwners.has(launched)) return;
+    cleanupOwners.add(launched);
+    let cleanupStarted = false;
+    const cleanup = (): void => {
+      if (cleanupStarted) return;
+      cleanupStarted = true;
+      launched.off('exit', cleanup);
+      launched.off('close', cleanup);
+      void verifiedWaylandNanoBinary.cleanupAfterLaunch().catch(async () => {
+        try {
+          await verifiedWaylandNanoBinary.dispose();
+        } catch {
+          console.warn('[ACP] Wayland Nano staged executable cleanup failed after process termination');
+        }
+      });
+    };
+    // A child can also emit error for a failed kill/send while still alive.
+    // Only a spawn failure (no PID) makes error terminal for this purpose.
+    launched.on('error', () => {
+      if (launched.pid === undefined) cleanup();
+    });
+    launched.once('exit', cleanup);
+    launched.once('close', cleanup);
+    if (launched.exitCode !== null || launched.signalCode !== null) cleanup();
+  };
+  const launchChild = (command: string): ChildProcess => {
+    const launched = spawn(command, config.args, {
       ...config.options,
       detached,
     });
+    // Bind before consume awaits closing its verification file handle: a
+    // failed spawn can emit error during that await, before we regain control.
+    retainStageUntilTerminal(launched);
+    return launched;
+  };
   let child: ChildProcess;
   if (verifiedWaylandNanoBinary) {
     try {
       child = await verifiedWaylandNanoBinary.consume((canonicalPath) => launchChild(canonicalPath));
+      retainStageUntilTerminal(child);
     } catch (error) {
       try {
         await verifiedWaylandNanoBinary.dispose();
@@ -756,27 +789,9 @@ export async function spawnGenericBackend(
       }
       throw error;
     }
-    try {
-      await verifiedWaylandNanoBinary.cleanupAfterLaunch();
-    } catch {
-      // The child already owns its executable image. Do not kill or orphan it
-      // merely because post-spawn unlink was transiently denied (notably on
-      // Windows). Retry through dispose now and once more at child exit.
-      const cleaned = await verifiedWaylandNanoBinary
-        .dispose()
-        .then(() => true)
-        .catch(() => false);
-      if (!cleaned) {
-        const cleanupOnExit = () => {
-          void verifiedWaylandNanoBinary.dispose().catch(() => {});
-        };
-        child.once('exit', cleanupOnExit);
-        if (child.exitCode !== null || child.signalCode !== null) {
-          child.off('exit', cleanupOnExit);
-          cleanupOnExit();
-        }
-      }
-    }
+    // Keep the pathname for the whole child lifetime. On macOS, unlinking a
+    // staged signed executable immediately after spawn can trigger SIGKILL
+    // before startup finishes. Windows can keep the image locked until exit.
   } else {
     child = launchChild(config.command);
   }

--- a/src/process/agent/activation/waylandNanoActivationOwner.ts
+++ b/src/process/agent/activation/waylandNanoActivationOwner.ts
@@ -256,7 +256,9 @@ export class WaylandNanoActivationOwner implements WaylandNanoBindingOwner {
     this.#resumeFingerprints.clear();
     const tokens = [...this.#binaryTokens];
     this.#binaryTokens.clear();
-    await Promise.allSettled(tokens.map((token) => token.dispose()));
+    // Launchers own consumed tokens until process termination. Owner shutdown
+    // precedes worker shutdown, so disposing those stages here races live code.
+    await Promise.allSettled(tokens.map((token) => token.disposeIfUnconsumed()));
   }
 
   private continuity(operation: 'new' | 'load', sessionId: string | null) {

--- a/src/process/agent/activation/waylandNanoBinaryVerifier.ts
+++ b/src/process/agent/activation/waylandNanoBinaryVerifier.ts
@@ -93,7 +93,12 @@ export class VerifiedWaylandNanoBinary {
     await this.cleanupAfterLaunch();
   }
 
-  /** Plan 09/15 launch owners call this after the immediate spawn has consumed the staged image. */
+  /** The activation owner may reclaim unused tokens, never a launcher's live stage. */
+  async disposeIfUnconsumed(): Promise<void> {
+    if (!this.#consumed) await this.dispose();
+  }
+
+  /** Launch owners call this only after the child exits or fails to spawn. */
   async cleanupAfterLaunch(): Promise<void> {
     if (!this.#consumed) throw new Error('Wayland Nano staged executable cannot be cleaned before launch');
     if (this.#cleaned) return;

--- a/tests/unit/process/agent/acp/waylandNanoActivationCarrier.test.ts
+++ b/tests/unit/process/agent/acp/waylandNanoActivationCarrier.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'node:events';
+import type { ChildProcess } from 'node:child_process';
 import { copyFile, mkdtemp, realpath, rm, stat, unlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -355,10 +356,135 @@ describe('Wayland Nano legacy activation carrier', () => {
       token
     );
     const exitCode = await new Promise<number | null>((resolve) => result.child.once('exit', resolve));
+    await vi.waitFor(() => expect(dispose).toHaveBeenCalledOnce());
 
     expect(exitCode).toBe(1);
     expect(cleanupAfterLaunch).toHaveBeenCalledOnce();
     expect(dispose).toHaveBeenCalledOnce();
+  });
+
+  it('retains the staged executable until the child exits', async () => {
+    registerPlatformServices(new NodePlatformServices());
+    const child = Object.assign(new EventEmitter(), {
+      pid: 12345,
+      exitCode: null as number | null,
+      signalCode: null,
+      unref: vi.fn(),
+      kill: vi.fn(),
+    }) as unknown as ChildProcess;
+    const cleanupAfterLaunch = vi.fn().mockResolvedValue(undefined);
+    const token = {
+      canonicalPath: process.execPath,
+      consume: async () => child,
+      cleanupAfterLaunch,
+      dispose: vi.fn().mockResolvedValue(undefined),
+    } as unknown as VerifiedWaylandNanoBinary;
+    await spawnGenericBackend(
+      'wnano',
+      process.execPath,
+      process.cwd(),
+      ['acp-host'],
+      { NANO_HOME: path.join(process.cwd(), 'owner-home') },
+      undefined,
+      token
+    );
+    expect(cleanupAfterLaunch).not.toHaveBeenCalled();
+    child.emit('error', new Error('a failed kill does not mean the process exited'));
+    expect(cleanupAfterLaunch).not.toHaveBeenCalled();
+    child.emit('exit', 0, null);
+    child.emit('close', 0, null);
+    await vi.waitFor(() => expect(cleanupAfterLaunch).toHaveBeenCalledOnce());
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it('cleans a failed spawn with no PID even when no exit event follows', async () => {
+    registerPlatformServices(new NodePlatformServices());
+    const child = Object.assign(new EventEmitter(), {
+      pid: undefined,
+      exitCode: null,
+      signalCode: null,
+      unref: vi.fn(),
+    }) as unknown as ChildProcess;
+    const cleanupAfterLaunch = vi.fn().mockResolvedValue(undefined);
+    const token = {
+      canonicalPath: process.execPath,
+      consume: async () => child,
+      cleanupAfterLaunch,
+      dispose: vi.fn().mockResolvedValue(undefined),
+    } as unknown as VerifiedWaylandNanoBinary;
+    await spawnGenericBackend(
+      'wnano',
+      process.execPath,
+      process.cwd(),
+      ['acp-host'],
+      { NANO_HOME: path.join(process.cwd(), 'owner-home') },
+      undefined,
+      token
+    );
+    expect(cleanupAfterLaunch).not.toHaveBeenCalled();
+    child.emit('error', Object.assign(new Error('spawn failed'), { code: 'ENOENT' }));
+    child.emit('close', -2, null);
+    await vi.waitFor(() => expect(cleanupAfterLaunch).toHaveBeenCalledOnce());
+  });
+
+  it('handles a real spawn failure while consume is still releasing its verification handle', async () => {
+    registerPlatformServices(new NodePlatformServices());
+    const root = await mkdtemp(path.join(tmpdir(), 'nano-failed-spawn-'));
+    const cleanupAfterLaunch = vi.fn().mockResolvedValue(undefined);
+    const token = {
+      canonicalPath: path.join(root, 'does-not-exist'),
+      consume: async (launch: (canonicalPath: string) => ChildProcess) => {
+        const child = launch(path.join(root, 'does-not-exist'));
+        // Match consume's async handle-close boundary. The spawn error fires
+        // before its promise resolves, so a listener attached afterward loses it.
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        return child;
+      },
+      cleanupAfterLaunch,
+      dispose: vi.fn().mockResolvedValue(undefined),
+    } as unknown as VerifiedWaylandNanoBinary;
+    try {
+      const result = await spawnGenericBackend(
+        'wnano',
+        token.canonicalPath,
+        root,
+        ['acp-host'],
+        { NANO_HOME: path.join(root, 'owner-home') },
+        undefined,
+        token
+      );
+      expect(result.child.pid).toBeUndefined();
+      await vi.waitFor(() => expect(cleanupAfterLaunch).toHaveBeenCalledOnce());
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('cleans a child already terminal when ownership is attached', async () => {
+    registerPlatformServices(new NodePlatformServices());
+    const child = Object.assign(new EventEmitter(), {
+      pid: 12345,
+      exitCode: 0,
+      signalCode: null,
+      unref: vi.fn(),
+    }) as unknown as ChildProcess;
+    const cleanupAfterLaunch = vi.fn().mockResolvedValue(undefined);
+    const token = {
+      canonicalPath: process.execPath,
+      consume: async () => child,
+      cleanupAfterLaunch,
+      dispose: vi.fn().mockResolvedValue(undefined),
+    } as unknown as VerifiedWaylandNanoBinary;
+    await spawnGenericBackend(
+      'wnano',
+      process.execPath,
+      process.cwd(),
+      ['acp-host'],
+      { NANO_HOME: path.join(process.cwd(), 'owner-home') },
+      undefined,
+      token
+    );
+    await vi.waitFor(() => expect(cleanupAfterLaunch).toHaveBeenCalledOnce());
   });
 
   it('disposes an abandoned staged token when identity consumption refuses launch', async () => {

--- a/tests/unit/process/agent/activation/waylandNanoBinaryVerifier.test.ts
+++ b/tests/unit/process/agent/activation/waylandNanoBinaryVerifier.test.ts
@@ -57,6 +57,24 @@ async function executableFixture() {
 }
 
 describe('Wayland Nano executable identity', () => {
+  it('owner cleanup retains a consumed stage for the launcher terminal cleanup', async () => {
+    const { expectation } = await fixture();
+    const token = await verifyWaylandNanoBinary(expectation);
+    await token.consume(() => undefined);
+    await token.disposeIfUnconsumed();
+    expect(await readFile(token.canonicalPath, 'utf8')).toBe('immutable nano executable');
+    await token.cleanupAfterLaunch();
+    await expect(readFile(token.canonicalPath)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('owner cleanup still removes a token abandoned before launch', async () => {
+    const { expectation } = await fixture();
+    const token = await verifyWaylandNanoBinary(expectation);
+    await token.disposeIfUnconsumed();
+    await expect(readFile(token.canonicalPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(token.consume(() => undefined)).rejects.toThrow('stale');
+  });
+
   it('binds the canonical digest and immutable Nano source/lock identity to one launch', async () => {
     const { binary, expectation } = await fixture();
     const token = await verifyWaylandNanoBinary(expectation);


### PR DESCRIPTION
## Description

Keep Nano's verified staged executable until its child exits or fails to spawn. Immediate post-spawn unlink could kill a macOS child before startup completed. Cleanup now binds before the verification handle is released, retries terminal cleanup without killing the child, and keeps activation-owner shutdown from disposing a stage already owned by a launcher.

## Related Issues

- Refs #1326. Issue closure remains a release action.

## Type of Change

- [x] Bug fix

## Testing

- [x] macOS: 68 targeted tests pass; startup failure, already-exited children, runtime errors, cleanup retries and consumed/unconsumed token ownership covered.
- [x] macOS: real staged-executable test passed five consecutive runs after the launcher repair. Pre-fix early-unlink control reproduced SIGKILL.
- [x] Linux: 21,466 Vitest tests passed, 53 skipped; Bun-native suite passed; typecheck passed. Isolated unprivileged Hetzner account with private mount-namespace `/tmp`.
- [x] Tested source tree `cc3ff61d179d66512b53598e0f913e4ef8ce8cf1` matches the commit; no source drift during the run.
- [ ] Windows CI and native packaged acceptance pending.

## Additional Context

The first Hetzner attempt had incomplete Electron installation and a restricted host `/tmp`; those logs were retained. The successful rerun prepared Electron and isolated temporary storage without changing host permissions. No shared build caches or other lanes' processes were modified.
