### PR TITLE
fix(release): verify built manifest variants

### DIFF
--- a/scripts/candidate-whatsapp-source.js
+++ b/scripts/candidate-whatsapp-source.js
@@ -39,6 +39,77 @@ function regularFile(root, relative) {
   return current;
 }
 
+function dependencyManifestVariants(root, sourceDir) {
+  const rootPackage = JSON.parse(fs.readFileSync(regularFile(root, 'package.json'), 'utf8'));
+  const overrideNames = new Set();
+  for (const field of ['resolutions', 'overrides']) {
+    const map = rootPackage[field];
+    if (map === undefined) continue;
+    if (!map || typeof map !== 'object' || Array.isArray(map))
+      throw new Error('Candidate dependency overrides must be string maps');
+    for (const [name, range] of Object.entries(map)) {
+      if (
+        !/^[a-zA-Z0-9@][a-zA-Z0-9@/._-]*$/.test(name) ||
+        typeof range !== 'string' ||
+        !range ||
+        range.includes('\0')
+      ) {
+        throw new Error('Candidate dependency overrides must be string maps');
+      }
+      overrideNames.add(name);
+    }
+  }
+  const variants = {};
+  const digest = (bytes) => ({ size: bytes.length, sha256: crypto.createHash('sha256').update(bytes).digest('hex') });
+  const visit = (directory) => {
+    if (!fs.existsSync(directory)) return;
+    if (!fs.lstatSync(directory).isDirectory()) throw new Error('Candidate dependency directory is redirected');
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const full = path.join(directory, entry.name);
+      if (entry.name.startsWith('@') || entry.name === 'node_modules') {
+        visit(full);
+        continue;
+      }
+      const file = path.join(full, 'package.json');
+      if (fs.existsSync(file)) {
+        const relative = path.relative(sourceDir, file).split(path.sep).join('/');
+        const bytes = fs.readFileSync(regularFile(sourceDir, relative));
+        const pkg = JSON.parse(bytes.toString('utf8'));
+        let changed = false;
+        for (const field of ['dependencies', 'optionalDependencies']) {
+          const deps = pkg[field];
+          if (deps === undefined) continue;
+          if (
+            !deps ||
+            typeof deps !== 'object' ||
+            Array.isArray(deps) ||
+            Object.values(deps).some((range) => typeof range !== 'string')
+          ) {
+            throw new Error(`Invalid reconstructed dependency manifest: ${relative}`);
+          }
+          for (const name of Object.keys(deps)) {
+            if (overrideNames.has(name) && deps[name] !== '*') {
+              deps[name] = '*';
+              changed = true;
+            }
+          }
+        }
+        // Reproduce ONLY the protected producer's patchOverriddenDepRanges
+        // transformation. Installed bytes never enter this derivation.
+        if (changed)
+          variants[relative] = {
+            pristine: digest(bytes),
+            normalized: digest(Buffer.from(JSON.stringify(pkg, null, 2) + '\n')),
+          };
+      }
+      visit(path.join(full, 'node_modules'));
+    }
+  };
+  visit(path.join(sourceDir, 'node_modules'));
+  return variants;
+}
+
 function resolveCandidateWhatsAppSource(sourceRoot, expectedIdentity) {
   const root = fs.realpathSync(sourceRoot);
   assertCandidateIdentity(root, expectedIdentity);
@@ -70,7 +141,11 @@ function resolveCandidateWhatsAppSource(sourceRoot, expectedIdentity) {
       throw new Error(`Candidate WhatsApp source differs from its committed pin: ${relative}`);
     }
   }
-  return { whatsappSourceDir: sourceDir, whatsappAuthority: authority };
+  return {
+    whatsappSourceDir: sourceDir,
+    whatsappAuthority: authority,
+    whatsappDependencyManifestVariants: dependencyManifestVariants(root, sourceDir),
+  };
 }
 
 function prepareCandidateWhatsAppSource(sourceRoot, expectedIdentity, execute = execFileSync) {
@@ -83,8 +158,7 @@ function prepareCandidateWhatsAppSource(sourceRoot, expectedIdentity, execute = 
     stdio: 'inherit',
   });
   // A frozen install must not change the pinned source inputs.
