### PR TITLE
chore(fuigo): bump 1.0.15 -> 1.0.16 and stop the ~/.agents/skills scan

### DIFF
--- a/scripts/fuigo/authority.json
+++ b/scripts/fuigo/authority.json
@@ -1,41 +1,41 @@
 {
-  "version": "1.0.15",
+  "version": "1.0.16",
   "platforms": {
     "darwin-arm64": {
-      "url": "https://registry.npmjs.org/@fuigo/darwin-arm64/-/darwin-arm64-1.0.15.tgz",
-      "integrity": "sha512-XtVsfj0v7xRjdrAQ0I6QzlH9HIMmU3DOq/Re1bx7j8wF/n8GoJU+8sUZDdGPt6naDfhcHWIeZRFYG9NU5oh4Sw==",
-      "archiveSha256": "6be2db159ee966f74e2025c026ad479f5c3eee89665b266f2c2564e69aeb964f",
-      "binarySha256": "29e7897a5be703d72b722ab8fe6506b937e8e94455f844531745ead9302e8009"
+      "url": "https://registry.npmjs.org/@fuigo/darwin-arm64/-/darwin-arm64-1.0.16.tgz",
+      "integrity": "sha512-IuI+4RalKWIhd5KGvYOt/Wgoaig55cDO1DAWbCR7YLWwA1zW5JK7FewBlFYL5EZMWsoOxuRQxM001DSLpm785w==",
+      "archiveSha256": "61ff011dd6638a7e24fec114b5bf5db8edac101046036cf76725c267e8bab9ee",
+      "binarySha256": "0db743099591cd15d218cd32426e210fcd491b11cea12974d273fefaf20bac65"
     },
     "darwin-x64": {
-      "url": "https://registry.npmjs.org/@fuigo/darwin-x64/-/darwin-x64-1.0.15.tgz",
-      "integrity": "sha512-/IDrFAfJciuA3iBkNaXuHe0guGR1FTqU1DBYdoFXHzZMIjQk/z3TPxWDTOL6BC5L9z1tvV5lJi0eWP2pp+qweg==",
-      "archiveSha256": "7379bc79aa0cf5ed564963bd28c155c0125cd401eca4d99dfe7cb3101a80275f",
-      "binarySha256": "d4ab8d09970bf84eeada34831efc76d2bbb0502c8d3449c87e9dfa2f3cc4ad4c"
+      "url": "https://registry.npmjs.org/@fuigo/darwin-x64/-/darwin-x64-1.0.16.tgz",
+      "integrity": "sha512-RqAkH3AkbvGUSlIjTf5i51uD0WZOxqUoA4CsS6rYOONlEVjdOl4gua5r5T6VMhw7OnqF8f4HbpB7w/SncpcvnQ==",
+      "archiveSha256": "620cfc15cfe1a30815ff386da0f2d2391076b3cf38bbb130eba65d6279e10d1e",
+      "binarySha256": "188a23952062cd637bf8ad9a4196a1a3efd1e59f63d9f008e0551a4ac7dfb4db"
     },
     "linux-arm64": {
-      "url": "https://registry.npmjs.org/@fuigo/linux-arm64/-/linux-arm64-1.0.15.tgz",
-      "integrity": "sha512-puoG+rKPOnSUBjJUMMgGOTCJ8VvJefzdz6py5lBBdUis8uRbsjhu1LwywzPeX1tyTFkoU7LgoTGp4l6cn3/wAw==",
-      "archiveSha256": "6f088c023a64c7e7d3e1b123fd07916accfd8ffa0ea762c3b6d4b8d086274471",
-      "binarySha256": "62f61ec774f6e7e1a2f1510e167a34c2a8d79d5ad41df6a7874a0f7483c56353"
+      "url": "https://registry.npmjs.org/@fuigo/linux-arm64/-/linux-arm64-1.0.16.tgz",
+      "integrity": "sha512-JdNtb8YJ/LmBZIsHKKfE2pI3FAdQ2ehcbKMIZQu4lkjjAj9wcAqr+MRjdGqbfehz23jA6js72jRkrXqSzTEvCA==",
+      "archiveSha256": "daa8082315d071ddb01eeabe9433cd61a1e7a1b7a870ba634e36d678fcb54b68",
+      "binarySha256": "0ae2457ff08a43d8fefdd976a4c843956168f151cb4116a05aeb18396294a7a5"
     },
     "linux-x64": {
-      "url": "https://registry.npmjs.org/@fuigo/linux-x64/-/linux-x64-1.0.15.tgz",
-      "integrity": "sha512-q45AI8PfwBE+BCc++Gp9pRjtV8WtANTCgqC3cQ1efeP84RuI34ntdMl4unPJErtyHFgPeC9mmiOUtUjfMAacRA==",
-      "archiveSha256": "75f3a43d0611c7c82f313c3867a7686f876bcd2b2266f3d64ed31f3d5f7a47dc",
-      "binarySha256": "64dd0b6fe806bdf6c9451d2bd7d63efebe3961268d2a22c0af0d9321806b1438"
+      "url": "https://registry.npmjs.org/@fuigo/linux-x64/-/linux-x64-1.0.16.tgz",
+      "integrity": "sha512-L3lKWjs6NbKR8LzLWsYs72VsabaDLa4cZ68dc+w0VOwlc/hDf6YDrQueFanz8U+uUQFVLRtbG2Mu/5Aqx9TBgQ==",
+      "archiveSha256": "ae8588babab881c47f736b0604a76f918f7d5aba6f211f23bf84eddaaf330c7d",
+      "binarySha256": "1142b0b5a3818f2a2e314d0c03efe9f4429d25e7ec71922227eb7dcd1b59b581"
     },
     "win32-arm64": {
-      "url": "https://registry.npmjs.org/@fuigo/win32-arm64/-/win32-arm64-1.0.15.tgz",
-      "integrity": "sha512-f8FsmQ+6jnFoBliMSlcZCV+blAtBTULx1SsCcMhOV1PK98ijeU9blYlb0I+n/mwq+zHWw854ABZSVcqnxhQrOA==",
-      "archiveSha256": "d7cd32cc240b55e7f073d49201ade2a626183fa38abe700dbb25c7f055463fea",
-      "binarySha256": "8eda995f6eff2e005324b9d4a8ee44279a2c414d0349fc0247f0ed394da2c439"
+      "url": "https://registry.npmjs.org/@fuigo/win32-arm64/-/win32-arm64-1.0.16.tgz",
+      "integrity": "sha512-S4eOfCkHm4bTztagCpNlBzG2vRoxzhCgamY8lyzm8LVutSaq46YPTJphQ9ncCKtv7hwAz2rnMKw/BdIYZueoqg==",
+      "archiveSha256": "0513825e94504f6f89f5adb1ea47816abd10045b8b556f43584bc7940b9c0495",
+      "binarySha256": "d91b8afb882973ea190742b2e8eca527db4279b0071a385830981e97766846b6"
     },
     "win32-x64": {
-      "url": "https://registry.npmjs.org/@fuigo/win32-x64/-/win32-x64-1.0.15.tgz",
-      "integrity": "sha512-+R+NB/wLazXt+hV/vhcA2hC0xv2SR0zgSP0/Tsd71qZP6V86kf4wk6dTQG5F4IGJf55JmChDKJwmkRLOUxoy/Q==",
-      "archiveSha256": "d0e622aebbb95ab2cb020a8469294b1630a0b5c06f291f9950af82cccd074b85",
-      "binarySha256": "919d117871cfc0ef78504e2215a3c153e285b23318998700a8fad5cb6a38ef16"
+      "url": "https://registry.npmjs.org/@fuigo/win32-x64/-/win32-x64-1.0.16.tgz",
+      "integrity": "sha512-DnGzmDY0DazkFN7V97tqUbFOQRPL6CtSVAU+kBEPzDech6Fpe2LKy3jUmRJQxYbkUhOnmnCgscNH/2jQHFUZhQ==",
+      "archiveSha256": "c74eb10772f37df30db2b1c90ff33ca88611f3b4504f29c68e1904c6c670bfd2",
+      "binarySha256": "416c5a418e554c0519a4505789f21d26b2adc9ea01b93555218cba71a22da7a3"
     }
   }
 }

