### PR TITLE
fix(teams): preserve Gemini model provider provenance

### DIFF
--- a/src/process/team/TeamSessionService.ts
+++ b/src/process/team/TeamSessionService.ts
@@ -44,6 +44,7 @@ import {
 import { TeamExportSchema, type TeamExport } from './importExport/TeamExportSchema';
 import { TeamImportError } from './importExport/errors';
 import { inspectConversationDeletionSchedules } from '@process/services/conversationDeletionSafety';
+import { flattenGeminiModeIds } from '@/common/utils/geminiModes';
 
 /** Bare ids of the native built-in catalog, resolved once on first import. */
 let builtinCatalogBareIds: Set<string> | null = null;
@@ -257,6 +258,9 @@ export class TeamSessionService {
   private async resolveDefaultGeminiModel(): Promise<TProviderWithModel> {
     const savedGeminiModel = await ProcessConfig.get('gemini.defaultModel');
     const configuredProviders = await ProcessConfig.get('model.config');
+    const googleAuthModelIds = flattenGeminiModeIds();
+    const googleAuthModels = new Set(googleAuthModelIds);
+    const googleAuthFallbackModel = googleAuthModelIds[0];
     // #983: `gemini.defaultModel` is state SHARED with plain Gemini chats, and
     // every fallback below walks `model.config` in configuration order. Both
     // reach providers that have nothing to do with the selected backend, so the
@@ -277,24 +281,30 @@ export class TeamSessionService {
       } as TProviderWithModel;
     };
 
-    if (
-      savedGeminiModel &&
-      typeof savedGeminiModel === 'object' &&
-      'id' in savedGeminiModel &&
-      'useModel' in savedGeminiModel
-    ) {
-      if (savedGeminiModel.id === GOOGLE_AUTH_PROVIDER_ID && (await hasGeminiOauthCreds())) {
-        return this.createGoogleAuthGeminiModel(savedGeminiModel.useModel);
+    if (savedGeminiModel && typeof savedGeminiModel === 'object') {
+      const savedProviderId =
+        'id' in savedGeminiModel && typeof savedGeminiModel.id === 'string' ? savedGeminiModel.id : undefined;
+      const savedModelId =
+        'useModel' in savedGeminiModel && typeof savedGeminiModel.useModel === 'string'
+          ? savedGeminiModel.useModel
+          : undefined;
+      if (
+        savedProviderId === GOOGLE_AUTH_PROVIDER_ID &&
+        savedModelId &&
+        googleAuthModels.has(savedModelId) &&
+        (await hasGeminiOauthCreds())
+      ) {
+        return this.createGoogleAuthGeminiModel(savedModelId);
       }
 
       const matchedProvider = providers.find(
         (provider) =>
-          provider.id === savedGeminiModel.id &&
-          provider.model?.includes(savedGeminiModel.useModel) &&
-          usable(provider, savedGeminiModel.useModel)
+          provider.id === savedProviderId &&
+          provider.model?.includes(savedModelId ?? '') &&
+          usable(provider, savedModelId)
       );
-      if (matchedProvider) {
-        return buildProviderModel(matchedProvider, savedGeminiModel.useModel);
+      if (matchedProvider && savedModelId) {
+        return buildProviderModel(matchedProvider, savedModelId);
       }
     }
 
@@ -318,14 +328,11 @@ export class TeamSessionService {
       if (enabledModel) return buildProviderModel(geminiProvider, enabledModel);
     }
 
-    if (await hasGeminiOauthCreds()) {
-      const oauthModel =
-        typeof savedGeminiModel === 'object' && 'useModel' in savedGeminiModel
-          ? savedGeminiModel.useModel
-          : typeof savedGeminiModel === 'string'
-            ? savedGeminiModel
-            : 'gemini-2.0-flash';
-      return this.createGoogleAuthGeminiModel(oauthModel);
+    if ((await hasGeminiOauthCreds()) && googleAuthFallbackModel) {
+      // A rejected saved selection has no authority over Google OAuth. In
+      // particular, never transplant a model from a disabled/removed API
+      // provider onto the OAuth route merely because credentials exist.
+      return this.createGoogleAuthGeminiModel(googleAuthFallbackModel);
     }
 
     const fallbackProvider = providers.find((provider) => provider.model?.some((model) => usable(provider, model)));

--- a/tests/unit/process/team/teamSession-geminiModelPropagation.test.ts
+++ b/tests/unit/process/team/teamSession-geminiModelPropagation.test.ts
@@ -1,0 +1,185 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { TProviderWithModel } from '@/common/config/storage';
+import type { IConversationService } from '@process/services/IConversationService';
+import type { ITeamRepository } from '@process/team/repository/ITeamRepository';
+import type { MailboxMessage, TeamAgent, TeamTask, TTeam } from '@process/team/types';
+
+const { configGet, hasOauth, ipc } = vi.hoisted(() => ({
+  configGet: vi.fn(),
+  hasOauth: vi.fn(),
+  ipc: {
+    team: {
+      agentStatusChanged: { emit: vi.fn() },
+      agentSpawned: { emit: vi.fn() },
+      agentRemoved: { emit: vi.fn() },
+      agentRenamed: { emit: vi.fn() },
+      listChanged: { emit: vi.fn() },
+      mcpStatus: { emit: vi.fn() },
+    },
+  },
+}));
+
+vi.mock('@/common', () => ({ ipcBridge: ipc }));
+vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }));
+vi.mock('@process/utils/initStorage', () => ({
+  ProcessConfig: { get: configGet },
+  getAssistantsDir: () => '/assistants',
+}));
+vi.mock('@process/team/googleAuthCheck', () => ({ hasGeminiOauthCreds: hasOauth }));
+
+import { TeamSessionService } from '@process/team/TeamSessionService';
+
+function makeRepo(): ITeamRepository {
+  const teams = new Map<string, TTeam>();
+  const mailbox = new Map<string, MailboxMessage>();
+  const tasks = new Map<string, TeamTask>();
+  return {
+    create: async (team: TTeam) => {
+      teams.set(team.id, team);
+      return team;
+    },
+    findById: async (id: string) => teams.get(id) ?? null,
+    findAll: async () => [...teams.values()],
+    update: async (id: string, patch: Partial<TTeam>) => {
+      const next = { ...teams.get(id)!, ...patch };
+      teams.set(id, next);
+      return next;
+    },
+    mutateAgents: async (id: string, mutate: (agents: TeamAgent[]) => TeamAgent[] | null) => {
+      const team = teams.get(id);
+      if (!team) return null;
+      const nextAgents = mutate([...team.agents]);
+      if (nextAgents) teams.set(id, { ...team, agents: nextAgents });
+      return teams.get(id)!;
+    },
+    delete: async () => {},
+    deleteMailboxByTeam: async () => {},
+    deleteTasksByTeam: async () => {},
+    writeMessage: async (message: MailboxMessage) => {
+      mailbox.set(message.id, message);
+      return message;
+    },
+    readUnread: async () => [...mailbox.values()].filter((message) => !message.read),
+    readUnreadAndMark: async () => [],
+    markRead: async () => {},
+    getMailboxHistory: async () => [...mailbox.values()],
+    createTask: async (task: TeamTask) => {
+      tasks.set(task.id, task);
+      return task;
+    },
+    findTaskById: async (id: string) => tasks.get(id) ?? null,
+    updateTask: async (id: string, patch: Partial<TeamTask>) => {
+      const next = { ...tasks.get(id)!, ...patch };
+      tasks.set(id, next);
+      return next;
+    },
+    findTasksByTeam: async () => [...tasks.values()],
+    findTasksByOwner: async () => [],
+    deleteTask: async () => {},
+    appendToBlocks: async () => {},
+    removeFromBlockedBy: async () => undefined as never,
+    appendEvent: async () => undefined,
+    findEventsByTeam: async () => [],
+  } as unknown as ITeamRepository;
+}
+
+const roster = (): TeamAgent[] =>
+  ['Lead', 'Builder', 'Reviewer'].map((agentName, index) => ({
+    slotId: '',
+    conversationId: '',
+    role: index === 0 ? ('leader' as const) : ('teammate' as const),
+    agentType: 'gemini',
+    agentName,
+    conversationType: 'gemini' as const,
+    status: 'pending' as const,
+  }));
+
+const services: TeamSessionService[] = [];
+
+afterEach(async () => {
+  await Promise.all(services.splice(0).map((service) => service.stopAllSessions()));
+});
+
+describe('Gemini Team default pair propagates from creation to worker construction (#983)', () => {
+  it('keeps one supported OAuth pair for all three members after rejecting a disabled Kimi default', async () => {
+    hasOauth.mockResolvedValue(true);
+    configGet.mockImplementation((key: string) => {
+      if (key === 'gemini.defaultModel') {
+        return Promise.resolve({ id: 'moonshot', useModel: 'kimi-k2.7-code' });
+      }
+      if (key === 'model.config') {
+        return Promise.resolve([
+          {
+            id: 'moonshot',
+            name: 'Moonshot',
+            platform: 'openai-compatible',
+            baseUrl: 'https://rejected.invalid',
+            apiKey: 'fake-rejected-key',
+            enabled: true,
+            model: ['kimi-k2.7-code'],
+            modelEnabled: { 'kimi-k2.7-code': false },
+          },
+        ]);
+      }
+      return Promise.resolve(undefined);
+    });
+
+    const repo = makeRepo();
+    const conversations = new Map<string, { id: string; model: TProviderWithModel; extra: Record<string, unknown> }>();
+    let nextConversation = 0;
+    const conversationService = {
+      createConversation: vi.fn(async (params: { model: TProviderWithModel; extra?: Record<string, unknown> }) => {
+        const conversation = {
+          id: `conversation-${++nextConversation}`,
+          model: params.model,
+          extra: { ...params.extra },
+        };
+        conversations.set(conversation.id, conversation);
+        return conversation;
+      }),
+      updateConversation: vi.fn(async (id: string, patch: { extra?: Record<string, unknown> }) => {
+        Object.assign(conversations.get(id)?.extra ?? {}, patch.extra ?? {});
+      }),
+      getConversation: vi.fn(async (id: string) => conversations.get(id)),
+      deleteConversation: vi.fn(),
+      createWithMigration: vi.fn(),
+      listAllConversations: vi.fn(async () => []),
+    } as unknown as IConversationService;
+    const workerPairs: TProviderWithModel[] = [];
+    const workerTaskManager = {
+      getOrBuildTask: vi.fn(async (conversationId: string) => {
+        workerPairs.push(conversations.get(conversationId)!.model);
+        return { sendMessage: vi.fn() };
+      }),
+      kill: vi.fn(),
+    };
+    const service = new TeamSessionService(repo, workerTaskManager as never, conversationService);
+    services.push(service);
+
+    const team = await service.createTeam({
+      userId: 'user-1',
+      name: 'OAuth provenance',
+      workspace: '/tmp/team-oauth-provenance',
+      workspaceMode: 'shared',
+      agents: roster(),
+    });
+    await service.getOrStartSession(team.id);
+
+    const createdPairs = [...conversations.values()].map(({ model }) => model);
+    expect(createdPairs).toHaveLength(3);
+    expect(workerPairs).toHaveLength(3);
+    for (const pair of [...createdPairs, ...workerPairs]) {
+      expect(pair.id).toBe('google-auth-gemini');
+      expect(pair.platform).toBe('gemini-with-google-auth');
+      expect(pair.useModel).toBe('auto');
+      expect(pair.baseUrl).toBe('');
+      expect(pair.apiKey).toBe('');
+    }
+  });
+});

--- a/tests/unit/process/team/teamSession-resolveDefaultGeminiModel.test.ts
+++ b/tests/unit/process/team/teamSession-resolveDefaultGeminiModel.test.ts
@@ -54,6 +54,7 @@ import { TeamSessionService } from '@process/team/TeamSessionService';
 import type { ITeamRepository } from '@process/team/repository/ITeamRepository';
 import type { IConversationService } from '@process/services/IConversationService';
 import type { IProvider, TProviderWithModel } from '@/common/config/storage';
+import { flattenGeminiModeIds } from '@/common/utils/geminiModes';
 
 function makeRepo(): ITeamRepository {
   return {
@@ -257,5 +258,61 @@ describe('TeamSessionService gemini default model is constrained by the backend 
     const model = await geminiDefault();
     expect(model.id).toBe('google-auth-gemini');
     expect(model.useModel).toBe('gemini-2.5-flash');
+  });
+
+  it('#983: does not rebind a rejected saved API model onto Google OAuth', async () => {
+    mockHasOauth.mockResolvedValue(true);
+    config({
+      modelConfig: [MOONSHOT],
+      geminiDefault: { id: 'moonshot', useModel: 'kimi-k2.7-code' },
+    });
+
+    const model = await geminiDefault();
+
+    expect(model.id).toBe('google-auth-gemini');
+    expect(model.useModel).not.toBe('kimi-k2.7-code');
+    expect(flattenGeminiModeIds()).toContain(model.useModel);
+  });
+
+  it('does not reuse a removed provider model or legacy string as an OAuth model', async () => {
+    mockHasOauth.mockResolvedValue(true);
+    config({ modelConfig: [], geminiDefault: { id: 'removed-provider', useModel: 'kimi-k2.7-code' } });
+    const removed = await geminiDefault();
+
+    config({ modelConfig: [], geminiDefault: 'kimi-k2.7-code' });
+    const legacy = await geminiDefault();
+
+    expect(removed.id).toBe('google-auth-gemini');
+    expect(legacy.id).toBe('google-auth-gemini');
+    expect(removed.useModel).not.toBe('kimi-k2.7-code');
+    expect(legacy.useModel).not.toBe('kimi-k2.7-code');
+    expect(flattenGeminiModeIds()).toContain(removed.useModel);
+    expect(flattenGeminiModeIds()).toContain(legacy.useModel);
+  });
+
+  it('keeps an enabled API-provider Kimi selection even when OAuth is also available', async () => {
+    mockHasOauth.mockResolvedValue(true);
+    config({
+      modelConfig: [MOONSHOT],
+      geminiDefault: { id: 'moonshot', useModel: 'kimi-k3' },
+    });
+
+    const model = await geminiDefault();
+
+    expect(model.id).toBe('moonshot');
+    expect(model.platform).toBe('openai-compatible');
+    expect(model.useModel).toBe('kimi-k3');
+  });
+
+  it('falls back safely for malformed saved values without carrying their fields into OAuth', async () => {
+    mockHasOauth.mockResolvedValue(true);
+    config({ modelConfig: [], geminiDefault: { id: 'moonshot', useModel: null, baseUrl: 'https://rejected' } });
+
+    const model = await geminiDefault();
+
+    expect(model.id).toBe('google-auth-gemini');
+    expect(model.baseUrl).toBe('');
+    expect(model.apiKey).toBe('');
+    expect(flattenGeminiModeIds()).toContain(model.useModel);
   });
 });


### PR DESCRIPTION
A rejected Gemini Team default could be rebound to Google OAuth with the rejected model ID. For example, disabled `moonshot/kimi-k2.7-code` resolved as `google-auth-gemini + kimi-k2.7-code` whenever OAuth credentials existed.

This change retains supported explicit Google OAuth selections, keeps valid enabled API selections on their owning provider, and routes rejected object/string defaults to the existing shared Gemini `auto` mode without carrying the rejected provider key or base URL. A three-member fixture covers conversation persistence and worker construction.

Validation:

- ASTRA bounded adversarial audit
- typecheck, focused provider/team/lifecycle tests, and prek
- Linux pairing fixture
- full Linux aggregate: 21,519 Vitest passed / 53 skipped and 285 Bun tests passed

Live Google OAuth provider acceptance was unavailable on the verification machine and remains unverified. No release or issue closure is included.

Refs #983