-  resolveCandidateWhatsAppSource(sourceRoot, expectedIdentity);
-  return resolved;
+  return resolveCandidateWhatsAppSource(sourceRoot, expectedIdentity);
 }
 
 module.exports = { resolveCandidateWhatsAppSource, prepareCandidateWhatsAppSource };

--- a/scripts/verify-packaged-resources.js
+++ b/scripts/verify-packaged-resources.js
@@ -1138,7 +1138,8 @@ function verifySourceMirror(
   targetPlatform = process.platform,
   targetArch = process.arch,
   signedCheck = isDarwinDeveloperIdSigned,
-  reasons = []
+  reasons = [],
+  dependencyManifestVariants = {}
 ) {
   if (authority.contract !== 'wayland-whatsapp-bridge-source/1.0') {
     reasons.push(`authority contract is ${authority.contract}`);
@@ -1184,6 +1185,32 @@ function verifySourceMirror(
     reasons.push('could not inventory the source or bundled tree');
     return false;
   }
+  // Accept only an entire source-derived producer-normalized package manifest,
+  // not arbitrary installed JSON with selected fields erased. Every other byte
+  // remains under the original source-inventory and native-signature checks.
+  const alternatives = new Map();
+  for (const [relative, variant] of Object.entries(dependencyManifestVariants)) {
+    if (
+      !relative.startsWith('node_modules/') ||
+      !relative.endsWith('/package.json') ||
+      relative.split('/').some((part) => part === '..' || part === '.' || !part)
+    ) {
+      reasons.push('invalid dependency manifest alternative path');
+      return false;
+    }
+    const record = (pin) =>
+      pin && Number.isSafeInteger(pin.size) && pin.size >= 0 && /^[a-f0-9]{64}$/.test(pin.sha256)
+        ? `file:${relative}:${pin.size}:${pin.sha256}`
+        : null;
+    const pristine = record(variant?.pristine);
+    const normalized = record(variant?.normalized);
+    if (!pristine || !normalized || !source.includes(pristine)) {
+      reasons.push('dependency manifest alternative does not match reconstructed source');
+      return false;
+    }
+    alternatives.set(normalized, pristine);
+  }
+  bundled = bundled.map((record) => alternatives.get(record) || record);
   if (targetPlatform === 'darwin') bundled = reconcileStagedDarwinNatives(bundleDir, source, bundled, signedCheck);
   if (JSON.stringify(bundled) === JSON.stringify(source)) return true;
   const srcSet = new Set(source);
@@ -1394,7 +1421,8 @@ function isNonEmpty(
   wnanoAuthority = prepareWaylandNano,
   wnanoPolicySelector = selectPolicy,
   darwinSignedCheck = isDarwinDeveloperIdSigned,
-  requireDarwinSignature = false
+  requireDarwinSignature = false,
+  whatsappDependencyManifestVariants
 ) {
   // Per-resource, NOT cumulative. `hub` is optional and absent on every build, so
   // its stat throws and left a `threw: ENOENT ... resources\hub` line sitting in
@@ -1523,7 +1551,8 @@ function isNonEmpty(
         targetPlatform,
         targetArch,
         isDarwinDeveloperIdSigned,
-        failureReasons
+        failureReasons,
+        whatsappDependencyManifestVariants
       );
     return hasNonHiddenRegularFile(p);
   } catch (error) {
@@ -1706,7 +1735,8 @@ function verifyPackagedResources(options = {}) {
         wnanoAuthority,
         wnanoPolicySelector,
         darwinSignedCheck,
-        requireDarwinSignature
+        requireDarwinSignature,
+        options.whatsappDependencyManifestVariants
       );
       if (ok) {
         logger.log(`${TAG}   OK   ${req.rel}`);

--- a/tests/unit/candidateWhatsAppSource.test.ts
+++ b/tests/unit/candidateWhatsAppSource.test.ts
@@ -48,6 +48,7 @@ function fixture() {
   }
   fs.mkdirSync(path.dirname(authorityPath), { recursive: true });
   fs.writeFileSync(authorityPath, JSON.stringify(authority));
+  fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ overrides: { 'form-data': '4.0.6' } }));
   fs.writeFileSync(path.join(root, '.gitignore'), 'node_modules/\n');
   fs.mkdirSync(path.join(source, 'node_modules/axios'), { recursive: true });
   fs.writeFileSync(path.join(source, 'node_modules/axios/index.js'), 'module.exports = "1.20.0";');
@@ -139,5 +140,134 @@ describe('protected observer verifies candidate WhatsApp source as pinned data',
     expect(() => prepareCandidateWhatsAppSource(f.root, f.identity, execute)).toThrow(
       'identity changed or worktree is dirty'
     );
+  });
+});
+
+describe('protected source-derived dependency manifest alternatives', () => {
+  function manifestFixture() {
+    const f = fixture();
+    const relative = 'node_modules/axios/package.json';
+    const manifest = {
+      name: 'axios',
+      version: '1.20.0',
+      dependencies: { 'form-data': '^4.0.6', other: '^1.0.0' },
+      optionalDependencies: { 'form-data': '^4.0.6', optional: '^2.0.0' },
+      scripts: { test: 'original-test-command' },
+    };
+    const pristine = JSON.stringify(manifest, null, 2) + '\n';
+    fs.writeFileSync(path.join(f.source, relative), pristine);
+    const resolved = resolveCandidateWhatsAppSource(f.root, f.identity);
+    const bundle = fs.mkdtempSync(path.join(os.tmpdir(), 'installed-manifest-'));
+    roots.push(bundle);
+    fs.cpSync(f.source, bundle, { recursive: true });
+    const normalized = {
+      ...manifest,
+      dependencies: { ...manifest.dependencies, 'form-data': '*' },
+      optionalDependencies: { ...manifest.optionalDependencies, 'form-data': '*' },
+    };
+    const installedManifest = path.join(bundle, relative);
+    const writeInstalled = (value: unknown) =>
+      fs.writeFileSync(installedManifest, JSON.stringify(value, null, 2) + '\n');
+    const check = (variants = resolved.whatsappDependencyManifestVariants) =>
+      verifySourceMirror(bundle, f.source, resolved.whatsappAuthority, 'linux', 'x64', undefined, [], variants);
+    return { ...f, relative, pristine, resolved, bundle, normalized, installedManifest, writeInstalled, check };
+  }
+
+  it('accepts pristine dependency bytes with the alternative present', () => {
+    const f = manifestFixture();
+    expect(f.check()).toBe(true);
+  });
+
+  it('accepts exactly the existing producer transformation of overridden dependency ranges', () => {
+    const f = manifestFixture();
+    f.writeInstalled(f.normalized);
+    expect(f.check()).toBe(true);
+    expect(f.check({})).toBe(false);
+  });
+
+  it.each(['version', 'script', 'extra field', 'unrelated dependency', 'unrelated optional', 'partial transformation'])(
+    'rejects %s changes even alongside the allowed transformation',
+    (mutation) => {
+      const f = manifestFixture();
+      const changed = structuredClone(f.normalized);
+      if (mutation === 'version') changed.version = '1.20.1';
+      if (mutation === 'script') changed.scripts.test = 'changed-command';
+      if (mutation === 'extra field') Object.assign(changed, { injected: true });
+      if (mutation === 'unrelated dependency') changed.dependencies.other = '*';
+      if (mutation === 'unrelated optional') changed.optionalDependencies.optional = '*';
+      if (mutation === 'partial transformation') changed.optionalDependencies['form-data'] = '^4.0.6';
+      f.writeInstalled(changed);
+      expect(f.check()).toBe(false);
+    }
+  );
+
+  it('does not normalize installed JSON formatting before comparing it', () => {
+    const f = manifestFixture();
+    fs.writeFileSync(f.installedManifest, JSON.stringify(f.normalized));
+    expect(f.check()).toBe(false);
+  });
+
+  it.each(['runtime', 'extra file', 'missing file', 'symlink'])(
+    'retains rejection of %s changes with an otherwise valid manifest',
+    (mutation) => {
+      const f = manifestFixture();
+      f.writeInstalled(f.normalized);
+      const runtime = path.join(f.bundle, 'node_modules/axios/index.js');
+      if (mutation === 'runtime') fs.appendFileSync(runtime, 'tampered');
+      if (mutation === 'extra file') fs.writeFileSync(path.join(f.bundle, 'extra.js'), 'extra');
+      if (mutation === 'missing file') fs.unlinkSync(runtime);
+      if (mutation === 'symlink') {
+        fs.unlinkSync(f.installedManifest);
+        fs.symlinkSync(path.join(f.source, f.relative), f.installedManifest);
+      }
+      expect(f.check()).toBe(false);
+    }
+  );
+
+  it.each(['wrong pristine hash', 'invalid normalized hash', 'null pin', 'traversal', 'root manifest'])(
+    'rejects an invalid alternative: %s',
+    (mutation) => {
+      const f = manifestFixture();
+      const variants = structuredClone(f.resolved.whatsappDependencyManifestVariants);
+      const pin = variants[f.relative];
+      if (mutation === 'wrong pristine hash') pin.pristine.sha256 = '0'.repeat(64);
+      if (mutation === 'invalid normalized hash') pin.normalized.sha256 = 'not-a-hash';
+      if (mutation === 'null pin') variants[f.relative] = null;
+      if (mutation === 'traversal') variants['node_modules/../package.json'] = pin;
+      if (mutation === 'root manifest') variants['package.json'] = pin;
+      expect(f.check(variants)).toBe(false);
+    }
+  );
+
+  it('derives no alternatives when the candidate has no dependency overrides', () => {
+    const f = manifestFixture();
+    fs.writeFileSync(path.join(f.root, 'package.json'), '{}');
+    const resolved = resolveCandidateWhatsAppSource(f.root, f.commit());
+    expect(resolved.whatsappDependencyManifestVariants).toEqual({});
+  });
+
+  it.each([null, [], { 'form-data': {} }, { '../outside': '1.0.0' }])(
+    'refuses a malformed candidate override map %#',
+    (overrides) => {
+      const f = fixture();
+      fs.writeFileSync(path.join(f.root, 'package.json'), JSON.stringify({ overrides }));
+      expect(() => resolveCandidateWhatsAppSource(f.root, f.commit())).toThrow('must be string maps');
+    }
+  );
+
+  it('returns alternatives derived after frozen dependency installation, not a stale pre-install snapshot', () => {
+    const f = fixture();
+    const execute = vi
+      .fn()
+      .mockReturnValueOnce('1.3.14\n')
+      .mockImplementation(() => {
+        fs.writeFileSync(
+          path.join(f.source, 'node_modules/axios/package.json'),
+          JSON.stringify({ name: 'axios', version: '1.20.0', dependencies: { 'form-data': '^4.0.6' } })
+        );
+        return '';
+      });
+    const resolved = prepareCandidateWhatsAppSource(f.root, f.identity, execute);
+    expect(Object.keys(resolved.whatsappDependencyManifestVariants)).toEqual(['node_modules/axios/package.json']);
   });
 });


### PR DESCRIPTION
The protected observer rejects a packaged WhatsApp dependency manifest after the normal producer rewrites override-pinned dependency ranges. Derive the complete permitted manifest variant from the verified candidate source and accept only its exact bytes or the pristine bytes. Preserve the full source inventory, identity checks, scripts-disabled reconstruction and native-signature checks.

The helper also returns the post-install derivation. Regression tests reject unrelated metadata, scripts, versions, dependency ranges, partial rewrites, runtime changes, missing/extra files, symlinks and malformed paths/pins.

Validation: 196 tests passed across the three frozen candidate/source-mirror/platform-smoke suites; changed JavaScript syntax, changed-file formatting and diff checks passed. The preserved local macOS bridge passes; the derived Axios bytes match the recorded Linux hash exactly. No new six-platform protected observer pass is claimed.

Release-owner authorization covers this exact locally reviewed patch, protected trust integration and matching pin deployment, followed by one failed-jobs-only producer retry and normal gated publication if every required check passes. No workflow, branch protection, installer bytes or release tag is changed by this PR. Historical failed attempts remain recorded; no additional correction loop is authorized.
