### PR TITLE
fix(release): verify candidate bridge source as data

### DIFF
--- a/.github/workflows/protected-platform-package-observer.yml
+++ b/.github/workflows/protected-platform-package-observer.yml
@@ -139,6 +139,16 @@ jobs:
           echo "bun install failed after 3 attempts (GitHub API or registry unreachable)" >&2
           exit 1
 
+      - name: Reconstruct exact candidate bridge dependencies as data
+        shell: bash
+        env:
+          EXPECTED_COMMIT: ${{ inputs.candidate_commit }}
+          EXPECTED_TREE: ${{ inputs.candidate_tree }}
+        run: |
+          set -euo pipefail
+          cd candidate
+          node ../trust/scripts/candidate-whatsapp-source.js
+
       - name: Capture empty pre-download package state
         id: package-state
         shell: bash

--- a/.github/workflows/protected-updater-journey-observer.yml
+++ b/.github/workflows/protected-updater-journey-observer.yml
@@ -165,6 +165,16 @@ jobs:
       # provably empty. The digest is published as a step output because a step cannot
       # read its own outputs: `${{ steps.<id>.outputs.* }}` is expanded before the step
       # body runs and would interpolate to the empty string.
+      - name: Reconstruct exact candidate bridge dependencies as data
+        shell: bash
+        env:
+          EXPECTED_COMMIT: ${{ inputs.candidate_commit }}
+          EXPECTED_TREE: ${{ inputs.candidate_tree }}
+        run: |
+          set -euo pipefail
+          cd candidate
+          node ../trust/scripts/candidate-whatsapp-source.js
+
       - name: Capture empty pre-download package state
         id: package-state
         shell: bash