--- a/src/process/agent/fuigo/launch.ts
+++ b/src/process/agent/fuigo/launch.ts
@@ -86,6 +86,10 @@ export function fuigoCompatIsolationEnv(): Record<string, string> {
   const env: Record<string, string> = {};
   for (const vendor of FUIGO_COMPAT_VENDORS)
     for (const surface of FUIGO_COMPAT_SURFACES) env[`FUIGO_${vendor}_${surface}_ENABLED`] = '0';
+  // The cross-vendor `~/.agents/skills` root is scanned unconditionally by
+  // 1.0.14/1.0.15 (every session listed the user's ~200 personal skills on top
+  // of the workspace ones); 1.0.16 gates it behind this cell (fuigo#16).
+  env.FUIGO_AGENTS_SKILLS_ENABLED = '0';
   return env;
 }
 

--- a/tests/integration/fuigoAcpEndToEnd.test.ts
+++ b/tests/integration/fuigoAcpEndToEnd.test.ts
@@ -70,6 +70,13 @@ const SKILL = 'wayland-canary-skill';
 const SKILL_CODEWORD = 'ZEBRA-7731';
 const SKILL_MD = `---\nname: ${SKILL}\ndescription: Wayland canary skill; defines the code word ${SKILL_CODEWORD}.\n---\n# ${SKILL}\n\nThe code word is ${SKILL_CODEWORD}.\n`;
 
