### PR TITLE
fix(acp): preserve custom launch and initial models

### DIFF
--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -1351,10 +1351,13 @@ ${collectedResponses.join('\n')}`;
     customArgs?: string[];
     customEnv?: Record<string, string>;
   }> {
-    const customAgents = await ProcessConfig.get('assistants');
-    let customAgentConfig: CustomAgentLaunchConfig | undefined = customAgents?.find(
-      (agent) => agent.id === data.customAgentId
-    );
+    const [customAgents, assistants] = await Promise.all([
+      ProcessConfig.get('acp.customAgents'),
+      ProcessConfig.get('assistants'),
+    ]);
+    let customAgentConfig: CustomAgentLaunchConfig | undefined =
+      customAgents?.find((agent) => agent.id === data.customAgentId) ??
+      assistants?.find((agent) => agent.id === data.customAgentId);
 
     // Fallback: extension adapter (customAgentId format: ext:{extensionName}:{adapterId})
     if (!customAgentConfig && data.customAgentId!.startsWith('ext:')) {
@@ -2092,6 +2095,20 @@ ${collectedResponses.join('\n')}`;
       return this.agent.start().then(async () => {
         await this.restorePersistedState();
         this.bootstrapping = false;
+        // Bootstrap suppresses stream events, including the initial model snapshot.
+        // Publish the cached authoritative catalog once the host is ready.
+        const modelInfo = this.agent.getModelInfo();
+        if (modelInfo?.availableModels.length) {
+          this.handleStreamEvent(
+            {
+              type: 'acp_model_info',
+              conversation_id: this.conversation_id,
+              msg_id: `model_ready_${this.conversation_id}`,
+              data: modelInfo,
+            },
+            data.backend
+          );
+        }
         return this.agent;
       });
     })();

