### PR TITLE
fix(fuigo): first chat stalls on Fuigo's 25 KB prompt offload

### DIFF
--- a/src/common/types/acpTypes.ts
+++ b/src/common/types/acpTypes.ts
@@ -468,6 +468,13 @@ export const ACP_BACKENDS_ALL: Record<AcpBackendAll, AcpBackendConfig> = {
     enabled: true,
     supportsStreaming: true,
     acpArgs: ['--permission-mode', 'default', 'agent', 'stdio'],
+    // Skills are staged under `<workspace>/.wayland/skills` and handed to Fuigo
+    // natively as a `session/new` `_meta.pluginDirs` root (launch.ts). Declaring
+    // the dir here keeps the first-message skills index OUT of the prompt: with
+    // it in, a default Concierge first turn was 28,875 bytes, over Fuigo's
+    // 25,000-byte prompt offload threshold, and the offloaded file lives in
+    // $FUIGO_HOME where the model could not read it back.
+    skillsDirs: ['.wayland/skills'],
     fluxCompat: 'env',
   },
   grok: {

--- a/src/process/acp/session/AcpSession.ts
+++ b/src/process/acp/session/AcpSession.ts
@@ -8,6 +8,7 @@ import { RequestError } from '@agentclientprotocol/sdk';
 import * as path from 'node:path';
 import { resolveAcpSessionModeId } from '@/common/types/agentModes';
 import { AcpError } from '@process/acp/errors/AcpError';
+import { isFuigoSessionPromptFile } from '@process/agent/fuigo/launch';
 import { buildAcpAdapterCorruptionGuidance, buildAcpSetupGuidance } from '@process/acp/errors/setupFailure';
 import type { ClientFactory, DisconnectInfo } from '@process/acp/infra/IAcpClient';
 import { noopMetrics, type AcpMetrics } from '@process/acp/metrics/AcpMetrics';
@@ -431,6 +432,18 @@ export class AcpSession {
     }
   }
 
