### PR TITLE
fix(desktop): restore bundled TC-TIDE workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ jspm_packages/
 
 # Lock files for other package managers (project uses bun.lock)
 package-lock.json
+!scripts/tvcontrol/package-lock.json
 yarn.lock
 
 # TypeScript v1 declaration files
@@ -211,6 +212,7 @@ resources/bundled-bun
 resources/bundled-wayland-core
 resources/bundled-wayland-nano
 resources/bundled-officecli
+resources/bundled-tvcontrol
 resources/bundled-constitution-fs
 resources/hub
 resources/voice-models

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the Wayland Electron app are documented in this file. For
 
 ## [Unreleased]
 
+## [0.12.16] - 2026-09-07
+
+### Fixed
+
+- Preserve the first chat message while recovery state loads, without sending it twice.
+- Keep newer turn activity when delayed status responses arrive after navigation, so completed turns stay idle and active turns stay busy.
+- Bundle TVControl **2.4.7** and provision it for sandboxed collector scripts, including the temporary directory confirmed by the engine.
+
 ## [0.12.2] - 2026-08-19
 
 Two bugs that made a fully configured install look broken, and the engine everyone is already running.

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -128,6 +128,12 @@ extraResources:
     to: app.png
   - from: resources/bundled-bun
     to: bundled-bun
+  # Frozen TVControl dependency tree. Dedicated node_modules matcher prevents
+  # electron-builder's automatic production-dependency filtering of nested roots.
+  - from: resources/bundled-tvcontrol/node_modules
+    to: bundled-tvcontrol/node_modules
+    filter:
+      - '**/*'
   # wayland-core engine binary (pre-compiled per platform/arch)
   - from: resources/bundled-wayland-core
     to: bundled-wayland-core

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Wayland",
-  "version": "0.12.15",
+  "version": "0.12.16",
   "description": "The local-first desktop AI agent that drives every AI CLI on your machine - Claude Code, Codex, Gemini and more, on your keys.",
   "keywords": [],
   "license": "AGPL-3.0-or-later",

--- a/scripts/build-with-builder.js
+++ b/scripts/build-with-builder.js
@@ -18,6 +18,7 @@ const prepareBundledBun = require('./prepareBundledBun');
 const prepareWaylandCore = require('./prepareWaylandCore');
 const prepareWaylandNano = require('./prepareWaylandNano');
 const prepareOfficeCli = require('./prepareOfficeCli');
+const prepareTvControl = require('./prepareTvControl');
 const {
   signDarwinStagedBinary,
   resolveDarwinSigningIdentity,
@@ -868,6 +869,7 @@ try {
   const bunPlatform = packagePlatforms[0];
   const bunArch = packageArchitectures[0];
   const bunRuntimeAvailable = prepareBundledBun.isSupportedBunTarget(bunPlatform, bunArch);
+  prepareTvControl();
   if (bunRuntimeAvailable) {
     prepareBundledBun({ platform: bunPlatform, arch: bunArch });
   } else {

--- a/scripts/prepareTvControl.js
+++ b/scripts/prepareTvControl.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+'use strict';
+
+// Install only the committed lock's integrity-checked archives. No dependency
+// lifecycle scripts or global cache lookup forms part of the shipped runtime.
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const crypto = require('node:crypto');
+const { execFileSync } = require('node:child_process');
+const authority = require('./tvcontrol/authority.json');
+
+function treeDigest(root) {
+  const entries = [];
+  function visit(dir, prefix) {
+    if (!fs.lstatSync(dir).isDirectory()) throw new Error('TVControl directory is not a real directory');
+    for (const name of fs.readdirSync(dir).sort()) {
+      const file = path.join(dir, name);
+      const rel = prefix ? `${prefix}/${name}` : name;
+      const stat = fs.lstatSync(file);
+      if (stat.isDirectory()) visit(file, rel);
+      else if (stat.isFile())
+        entries.push([rel, crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex')]);
+      else throw new Error(`TVControl contains a non-regular entry: ${rel}`);
+    }
+  }
+  visit(root, '');
+  return crypto.createHash('sha256').update(JSON.stringify(entries)).digest('hex');
+}
+
+function verifyTvControl(root, expected = authority) {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(root, 'node_modules/@ferroxlabs/tvcontrol/package.json'), 'utf8'));
+    return (
+      pkg.name === '@ferroxlabs/tvcontrol' &&
+      pkg.version === expected.version &&
+      treeDigest(path.join(root, 'node_modules')) === expected.treeSha256
+    );
+  } catch {
+    return false;
+  }
+}
+
+function prepareTvControl() {
+  const output = path.resolve(__dirname, '../resources/bundled-tvcontrol');
+  if (verifyTvControl(output)) return output;
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'wayland-tvcontrol-'));
+  try {
+    for (const name of ['package.json', 'package-lock.json'])
+      fs.copyFileSync(path.join(__dirname, 'tvcontrol', name), path.join(temp, name));
+    execFileSync(
+      process.platform === 'win32' ? 'npm.cmd' : 'npm',
+      ['ci', '--ignore-scripts', '--bin-links=false', '--omit=dev', '--no-audit', '--no-fund'],
+      { cwd: temp, stdio: 'inherit', shell: process.platform === 'win32' }
+    );
+    // npm's install receipt contains platform-specific bookkeeping, not code.
+    fs.rmSync(path.join(temp, 'node_modules/.package-lock.json'), { force: true });
+    if (!verifyTvControl(temp)) throw new Error('TVControl 2.4.7 dependency tree differs from the pinned authority');
+    if (fs.existsSync(output))
+      throw new Error('Invalid existing TVControl staging directory; preserve it before restaging');
+    fs.mkdirSync(output, { recursive: true });
+    fs.cpSync(path.join(temp, 'node_modules'), path.join(output, 'node_modules'), { recursive: true });
+    if (!verifyTvControl(output)) throw new Error('TVControl staging verification failed');
+    return output;
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+}
+
+module.exports = prepareTvControl;
+module.exports.treeDigest = treeDigest;
+module.exports.verifyTvControl = verifyTvControl;
+if (require.main === module) prepareTvControl();

--- a/scripts/tvcontrol/authority.json
+++ b/scripts/tvcontrol/authority.json
@@ -1,0 +1,4 @@
+{
+  "version": "2.4.7",
+  "treeSha256": "cd628dd4067225cb3f0a20146ff2c6f8b2ceb1c005406ce30454d2d072892ed7"
+}

--- a/scripts/tvcontrol/package-lock.json
+++ b/scripts/tvcontrol/package-lock.json
@@ -1,0 +1,1256 @@
+{
+  "name": "wayland-bundled-tvcontrol",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "wayland-bundled-tvcontrol",
+      "version": "1.0.0",
+      "dependencies": {
+        "@ferroxlabs/tvcontrol": "2.4.7"
+      }
+    },
+    "node_modules/@ferroxlabs/tvcontrol": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@ferroxlabs/tvcontrol/-/tvcontrol-2.4.7.tgz",
+      "integrity": "sha512-5GFu5zApaz6xHj8Mldp98skSD6ofZ3WWIwO+Be+UhL6gRsQDhl+b+fekwSkMod4UinmR/qDeT1XStRWPIMTfrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "1.29.0",
+        "chrome-remote-interface": "0.34.0",
+        "zod": "4.3.6"
+      },
+      "bin": {
+        "tv": "src/cli/index.js",
+        "tvcontrol": "src/server.js"
+      },
+      "engines": {
+        "node": ">=18.14.1"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chrome-remote-interface": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.34.0.tgz",
+      "integrity": "sha512-rTTcTZ3zemx8I+nvBii7d8BAF0Ms8LLEroypfvwwZOwSpyNGLE28nStXyCA6VwGp2YSQfmCrQH21F/E+oBFvMw==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "2.11.x",
+        "ws": "^7.2.0"
+      },
+      "bin": {
+        "chrome-remote-interface": "bin/client.js"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
+      "integrity": "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.12",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.12.tgz",
+      "integrity": "sha512-9NiFmJEex0sy2Dk58j2UGBSHgUs2ypF9eZSu4L6vjOX3Dp96Sw1F3uL+H+D1sx02jZZdzUT0HgvCy59CuvXcWw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/negotiator/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/scripts/tvcontrol/package.json
+++ b/scripts/tvcontrol/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "wayland-bundled-tvcontrol",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "@ferroxlabs/tvcontrol": "2.4.7"
+  }
+}

--- a/scripts/verify-packaged-resources.js
+++ b/scripts/verify-packaged-resources.js
@@ -25,6 +25,7 @@
 'use strict';
 
 const fs = require('fs');
+const { verifyTvControl } = require('./prepareTvControl');
 const path = require('path');
 const crypto = require('crypto');
 const { execFileSync } = require('child_process');