+// Two real skills from this developer's ~/.agents/skills, the root Fuigo
+// scanned unconditionally before 1.0.16 (fuigo#16). Filtered to what exists on
+// this machine so the leak case is skipped, not vacuous, elsewhere.
+const AGENTS_SKILLS_PROBES = ['oversized-cursor', 'faceless-explainer'].filter((name) =>
+  existsSync(join(homedir(), '.agents', 'skills', name, 'SKILL.md'))
+);
+
 const cleanups: Array<() => void> = [];
 afterAll(() => {
   for (const c of cleanups.splice(0)) c();
@@ -201,6 +208,25 @@ describe.skipIf(!ENABLED)('Fuigo ACP end-to-end (staged binary, real FluxRouter)
     expect(turn.stopReason).toBe('end_turn');
     expect(turn.text).toContain(SKILL_CODEWORD);
   }, 180_000);
+
+  // 1.0.16 gates the ~/.agents/skills scan behind FUIGO_AGENTS_SKILLS_ENABLED,
+  // which fuigoCompatIsolationEnv() switches off. On 1.0.15 the same run names
+  // the probes (the switch is unknown there), which is what proves it acts.
+  it.skipIf(AGENTS_SKILLS_PROBES.length === 0)(
+    'lists only the workspace skills under the managed home (no ~/.agents/skills leak)',
+    async () => {
+      const turn = await runTurn({
+        trusted: true,
+        key: key!,
+        stageSkill: true,
+        prompt: `List the skills available to you by name, one per line, nothing else. Do not use tools.`,
+      });
+      expect(turn.stopReason).toBe('end_turn');
+      expect(turn.text).toContain(SKILL);
+      for (const leaked of AGENTS_SKILLS_PROBES) expect(turn.text).not.toContain(leaked);
+    },
+    180_000
+  );
 
   // Fuigo defect: the shipped 1.0.13 loads project instructions for an
   // untrusted cwd on the headless/stdio path. When this starts failing, the

--- a/tests/unit/fuigo/launchContract.test.ts
+++ b/tests/unit/fuigo/launchContract.test.ts
@@ -235,10 +235,12 @@ describe('launch helpers', () => {
 
   it('switches off every vendor-compat surface Fuigo would import from the user home', () => {
     const env = fuigoCompatIsolationEnv();
-    expect(Object.keys(env)).toHaveLength(18);
+    expect(Object.keys(env)).toHaveLength(19);
     for (const vendor of ['CLAUDE', 'CURSOR', 'CODEX'])
       for (const surface of ['SKILLS', 'RULES', 'AGENTS', 'MCPS', 'HOOKS', 'SESSIONS'])
         expect(env[`FUIGO_${vendor}_${surface}_ENABLED`]).toBe('0');
+    // 1.0.16: the ~/.agents/skills scan has its own cell outside the vendor grid.
+    expect(env.FUIGO_AGENTS_SKILLS_ENABLED).toBe('0');
   });
 
   describe('ensureFuigoHome', () => {


### PR DESCRIPTION
Fixes #1370

## What

Fuigo 1.0.14/1.0.15 scanned ~/.agents/skills unconditionally (compat.rs skill_config_dirs), so every Desktop session loaded the user's whole personal skill library on top of the workspace skills passed through _meta.pluginDirs. Fuigo 1.0.16 (FerroxLabs/fuigo#16) gates that root behind FUIGO_AGENTS_SKILLS_ENABLED.

1. src/process/agent/fuigo/launch.ts fuigoCompatIsolationEnv() sets FUIGO_AGENTS_SKILLS_ENABLED=0 as the 19th cell. tests/unit/fuigo/launchContract.test.ts pins it (fails "expected 18 to have length 19" without the launch.ts change).
2. Pin bump 1.0.15 -> 1.0.16: scripts/fuigo/authority.json regenerated for all six targets (bump-fuigo.cjs, independent download + hash). Staged darwin-arm64 receipt reads 1.0.16, sha256 0db743099591cd15d218cd32426e210fcd491b11cea12974d273fefaf20bac65, matches the pin.
3. New live case in tests/integration/fuigoAcpEndToEnd.test.ts: under the managed home with the isolation env, session/new + "list the skills available to you by name" must name the workspace .wayland/skills canary and must NOT name two real skills from this Mac's ~/.agents/skills (oversized-cursor, faceless-explainer; skipped where neither exists).

## Probe evidence (A/B on the same test, same prompt, same managed home)

- staged 1.0.15 (sha256 29e7897a5be7): 204 names listed, both probes present, canary present -> FAIL (the leak)
- staged 1.0.16 (sha256 0db743099591): reply is exactly "wayland-canary-skill"; both probes absent -> PASS

The switch acts; 1.0.15 ignores it.

## Trust gate

The it.fails case "drops AGENTS.md without --trust" is still an expected failure on 1.0.16, so fuigo#18 is not fixed in this release and .fails stays.

Observed but benign: 1.0.16 emits a _fuigo/mcp/servers_updated ext notification after session/new. Desktop's ProcessAcpClient registers extNotification so it is routed; the bare e2e client logs "Method not found" for it and continues.

## Gates

- FUIGO_ACP_E2E=1 vitest tests/integration/fuigoAcpEndToEnd.test.ts: 5 passed, 1 expected fail
- vitest tests/unit/fuigo: 5 files / 49 tests green
- bun run typecheck 0; oxfmt --check on touched files clean; bun run test:bun 0 fail
- node scripts/check-public-counts.mjs: all public counts match
- prek run --from-ref ferrox/main --to-ref HEAD: all pass

Not merged, auto-merge not enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvuJEwapJMLSJ7BCaSbeuW