+  /**
+   * The one read allowed outside the workspace: Fuigo's own prompt offload
+   * file under `$FUIGO_HOME/sessions/` (see isFuigoSessionPromptFile). The home
+   * is the exact value Desktop put in the engine's environment at spawn.
+   */
+  private isFuigoPromptOffloadRead(filePath: string): boolean {
+    if (this.agentConfig.agentBackend !== 'fuigo') return false;
+    const home = this.agentConfig.env?.FUIGO_HOME;
+    if (!home) return false;
+    return isFuigoSessionPromptFile(home, filePath);
+  }
+
   // ─── Protocol handlers (glue) ─────────────────────────────────
 
   private buildProtocolHandlers(): ProtocolHandlers {
@@ -440,7 +453,7 @@ export class AcpSession {
       onExtMethod: (method, params) => this.handleExtMethod(method, params),
       onExtNotification: (method, params) => this.handleExtNotification(method, params),
       onReadTextFile: async (req) => {
-        this.assertPathAllowed(req.path);
+        if (!this.isFuigoPromptOffloadRead(req.path)) this.assertPathAllowed(req.path);
         try {
           const content = fs.readFileSync(req.path, 'utf-8');
           return { content };

--- a/src/process/agent/fuigo/launch.ts
+++ b/src/process/agent/fuigo/launch.ts
@@ -160,3 +160,38 @@ export function extractFuigoPromptUsage(meta: unknown): FuigoPromptUsage | null 
     incomplete: u.usageIsIncomplete === true,
   };
 }
+
+/**
+ * Fuigo's prompt offload. A `session/prompt` over `LARGE_PROMPT_THRESHOLD`
+ * (25,000 bytes, `prompt_build.rs`) is truncated to a preview, written to
+ * `$FUIGO_HOME/sessions/<cwd>/<session>/prompts/prompt_N.txt`, and the model is
+ * told to `read_file` it before answering. That read comes back to Desktop as
+ * `fs/read_text_file`, and the workspace-only fs guard refused it ($FUIGO_HOME
+ * is outside every workspace): the model then fell back to a terminal `cat`,
+ * hit a permission prompt, and a fresh profile's first chat stalled for the
+ * whole prompt timeout.
+ *
+ * True only for an existing regular `.txt` / `.md` file whose real path is
+ * under `<home>/sessions/`; both sides are canonicalised with the same
+ * libuv realpath so a symlink planted under `sessions/` cannot reach
+ * `config.toml`, keys, or anything outside the tree. Read-only by contract:
+ * the caller must never route `fs/write_text_file` through this.
+ */
+export function isFuigoSessionPromptFile(homeDir: string, filePath: string): boolean {
+  let realSessions: string;
+  let realFile: string;
+  try {
+    realSessions = fs.realpathSync.native(path.join(homeDir, 'sessions'));
+    realFile = fs.realpathSync.native(filePath);
+  } catch {
+    return false;
+  }
+  if (!realFile.startsWith(realSessions + path.sep)) return false;
+  const ext = path.extname(realFile).toLowerCase();
+  if (ext !== '.txt' && ext !== '.md') return false;
+  try {
+    return fs.statSync(realFile).isFile();
+  } catch {
+    return false;
+  }
+}

--- a/src/process/utils/initAgent.ts
+++ b/src/process/utils/initAgent.ts
@@ -142,7 +142,7 @@ export async function setupAssistantWorkspace(
 ): Promise<void> {
   // Determine skills directories from ACP_BACKENDS_ALL config
   const key = options.backend || options.agentType || '';
-  const skillsDirs = getSkillsDirsForBackend(key) ?? (key === 'fuigo' ? ['.wayland/skills'] : undefined);
+  const skillsDirs = getSkillsDirsForBackend(key);
 
   // If no native skill directory is known for this CLI, skip symlink setup.
   // The caller should use prompt injection as fallback.

--- a/tests/unit/AcpAgentManagerSkillInjection.test.ts
+++ b/tests/unit/AcpAgentManagerSkillInjection.test.ts
@@ -220,6 +220,29 @@ describe('AcpAgentManager - first-message skill injection', () => {
     expect(sentContent).toContain('[User Request]');
   });
 
+  it('does not inject the skills index for fuigo: skills reach it natively via session/new pluginDirs', async () => {
+    // Real hasNativeSkillSupport from acpTypes (AcpAgentManager imports it from
+    // there, not from initAgent). With the index in, a default Concierge first
+    // turn was 28,875 bytes and tripped Fuigo's 25,000-byte prompt offload.
+    const manager = createManager({
+      backend: 'fuigo',
+      customWorkspace: false,
+      presetContext: 'You are Concierge.',
+      enabledSkills: ['cron'],
+    });
+
+    await sendFirstMessage(manager, 'Say hi');
+
+    expect(mockPrepareFirstMessage).not.toHaveBeenCalled();
+    const sentContent = mockAgentSendMessage.mock.calls[0][0].content as string;
+    expect(sentContent).not.toContain('[Available Skills]');
+    expect(sentContent).not.toContain('[Skills Location]');
+    // The persona / rules wrapper is unchanged on the native path.
+    expect(sentContent).toContain('[Assistant Rules');
+    expect(sentContent).toContain('You are Concierge.');
+    expect(sentContent).toContain('[User Request]\nSay hi');
+  });
+
   it('falls back to prompt injection for supported backend WITH customWorkspace', async () => {
     const manager = createManager({
       backend: 'claude',

--- a/tests/unit/initAgent.skills.test.ts
+++ b/tests/unit/initAgent.skills.test.ts
@@ -111,6 +111,7 @@ describe('initAgent - skill support', () => {
         'cursor',
         'gemini',
         'opencode',
+        'fuigo',
       ];
       for (const backend of supported) {
         expect(hasNativeSkillSupport(backend)).toBe(true);
@@ -143,7 +144,7 @@ describe('initAgent - skill support', () => {
         source: '/mock/user/skills/tide-example',
         target: '/tmp/workspace/.wayland/skills/tide-example',
       });
-      expect(hasNativeSkillSupport('fuigo')).toBe(false);
+      expect(hasNativeSkillSupport('fuigo')).toBe(true);
     });
 
     it('should create skills dir even when enabledSkills is empty', async () => {

--- a/tests/unit/process/acp/session/fuigoPromptOffloadRead.test.ts
+++ b/tests/unit/process/acp/session/fuigoPromptOffloadRead.test.ts
@@ -1,0 +1,143 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Fuigo offloads a >25 KB prompt to `$FUIGO_HOME/sessions/.../prompts/prompt_N.txt`
+ * and asks the model to read it back through `fs/read_text_file`. That path is
+ * outside every workspace, so the fs guard must allow exactly that read and
+ * nothing else in the engine home (config.toml, keys), never a write, and only
+ * for the fuigo backend.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AcpSession } from '@process/acp/session/AcpSession';
+import type { AgentConfig, ProtocolHandlers, SessionCallbacks } from '@process/acp/types';
+
+const SESSION = 'session-1';
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'fuigo-offload-'));
+  roots.push(root);
+  const workspace = path.join(root, 'workspace');
+  const home = path.join(root, 'fuigo');
+  const prompts = path.join(home, 'sessions', '%2Fworkspace', SESSION, 'prompts');
+  fs.mkdirSync(workspace, { recursive: true });
+  fs.mkdirSync(prompts, { recursive: true });
+  fs.writeFileSync(path.join(prompts, 'prompt_0.txt'), 'the full prompt');
+  fs.writeFileSync(path.join(home, 'config.toml'), '[plugins]\nauto_discover = false\n');
+  fs.writeFileSync(path.join(workspace, 'notes.md'), 'workspace file');
+  return { root, workspace, home, promptFile: path.join(prompts, 'prompt_0.txt') };
+}
+
+function build(agentConfig: AgentConfig) {
+  const callbacks = {
+    onMessage: vi.fn(),
+    onSessionId: vi.fn(),
+    onStatusChange: vi.fn(),
+    onConfigUpdate: vi.fn(),
+    onModelUpdate: vi.fn(),
+    onModeUpdate: vi.fn(),
+    onContextUsage: vi.fn(),
+    onPermissionRequest: vi.fn(),
+    onSignal: vi.fn(),
+  } satisfies SessionCallbacks;
+  const session = new AcpSession(agentConfig, () => ({}) as never, callbacks);
+  return (session as unknown as { buildProtocolHandlers(): ProtocolHandlers }).buildProtocolHandlers();
+}
+
+const read = (handlers: ProtocolHandlers, p: string) => handlers.onReadTextFile!({ sessionId: SESSION, path: p });
+const write = (handlers: ProtocolHandlers, p: string) =>
+  handlers.onWriteTextFile!({ sessionId: SESSION, path: p, content: 'x' });
+
+describe('AcpSession fs guard: Fuigo prompt offload', () => {
+  it('allows reading the offloaded prompt under $FUIGO_HOME/sessions/', async () => {
+    const { workspace, home, promptFile } = fixture();
+    const handlers = build({
+      agentBackend: 'fuigo',
+      agentSource: 'builtin',
+      agentId: 'conv-1',
+      cwd: workspace,
+      env: { FUIGO_HOME: home },
+    } as AgentConfig);
+
+    await expect(read(handlers, promptFile)).resolves.toEqual({ content: 'the full prompt' });
+  });
+
+  it('still refuses the rest of the engine home (config.toml) and anything outside the tree', async () => {
+    const { root, workspace, home } = fixture();
+    const handlers = build({
+      agentBackend: 'fuigo',
+      agentSource: 'builtin',
+      agentId: 'conv-1',
+      cwd: workspace,
+      env: { FUIGO_HOME: home },
+    } as AgentConfig);
+
+    await expect(read(handlers, path.join(home, 'config.toml'))).rejects.toThrow('Path not allowed');
+    // A .txt under sessions/ that is a symlink out of the tree resolves to its
+    // real target and is refused too.
+    const outside = path.join(root, 'secret.txt');
+    fs.writeFileSync(outside, 'secret');
+    const planted = path.join(home, 'sessions', 'planted.txt');
+    fs.symlinkSync(outside, planted);
+    await expect(read(handlers, planted)).rejects.toThrow('Path not allowed');
+    // Only .txt / .md prompt files, and only regular files.
+    const toml = path.join(home, 'sessions', 'state.toml');
+    fs.writeFileSync(toml, 'x');
+    await expect(read(handlers, toml)).rejects.toThrow('Path not allowed');
+    await expect(read(handlers, path.join(home, 'sessions'))).rejects.toThrow('Path not allowed');
+  });
+
+  it('never allows a write under sessions/', async () => {
+    const { workspace, home, promptFile } = fixture();
+    const handlers = build({
+      agentBackend: 'fuigo',
+      agentSource: 'builtin',
+      agentId: 'conv-1',
+      cwd: workspace,
+      env: { FUIGO_HOME: home },
+    } as AgentConfig);
+
+    await expect(write(handlers, promptFile)).rejects.toThrow('Path not allowed');
+    expect(fs.readFileSync(promptFile, 'utf8')).toBe('the full prompt');
+  });
+
+  it('leaves the workspace rule unchanged, and does not apply to other backends', async () => {
+    const { workspace, home, promptFile } = fixture();
+    const fuigo = build({
+      agentBackend: 'fuigo',
+      agentSource: 'builtin',
+      agentId: 'conv-1',
+      cwd: workspace,
+      env: { FUIGO_HOME: home },
+    } as AgentConfig);
+    await expect(read(fuigo, path.join(workspace, 'notes.md'))).resolves.toEqual({ content: 'workspace file' });
+
+    const claude = build({
+      agentBackend: 'claude',
+      agentSource: 'builtin',
+      agentId: 'conv-2',
+      cwd: workspace,
+      env: { FUIGO_HOME: home },
+    } as AgentConfig);
+    await expect(read(claude, promptFile)).rejects.toThrow('Path not allowed');
+
+    const noHome = build({
+      agentBackend: 'fuigo',
+      agentSource: 'builtin',
+      agentId: 'conv-3',
+      cwd: workspace,
+    } as AgentConfig);
+    await expect(read(noHome, promptFile)).rejects.toThrow('Path not allowed');
+  });
+});


### PR DESCRIPTION
## Release blocker

A fresh profile's first Concierge chat stalled for the whole prompt timeout (packaged mac build and the Windows runner). Desktop's composed first prompt was 28,875 bytes. Fuigo 1.0.14-1.0.16 (LARGE_PROMPT_THRESHOLD = 25,000 in prompt_build.rs) truncates such a prompt, writes it to FUIGO_HOME/sessions/(cwd)/(session)/prompts/prompt_0.txt and tells the model to read_file it before answering. That read comes back over ACP fs/read_text_file and AcpSession's workspace-only guard refused it (Path not allowed - FUIGO_HOME is outside every workspace). On mac the model then tried a terminal cat, hit a permission prompt, and the turn never answered. Windows only "passed" because the model answered from the truncated preview.

## Fix (belt and braces)

1. fuigo is now a native-skills backend: skillsDirs ['.wayland/skills'] in src/common/types/acpTypes.ts. Skills already reach Fuigo through session/new _meta.pluginDirs (e74cfa5e3), so the first-message [Available Skills] / [Skills Location] / [Scheduling] index was a duplicate and is no longer injected. The [Output Directive] prefix and the [Assistant Rules] wrapper are unchanged (existing fuigo directive tests cover it). initAgent's fuigo-only fallback for the same dir is removed as redundant.

2. The ACP fs bridge allows fs/read_text_file for Fuigo's own offload files only: backend fuigo, both sides realpath'd with the libuv native realpath, file under (FUIGO_HOME)/sessions/ where FUIGO_HOME is the exact value Desktop put in the engine's env at spawn, regular file, .txt or .md extension. Everything else keeps the workspace rule: config.toml, keys, a symlink planted under sessions/ that resolves outside it, and every fs/write_text_file are still refused. Helper isFuigoSessionPromptFile in src/process/agent/fuigo/launch.ts, wired in src/process/acp/session/AcpSession.ts.

## Measured prompt sizes (on the wire, packaged build, default Concierge chat)

- before: 28,875 bytes (offloaded, read refused, stall)
- after: 25,473 bytes (index removed: -3,402). Still ~470 bytes over the threshold: the remaining bulk is the Concierge persona (~15 KB), the Team Mode guide (~3.6 KB), the "[Skill added to this chat: concierge]" body (~3 KB) and the per-turn advert (~1.4 KB). Those are product content and not touched here; fix 2 is what makes the offload round-trip work regardless.

## Live proof (bun run dist:verify:mac + scripts/packaged-cockpit-smoke.mjs, fresh mkdtemp profile)

- PASS, 12/12 surfaces, chat reply in 12.5 s (prompt request 22:57:37.013, end_turn 22:57:49.565)
- Fuigo journal: read_file on prompts/prompt_0.txt completed, success, 6 ms; the chat shows "Reading prompt_0.txt" then the answer with the canary token
- "Path not allowed" in the app log: 0 (previous run: 2)
- Second chat with a deliberately 36,161-byte user message (secret word at the very end, past the truncated preview) answered correctly in 24 s; two offload reads success 10 ms / 8 ms
- Bundle check: the packaged asar chunk contains isFuigoSessionPromptFile and .wayland/skills

## Tests and gates

- tests/unit/process/acp/session/fuigoPromptOffloadRead.test.ts (4 cases: allow under sessions/, refuse config.toml / symlink-out / non-.txt / directory, refuse write, workspace rule + other backends unchanged) - the allow case fails without the AcpSession change
- fuigo no-index case in tests/unit/AcpAgentManagerSkillInjection.test.ts and hasNativeSkillSupport('fuigo') === true - fail without the acpTypes change; auggie (no native support) still injects
- bun run typecheck 0; vitest tests/unit/fuigo + tests/unit/process/acp + AcpAgentManager/initAgent families: 40 files / 472 tests and 19 files / 121 tests green
- oxfmt --check on touched files clean; oxlint on touched files at main's baseline (13 pre-existing warnings, 0 new)
- bun run test:bun 0 fail; node scripts/check-public-counts.mjs match; prek run --from-ref origin/main --to-ref HEAD all pass

Not merged, auto-merge not enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvuJEwapJMLSJ7BCaSbeuW