--- a/scripts/candidate-whatsapp-source.js
+++ b/scripts/candidate-whatsapp-source.js
@@ -1,0 +1,101 @@
+'use strict';
+
+// Executed from the protected observer checkout. Candidate files are DATA:
+// never require a candidate module or execute its package lifecycle scripts.
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const { execFileSync } = require('node:child_process');
+const protectedAuthority = require('./whatsapp-bridge-source.json');
+const REQUIRED_FILES = Object.keys(protectedAuthority.files).sort();
+
+function assertCandidateIdentity(sourceRoot, expectedIdentity) {
+  if (
+    !/^[a-f0-9]{40,64}$/.test(expectedIdentity?.commit || '') ||
+    !/^[a-f0-9]{40,64}$/.test(expectedIdentity?.tree || '')
+  ) {
+    throw new Error('Candidate WhatsApp source requires a verified commit/tree identity');
+  }
+  const git = (...args) => execFileSync('git', args, { cwd: sourceRoot, encoding: 'utf8' }).trim();
+  if (
+    git('rev-parse', 'HEAD') !== expectedIdentity.commit ||
+    git('rev-parse', 'HEAD^{tree}') !== expectedIdentity.tree ||
+    git('status', '--porcelain=v1', '--untracked-files=all')
+  ) {
+    throw new Error('Candidate WhatsApp source identity changed or worktree is dirty');
+  }
+}
+
+function regularFile(root, relative) {
+  let current = root;
+  const parts = relative.split('/');
+  for (let index = 0; index < parts.length; index++) {
+    current = path.join(current, parts[index]);
+    const stat = fs.lstatSync(current);
+    if (stat.isSymbolicLink() || (index === parts.length - 1 ? !stat.isFile() : !stat.isDirectory())) {
+      throw new Error(`Candidate WhatsApp source must be regular files: ${relative}`);
+    }
+  }
+  return current;
+}
+
+function resolveCandidateWhatsAppSource(sourceRoot, expectedIdentity) {
+  const root = fs.realpathSync(sourceRoot);
+  assertCandidateIdentity(root, expectedIdentity);
+  const authority = JSON.parse(fs.readFileSync(regularFile(root, 'scripts/whatsapp-bridge-source.json'), 'utf8'));
+  if (
+    JSON.stringify(Object.keys(authority).sort()) !== JSON.stringify(['contract', 'files']) ||
+    authority.contract !== protectedAuthority.contract ||
+    !authority.files ||
+    Array.isArray(authority.files) ||
+    JSON.stringify(Object.keys(authority.files).sort()) !== JSON.stringify(REQUIRED_FILES)
+  ) {
+    throw new Error('Candidate WhatsApp authority must retain the protected contract and exact required file set');
+  }
+  const sourceDir = path.join(root, 'src/process/channels/whatsapp-bridge');
+  for (const relative of REQUIRED_FILES) {
+    const expected = authority.files[relative];
+    if (
+      !expected ||
+      JSON.stringify(Object.keys(expected).sort()) !== JSON.stringify(['sha256', 'size']) ||
+      !Number.isSafeInteger(expected.size) ||
+      expected.size < 0 ||
+      !/^[a-f0-9]{64}$/.test(expected.sha256 || '')
+    ) {
+      throw new Error(`Candidate WhatsApp authority has an invalid file pin: ${relative}`);
+    }
+    const file = regularFile(root, `src/process/channels/whatsapp-bridge/${relative}`);
+    const bytes = fs.readFileSync(file);
+    if (bytes.length !== expected.size || crypto.createHash('sha256').update(bytes).digest('hex') !== expected.sha256) {
+      throw new Error(`Candidate WhatsApp source differs from its committed pin: ${relative}`);
+    }
+  }
+  return { whatsappSourceDir: sourceDir, whatsappAuthority: authority };
+}
+
+function prepareCandidateWhatsAppSource(sourceRoot, expectedIdentity, execute = execFileSync) {
+  const resolved = resolveCandidateWhatsAppSource(sourceRoot, expectedIdentity);
+  const version = String(execute('bun', ['--version'], { encoding: 'utf8' })).trim();
+  if (version !== '1.3.14')
+    throw new Error(`Protected WhatsApp reconstruction requires Bun 1.3.14, received ${version}`);
+  execute('bun', ['install', '--frozen-lockfile', '--ignore-scripts'], {
+    cwd: resolved.whatsappSourceDir,
+    stdio: 'inherit',
+  });
+  // A frozen install must not change the pinned source inputs.
+  resolveCandidateWhatsAppSource(sourceRoot, expectedIdentity);
+  return resolved;
+}
+
+module.exports = { resolveCandidateWhatsAppSource, prepareCandidateWhatsAppSource };
+if (require.main === module) {
+  try {
+    prepareCandidateWhatsAppSource(process.cwd(), {
+      commit: process.env.EXPECTED_COMMIT,
+      tree: process.env.EXPECTED_TREE,
+    });
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/platform-package-smoke.mjs
+++ b/scripts/platform-package-smoke.mjs
@@ -20,6 +20,7 @@ const {
 } = require('./verify-packaged-resources.js');
 const { isSupportedWNanoTarget } = require('./prepareWaylandNano.js');
 const { isSupportedBunTarget } = require('./prepareBundledBun.js');
+const { resolveCandidateWhatsAppSource } = require('./candidate-whatsapp-source.js');
 
 const TAG = '[platform-package-smoke]';
 const OPTIONAL_RESOURCES = ['hub', 'whatsapp-bridge', 'signal-cli-runtime'];
@@ -1550,7 +1551,12 @@ export async function runSmoke(options, dependencies = {}) {
     // mismatch from an absent file. Replay them before rethrowing.
     let verification;
     try {
+      const candidateBridge = (dependencies.resolveCandidateWhatsAppSource || resolveCandidateWhatsAppSource)(
+        dependencies.sourceRoot || process.cwd(),
+        installed.installerFreshness.sourceIdentity
+      );
       verification = verifyResources({
+        ...candidateBridge,
         argv: [
           'node',
           'verify-packaged-resources.js',

--- a/tests/unit/candidateWhatsAppSource.test.ts
+++ b/tests/unit/candidateWhatsAppSource.test.ts
@@ -1,0 +1,143 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const {
+  resolveCandidateWhatsAppSource,
+  prepareCandidateWhatsAppSource,
+} = require('../../scripts/candidate-whatsapp-source.js');
+const { verifySourceMirror } = require('../../scripts/verify-packaged-resources.js');
+const protectedAuthority = require('../../scripts/whatsapp-bridge-source.json');
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+function fixture() {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'candidate-bridge-')));
+  roots.push(root);
+  const source = path.join(root, 'src/process/channels/whatsapp-bridge');
+  const authorityPath = path.join(root, 'scripts/whatsapp-bridge-source.json');
+  const files: Record<string, string> = Object.fromEntries(
+    Object.keys(protectedAuthority.files).map((name) => [name, `fixture ${name}\n`])
+  );
+  files['package.json'] = JSON.stringify({
+    name: '@wayland/whatsapp-bridge',
+    dependencies: { axios: '1.20.0' },
+    scripts: { postinstall: 'untrusted-candidate-command' },
+  });
+  files['bun.lock'] =
+    '{\n"dependencies": {\n"axios": "1.20.0"\n},\n"packages": {\n"axios": ["axios@1.20.0", "", {}, "sha512-YQ=="]\n}\n}\n';
+  const authority = {
+    contract: protectedAuthority.contract,
+    files: {} as Record<string, { size: number; sha256: string }>,
+  };
+  for (const [name, content] of Object.entries(files)) {
+    const file = path.join(source, name);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, content);
+    authority.files[name] = {
+      size: Buffer.byteLength(content),
+      sha256: crypto.createHash('sha256').update(content).digest('hex'),
+    };
+  }
+  fs.mkdirSync(path.dirname(authorityPath), { recursive: true });
+  fs.writeFileSync(authorityPath, JSON.stringify(authority));
+  fs.writeFileSync(path.join(root, '.gitignore'), 'node_modules/\n');
+  fs.mkdirSync(path.join(source, 'node_modules/axios'), { recursive: true });
+  fs.writeFileSync(path.join(source, 'node_modules/axios/index.js'), 'module.exports = "1.20.0";');
+  const git = (...args: string[]) => execFileSync('git', args, { cwd: root, encoding: 'utf8' }).trim();
+  git('init', '--quiet');
+  const commit = () => {
+    git('add', '.');
+    git('-c', 'user.name=Fixture', '-c', 'user.email=fixture@example.invalid', 'commit', '--quiet', '-m', 'fixture');
+    return { commit: git('rev-parse', 'HEAD'), tree: git('rev-parse', 'HEAD^{tree}') };
+  };
+  return { root, source, authorityPath, authority, commit, identity: commit() };
+}
+
+describe('protected observer verifies candidate WhatsApp source as pinned data', () => {
+  it('accepts a committed dependency update while retaining the full installed-source inventory check', () => {
+    const f = fixture();
+    const resolved = resolveCandidateWhatsAppSource(f.root, f.identity);
+    const bundle = fs.mkdtempSync(path.join(os.tmpdir(), 'installed-bridge-'));
+    roots.push(bundle);
+    fs.cpSync(f.source, bundle, { recursive: true });
+    expect(verifySourceMirror(bundle, f.source, protectedAuthority, 'linux', 'x64')).toBe(false);
+    expect(verifySourceMirror(bundle, resolved.whatsappSourceDir, resolved.whatsappAuthority, 'linux', 'x64')).toBe(
+      true
+    );
+    fs.appendFileSync(path.join(bundle, 'node_modules/axios/index.js'), 'tampered');
+    expect(verifySourceMirror(bundle, resolved.whatsappSourceDir, resolved.whatsappAuthority, 'linux', 'x64')).toBe(
+      false
+    );
+  });
+  it('rejects a changed source file even when the caller keeps the old identity', () => {
+    const f = fixture();
+    fs.appendFileSync(path.join(f.source, 'bridge.js'), 'changed');
+    expect(() => resolveCandidateWhatsAppSource(f.root, f.identity)).toThrow('identity changed or worktree is dirty');
+  });
+  it('rejects a committed source change with an unchanged manifest pin', () => {
+    const f = fixture();
+    fs.appendFileSync(path.join(f.source, 'bridge.js'), 'changed');
+    expect(() => resolveCandidateWhatsAppSource(f.root, f.commit())).toThrow('differs from its committed pin');
+  });
+  it.each(['omission', 'extra-path', 'invalid-pin'])(
+    'rejects a candidate-authored %s authority even when committed',
+    (mutation) => {
+      const f = fixture();
+      if (mutation === 'omission') delete f.authority.files['bun.lock'];
+      if (mutation === 'extra-path') f.authority.files['../outside'] = f.authority.files['bun.lock'];
+      if (mutation === 'invalid-pin') f.authority.files['bun.lock'].sha256 = 'invalid';
+      fs.writeFileSync(f.authorityPath, JSON.stringify(f.authority));
+      expect(() => resolveCandidateWhatsAppSource(f.root, f.commit())).toThrow(/protected contract|invalid file pin/);
+    }
+  );
+  it('rejects a candidate source symlink', () => {
+    const f = fixture();
+    const file = path.join(f.source, 'bridge.js');
+    fs.unlinkSync(file);
+    fs.symlinkSync(path.join(f.source, 'allowlist.js'), file);
+    expect(() => resolveCandidateWhatsAppSource(f.root, f.commit())).toThrow('regular files');
+  });
+  it('requires the exact captured source identity', () => {
+    const f = fixture();
+    expect(() => resolveCandidateWhatsAppSource(f.root, { ...f.identity, commit: '1'.repeat(40) })).toThrow(
+      'identity changed'
+    );
+    expect(() => resolveCandidateWhatsAppSource(f.root, undefined)).toThrow('verified commit/tree');
+  });
+  it('reconstructs with pinned Bun, frozen lock, and lifecycle scripts disabled', () => {
+    const f = fixture();
+    const execute = vi.fn().mockReturnValueOnce('1.3.14\n').mockReturnValue('');
+    prepareCandidateWhatsAppSource(f.root, f.identity, execute);
+    expect(execute).toHaveBeenLastCalledWith('bun', ['install', '--frozen-lockfile', '--ignore-scripts'], {
+      cwd: f.source,
+      stdio: 'inherit',
+    });
+  });
+  it('refuses a different package manager version before installing dependencies', () => {
+    const f = fixture();
+    const execute = vi.fn().mockReturnValue('1.4.2\n');
+    expect(() => prepareCandidateWhatsAppSource(f.root, f.identity, execute)).toThrow('requires Bun 1.3.14');
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+  it('refuses a dependency installation that changes tracked inputs', () => {
+    const f = fixture();
+    const execute = vi
+      .fn()
+      .mockReturnValueOnce('1.3.14\n')
+      .mockImplementation(() => {
+        fs.appendFileSync(path.join(f.source, 'bun.lock'), 'changed');
+        return '';
+      });
+    expect(() => prepareCandidateWhatsAppSource(f.root, f.identity, execute)).toThrow(
+      'identity changed or worktree is dirty'
+    );
+  });
+});

--- a/tests/unit/platformPackageSmoke.test.ts
+++ b/tests/unit/platformPackageSmoke.test.ts
@@ -249,6 +249,10 @@ function smokeHarness() {
     assertPortVacant: vi.fn(async () => undefined),
     spawn: vi.fn(() => child),
     verifyPackagedResources: verify,
+    resolveCandidateWhatsAppSource: vi.fn(() => ({
+      whatsappSourceDir: '/candidate/whatsapp-bridge',
+      whatsappAuthority: { contract: 'wayland-whatsapp-bridge-source/1.0', files: {} },
+    })),
     waitForRendererReady: vi.fn(
       async (
         _port: number,
@@ -1343,6 +1347,16 @@ describe('runSmoke hostile orchestration', () => {
     const report = await runSmoke(harness.options, harness.dependencies);
     expect(harness.dependencies.prepareInstalledCandidate).toHaveBeenCalledOnce();
     expect(harness.verify).toHaveBeenCalledOnce();
+    expect(harness.dependencies.resolveCandidateWhatsAppSource).toHaveBeenCalledWith(
+      process.cwd(),
+      harness.installed.installerFreshness.sourceIdentity
+    );
+    expect(harness.verify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        whatsappSourceDir: '/candidate/whatsapp-bridge',
+        whatsappAuthority: expect.objectContaining({ contract: 'wayland-whatsapp-bridge-source/1.0' }),
+      })
+    );
     expect(report.criticalResources).toBe('verified');
     expect(report.installerDigest).toMatch(/^sha256:[a-f0-9]{64}$/);
     expect(report.verifiedCandidateDigest).toBe(harness.installed.installedDigest);


### PR DESCRIPTION
## Problem

The protected installer/updater observers run trusted verifier code from release-trust-v1 but accidentally compare the new candidate's WhatsApp bridge against source files from the older trusted checkout. The0.12.16 signed installers therefore fail on intended, already-reviewed dependency changes.

## Correction

Keep verification code protected. Reconstruct the authenticated candidate bridge as data with pinnedBun1.3.14, frozen lock and lifecycle scripts disabled. Enforce exact candidatecommit/tree/cleanstate, the protected contract and exact required file set, regular paths and matching committed hashes. Pass that verified data into the existing full installed-source comparison. No signature, provenance, inventory or publication checks are removed.

## Validation

181 focused tests pass, including malformed/missing authority, source/path/identity rejection and installed-byte tampering. Real candidateae9c3f815/tree98ba71a42 reconstruction produced265packages; protected verification against the actual emitted bridge passed with no discrepancies. No candidate installer or release tag changed.

## Deployment boundary

Proposed protected revision b41e08af90184583328c2166c982e49de557f4fc, based only on8354ea7e4. After review, advance protected branch and matching WAYLAND_RELEASE_TRUST_ROOT_SHA together; then rerun only failed producer observer callers with new current-attempt attestations. Existing six signed installer artifacts are reused. Never force/move release tags or manually publish the draft.