@@ -57,6 +58,7 @@ const REQUIRED = [
   { rel: 'bundled-wayland-core', critical: true, kind: 'wcore-bundle' },
   { rel: 'bundled-wayland-nano', critical: true, kind: 'wnano-bundle', absentWhen: 'noWNanoRuntime' },
   { rel: 'bundled-officecli', critical: true, kind: 'officecli-bundle' },
+  { rel: 'bundled-tvcontrol', critical: true, kind: 'tvcontrol-bundle' },
   {
     rel: 'managed-cli-shims/officecli',
     critical: true,
@@ -1394,7 +1396,8 @@ function isNonEmpty(
   wnanoAuthority = prepareWaylandNano,
   wnanoPolicySelector = selectPolicy,
   darwinSignedCheck = isDarwinDeveloperIdSigned,
-  requireDarwinSignature = false
+  requireDarwinSignature = false,
+  tvControlAuthority
 ) {
   // Per-resource, NOT cumulative. `hub` is optional and absent on every build, so
   // its stat throws and left a `threw: ENOENT ... resources\hub` line sitting in
@@ -1418,6 +1421,7 @@ function isNonEmpty(
       return true;
     }
     if (!st.isDirectory()) return false;
+    if (kind === 'tvcontrol-bundle') return verifyTvControl(p, tvControlAuthority);
     if (kind === 'wcore-bundle') {
       return verifyWCoreBundle(p, requiredWCoreRuntimes, wcoreAuthority, darwinSignedCheck, requireDarwinSignature);
     }
@@ -1706,7 +1710,8 @@ function verifyPackagedResources(options = {}) {
         wnanoAuthority,
         wnanoPolicySelector,
         darwinSignedCheck,
-        requireDarwinSignature
+        requireDarwinSignature,
+        options.tvControlAuthority
       );
       if (ok) {
         logger.log(`${TAG}   OK   ${req.rel}`);

--- a/src/process/agent/wcore/envBuilder.ts
+++ b/src/process/agent/wcore/envBuilder.ts
@@ -1114,6 +1114,7 @@ export function buildOutputDirective(absoluteOutputDir: string, opts?: { ephemer
 }
 
 export function buildEngineSpawnEnv(opts: {
+  managedTempDir?: string;
   providerEnv: Record<string, string>;
   toolKeys?: Record<string, string>;
   waylandHome?: string;
@@ -1258,6 +1259,18 @@ export function buildEngineSpawnEnv(opts: {
   // which is exactly what P2-10 forbids. Bundled skills already `mkdir -p`.
   if (opts.workspace) {
     out.WAYLAND_OUTPUT_DIR = resolveOutputDir(opts.workspace, opts.outputDir, opts.conversationId);
+  }
+
+  if (opts.managedTempDir) {
+    if (!opts.workspace) throw new Error('Managed connector temp directory requires a workspace');
+    const workspace = realpathSync(opts.workspace);
+    const temp = realpathSync(opts.managedTempDir);
+    if (temp !== path.join(workspace, '.wayland-runtime', 'tmp')) {
+      throw new Error('Managed connector temp directory must remain inside its workspace');
+    }
+    out.TMPDIR = temp;
+    out.TMP = temp;
+    out.TEMP = temp;
   }
 
   return out;

--- a/src/process/agent/wcore/index.ts
+++ b/src/process/agent/wcore/index.ts
@@ -10,6 +10,7 @@ import { chmodSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync 
 import { tmpdir } from 'node:os';
 import { basename, dirname, isAbsolute, join, resolve as resolvePath } from 'node:path';
 import type { LiveFolderGrant } from '@/common/workspace/folderGrants';
+import { provisionTvControlForWorkspacePolicy } from '@process/services/mcpServices/bundledTvControl';
 import type { FolderGrantSessionView } from '@/common/workspace/folderGrantsIpc';
 import { isWithin } from '@process/services/workspace/folderGrantRoots';
 import { MAX_FOLDER_GRANTS_PER_WORKSPACE } from '@process/services/workspace/folderGrantStore';
@@ -571,6 +572,8 @@ export class WCoreAgent {
    * is host-authored: this is stored exactly as received.
    */
   private lastWorkspacePolicy: WCoreWorkspacePolicy | null = null;
+  private tvControlScratchReady = false;
+  private tvControlScratchError: Error | null = null;
   /** Resolvers waiting for the NEXT receipt. Drained and cleared on arrival. */
   private workspacePolicyWaiters: Array<(policy: WCoreWorkspacePolicy) => void> = [];
   private readonly pathGrantSessionId = randomUUID();
@@ -1473,6 +1476,7 @@ export class WCoreAgent {
     // Own the first idle command phase: no MCP/history/heartbeat/message may
     // precede the grant response tail and its single ping/pong barrier.
     await this.replayStartupPathGrants();
+    await this.ensureTvControlScratchReady();
     if (this.disposed || this.startupPathReplayCancelled || !this.transportAlive || !this.ownsStartupPathSession()) {
       throw new Error('Wayland Core startup folder replay lost session ownership');
     }
@@ -1611,6 +1615,8 @@ export class WCoreAgent {
       this.pathGrantApplications.set(grant.grantId, { grantId: grant.grantId, root: grant.root, status: 'pending' });
     }
     this.ready = false;
+    this.tvControlScratchReady = false;
+    this.tvControlScratchError = null;
     this.recoverySupported = false;
     this.readyPromise = new Promise((resolve, reject) => {
       this.readyResolve = resolve;
@@ -1981,6 +1987,23 @@ export class WCoreAgent {
       // A receipt carries authority, but only the batch pong completes its
       // ordered response tail. A matching typed refusal takes precedence.
       case 'workspace_policy':
+        if (this.options.managedTempDir) {
+          try {
+            provisionTvControlForWorkspacePolicy(
+              this.options.workspace,
+              this.options.managedTempDir,
+              event.policy.writable_roots
+            );
+            this.tvControlScratchReady = true;
+            this.tvControlScratchError = null;
+          } catch (error) {
+            this.tvControlScratchReady = false;
+            this.tvControlScratchError = new Error(
+              `TVControl 2.4.7 could not be prepared for this session: ${error instanceof Error ? error.message : String(error)}. Reopen the conversation after checking the bundled connector.`
+            );
+            console.warn('[WCoreAgent]', this.tvControlScratchError.message);
+          }
+        }
         this.lastWorkspacePolicy = event.policy;
         if (this.startupPathBatch) this.startupPathBatch.policy = event.policy;
         this.resolveWorkspacePolicyWaiters(event.policy);
@@ -2601,6 +2624,7 @@ export class WCoreAgent {
 
   async send(content: string, msgId: string, files?: string[]): Promise<void> {
     await this.readyPromise;
+    await this.ensureTvControlScratchReady();
     // A retained child after root exit is shutdown authority, not a live
     // transport. Reject before publishing turn identity or arming the watchdog
     // so a write to dead stdin cannot become a silent ten-minute stall.
@@ -2867,6 +2891,19 @@ export class WCoreAgent {
     const receipt = this.awaitNextWorkspacePolicy(timeoutMs);
     this.sendCommand({ type: 'revoke_path', grant_id: grantId });
     return receipt;
+  }
+
+  private async ensureTvControlScratchReady(): Promise<void> {
+    if (!this.options.managedTempDir) return;
+    if (!this.tvControlScratchReady && !this.tvControlScratchError) {
+      await this.awaitNextWorkspacePolicy(WORKSPACE_POLICY_RECEIPT_TIMEOUT_MS);
+    }
+    if (this.tvControlScratchError) throw this.tvControlScratchError;
+    if (!this.tvControlScratchReady) {
+      throw new Error(
+        'TVControl 2.4.7 is waiting for Core to report its writable scratch directory. Reopen the conversation; no collector command was sent.'
+      );
+    }
   }
 
   private awaitNextWorkspacePolicy(timeoutMs: number): Promise<WCoreWorkspacePolicy | null> {

--- a/src/process/agent/wcore/index.ts
+++ b/src/process/agent/wcore/index.ts
@@ -417,6 +417,7 @@ export type WCoreAgentOptions = {
    */
   managedWorkRoot?: string;
   /** True when the user picked this workspace directory themselves. Never trusted. */
+  managedTempDir?: string;
   customWorkspace?: boolean;
   /** Set when this chat belongs to a project (#455), i.e. the user's own tree. Never trusted. */
   projectId?: string;
@@ -1086,6 +1087,7 @@ export class WCoreAgent {
     try {
       this.childProcess = spawn(binaryPath, args, {
         env: buildEngineSpawnEnv({
+          managedTempDir: this.options.managedTempDir,
           providerEnv,
           toolKeys,
           waylandHome,

--- a/src/process/services/mcpServices/builtinMcpRuntime.ts
+++ b/src/process/services/mcpServices/builtinMcpRuntime.ts
@@ -50,6 +50,7 @@ import { isBuiltinCoreMcpArg, isOwnBuiltinWaylandMcpScript } from '@process/reso
 import { getMcpScriptPath } from '@process/utils/mcpScriptDir';
 import { resolveJsRuntime, type ResolvedJsRuntime } from '@process/utils/jsRuntime';
 import { resolveMcpStdioSpawn } from './mcpStdioSpawn';
+import { isBundledTvControlDeclaration, resolveBundledTvControlEntry } from './bundledTvControl';
 
 /** A spawnable stdio tuple. `env` is ADDITIVE runtime env, not the server's own. */
 export interface McpStdioSpawnTuple {
@@ -60,6 +61,7 @@ export interface McpStdioSpawnTuple {
 }
 
 export interface BuiltinMcpRuntimeDeps {
+  tvControlEntry?: () => string;
   resolveRuntime?: () => ResolvedJsRuntime;
   scriptPath?: (name: string) => string;
   platform?: NodeJS.Platform;
@@ -115,6 +117,14 @@ export function resolveBuiltinMcpRuntimeSpawn(
   args: readonly string[] = [],
   deps: BuiltinMcpRuntimeDeps = {}
 ): McpStdioSpawnTuple | null {
+  if (isBundledTvControlDeclaration(command, args, deps.libraryEntryId)) {
+    const runtime = (deps.resolveRuntime ?? resolveJsRuntime)();
+    return {
+      command: runtime.command,
+      args: [(deps.tvControlEntry ?? resolveBundledTvControlEntry)()],
+      env: { ...runtime.env },
+    };
+  }
   if (command !== 'node') return null;
   const rawArgs = [...args];
   const first = rawArgs[0];

--- a/src/process/services/mcpServices/bundledTvControl.ts
+++ b/src/process/services/mcpServices/bundledTvControl.ts
@@ -1,0 +1,104 @@
+import { createHash, randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { app } from 'electron';
+import authority from '../../../../scripts/tvcontrol/authority.json';
+
+export const TVCONTROL_VERSION = authority.version;
+export const TVCONTROL_CATALOG_ID = 'com.ferroxlabs/tvcontrol';
+
+/** Only the catalog's exact managed declaration is eligible for replacement. */
+export function isBundledTvControlDeclaration(
+  command: string,
+  args: readonly string[],
+  libraryEntryId?: string
+): boolean {
+  return (
+    libraryEntryId === TVCONTROL_CATALOG_ID &&
+    command === 'npx' &&
+    (args.length === 1 || (args.length === 2 && args[0] === '-y')) &&
+    args.at(-1) === `@ferroxlabs/tvcontrol@${TVCONTROL_VERSION}`
+  );
+}
+
+// Same byte contract as scripts/prepareTvControl.js. The authority is compiled
+// into Desktop, not read from the mutable workspace alongside the connector.
+export function verifyTvControlTree(root: string, expectedDigest = authority.treeSha256): boolean {
+  try {
+    const entries: [string, string][] = [];
+    const visit = (dir: string, prefix: string): void => {
+      if (!fs.lstatSync(dir).isDirectory()) throw new Error('Not a real directory');
+      for (const name of fs.readdirSync(dir).sort()) {
+        const file = path.join(dir, name);
+        const rel = prefix ? `${prefix}/${name}` : name;
+        const stat = fs.lstatSync(file);
+        if (stat.isDirectory()) visit(file, rel);
+        else if (stat.isFile()) entries.push([rel, createHash('sha256').update(fs.readFileSync(file)).digest('hex')]);
+        else throw new Error('Non-regular connector entry');
+      }
+    };
+    visit(path.join(root, 'node_modules'), '');
+    const pkg = JSON.parse(fs.readFileSync(path.join(root, 'node_modules/@ferroxlabs/tvcontrol/package.json'), 'utf8'));
+    return (
+      pkg.name === '@ferroxlabs/tvcontrol' &&
+      pkg.version === TVCONTROL_VERSION &&
+      createHash('sha256').update(JSON.stringify(entries)).digest('hex') === expectedDigest
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function bundledTvControlRoot(): string {
+  return path.join(
+    app.isPackaged ? process.resourcesPath : path.join(app.getAppPath(), 'resources'),
+    'bundled-tvcontrol'
+  );
+}
+
+export function resolveBundledTvControlEntry(root = bundledTvControlRoot()): string {
+  if (!verifyTvControlTree(root))
+    throw new Error('Bundled TVControl 2.4.7 is missing or failed integrity verification');
+  return path.join(root, 'node_modules/@ferroxlabs/tvcontrol/src/server.js');
+}
+
+/**
+ * The collector already discovers bunx packages under TMPDIR. Give this session
+ * its own real temp directory and a verified package there; no external grant,
+ * HOME change, symlink, global install, or executable skill-tree copy is needed.
+ */
+export function provisionWorkspaceTvControl(workspace: string, source = bundledTvControlRoot()): string {
+  resolveBundledTvControlEntry(source);
+  const canonicalWorkspace = fs.realpathSync(workspace);
+  let current = canonicalWorkspace;
+  for (const part of ['.wayland-runtime', 'tmp']) {
+    current = path.join(current, part);
+    try {
+      fs.mkdirSync(current);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+    }
+    if (!fs.lstatSync(current).isDirectory() || fs.realpathSync(current) !== current) {
+      throw new Error('TVControl workspace runtime must remain inside the workspace');
+    }
+  }
+  const target = path.join(current, `bunx-wayland-tvcontrol-${TVCONTROL_VERSION}`);
+  if (fs.existsSync(target)) {
+    if (!fs.lstatSync(target).isDirectory() || !verifyTvControlTree(target))
+      throw new Error('Existing workspace TVControl failed integrity verification');
+    return current;
+  }
+  const staging = path.join(current, `.tvcontrol-${randomUUID()}`);
+  try {
+    fs.mkdirSync(staging);
+    fs.cpSync(path.join(source, 'node_modules'), path.join(staging, 'node_modules'), {
+      recursive: true,
+      dereference: false,
+    });
+    if (!verifyTvControlTree(staging)) throw new Error('Workspace TVControl copy failed integrity verification');
+    fs.renameSync(staging, target);
+  } finally {
+    fs.rmSync(staging, { recursive: true, force: true });
+  }
+  return current;
+}

--- a/src/process/services/mcpServices/bundledTvControl.ts
+++ b/src/process/services/mcpServices/bundledTvControl.ts
@@ -82,11 +82,16 @@ export function provisionWorkspaceTvControl(workspace: string, source = bundledT
       throw new Error('TVControl workspace runtime must remain inside the workspace');
     }
   }
+  copyTvControlToTempRoot(current, source);
+  return current;
+}
+
+function copyTvControlToTempRoot(current: string, source: string): void {
   const target = path.join(current, `bunx-wayland-tvcontrol-${TVCONTROL_VERSION}`);
   if (fs.existsSync(target)) {
     if (!fs.lstatSync(target).isDirectory() || !verifyTvControlTree(target))
       throw new Error('Existing workspace TVControl failed integrity verification');
-    return current;
+    return;
   }
   const staging = path.join(current, `.tvcontrol-${randomUUID()}`);
   try {
@@ -100,5 +105,43 @@ export function provisionWorkspaceTvControl(workspace: string, source = bundledT
   } finally {
     fs.rmSync(staging, { recursive: true, force: true });
   }
-  return current;
+}
+
+/**
+ * Core 0.13.12 (6e4eca07) redirects Bash's TMPDIR to its writable scratch
+ * grant. The engine's inherited TMPDIR is only the parent of that directory.
+ * Use the accepted policy receipt, never Core's private uid/trust path scheme.
+ */
+export function provisionTvControlForWorkspacePolicy(
+  workspace: string,
+  managedTempDir: string,
+  writableRoots: readonly string[],
+  source = bundledTvControlRoot()
+): string {
+  resolveBundledTvControlEntry(source);
+  const canonicalWorkspace = fs.realpathSync(workspace);
+  const expectedTemp = path.join(canonicalWorkspace, '.wayland-runtime', 'tmp');
+  if (path.resolve(managedTempDir) !== expectedTemp)
+    throw new Error('TVControl managed temp directory does not belong to this workspace');
+  // Check every owned ancestor, including symlinks that resolve back inside.
+  for (const dir of [path.dirname(expectedTemp), expectedTemp]) {
+    if (!fs.lstatSync(dir).isDirectory() || fs.realpathSync(dir) !== dir)
+      throw new Error('TVControl managed temp directory is redirected');
+  }
+  const candidates = [...new Set(writableRoots)].filter((root) => {
+    if (!path.isAbsolute(root)) return false;
+    const relative = path.relative(expectedTemp, root);
+    return relative !== '' && relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+  });
+  if (candidates.length !== 1)
+    throw new Error('TVControl requires exactly one workspace-contained scratch directory from Core');
+  const scratch = path.resolve(candidates[0]);
+  let current = expectedTemp;
+  for (const part of path.relative(expectedTemp, scratch).split(path.sep)) {
+    current = path.join(current, part);
+    if (!fs.lstatSync(current).isDirectory() || fs.realpathSync(current) !== current)
+      throw new Error('TVControl Core scratch directory is redirected');
+  }
+  copyTvControlToTempRoot(scratch, source);
+  return scratch;
 }

--- a/src/process/task/WCoreManager.ts
+++ b/src/process/task/WCoreManager.ts
@@ -40,6 +40,10 @@ import { WCoreMcpAgent } from '@process/services/mcpServices/agents/WCoreMcpAgen
 import { mcpService } from '@process/services/mcpServices/McpService';
 import { normalizeMcpServerForSpawn } from '@/common/mcp/normalizeMcpServer';
 import { applyBuiltinMcpRuntime } from '@process/services/mcpServices/builtinMcpRuntime';
+import {
+  isBundledTvControlDeclaration,
+  provisionWorkspaceTvControl,
+} from '@process/services/mcpServices/bundledTvControl';
 import { validateMcpServer } from '@process/services/mcpServices/validateMcpServer';
 import { getCandidateTools } from '@process/services/mcpServices/getCandidateTools';
 import type { CandidateTool } from '@process/services/tools/toolContract';
@@ -836,6 +840,7 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
     // but no chat tools. The launch-local Core profile below then narrows the
     // global config to exactly this conversation's selection (all transports).
     let sessionMcpServerNames: string[] | undefined;
+    let managedTempDir: string | undefined;
     let expectedSessionMcpNames: string[] = [];
     let expectedSessionMcpServers: McpSessionExpectedServer[] = [];
     if (!rawEngineMode) {
@@ -854,6 +859,19 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
           );
           this.beginMcpSession(expectedSessionMcpServers);
           for (const server of normalizedServers) validateMcpServer(server);
+          if (
+            selectedServers.some(
+              (server) =>
+                server.transport.type === 'stdio' &&
+                isBundledTvControlDeclaration(
+                  server.transport.command,
+                  server.transport.args ?? [],
+                  server.libraryEntryId
+                )
+            )
+          ) {
+            managedTempDir = provisionWorkspaceTvControl(mergedData.workspace);
+          }
           // #1015 F1: this launch-local config.toml is the ONLY thing the wcore
           // chat loads its connectors from, and it is NOT one of the
           // `McpService.syncMcpToAgents` targets — so the shared builtin-runtime
@@ -893,6 +911,7 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
           }
         }
       } catch (err) {
+        managedTempDir = undefined;
         sessionMcpServerNames = [];
         // Keep the exact requested connector set visible and terminal. Erasing
         // it here made OAuth/validation/config-write failures look like a chat
@@ -948,6 +967,7 @@ export class WCoreManager extends BaseAgentManager<WCoreManagerData, string> {
 
     const agent = new WCoreAgent({
       workspace: mergedData.workspace,
+      managedTempDir,
       model: mergedData.model,
       proxy: mergedData.proxy,
       yoloMode: mergedData.yoloMode,

--- a/src/renderer/pages/conversation/platforms/wcore/WCoreSendBox.tsx
+++ b/src/renderer/pages/conversation/platforms/wcore/WCoreSendBox.tsx
@@ -374,7 +374,7 @@ const WCoreSendBox: React.FC<{
 
   // Handle initial message from Guid page
   useEffect(() => {
-    if (!conversation_id) return;
+    if (!conversation_id || recoveryBlocked || !currentModel?.useModel) return;
 
     const storageKey = `wcore_initial_message_${conversation_id}`;
     const processedKey = `wcore_initial_processed_${conversation_id}`;
@@ -385,19 +385,37 @@ const WCoreSendBox: React.FC<{
       if (!storedMessage) return;
 
       sessionStorage.setItem(processedKey, '1');
-      sessionStorage.removeItem(storageKey);
-
       try {
         const { input, files: initialFiles } = JSON.parse(storedMessage);
         await executeCommand({ input, files: initialFiles || [] });
+        sessionStorage.removeItem(storageKey);
       } catch (error) {
         console.error('[WCoreSendBox] Failed to send initial message:', error);
-        sessionStorage.removeItem(processedKey);
+        // Keep the original payload and the attempted marker: a rejected bridge
+        // response may follow an accepted send, so never automatically duplicate it.
+        // Restore the draft for an explicit user retry instead of losing the prompt.
+        try {
+          const { input, files: initialFiles } = JSON.parse(storedMessage);
+          setContent(input);
+          setUploadFile(initialFiles || []);
+        } catch {
+          // Malformed handoff stays in storage for diagnosis.
+        }
+        setWaitingResponse(false);
+        Message.error(error instanceof Error ? error.message : String(error));
       }
     };
 
     void processInitialMessage();
-  }, [conversation_id, executeCommand]);
+  }, [
+    conversation_id,
+    currentModel?.useModel,
+    recoveryBlocked,
+    executeCommand,
+    setContent,
+    setUploadFile,
+    setWaitingResponse,
+  ]);
 
   const onSendHandler = async (message: string) => {
     const filesToSend = collectSelectedFiles(uploadFile, atPath);

--- a/src/renderer/pages/conversation/platforms/wcore/useWCoreMessage.ts
+++ b/src/renderer/pages/conversation/platforms/wcore/useWCoreMessage.ts
@@ -57,6 +57,9 @@ export const useWCoreMessage = (
   const [tokenUsage, setTokenUsage] = useState<TokenUsageData | null>(null);
   // Current active message ID to filter out events from old requests (prevents aborted request events from interfering with new ones)
   const activeMsgIdRef = useRef<string | null>(null);
+  // Status snapshots must not overwrite turn events or sends observed after the read began.
+  const runningRevisionRef = useRef(0);
+  const conversationGenerationRef = useRef(0);
 
   // Use refs to avoid useEffect re-subscription when these states change
   const hasActiveToolsRef = useRef(hasActiveTools);
@@ -166,6 +169,9 @@ export const useWCoreMessage = (
         }
       }
 
+      if (['thought', 'start', 'finish', 'tool_group', 'error'].includes(message.type)) {
+        runningRevisionRef.current += 1;
+      }
       switch (message.type) {
         case 'thought':
           // Auto-recover streamRunning if thought arrives after finish
@@ -445,6 +451,7 @@ export const useWCoreMessage = (
             hasContentInTurnRef.current = true;
             // Successful content after an error means that error was transient.
             if (isTurnOutput) {
+              runningRevisionRef.current += 1;
               turnEndedInErrorRef.current = false;
             }
             // Reset waitingResponse when actual content arrives
@@ -469,6 +476,8 @@ export const useWCoreMessage = (
 
   useEffect(() => {
     let cancelled = false;
+    const generation = ++conversationGenerationRef.current;
+    const revision = runningRevisionRef.current;
 
     setThought({ subject: '', description: '' });
     setTokenUsage(null);
@@ -484,6 +493,10 @@ export const useWCoreMessage = (
         return;
       }
 
+      if (revision !== runningRevisionRef.current) {
+        setHasHydratedRunningState(true);
+        return;
+      }
       if (!res) {
         setStreamRunning(false);
         streamRunningRef.current = false;
@@ -514,6 +527,7 @@ export const useWCoreMessage = (
 
     return () => {
       cancelled = true;
+      if (conversationGenerationRef.current === generation) conversationGenerationRef.current += 1;
     };
   }, [conversation_id]);
 
@@ -521,8 +535,16 @@ export const useWCoreMessage = (
   // tab that was backgrounded while a turn finished comes back showing a stale
   // running state. On resume, re-check the backend status and reconcile. (#57)
   const reconcileRunningOnResume = useCallback(() => {
+    const generation = conversationGenerationRef.current;
+    const revision = runningRevisionRef.current;
     void ipcBridge.conversation.get.invoke({ id: conversation_id }).then((res) => {
-      if (!res) return;
+      if (
+        !res ||
+        generation !== conversationGenerationRef.current ||
+        revision !== runningRevisionRef.current
+      ) {
+        return;
+      }
       const isRunning = res.status === 'running';
       if (!isRunning && (streamRunningRef.current || waitingResponseRef.current)) {
         setStreamRunning(false);
@@ -543,6 +565,7 @@ export const useWCoreMessage = (
   useTabResumeEffect(reconcileRunningOnResume, [conversation_id]);
 
   const resetState = useCallback(() => {
+    runningRevisionRef.current += 1;
     setWaitingResponse(false);
     waitingResponseRef.current = false;
     setStreamRunning(false);
@@ -557,6 +580,12 @@ export const useWCoreMessage = (
     activeMsgIdRef.current = null;
   }, []);
 
+  const setOutgoingWaitingResponse = useCallback((waiting: boolean) => {
+    runningRevisionRef.current += 1;
+    waitingResponseRef.current = waiting;
+    setWaitingResponse(waiting);
+  }, []);
+
   return {
     thought,
     setThought,
@@ -564,7 +593,7 @@ export const useWCoreMessage = (
     hasHydratedRunningState,
     tokenUsage,
     setActiveMsgId,
-    setWaitingResponse,
+    setWaitingResponse: setOutgoingWaitingResponse,
     resetState,
   };
 };

--- a/src/renderer/pages/conversation/platforms/wcore/useWCoreMessage.ts
+++ b/src/renderer/pages/conversation/platforms/wcore/useWCoreMessage.ts
@@ -538,11 +538,7 @@ export const useWCoreMessage = (
     const generation = conversationGenerationRef.current;
     const revision = runningRevisionRef.current;
     void ipcBridge.conversation.get.invoke({ id: conversation_id }).then((res) => {
-      if (
-        !res ||
-        generation !== conversationGenerationRef.current ||
-        revision !== runningRevisionRef.current
-      ) {
+      if (!res || generation !== conversationGenerationRef.current || revision !== runningRevisionRef.current) {
         return;
       }
       const isRunning = res.status === 'running';

--- a/tests/unit/process/agent/wcore/tvControlScratchReceipt.test.ts
+++ b/tests/unit/process/agent/wcore/tvControlScratchReceipt.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({ provision: vi.fn(), order: [] as string[] }));
+vi.mock('@process/services/mcpServices/bundledTvControl', () => ({
+  provisionTvControlForWorkspacePolicy: h.provision,
+}));
+import { WCoreAgent } from '@process/agent/wcore';
+
+type Harness = {
+  handleEvent: (event: unknown) => void;
+  writeCommand: (command: unknown) => boolean;
+  lastWorkspacePolicy: unknown;
+};
+const agents: WCoreAgent[] = [];
+function createAgent(managed = true) {
+  const agent = new WCoreAgent({
+    workspace: '/workspace',
+    managedTempDir: managed ? '/workspace/.wayland-runtime/tmp' : undefined,
+    model: {} as never,
+    onStreamEvent: (event) => {
+      if (event.type === 'workspace_policy') h.order.push('forward');
+    },
+  });
+  agents.push(agent);
+  const internal = agent as unknown as Harness;
+  const write = vi.spyOn(internal, 'writeCommand').mockReturnValue(true);
+  internal.handleEvent({ type: 'ready', session_id: 'core-session', capabilities: [] });
+  return { agent, internal, write };
+}
+beforeEach(() => {
+  h.order.length = 0;
+  h.provision.mockReset().mockImplementation(() => {
+    h.order.push('provision');
+    return '/workspace/.wayland-runtime/tmp/core-scratch';
+  });
+});
+afterEach(async () => {
+  vi.useRealTimers();
+  for (const agent of agents.splice(0)) await agent.kill();
+});
+
+describe('Core scratch receipt gates bundled collector sends', () => {
+  it('waits for the current transport receipt even when a preceding transport left a policy snapshot', async () => {
+    const { agent, internal, write } = createAgent();
+    internal.lastWorkspacePolicy = { writable_roots: ['/old/scratch'] };
+    const sending = agent.send('collect', 'first');
+    await Promise.resolve();
+    expect(write).not.toHaveBeenCalled();
+    internal.handleEvent({
+      type: 'workspace_policy',
+      policy: { writable_roots: ['/workspace/.wayland-runtime/tmp/new-scratch'] },
+    });
+    await sending;
+    expect(write).toHaveBeenCalledWith(expect.objectContaining({ msg_id: 'first' }));
+  });
+  it('provisions before forwarding the policy and before the first message', async () => {
+    const { agent, internal, write } = createAgent();
+    const sending = agent.send('collect', 'first');
+    await Promise.resolve();
+    expect(write).not.toHaveBeenCalled();
+    internal.handleEvent({
+      type: 'workspace_policy',
+      policy: { writable_roots: ['/workspace', '/workspace/.wayland-runtime/tmp/core-scratch'] },
+    });
+    await sending;
+    expect(h.order).toEqual(['provision', 'forward']);
+    expect(write).toHaveBeenCalledWith(expect.objectContaining({ type: 'message', msg_id: 'first' }));
+  });
+  it('surfaces a preparation failure without throwing from the stream listener or sending a command', async () => {
+    const { agent, internal, write } = createAgent();
+    h.provision.mockImplementation(() => {
+      throw new Error('ambiguous scratch roots');
+    });
+    expect(() => internal.handleEvent({ type: 'workspace_policy', policy: { writable_roots: [] } })).not.toThrow();
+    await expect(agent.send('collect', 'first')).rejects.toThrow('TVControl 2.4.7 could not be prepared');
+    expect(write).not.toHaveBeenCalled();
+  });
+  it('bounds a missing receipt wait and returns an actionable error', async () => {
+    vi.useFakeTimers();
+    const { agent, write } = createAgent();
+    const assertion = expect(agent.send('collect', 'first')).rejects.toThrow(
+      'Core to report its writable scratch directory'
+    );
+    await vi.advanceTimersByTimeAsync(60_000);
+    await assertion;
+    expect(write).not.toHaveBeenCalled();
+  });
+  it('leaves sessions without selected bundled TVControl unchanged', async () => {
+    const { agent, write } = createAgent(false);
+    await agent.send('hello', 'first');
+    expect(h.provision).not.toHaveBeenCalled();
+    expect(write).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/process/services/mcpServices/builtinMcpRuntime.test.ts
+++ b/tests/unit/process/services/mcpServices/builtinMcpRuntime.test.ts
@@ -73,6 +73,44 @@ const deps = (over: Record<string, unknown> = {}) => ({
   ...over,
 });
 
+describe('pinned TVControl uses the same bundled runtime in probes and sessions', () => {
+  const args = ['@ferroxlabs/tvcontrol@2.4.7'];
+  const entry = '/resources/bundled-tvcontrol/node_modules/@ferroxlabs/tvcontrol/src/server.js';
+  it('resolves a catalog-owned declaration without npx or a user cache', () => {
+    expect(
+      resolveBuiltinMcpRuntimeSpawn(
+        'npx',
+        args,
+        deps({ libraryEntryId: 'com.ferroxlabs/tvcontrol', tvControlEntry: () => entry })
+      )
+    ).toEqual({ command: PACKAGED_BUN, args: [entry], env: {} });
+  });
+  it('keeps a user declaration and a custom version untouched', () => {
+    expect(resolveBuiltinMcpRuntimeSpawn('npx', args, deps())).toBeNull();
+    expect(
+      resolveBuiltinMcpRuntimeSpawn(
+        'npx',
+        ['@ferroxlabs/tvcontrol@2.4.6'],
+        deps({ libraryEntryId: 'com.ferroxlabs/tvcontrol' })
+      )
+    ).toBeNull();
+  });
+  it('reports a missing bundle instead of falling back to network installation', () => {
+    expect(() =>
+      resolveBuiltinMcpRuntimeSpawn(
+        'npx',
+        args,
+        deps({
+          libraryEntryId: 'com.ferroxlabs/tvcontrol',
+          tvControlEntry: () => {
+            throw new Error('missing bundle');
+          },
+        })
+      )
+    ).toThrow('missing bundle');
+  });
+});
+
 describe('F2 — our own script is matched by exact path, never by basename', () => {
   it('accepts the absolute path this install actually seeds', () => {
     expect(isOwnBuiltinCoreMcpScript(OURS, deps())).toBe(true);

--- a/tests/unit/process/services/mcpServices/bundledTvControl.test.ts
+++ b/tests/unit/process/services/mcpServices/bundledTvControl.test.ts
@@ -1,0 +1,105 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const fixture = vi.hoisted(() => ({ digest: '', root: '' }));
+vi.mock('../../../../../scripts/tvcontrol/authority.json', () => ({
+  default: {
+    version: '2.4.7',
+    get treeSha256() {
+      return fixture.digest;
+    },
+  },
+}));
+import { createHash } from 'node:crypto';
+import {
+  isBundledTvControlDeclaration,
+  provisionWorkspaceTvControl,
+  verifyTvControlTree,
+} from '@process/services/mcpServices/bundledTvControl';
+import { buildEngineSpawnEnv } from '@process/agent/wcore/envBuilder';
+
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+function setup() {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'tvcontrol-test-')));
+  roots.push(root);
+  const source = path.join(root, 'source');
+  const workspace = path.join(root, 'workspace');
+  fs.mkdirSync(workspace);
+  const files = {
+    '@ferroxlabs/tvcontrol/package.json': JSON.stringify({ name: '@ferroxlabs/tvcontrol', version: '2.4.7' }),
+    '@ferroxlabs/tvcontrol/src/server.js': 'export const version = "2.4.7";',
+  };
+  for (const [name, text] of Object.entries(files)) {
+    const target = path.join(source, 'node_modules', name);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, text);
+  }
+  fixture.digest = createHash('sha256')
+    .update(
+      JSON.stringify(
+        Object.entries(files).map(([name, text]) => [name, createHash('sha256').update(text).digest('hex')])
+      )
+    )
+    .digest('hex');
+  return { root, source, workspace };
+}
+
+describe('bundled TVControl session provisioning', () => {
+  it('rejects wrong versions and user-owned declarations', () => {
+    expect(isBundledTvControlDeclaration('npx', ['@ferroxlabs/tvcontrol@2.4.6'], 'com.ferroxlabs/tvcontrol')).toBe(
+      false
+    );
+    expect(isBundledTvControlDeclaration('npx', ['@ferroxlabs/tvcontrol@2.4.7'])).toBe(false);
+    expect(isBundledTvControlDeclaration('npx', ['@ferroxlabs/tvcontrol@2.4.7'], 'com.ferroxlabs/tvcontrol')).toBe(
+      true
+    );
+  });
+  it('fails before copying a corrupted bundled dependency', () => {
+    const { source, workspace } = setup();
+    fs.appendFileSync(path.join(source, 'node_modules/@ferroxlabs/tvcontrol/src/server.js'), 'tampered');
+    expect(() => provisionWorkspaceTvControl(workspace, source)).toThrow('integrity');
+    expect(fs.existsSync(path.join(workspace, '.wayland-runtime'))).toBe(false);
+  });
+  it('copies a verified tree where the unmodified collector TMPDIR search finds it', () => {
+    const { source, workspace } = setup();
+    const temp = provisionWorkspaceTvControl(workspace, source);
+    const candidate = fs.readdirSync(temp).find((name) => name.startsWith('bunx-') && name.includes('tvcontrol'))!;
+    expect(verifyTvControlTree(path.join(temp, candidate))).toBe(true);
+    expect(provisionWorkspaceTvControl(workspace, source)).toBe(temp);
+    expect(fs.existsSync(path.join(workspace, '.wayland-core/skills'))).toBe(false);
+  });
+  it('preserves and refuses a modified existing session copy', () => {
+    const { source, workspace } = setup();
+    const temp = provisionWorkspaceTvControl(workspace, source);
+    const changed = path.join(temp, 'bunx-wayland-tvcontrol-2.4.7/node_modules/@ferroxlabs/tvcontrol/src/server.js');
+    fs.writeFileSync(changed, 'user change');
+    expect(() => provisionWorkspaceTvControl(workspace, source)).toThrow('Existing workspace');
+    expect(fs.readFileSync(changed, 'utf8')).toBe('user change');
+  });
+  it('refuses a workspace runtime directory redirected outside the workspace', () => {
+    const { root, source, workspace } = setup();
+    fs.symlinkSync(source, path.join(workspace, '.wayland-runtime'), process.platform === 'win32' ? 'junction' : 'dir');
+    expect(() => provisionWorkspaceTvControl(workspace, source)).toThrow('inside the workspace');
+    expect(fs.existsSync(path.join(root, 'source/tmp'))).toBe(false);
+  });
+  it('changes only the engine child temp environment and preserves its output destination', () => {
+    const { source, workspace } = setup();
+    const before = { TMPDIR: process.env.TMPDIR, TEMP: process.env.TEMP, HOME: process.env.HOME };
+    const temp = provisionWorkspaceTvControl(workspace, source);
+    const env = buildEngineSpawnEnv({ providerEnv: {}, workspace, managedTempDir: temp });
+    expect([env.TMPDIR, env.TEMP, env.TMP]).toEqual([temp, temp, temp]);
+    expect(env.WAYLAND_OUTPUT_DIR).toBe(path.join(workspace, 'artifacts'));
+    expect({ TMPDIR: process.env.TMPDIR, TEMP: process.env.TEMP, HOME: process.env.HOME }).toEqual(before);
+  });
+  it('rejects an external temp override', () => {
+    const { source, workspace } = setup();
+    expect(() => buildEngineSpawnEnv({ providerEnv: {}, workspace, managedTempDir: source })).toThrow(
+      'inside its workspace'
+    );
+  });
+});

--- a/tests/unit/process/services/mcpServices/bundledTvControl.test.ts
+++ b/tests/unit/process/services/mcpServices/bundledTvControl.test.ts
@@ -16,6 +16,7 @@ import { createHash } from 'node:crypto';
 import {
   isBundledTvControlDeclaration,
   provisionWorkspaceTvControl,
+  provisionTvControlForWorkspacePolicy,
   verifyTvControlTree,
 } from '@process/services/mcpServices/bundledTvControl';
 import { buildEngineSpawnEnv } from '@process/agent/wcore/envBuilder';
@@ -50,6 +51,47 @@ function setup() {
 }
 
 describe('bundled TVControl session provisioning', () => {
+  it('uses the received scratch root that Core assigns to Bash instead of the inherited temp parent', () => {
+    const { source, workspace } = setup();
+    const temp = provisionWorkspaceTvControl(workspace, source);
+    const scratch = path.join(temp, 'engine-owned-layout', 'trusted');
+    fs.mkdirSync(scratch, { recursive: true });
+    expect(provisionTvControlForWorkspacePolicy(workspace, temp, [workspace, scratch], source)).toBe(scratch);
+    const candidate = fs.readdirSync(scratch).find((name) => name.startsWith('bunx-') && name.includes('tvcontrol'))!;
+    expect(verifyTvControlTree(path.join(scratch, candidate))).toBe(true);
+  });
+  it('refuses missing or ambiguous receipt scratch roots without guessing their names', () => {
+    const { source, workspace } = setup();
+    const temp = provisionWorkspaceTvControl(workspace, source);
+    expect(() => provisionTvControlForWorkspacePolicy(workspace, temp, [workspace], source)).toThrow('exactly one');
+    expect(() =>
+      provisionTvControlForWorkspacePolicy(workspace, temp, [path.join(temp, 'a'), path.join(temp, 'b')], source)
+    ).toThrow('exactly one');
+  });
+  it('refuses a scratch receipt redirected through a symlink', () => {
+    const { source, workspace } = setup();
+    const temp = provisionWorkspaceTvControl(workspace, source);
+    const redirected = path.join(temp, 'redirected');
+    fs.symlinkSync(source, redirected, process.platform === 'win32' ? 'junction' : 'dir');
+    expect(() => provisionTvControlForWorkspacePolicy(workspace, temp, [workspace, redirected], source)).toThrow(
+      'redirected'
+    );
+    expect(fs.existsSync(path.join(source, 'bunx-wayland-tvcontrol-2.4.7'))).toBe(false);
+  });
+  it('refuses a receipt outside the workspace and preserves a corrupt scratch copy', () => {
+    const { source, workspace } = setup();
+    const temp = provisionWorkspaceTvControl(workspace, source);
+    expect(() => provisionTvControlForWorkspacePolicy(workspace, temp, [source], source)).toThrow('exactly one');
+    const scratch = path.join(temp, 'scratch');
+    fs.mkdirSync(scratch);
+    provisionTvControlForWorkspacePolicy(workspace, temp, [scratch], source);
+    const file = path.join(scratch, 'bunx-wayland-tvcontrol-2.4.7/node_modules/@ferroxlabs/tvcontrol/src/server.js');
+    fs.writeFileSync(file, 'changed');
+    expect(() => provisionTvControlForWorkspacePolicy(workspace, temp, [scratch], source)).toThrow(
+      'Existing workspace'
+    );
+    expect(fs.readFileSync(file, 'utf8')).toBe('changed');
+  });
   it('rejects wrong versions and user-owned declarations', () => {
     expect(isBundledTvControlDeclaration('npx', ['@ferroxlabs/tvcontrol@2.4.6'], 'com.ferroxlabs/tvcontrol')).toBe(
       false

--- a/tests/unit/process/task/wcoreBuiltinMcpPublication.test.ts
+++ b/tests/unit/process/task/wcoreBuiltinMcpPublication.test.ts
@@ -50,9 +50,16 @@ const h = vi.hoisted(() => ({
   launchLocalFlags: [] as Array<boolean | undefined>,
   resolveJsRuntime: vi.fn<() => ResolvedJsRuntime>(),
   runtimeServers: [] as IMcpServer[],
+  engineOptions: [] as Array<{ managedTempDir?: string }>,
+  provisionTvControl: vi.fn(() => '/ws/.wayland-runtime/tmp'),
 }));
 
 vi.mock('@process/utils/jsRuntime', () => ({ resolveJsRuntime: h.resolveJsRuntime }));
+vi.mock('@process/services/mcpServices/bundledTvControl', async (orig) => ({
+  ...(await orig<typeof import('@process/services/mcpServices/bundledTvControl')>()),
+  provisionWorkspaceTvControl: h.provisionTvControl,
+  resolveBundledTvControlEntry: () => '/resources/bundled-tvcontrol/node_modules/@ferroxlabs/tvcontrol/src/server.js',
+}));
 
 // Keep the REAL `toWCoreConfig` (the config.toml serializer under test) and swap
 // only the agent, so what lands on disk is still produced by production code.
@@ -101,7 +108,8 @@ vi.mock('@process/agent/wcore/effectiveRuntimeActions', () => ({
 // Stop the launch immediately AFTER the publication block: the engine spawn and
 // everything downstream is irrelevant here and `start()` rethrows, which the test
 // catches. Nothing in the publication block runs after this point.
-function stopAfterPublication(): never {
+function stopAfterPublication(options: { managedTempDir?: string }): never {
+  h.engineOptions.push(options);
   throw new Error('STOP_AFTER_MCP_PUBLICATION');
 }
 vi.mock('@process/agent/wcore', () => ({ WCoreAgent: stopAfterPublication }));
@@ -208,15 +216,11 @@ const CORE_BUILTIN = server({
   transport: { type: 'stdio', command: 'node', args: [getMcpScriptPath('builtin-mcp-search-skills.js')], env: {} },
 });
 
-const startManager = async () => {
-  const manager = new WCoreManager({
-    id: 'conv-1',
-    data: {
-      workspace: '/ws',
-      model: { name: 'm', useModel: 'm', platform: 'openai', baseUrl: '' },
-      activeMcpServers: [APPLE.id, NPX.id, CORE_BUILTIN.id],
-    },
-  } as never);
+const startManager = async (activeIds = [APPLE.id, NPX.id, CORE_BUILTIN.id]) => {
+  const manager = new WCoreManager(
+    { id: 'conv-1', workspace: '/ws', activeMcpServers: activeIds } as never,
+    { name: 'm', useModel: 'm', platform: 'openai', baseUrl: '' } as never
+  );
   await expect(manager.start()).rejects.toThrow('STOP_AFTER_MCP_PUBLICATION');
   // `BaseAgentManager` may retry the bootstrap; each attempt republishes, and
   // every attempt must be correct, so assert over ALL of them.
@@ -403,5 +407,34 @@ describe('#1056 global config.toml survives an AppImage remount', () => {
       transport: { type: 'stdio', command: DEV_ELECTRON, args: ['s.mjs'], env: { ELECTRON_RUN_AS_NODE: '1' } },
     });
     expect(toWCoreConfig(dev).command).toBe(DEV_ELECTRON);
+  });
+});
+
+describe('TVControl workspace provisioning at the real manager launch boundary', () => {
+  const tv = server({
+    id: 'tv',
+    name: 'tvcontrol',
+    libraryEntryId: 'com.ferroxlabs/tvcontrol',
+    transport: { type: 'stdio', command: 'npx', args: ['@ferroxlabs/tvcontrol@2.4.7'] },
+  });
+  beforeEach(() => {
+    h.published.length = 0;
+    h.engineOptions.length = 0;
+    h.runtimeServers = [tv, NPX];
+    h.resolveJsRuntime.mockReturnValue({ command: PACKAGED_BUN, env: {}, kind: 'bundled-bun' });
+    h.provisionTvControl.mockReset().mockReturnValue('/ws/.wayland-runtime/tmp');
+  });
+  it('publishes the bundled entry and hands only the selected session its temporary directory', async () => {
+    const published = await startManager(['tv']);
+    expect(h.provisionTvControl).toHaveBeenCalledWith('/ws');
+    expect(h.engineOptions.at(-1)?.managedTempDir).toBe('/ws/.wayland-runtime/tmp');
+    expect((published[0].transport as { args: string[] }).args).toEqual([
+      '/resources/bundled-tvcontrol/node_modules/@ferroxlabs/tvcontrol/src/server.js',
+    ]);
+  });
+  it('does not provision an unselected connector or change its session temp directory', async () => {
+    await startManager([NPX.id]);
+    expect(h.provisionTvControl).not.toHaveBeenCalled();
+    expect(h.engineOptions.at(-1)?.managedTempDir).toBeUndefined();
   });
 });

--- a/tests/unit/renderer/platformSendBoxes.dom.test.tsx
+++ b/tests/unit/renderer/platformSendBoxes.dom.test.tsx
@@ -476,6 +476,62 @@ describe('platform send box queue integration', () => {
     sessionStorage.clear();
   });
 
+  it('preserves an initial Core prompt and files until recovery and model readiness, then sends exactly once', async () => {
+    const conversationId = 'initial-core';
+    const key = `wcore_initial_message_${conversationId}`;
+    const payload = JSON.stringify({ input: 'Run the TC-TIDE brief', files: ['/ws/watchlist.csv'] });
+    sessionStorage.setItem(key, payload);
+    const box = (blocked: boolean, model?: string) => (
+      <WCoreSendBox
+        conversation_id={conversationId}
+        recoveryBlocked={blocked}
+        modelSelection={{
+          currentModel: model ? { useModel: model } : undefined,
+          getDisplayModelName: (id: string) => id,
+        }}
+      />
+    );
+    const view = render(box(true, 'flux-reasoning'));
+    await waitFor(() => expect(mockConversationGetInvoke).toHaveBeenCalled());
+    expect(mockConversationSendInvoke).not.toHaveBeenCalled();
+    expect(sessionStorage.getItem(key)).toBe(payload);
+    view.rerender(box(false));
+    expect(mockConversationSendInvoke).not.toHaveBeenCalled();
+    expect(sessionStorage.getItem(key)).toBe(payload);
+    view.rerender(box(false, 'flux-reasoning'));
+    await waitFor(() => expect(mockConversationSendInvoke).toHaveBeenCalledOnce());
+    expect(mockConversationSendInvoke).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversation_id: 'initial-core',
+        files: ['/ws/watchlist.csv'],
+        input: expect.stringContaining('Run the TC-TIDE brief'),
+      })
+    );
+    await waitFor(() => expect(sessionStorage.getItem(key)).toBeNull());
+    view.rerender(box(false, 'flux-reasoning'));
+    expect(mockConversationSendInvoke).toHaveBeenCalledOnce();
+  });
+
+  it('retains a rejected initial send without automatically duplicating it on rerender', async () => {
+    const key = 'wcore_initial_message_failed-core';
+    const payload = JSON.stringify({ input: 'Keep this brief request', files: ['/ws/input.csv'] });
+    sessionStorage.setItem(key, payload);
+    mockConversationSendInvoke.mockRejectedValue(new Error('Recovery inspection unavailable'));
+    const box = (
+      <WCoreSendBox
+        conversation_id='failed-core'
+        recoveryBlocked={false}
+        modelSelection={{ currentModel: { useModel: 'flux-reasoning' }, getDisplayModelName: (id: string) => id }}
+      />
+    );
+    const view = render(box);
+    await waitFor(() => expect(mockArcoError).toHaveBeenCalledWith('Recovery inspection unavailable'));
+    expect(sessionStorage.getItem(key)).toBe(payload);
+    expect(sessionStorage.getItem('wcore_initial_processed_failed-core')).toBe('1');
+    view.rerender(box);
+    expect(mockConversationSendInvoke).toHaveBeenCalledOnce();
+  });
+
   it.each([
     ['acp', <AcpSendBox conversation_id='conv-acp' backend='claude' />],
     [

--- a/tests/unit/renderer/useWCoreMessageAfterTurnFrames.dom.test.tsx
+++ b/tests/unit/renderer/useWCoreMessageAfterTurnFrames.dom.test.tsx
@@ -44,7 +44,9 @@ import os from 'os';
 import path from 'path';
 
 import React from 'react';
-import { render, screen, act, waitFor } from '@testing-library/react';
+import { ipcBridge } from '@/common';
+import { useConversationCommandQueue } from '@/renderer/pages/conversation/platforms/useConversationCommandQueue';
+import { render, renderHook, screen, act, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IResponseMessage } from '@/common/adapter/ipcBridge';
 import { resolveOutputDir } from '@process/agent/wcore/envBuilder';
@@ -306,5 +308,105 @@ describe('wcore turn end — the deliverable recipe that wedged the composer', (
 
     // THE REGRESSION. Live, this line was the Stop button that never went away.
     expect(screen.getByTestId('running').textContent).toBe('false');
+  });
+});
+
+// Navigation can start a status read that resolves after a newer stream frame.
+describe('wcore navigation status ordering', () => {
+  beforeEach(() => {
+    streamHandler = null;
+    vi.mocked(ipcBridge.conversation.get.invoke).mockReset();
+  });
+  afterEach(() => {
+    vi.mocked(ipcBridge.conversation.get.invoke).mockReset().mockResolvedValue(null);
+  });
+
+  const deferredStatus = () => {
+    let resolve!: (value: Awaited<ReturnType<typeof ipcBridge.conversation.get.invoke>>) => void;
+    vi.mocked(ipcBridge.conversation.get.invoke).mockReturnValueOnce(new Promise(r => { resolve = r; }));
+    return (status: 'running' | 'finished') => resolve({ id: CONV, type: 'wcore', status } as Awaited<ReturnType<typeof ipcBridge.conversation.get.invoke>>);
+  };
+
+  it('does not overwrite finish with an older running mount response', async () => {
+    const resolve = deferredStatus();
+    renderHarness();
+    emit(frame('start'));
+    emit(frame('finish'));
+    await act(async () => { resolve('running'); });
+    expect(screen.getByTestId('running').textContent).toBe('false');
+  });
+
+  it('does not overwrite a new start with an older finished mount response', async () => {
+    const resolve = deferredStatus();
+    renderHarness();
+    emit(frame('start'));
+    await act(async () => { resolve('finished'); });
+    expect(screen.getByTestId('running').textContent).toBe('true');
+  });
+
+  it('retains genuinely running hydration with no newer event', async () => {
+    const resolve = deferredStatus();
+    renderHarness();
+    await act(async () => { resolve('running'); });
+    expect(screen.getByTestId('running').textContent).toBe('true');
+  });
+
+  it('does not let an older resume response erase a new start', async () => {
+    vi.mocked(ipcBridge.conversation.get.invoke).mockResolvedValueOnce(null);
+    renderHarness();
+    await act(async () => {});
+    const resolve = deferredStatus();
+    act(() => window.dispatchEvent(new Event('focus')));
+    emit(frame('start'));
+    await act(async () => { resolve('finished'); });
+    expect(screen.getByTestId('running').textContent).toBe('true');
+  });
+
+  it('does not let a pending mount read erase an outgoing send', async () => {
+    const resolve = deferredStatus();
+    const { result } = renderHook(() => useWCoreMessage(CONV), {
+      wrapper: ({ children }) => <MessageListProvider value={[]}>{children}</MessageListProvider>,
+    });
+    act(() => result.current.setWaitingResponse(true));
+    await act(async () => { resolve('finished'); });
+    expect(result.current.running).toBe(true);
+    expect(result.current.hasHydratedRunningState).toBe(true);
+  });
+
+  it.each(['running', 'finished'] as const)('dispatches a queued follow-up exactly once after current finish despite an older %s snapshot', async (snapshot) => {
+    const resolve = deferredStatus();
+    const conversationId = `navigation-queue-${snapshot}`;
+    const onExecute = vi.fn().mockResolvedValue(undefined);
+    const useHarness = () => {
+      const state = useWCoreMessage(conversationId);
+      const queue = useConversationCommandQueue({
+        conversationId, enabled: true, isBusy: state.running,
+        isHydrated: state.hasHydratedRunningState, onExecute,
+      });
+      return { state, queue };
+    };
+    const wrapper = ({ children }: { children: React.ReactNode }) => <MessageListProvider value={[]}>{children}</MessageListProvider>;
+    const mounted = renderHook(useHarness, { wrapper });
+    act(() => mounted.result.current.queue.enqueue({ input: 'one follow-up', files: [] }));
+    act(() => streamHandler?.({ ...frame('start'), conversation_id: conversationId }));
+    if (snapshot === 'running') {
+      act(() => streamHandler?.({ ...frame('finish'), conversation_id: conversationId }));
+    }
+    await act(async () => { resolve(snapshot); });
+    if (snapshot === 'finished') {
+      expect(mounted.result.current.state.running).toBe(true);
+      expect(onExecute).not.toHaveBeenCalled();
+      act(() => streamHandler?.({ ...frame('finish'), conversation_id: conversationId }));
+    }
+    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
+    expect(mounted.result.current.queue.items).toHaveLength(0);
+    vi.mocked(ipcBridge.conversation.get.invoke).mockResolvedValue(null);
+    act(() => window.dispatchEvent(new Event('focus')));
+    await act(async () => {});
+    mounted.unmount();
+    const remounted = renderHook(useHarness, { wrapper });
+    await waitFor(() => expect(remounted.result.current.state.hasHydratedRunningState).toBe(true));
+    expect(onExecute).toHaveBeenCalledTimes(1);
+    expect(remounted.result.current.queue.items).toHaveLength(0);
   });
 });

--- a/tests/unit/renderer/useWCoreMessageAfterTurnFrames.dom.test.tsx
+++ b/tests/unit/renderer/useWCoreMessageAfterTurnFrames.dom.test.tsx
@@ -323,8 +323,13 @@ describe('wcore navigation status ordering', () => {
 
   const deferredStatus = () => {
     let resolve!: (value: Awaited<ReturnType<typeof ipcBridge.conversation.get.invoke>>) => void;
-    vi.mocked(ipcBridge.conversation.get.invoke).mockReturnValueOnce(new Promise(r => { resolve = r; }));
-    return (status: 'running' | 'finished') => resolve({ id: CONV, type: 'wcore', status } as Awaited<ReturnType<typeof ipcBridge.conversation.get.invoke>>);
+    vi.mocked(ipcBridge.conversation.get.invoke).mockReturnValueOnce(
+      new Promise((r) => {
+        resolve = r;
+      })
+    );
+    return (status: 'running' | 'finished') =>
+      resolve({ id: CONV, type: 'wcore', status } as Awaited<ReturnType<typeof ipcBridge.conversation.get.invoke>>);
   };
 
   it('does not overwrite finish with an older running mount response', async () => {
@@ -332,7 +337,9 @@ describe('wcore navigation status ordering', () => {
     renderHarness();
     emit(frame('start'));
     emit(frame('finish'));
-    await act(async () => { resolve('running'); });
+    await act(async () => {
+      resolve('running');
+    });
     expect(screen.getByTestId('running').textContent).toBe('false');
   });
 
@@ -340,14 +347,18 @@ describe('wcore navigation status ordering', () => {
     const resolve = deferredStatus();
     renderHarness();
     emit(frame('start'));
-    await act(async () => { resolve('finished'); });
+    await act(async () => {
+      resolve('finished');
+    });
     expect(screen.getByTestId('running').textContent).toBe('true');
   });
 
   it('retains genuinely running hydration with no newer event', async () => {
     const resolve = deferredStatus();
     renderHarness();
-    await act(async () => { resolve('running'); });
+    await act(async () => {
+      resolve('running');
+    });
     expect(screen.getByTestId('running').textContent).toBe('true');
   });
 
@@ -358,7 +369,9 @@ describe('wcore navigation status ordering', () => {
     const resolve = deferredStatus();
     act(() => window.dispatchEvent(new Event('focus')));
     emit(frame('start'));
-    await act(async () => { resolve('finished'); });
+    await act(async () => {
+      resolve('finished');
+    });
     expect(screen.getByTestId('running').textContent).toBe('true');
   });
 
@@ -368,45 +381,57 @@ describe('wcore navigation status ordering', () => {
       wrapper: ({ children }) => <MessageListProvider value={[]}>{children}</MessageListProvider>,
     });
     act(() => result.current.setWaitingResponse(true));
-    await act(async () => { resolve('finished'); });
+    await act(async () => {
+      resolve('finished');
+    });
     expect(result.current.running).toBe(true);
     expect(result.current.hasHydratedRunningState).toBe(true);
   });
 
-  it.each(['running', 'finished'] as const)('dispatches a queued follow-up exactly once after current finish despite an older %s snapshot', async (snapshot) => {
-    const resolve = deferredStatus();
-    const conversationId = `navigation-queue-${snapshot}`;
-    const onExecute = vi.fn().mockResolvedValue(undefined);
-    const useHarness = () => {
-      const state = useWCoreMessage(conversationId);
-      const queue = useConversationCommandQueue({
-        conversationId, enabled: true, isBusy: state.running,
-        isHydrated: state.hasHydratedRunningState, onExecute,
+  it.each(['running', 'finished'] as const)(
+    'dispatches a queued follow-up exactly once after current finish despite an older %s snapshot',
+    async (snapshot) => {
+      const resolve = deferredStatus();
+      const conversationId = `navigation-queue-${snapshot}`;
+      const onExecute = vi.fn().mockResolvedValue(undefined);
+      const useHarness = () => {
+        const state = useWCoreMessage(conversationId);
+        const queue = useConversationCommandQueue({
+          conversationId,
+          enabled: true,
+          isBusy: state.running,
+          isHydrated: state.hasHydratedRunningState,
+          onExecute,
+        });
+        return { state, queue };
+      };
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <MessageListProvider value={[]}>{children}</MessageListProvider>
+      );
+      const mounted = renderHook(useHarness, { wrapper });
+      act(() => mounted.result.current.queue.enqueue({ input: 'one follow-up', files: [] }));
+      act(() => streamHandler?.({ ...frame('start'), conversation_id: conversationId }));
+      if (snapshot === 'running') {
+        act(() => streamHandler?.({ ...frame('finish'), conversation_id: conversationId }));
+      }
+      await act(async () => {
+        resolve(snapshot);
       });
-      return { state, queue };
-    };
-    const wrapper = ({ children }: { children: React.ReactNode }) => <MessageListProvider value={[]}>{children}</MessageListProvider>;
-    const mounted = renderHook(useHarness, { wrapper });
-    act(() => mounted.result.current.queue.enqueue({ input: 'one follow-up', files: [] }));
-    act(() => streamHandler?.({ ...frame('start'), conversation_id: conversationId }));
-    if (snapshot === 'running') {
-      act(() => streamHandler?.({ ...frame('finish'), conversation_id: conversationId }));
+      if (snapshot === 'finished') {
+        expect(mounted.result.current.state.running).toBe(true);
+        expect(onExecute).not.toHaveBeenCalled();
+        act(() => streamHandler?.({ ...frame('finish'), conversation_id: conversationId }));
+      }
+      await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
+      expect(mounted.result.current.queue.items).toHaveLength(0);
+      vi.mocked(ipcBridge.conversation.get.invoke).mockResolvedValue(null);
+      act(() => window.dispatchEvent(new Event('focus')));
+      await act(async () => {});
+      mounted.unmount();
+      const remounted = renderHook(useHarness, { wrapper });
+      await waitFor(() => expect(remounted.result.current.state.hasHydratedRunningState).toBe(true));
+      expect(onExecute).toHaveBeenCalledTimes(1);
+      expect(remounted.result.current.queue.items).toHaveLength(0);
     }
-    await act(async () => { resolve(snapshot); });
-    if (snapshot === 'finished') {
-      expect(mounted.result.current.state.running).toBe(true);
-      expect(onExecute).not.toHaveBeenCalled();
-      act(() => streamHandler?.({ ...frame('finish'), conversation_id: conversationId }));
-    }
-    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1));
-    expect(mounted.result.current.queue.items).toHaveLength(0);
-    vi.mocked(ipcBridge.conversation.get.invoke).mockResolvedValue(null);
-    act(() => window.dispatchEvent(new Event('focus')));
-    await act(async () => {});
-    mounted.unmount();
-    const remounted = renderHook(useHarness, { wrapper });
-    await waitFor(() => expect(remounted.result.current.state.hasHydratedRunningState).toBe(true));
-    expect(onExecute).toHaveBeenCalledTimes(1);
-    expect(remounted.result.current.queue.items).toHaveLength(0);
-  });
+  );
 });

--- a/tests/unit/verifyPackagedResources.test.ts
+++ b/tests/unit/verifyPackagedResources.test.ts
@@ -23,7 +23,7 @@ const {
   resolvePackagedTarget,
   snapshotPackagedTargets,
   verifyConstitutionFsBundle,
-  verifyPackagedResources,
+  verifyPackagedResources: verifyPackagedResourcesActual,
   verifyWhatsAppDarwinSignIgnoreInventory,
   verifyWhatsAppNativeTarget,
 } = require('../../scripts/verify-packaged-resources.js') as {
@@ -52,6 +52,23 @@ const {
   verifyWhatsAppDarwinSignIgnoreInventory: (root: string, arch: string) => boolean;
   verifyWhatsAppNativeTarget: (root: string, platform: string, arch: string) => boolean;
 };
+// The package sweep uses a tiny integrity-checked connector fixture. Real
+// published bytes are checked by prepareTvControl and the native package check.
+const TVCONTROL_FIXTURE = JSON.stringify({ name: '@ferroxlabs/tvcontrol', version: '2.4.7' });
+const tvControlAuthority = {
+  version: '2.4.7',
+  treeSha256: crypto
+    .createHash('sha256')
+    .update(
+      JSON.stringify([
+        ['@ferroxlabs/tvcontrol/package.json', crypto.createHash('sha256').update(TVCONTROL_FIXTURE).digest('hex')],
+      ])
+    )
+    .digest('hex'),
+};
+const verifyPackagedResources = (options: Record<string, unknown>) =>
+  verifyPackagedResourcesActual({ tvControlAuthority, ...options });
+
 // Derived from the live policy, never re-typed: verify-packaged-resources reads
 // the real DEFAULT_WCORE_VERSION and the real attestation policy, so a
 // hard-coded tag here fails the day the engine is bumped and proves nothing in
@@ -318,6 +335,9 @@ function addPackagedApp(
   writeSkillPack(resources, 'bundled-workflows');
   writeBunBundle(resources, arch);
   fs.mkdirSync(resources, { recursive: true });
+  const tvControlPackage = path.join(resources, 'bundled-tvcontrol/node_modules/@ferroxlabs/tvcontrol/package.json');
+  fs.mkdirSync(path.dirname(tvControlPackage), { recursive: true });
+  fs.writeFileSync(tvControlPackage, TVCONTROL_FIXTURE);
   fs.cpSync(path.resolve('resources/managed-cli-shims'), path.join(resources, 'managed-cli-shims'), {
     recursive: true,
   });
@@ -592,6 +612,15 @@ afterEach(() => {
 const itAcceptedSweep = it.skipIf(process.platform === 'win32');
 
 describe('packaged resource release gate', () => {
+  it('refuses a missing or tampered bundled TVControl tree', () => {
+    const out = createPackagedResources(true);
+    const connector = path.join(packagedResourcesPath(out), 'bundled-tvcontrol');
+    fs.appendFileSync(path.join(connector, 'node_modules/@ferroxlabs/tvcontrol/package.json'), ' ');
+    expect(() => verify(out)).toThrow();
+    fs.rmSync(connector, { recursive: true });
+    expect(() => verify(out)).toThrow();
+  });
+
   const verify = (
     out: string,
     officeCliRuntime = 'darwin-arm64',


### PR DESCRIPTION
## Problem and behavior

Restore the Smart Trader / Wayland Core first-message and TC-TIDE report workflow. New-chat prompts previously disappeared while recovery readiness loaded. Retain prompt/files until readiness, dispatch once, and preserve failed submissions without automatic duplicates. Delayed conversation status responses also no longer overwrite newer start/finish events or outgoing sends.

Bundle pinned TVControl 2.4.7 with its locked dependency tree and compiled integrity authority. For the selected catalog connector, provision a verified workspace copy into the scratch directory Core actually reports, before allowing the first command. This lets the unchanged collector discover the bundle under the shell sandbox without global filesystem grants, manual copies or runtime npm installation. Custom connector definitions remain unchanged.

## Validation

- First-send: 38 DOM checks, typecheck and lint passed; real UI prompt persisted in1.66s and tool activity began in8.79s.
- Navigation ordering: 52 hook/queue checks and typecheck passed, including stale response and exactly-once queue controls.
- Bundling: scoped bundle/runtime checks passed; receipt correction33 focused checks/typecheck passed. Pinned2.4.7 MCP initialization verified.
- Combined79 seam checks and typecheck passed; prior combined macOS package passed. Current receipt-corrected package and fresh full workflow remain in progress.
- Existing diagnostic live scan produced74/74 panels and HTML; it used assisted connector/output setup and is not final packaged acceptance.
- Current-source CI and packaged end-to-end acceptance remain required. No release completion claimed.

References #1339. Replaces the masterclass-blocking behavior observed after PR#1334; v0.12.15 publication was cancelled, existing tag preserved. No recovery/sandbox/terminal guard bypass.

## Release candidate

Prepare 0.12.16; the cancelled 0.12.15 tag remains unchanged. The only follow-up after verified4ce98e26 is package version and changelog metadata.

All PR CI and Nano gates passed on4ce98e26. Packaged93e4 (formatting-only predecessor) completed the real74-symbol TC-TIDE scan using bundled2.4.7 with no connector download, and the report opened through Artifacts. Operator assistance added the illustrative sizing disclosure and restored the chart; this is not claimed as fully autonomous completion. These limitations remain recorded.

Final-version commit checks and ordinary signed release acceptance remain required before publication.