--- a/tests/unit/acpAgentManagerLaunchSpec.test.ts
+++ b/tests/unit/acpAgentManagerLaunchSpec.test.ts
@@ -54,6 +54,7 @@ vi.mock('@process/acp/compat/AcpAgentV2', () => ({
       capturedAgentConfigs.push(config);
     }
     start = vi.fn().mockResolvedValue(undefined);
+    getModelInfo = vi.fn(() => null);
     stop = vi.fn();
     kill = vi.fn();
     cancelPrompt = vi.fn();

--- a/tests/unit/acpAgentManagerPresetCliResolve.test.ts
+++ b/tests/unit/acpAgentManagerPresetCliResolve.test.ts
@@ -118,6 +118,20 @@ describe('resolveCustomAgentCliConfig — thin-specialist fallthrough (#66)', ()
     mockGet.mockImplementation(async (key: string) => (key === 'assistants' ? ASSISTANTS : undefined));
   });
 
+  it('preserves registered custom launch arguments and environment ahead of legacy rows', async () => {
+    const custom = {
+      id: 'fuigo-pilot',
+      defaultCliPath: '/opt/fuigo',
+      acpArgs: ['agent', '--no-leader', 'stdio'],
+      env: { FUIGO_HOME: '/tmp/fuigo-pilot' },
+    };
+    mockGet.mockImplementation(async (key: string) =>
+      key === 'acp.customAgents' ? [custom] : key === 'assistants' ? [{ ...custom, acpArgs: ['legacy'] }] : undefined
+    );
+    const result = await resolver('custom')({ customAgentId: custom.id, backend: 'custom' });
+    expect(result).toMatchObject({ cliPath: custom.defaultCliPath, customArgs: custom.acpArgs, customEnv: custom.env });
+  });
+
   it('resolves a real cliPath for a thin builtin specialist (no defaultCliPath)', async () => {
     const res = await resolver('claude')({ customAgentId: 'builtin-social', backend: 'claude', cliPath: undefined });
     // The regression returned { cliPath: undefined } → spawn throws. The fix falls

--- a/tests/unit/acpAgentManagerSessionResumeReplay.test.ts
+++ b/tests/unit/acpAgentManagerSessionResumeReplay.test.ts
@@ -25,19 +25,25 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 
 // ── Hoisted mocks (shared with assertions) ───────────────────────────────────
-const { mockAddOrUpdateMessage, mockTransformMessage, mockResponseStreamEmit } = vi.hoisted(() => ({
-  mockAddOrUpdateMessage: vi.fn(),
-  mockTransformMessage: vi.fn((msg: { type: string; data: unknown; conversation_id: string }) => ({
-    type: 'text' as const,
-    id: 'fresh-uuid',
-    msg_id: 'fresh-uuid',
-    position: 'left' as const,
-    conversation_id: msg.conversation_id,
-    content: { content: String(msg.data ?? '') },
-    createdAt: Date.now(),
-  })),
-  mockResponseStreamEmit: vi.fn(),
-}));
+const { mockAddOrUpdateMessage, mockTransformMessage, mockResponseStreamEmit, mockStart, mockModelInfo } = vi.hoisted(
+  () => ({
+    mockStart: vi.fn().mockResolvedValue(undefined),
+    mockModelInfo: vi.fn<
+      () => { currentModelId: string; availableModels: Array<{ id: string; label: string }> } | null
+    >(() => null),
+    mockAddOrUpdateMessage: vi.fn(),
+    mockTransformMessage: vi.fn((msg: { type: string; data: unknown; conversation_id: string }) => ({
+      type: 'text' as const,
+      id: 'fresh-uuid',
+      msg_id: 'fresh-uuid',
+      position: 'left' as const,
+      conversation_id: msg.conversation_id,
+      content: { content: String(msg.data ?? '') },
+      createdAt: Date.now(),
+    })),
+    mockResponseStreamEmit: vi.fn(),
+  })
+);
 
 vi.mock('@process/services/cron/CronBusyGuard', () => ({
   cronBusyGuard: { setProcessing: vi.fn(), isProcessing: vi.fn(() => false) },
@@ -123,6 +129,7 @@ vi.mock('@process/task/ThinkTagDetector', () => ({
 }));
 vi.mock('@process/utils/initAgent', () => ({ hasNativeSkillSupport: vi.fn(() => false) }));
 vi.mock('@process/task/agentUtils', () => ({
+  isConciergeAssistant: vi.fn(() => false),
   prepareFirstMessageWithSkillsIndex: vi.fn((x: string) => Promise.resolve({ content: x, loadedSkills: [] })),
 }));
 vi.mock('@/common/utils', () => ({
@@ -146,11 +153,11 @@ vi.mock('@process/team/prompts/teamGuideCapability.ts', () => ({
 }));
 vi.mock('@process/acp/compat', () => ({
   AcpAgentV2: class {
-    start = vi.fn();
+    start = mockStart;
     sendMessage = vi.fn();
     stop = vi.fn();
     cancelPrompt = vi.fn();
-    getModelInfo = vi.fn(() => null);
+    getModelInfo = mockModelInfo;
     getConfigOptions = vi.fn(() => []);
   },
 }));
@@ -326,5 +333,39 @@ describe('AcpAgentManager - ACP tool titles are display-only MCP evidence', () =
       source: 'desktop',
       tools: [],
     });
+  });
+});
+
+describe('initial ACP model publication', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStart.mockResolvedValue(undefined);
+    mockModelInfo.mockReturnValue(null);
+  });
+
+  function isolatedManager() {
+    const manager = makeManager('initial-models');
+    const internals = manager as unknown as {
+      resolveAgentCliConfig: () => Promise<Record<string, unknown>>;
+      restorePersistedState: () => Promise<void>;
+    };
+    vi.spyOn(internals, 'resolveAgentCliConfig').mockResolvedValue({ cliPath: '/fixture/fuigo' });
+    vi.spyOn(internals, 'restorePersistedState').mockResolvedValue(undefined);
+    return manager;
+  }
+
+  it('publishes the cached model catalog when startup finishes', async () => {
+    const modelInfo = { currentModelId: 'fixture', availableModels: [{ id: 'fixture', label: 'Fixture' }] };
+    mockModelInfo.mockReturnValue(modelInfo);
+    await isolatedManager().initAgent();
+    expect(mockResponseStreamEmit).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'acp_model_info', data: modelInfo })
+    );
+  });
+
+  it('does not publish a model catalog after failed startup', async () => {
+    mockStart.mockRejectedValueOnce(new Error('startup refused'));
+    await expect(isolatedManager().initAgent()).rejects.toThrow('startup refused');
+    expect(mockResponseStreamEmit).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/process/task/acpAgentManagerReceiptLaunch.test.ts
+++ b/tests/unit/process/task/acpAgentManagerReceiptLaunch.test.ts
@@ -55,6 +55,7 @@ vi.mock('@process/acp/compat/AcpAgentV2', () => ({
       capturedAgentConfigs.push(config);
     }
     start = vi.fn().mockResolvedValue(undefined);
+    getModelInfo = vi.fn(() => null);
     stop = vi.fn();
     kill = vi.fn();
     cancelPrompt = vi.fn();


### PR DESCRIPTION
Custom ACP agents registered through `acp.customAgents` lose their configured arguments and environment because launch resolution reads only `assistants`. On first connection, the startup guard also drops the model catalog and leaves the picker empty until the conversation is reopened.

Resolve registered custom agents before the legacy assistant fallback, then publish the cached authoritative model catalog after startup and persisted-state restoration. Historical transcript replay remains guarded.

Validation: the same fixes passed a real isolated Fuigo/Desktop coding task, approval/denial, first-connection model selection, cancellation, reopen and provider handoff. Added regressions cover custom launch precedence and model publication after successful/failed startup. Current-main lint/type checks and the full prek gate pass. The initial Vitest run had 21,691 passes and 47 failures from stale fixture dependencies, nested Cargo-workspace setup and two incomplete mocks; all 130 tests in the 15 affected/new test files passed after correcting those fixtures. The separate Bun-native test gate also passed. No dependency lockfile or native helper source change is included.
