### PR TITLE
feat(fuigo): process budgets, workspace sandbox policy, BYOK providers

### DIFF
--- a/src/process/acp/session/PromptExecutor.ts
+++ b/src/process/acp/session/PromptExecutor.ts
@@ -1,10 +1,10 @@
-import type { AcpError, AcpErrorCode } from '@process/acp/errors/AcpError';
+import { AcpError, type AcpErrorCode } from '@process/acp/errors/AcpError';
 import { normalizeError } from '@process/acp/errors/errorNormalize';
 import type { AcpMetrics } from '@process/acp/metrics/AcpMetrics';
 import type { AuthNegotiator } from '@process/acp/session/AuthNegotiator';
 import type { MessageTranslator } from '@process/acp/session/MessageTranslator';
 import { PromptTimer } from '@process/acp/session/PromptTimer';
-import { extractFuigoPromptUsage } from '@process/agent/fuigo/launch';
+import { describeFuigoBudgetStop, extractFuigoPromptUsage } from '@process/agent/fuigo/launch';
 import { randomUUID } from 'node:crypto';
 import type { SessionLifecycle } from '@process/acp/session/SessionLifecycle';
 import type { AgentConfig, PromptContent, SessionCallbacks, SessionStatus } from '@process/acp/types';
@@ -363,6 +363,19 @@ export class PromptExecutor {
 
     console.error(`[PromptExecutor] prompt failed (${acpErr.code}):`, acpErr.message);
     this.host.metrics.recordError(this.host.agentConfig.agentBackend, acpErr.code);
+
+    // A Fuigo process budget (FUIGO_MAX_MODEL_CALLS / FUIGO_MAX_RUNTIME_SECS,
+    // set for unattended runs) ends the prompt with a JSON-RPC error whose
+    // `data` is the execution receipt or the budget string. That is a budget
+    // stop, not an engine failure: say so, and end the turn rather than
+    // offering a retry against a process that has nothing left to spend.
+    if (this.host.agentConfig.agentBackend === 'fuigo') {
+      const budgetStop = describeFuigoBudgetStop(acpErr);
+      if (budgetStop) {
+        this.host.enterError(budgetStop);
+        throw new AcpError(acpErr.code, budgetStop, { cause: acpErr, retryable: false });
+      }
+    }
 
     if (acpErr.retryable) {
       this.host.setStatus('active');

--- a/src/process/agent/fuigo/byok.ts
+++ b/src/process/agent/fuigo/byok.ts
@@ -1,0 +1,119 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * BYOK providers for the bundled Fuigo engine.
+ *
+ * Fuigo under Desktop authenticates with the Flux key (`FUIGO_API_KEY`), which
+ * made every Fuigo chat Flux-only. Users who connected their own Anthropic /
+ * OpenAI / OpenAI-compatible keys had them work on Core; this maps Desktop's
+ * provider rows (`model.config`, the legacy `IProvider` mirror every connected
+ * registry provider writes) into Fuigo `[model.<id>]` entries so those models
+ * are selectable in a Fuigo chat.
+ *
+ * Contract:
+ *   - The key travels in a per-provider env var on the spawn, never in the
+ *     TOML on disk (`FuigoByokModelEntry.envKey` ↔ `FuigoByokProvider.apiKey`).
+ *   - The Flux row is excluded (it is the engine's own route), as are
+ *     Bedrock / Vertex / Azure / ChatGPT-subscription (no API key shape Fuigo
+ *     can use) and Gemini (`google-gemini` is not an OpenAI-compatible base).
+ *   - Entry ids are `byok/<provider>/<model>`: never a Flux id, so the
+ *     `isFluxModelId` guards send them on `session/set_model` unchanged, and
+ *     never a bare catalog id, so a user's `claude-*` key can't silently
+ *     shadow the same id on the Flux route (config beats the prefetched
+ *     catalog in Fuigo's model resolution).
+ */
+import type { IProvider } from '@/common/config/storage';
+import { isFluxProviderRow } from '@/common/config/imageModels';
+import { ProcessConfig } from '@process/utils/initStorage';
+import type { FuigoByokModelEntry } from './launch';
+
+export type FuigoByokProvider = {
+  /** Env var the spawn sets to `apiKey`; every entry of this provider names it. */
+  envKey: string;
+  apiKey: string;
+  entries: FuigoByokModelEntry[];
+};
+
+const BRIDGE_TAG_KEY = '__waylandModelRegistryBridge';
+const SUPPORTED_PLATFORMS = new Set(['anthropic', 'openai', 'openai-compatible']);
+/** Registry providers whose mirror row is `openai-compatible` but whose creds are not a bearer key. */
+const SKIPPED_REGISTRY_PROVIDERS = new Set(['chatgpt-subscription', 'aws-bedrock', 'vertex', 'azure', 'ollama-local']);
+const DEFAULT_BASE_URL: Record<string, string> = {
+  anthropic: 'https://api.anthropic.com/v1',
+  openai: 'https://api.openai.com/v1',
+};
+
+function registryProviderId(row: IProvider): string | undefined {
+  const tag = (row as unknown as Record<string, unknown>)[BRIDGE_TAG_KEY];
+  return typeof tag === 'string' && tag.startsWith('v2:') ? tag.slice(3) : undefined;
+}
+
+function slug(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/** Fuigo appends `/messages` (Anthropic) or `/chat/completions` to `base_url`. */
+function resolveBaseUrl(row: IProvider): string | undefined {
+  const raw = (row.baseUrl || DEFAULT_BASE_URL[row.platform] || '').trim().replace(/\/+$/, '');
+  if (!/^https?:\/\//.test(raw)) return undefined;
+  if (row.platform === 'anthropic' && !raw.endsWith('/v1')) return `${raw}/v1`;
+  return raw;
+}
+
+/** Pure mapping from provider rows to Fuigo BYOK providers; deterministic for a given row order. */
+export function fuigoByokProvidersFromRows(rows: readonly IProvider[]): FuigoByokProvider[] {
+  const out: FuigoByokProvider[] = [];
+  const seenProviders = new Set<string>();
+  for (const row of rows) {
+    if (!row || row.enabled === false) continue;
+    if (!SUPPORTED_PLATFORMS.has(row.platform)) continue;
+    if (isFluxProviderRow(row)) continue;
+    const registryId = registryProviderId(row);
+    if (registryId && SKIPPED_REGISTRY_PROVIDERS.has(registryId)) continue;
+    const apiKey = typeof row.apiKey === 'string' ? row.apiKey.trim() : '';
+    if (!apiKey) continue;
+    const baseUrl = resolveBaseUrl(row);
+    if (!baseUrl) continue;
+    const provider = slug(registryId ?? row.name ?? row.platform) || row.platform;
+    if (seenProviders.has(provider)) continue;
+    const models = (Array.isArray(row.model) ? row.model : []).filter(
+      (m): m is string => typeof m === 'string' && m.trim().length > 0 && row.modelEnabled?.[m] !== false
+    );
+    if (models.length === 0) continue;
+    seenProviders.add(provider);
+    const envKey = `WAYLAND_BYOK_${provider.toUpperCase().replace(/[^A-Z0-9]+/g, '_')}_API_KEY`;
+    const apiBackend = row.platform === 'anthropic' ? 'messages' : 'chat_completions';
+    const label = row.name?.trim() || provider;
+    const contextWindow =
+      typeof row.contextLimit === 'number' && row.contextLimit > 0 ? Math.floor(row.contextLimit) : undefined;
+    out.push({
+      envKey,
+      apiKey,
+      entries: [...new Set(models)].map((model) => {
+        const entry: FuigoByokModelEntry = {
+          id: `byok/${provider}/${model}`,
+          name: `${model} · ${label}`,
+          model,
+          baseUrl,
+          apiBackend,
+          envKey,
+        };
+        if (contextWindow) entry.contextWindow = contextWindow;
+        return entry;
+      }),
+    });
+  }
+  return out;
+}
+
+export async function readFuigoByokProviders(): Promise<FuigoByokProvider[]> {
+  const raw = await ProcessConfig.get('model.config');
+  return fuigoByokProvidersFromRows(Array.isArray(raw) ? (raw as IProvider[]) : []);
+}

--- a/src/process/agent/fuigo/byok.ts
+++ b/src/process/agent/fuigo/byok.ts
@@ -29,6 +29,8 @@
 import type { IProvider } from '@/common/config/storage';
 import { isFluxProviderRow } from '@/common/config/imageModels';
 import { ProcessConfig } from '@process/utils/initStorage';
+import { CHAT_START_BASE_URL } from '@process/providers/ipc/modelRegistryIpc';
+import type { ProviderId } from '@process/providers/types';
 import type { FuigoByokModelEntry } from './launch';
 
 export type FuigoByokProvider = {
@@ -47,6 +49,16 @@ const DEFAULT_BASE_URL: Record<string, string> = {
   openai: 'https://api.openai.com/v1',
 };
 
+/**
+ * A registry-mirrored row carries an empty `baseUrl` unless the user typed
+ * one, so fall back to the canonical chat base the legacy dispatch uses
+ * (Groq, DeepSeek, Cerebras, xAI, …); a hand-added row must name its URL.
+ */
+function defaultBaseUrl(row: IProvider, registryId: string | undefined): string {
+  if (registryId) return CHAT_START_BASE_URL[registryId as ProviderId] ?? '';
+  return DEFAULT_BASE_URL[row.platform] ?? '';
+}
+
 function registryProviderId(row: IProvider): string | undefined {
   const tag = (row as unknown as Record<string, unknown>)[BRIDGE_TAG_KEY];
   return typeof tag === 'string' && tag.startsWith('v2:') ? tag.slice(3) : undefined;
@@ -60,8 +72,8 @@ function slug(value: string): string {
 }
 
 /** Fuigo appends `/messages` (Anthropic) or `/chat/completions` to `base_url`. */
-function resolveBaseUrl(row: IProvider): string | undefined {
-  const raw = (row.baseUrl || DEFAULT_BASE_URL[row.platform] || '').trim().replace(/\/+$/, '');
+function resolveBaseUrl(row: IProvider, registryId: string | undefined): string | undefined {
+  const raw = (row.baseUrl || defaultBaseUrl(row, registryId)).trim().replace(/\/+$/, '');
   if (!/^https?:\/\//.test(raw)) return undefined;
   if (row.platform === 'anthropic' && !raw.endsWith('/v1')) return `${raw}/v1`;
   return raw;
@@ -79,7 +91,7 @@ export function fuigoByokProvidersFromRows(rows: readonly IProvider[]): FuigoByo
     if (registryId && SKIPPED_REGISTRY_PROVIDERS.has(registryId)) continue;
     const apiKey = typeof row.apiKey === 'string' ? row.apiKey.trim() : '';
     if (!apiKey) continue;
-    const baseUrl = resolveBaseUrl(row);
+    const baseUrl = resolveBaseUrl(row, registryId);
     if (!baseUrl) continue;
     const provider = slug(registryId ?? row.name ?? row.platform) || row.platform;
     if (seenProviders.has(provider)) continue;

--- a/src/process/agent/fuigo/launch.ts
+++ b/src/process/agent/fuigo/launch.ts
@@ -70,6 +70,76 @@ export function buildFuigoAcpArgs(opts: { trusted: boolean; maxTurns?: number })
 }
 
 /**
+ * Process budgets for UNATTENDED runs (routines, team runs): the engine-side
+ * hard stop that replaced Core's BudgetController hard-stop + RunawayMonitor.
+ *
+ * Fuigo reads `FUIGO_MAX_MODEL_CALLS` / `FUIGO_MAX_RUNTIME_SECS` once per
+ * process (`fuigo-sampler/src/execution_budget.rs`; positive integers; the
+ * wall clock starts at process init and both are aggregate across every
+ * session, model switch, subagent and side call in that process). Verified on
+ * the staged 1.0.15 over stdio:
+ *   - calls: the last admission is reserved for a final answer, then the
+ *     prompt returns `-32603` whose `data` is the execution receipt
+ *     (`partial: true`, `reason: "Execution stopped with bounded capacity …"`).
+ *   - wall: a prompt past the deadline returns `-32602` with
+ *     `data: "execution budget: wall deadline exhausted"`; a running turn is
+ *     cancelled. The process stays alive either way.
+ * A scheduled run is one process per run (the idle reaper SIGTERMs it), so a
+ * per-process budget is a per-run budget. Core had no persisted keys for
+ * these — its hard stops were fixed thresholds — so the defaults live here
+ * and nothing is exposed in the UI.
+ *
+ * An interactive chat is deliberately uncapped: its process lives as long as
+ * the user keeps talking, and a wall clock started at spawn would end a long
+ * conversation mid-thought.
+ */
+export const FUIGO_UNATTENDED_MAX_MODEL_CALLS = 200;
+export const FUIGO_UNATTENDED_MAX_RUNTIME_SECS = 3600;
+
+export function fuigoBudgetEnv(opts: { unattended: boolean }): Record<string, string> {
+  if (!opts.unattended) return {};
+  return {
+    FUIGO_MAX_MODEL_CALLS: String(FUIGO_UNATTENDED_MAX_MODEL_CALLS),
+    FUIGO_MAX_RUNTIME_SECS: String(FUIGO_UNATTENDED_MAX_RUNTIME_SECS),
+  };
+}
+
+const BUDGET_RECEIPT_REASON = /^Execution stopped with bounded capacity/;
+const BUDGET_DATA = /^execution budget: (model dispatch limit|wall deadline) exhausted/;
+
+/**
+ * The user-facing reason when a prompt failed because Fuigo hit a process
+ * budget, or null for any other failure. Reads the JSON-RPC `data` of the
+ * prompt error (walking `cause`, since the ACP layer wraps the SDK error).
+ */
+export function describeFuigoBudgetStop(err: unknown): string | null {
+  const minutes = Math.round(FUIGO_UNATTENDED_MAX_RUNTIME_SECS / 60);
+  for (
+    let e: unknown = err, depth = 0;
+    e && typeof e === 'object' && depth < 4;
+    e = (e as { cause?: unknown }).cause, depth++
+  ) {
+    const data = (e as { data?: unknown }).data;
+    if (typeof data === 'string') {
+      const m = BUDGET_DATA.exec(data.trim());
+      if (m) {
+        return m[1] === 'wall deadline'
+          ? `Stopped by the run budget: this run passed its ${minutes}-minute limit. Work finished before the stop is kept; the next run starts fresh.`
+          : `Stopped by the run budget: this run used all ${FUIGO_UNATTENDED_MAX_MODEL_CALLS} of its model calls. Work finished before the stop is kept; the next run starts fresh.`;
+      }
+      continue;
+    }
+    if (data && typeof data === 'object') {
+      const r = data as { partial?: unknown; reason?: unknown };
+      if (r.partial === true && typeof r.reason === 'string' && BUDGET_RECEIPT_REASON.test(r.reason)) {
+        return `Stopped by the run budget: this run used all ${FUIGO_UNATTENDED_MAX_MODEL_CALLS} of its model calls before it finished. Work done so far is kept; the next run starts fresh.`;
+      }
+    }
+  }
+  return null;
+}
+
+/**
  * Fuigo's vendor-compat layer auto-discovers Claude Code, Cursor and Codex
  * state from the user's home (`~/.claude.json` MCP servers, `~/.claude/skills`,
  * rules, agents, hooks, sessions) and connects to every MCP server it finds.

--- a/src/process/agent/fuigo/launch.ts
+++ b/src/process/agent/fuigo/launch.ts
@@ -40,7 +40,67 @@ export const FUIGO_MANAGED_CONFIG = `# Managed by Wayland Desktop. Rewritten at 
 auto_discover = false
 `;
 
-export function ensureFuigoHome(homeDir: string): void {
+/**
+ * One BYOK model as Fuigo's `[model.<id>]` config entry (`ConfigModelOverride`,
+ * `fuigo-shell/src/agent/config.rs`; user guide `11-custom-models.md`).
+ *
+ * The API key is NEVER written: `env_key` names the process env var that
+ * carries it, and the spawn layer sets that var from the provider row. Fuigo
+ * resolves `api_key` → `env_key` → session token → `FUIGO_API_KEY`, so a
+ * per-entry `env_key` keeps a BYOK model off the Flux key.
+ *
+ * `apiBackend`: `messages` is the Anthropic Messages protocol (`/v1/messages`,
+ * credential in `x-api-key`, protocol version header required);
+ * `chat_completions` is OpenAI Chat Completions (`/v1/chat/completions`,
+ * bearer). Fuigo appends the endpoint path to `baseUrl`, so an Anthropic base
+ * must end in `/v1` and an OpenAI-compatible one is the usual `.../v1`.
+ */
+export type FuigoByokModelEntry = {
+  /** Catalog id sent on `session/set_model`; never a Flux id. */
+  id: string;
+  /** Picker label. */
+  name: string;
+  /** Model id sent to the provider. */
+  model: string;
+  baseUrl: string;
+  apiBackend: 'chat_completions' | 'messages';
+  /** Env var carrying the key. */
+  envKey: string;
+  contextWindow?: number;
+};
+
+/** TOML basic string: escape the backslash, the quote and control characters. */
+function tomlString(value: string): string {
+  // eslint-disable-next-line no-control-regex -- TOML basic strings must escape U+0000-U+001F and U+007F.
+  return `"${value.replace(/[\\"\u0000-\u001f\u007f]/g, (c) => {
+    if (c === '\\') return '\\\\';
+    if (c === '"') return '\\"';
+    return `\\u${c.charCodeAt(0).toString(16).padStart(4, '0')}`;
+  })}"`;
+}
+
+/** The managed config plus one `[model.<id>]` block per BYOK entry. */
+export function buildFuigoManagedConfig(entries: readonly FuigoByokModelEntry[] = []): string {
+  let out = FUIGO_MANAGED_CONFIG;
+  for (const e of entries) {
+    out += `\n[model.${tomlString(e.id)}]\n`;
+    out += `model = ${tomlString(e.model)}\n`;
+    out += `name = ${tomlString(e.name)}\n`;
+    out += `base_url = ${tomlString(e.baseUrl)}\n`;
+    out += `api_backend = ${tomlString(e.apiBackend)}\n`;
+    out += `env_key = ${tomlString(e.envKey)}\n`;
+    if (e.apiBackend === 'messages') {
+      out += `auth_scheme = "x_api_key"\n`;
+      out += `extra_headers = { "anthropic-version" = "2023-06-01" }\n`;
+    }
+    if (typeof e.contextWindow === 'number' && Number.isInteger(e.contextWindow) && e.contextWindow > 0) {
+      out += `context_window = ${e.contextWindow}\n`;
+    }
+  }
+  return out;
+}
+
+export function ensureFuigoHome(homeDir: string, config: string = FUIGO_MANAGED_CONFIG): void {
   fs.mkdirSync(homeDir, { recursive: true, mode: 0o700 });
   const file = path.join(homeDir, 'config.toml');
   let current: string | undefined;
@@ -49,7 +109,7 @@ export function ensureFuigoHome(homeDir: string): void {
   } catch {
     /* absent */
   }
-  if (current !== FUIGO_MANAGED_CONFIG) fs.writeFileSync(file, FUIGO_MANAGED_CONFIG, { mode: 0o600 });
+  if (current !== config) fs.writeFileSync(file, config, { mode: 0o600 });
 }
 
 /**

--- a/src/process/agent/fuigo/launch.ts
+++ b/src/process/agent/fuigo/launch.ts
@@ -55,6 +55,19 @@ export function ensureFuigoHome(homeDir: string): void {
 /**
  * Global flags go before the `agent` subcommand; `stdio` is the ACP transport.
  *
+ * No `--sandbox` (Fuigo's kernel sandbox: Seatbelt on darwin, Landlock on
+ * linux, nothing on win32), on purpose. Measured on the staged 1.0.15 under
+ * `--sandbox workspace`, from inside an MCP server Fuigo spawned on
+ * `session/new` (the profile is process-wide, so every MCP child inherits
+ * it): loopback HTTP to 127.0.0.1 OK, `node -e` subprocess OK, writes to the
+ * temp dir OK, writes to `$HOME` and `~/.npm/_npx` EPERM. That last one is
+ * every `npx`-launched connector — including the TC-TIDE brief's TVControl
+ * fallback — so a chat with MCP servers must keep the sandbox OFF, and there
+ * is no Desktop-side sandbox setting left to key it on (Core's `strict |
+ * trusted_local_smart` profile lived in Core's own config.toml and went with
+ * it). If a setting is ever added, default it off for any chat that carries
+ * MCP servers.
+ *
  * `--max-turns` is a top-level clap arg (`value_parser!(u32).range(1..)`) that
  * `run_agent_command` copies into `cli_agent_overrides.max_turns`, so it binds
  * the ACP session exactly as it binds headless mode. A non-positive or

--- a/src/process/providers/ipc/modelRegistryIpc.ts
+++ b/src/process/providers/ipc/modelRegistryIpc.ts
@@ -1463,7 +1463,7 @@ const CHAT_START_PLATFORM: Partial<Record<ProviderId, string>> = {
 };
 
 /** Canonical base URL per provider. A user-saved custom URL overrides this. */
-const CHAT_START_BASE_URL: Partial<Record<ProviderId, string>> = {
+export const CHAT_START_BASE_URL: Partial<Record<ProviderId, string>> = {
   anthropic: 'https://api.anthropic.com',
   openai: 'https://api.openai.com/v1',
   'google-gemini': 'https://generativelanguage.googleapis.com',

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -4,6 +4,7 @@ import {
   buildFuigoAcpArgs,
   buildFuigoSessionMetadata,
   ensureFuigoHome,
+  fuigoBudgetEnv,
   fuigoCompatIsolationEnv,
   fuigoHomeDir,
   fuigoPluginDirs,
@@ -922,6 +923,8 @@ ${collectedResponses.join('\n')}`;
       const key = await this.readFluxKey();
       if (key) mergedEnv.FUIGO_API_KEY = key;
       mergedEnv.FUIGO_MANAGED_BY_NPM = '1';
+      // Engine-side hard stop for unattended runs only (see fuigoBudgetEnv).
+      Object.assign(mergedEnv, fuigoBudgetEnv({ unattended: data.unattendedHoldDeadlineMs !== undefined }));
       // Desktop is the authority for MCP, skills and persona: keep Fuigo from
       // importing the user's Claude Code / Cursor / Codex state and dialling
       // their MCP servers. An explicit custom-agent env var still wins.

--- a/src/process/task/AcpAgentManager.ts
+++ b/src/process/task/AcpAgentManager.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { existsSync } from 'node:fs';
 import {
   buildFuigoAcpArgs,
+  buildFuigoManagedConfig,
   buildFuigoSessionMetadata,
   ensureFuigoHome,
   fuigoBudgetEnv,
@@ -9,6 +10,7 @@ import {
   fuigoHomeDir,
   fuigoPluginDirs,
 } from '@process/agent/fuigo/launch';
+import { readFuigoByokProviders } from '@process/agent/fuigo/byok';
 import { resolveFuigoBinary } from '@process/agent/fuigo/runtime';
 import { resolveTurnOutputDirective } from '@process/services/artifacts/outputDirective';
 import type { UserQuestionUIData } from '@process/acp/session/userQuestion';
@@ -919,7 +921,12 @@ ${collectedResponses.join('\n')}`;
       // One home for every conversation (memory, MCP config, trust grants and
       // the model cache carry across chats); Fuigo keys sessions by cwd.
       mergedEnv.FUIGO_HOME = fuigoHomeDir(app.getPath('userData'));
-      ensureFuigoHome(mergedEnv.FUIGO_HOME);
+      // The user's own Anthropic / OpenAI / OpenAI-compatible providers become
+      // `[model.byok/…]` entries in the managed config; each key rides its
+      // own env var on this spawn and is never written to disk.
+      const byok = await readFuigoByokProviders();
+      ensureFuigoHome(mergedEnv.FUIGO_HOME, buildFuigoManagedConfig(byok.flatMap((p) => p.entries)));
+      for (const p of byok) mergedEnv[p.envKey] = p.apiKey;
       const key = await this.readFluxKey();
       if (key) mergedEnv.FUIGO_API_KEY = key;
       mergedEnv.FUIGO_MANAGED_BY_NPM = '1';

--- a/src/renderer/components/agent/AcpModelSelector.tsx
+++ b/src/renderer/components/agent/AcpModelSelector.tsx
@@ -511,7 +511,25 @@ const AcpModelSelector: React.FC<{
   // and the agent's own native models below, unchanged. This wraps all native
   // states (null / read-only / switchable) so Flux is always selectable here.
   if (showFlux) {
-    const nativeModels = modelInfo?.availableModels ?? [];
+    // The bundled Fuigo engine advertises the user's own connected providers
+    // as `byok/<provider>/<model>` entries (Desktop writes them into its
+    // managed config); list those under their own heading, ahead of the
+    // engine's catalog, so a key the user added is one click away.
+    const advertised = modelInfo?.availableModels ?? [];
+    const byokModels = advertised.filter((m) => m.id.startsWith('byok/'));
+    const nativeModels = advertised.filter((m) => !m.id.startsWith('byok/'));
+    const renderModelItem = (model: { id: string; label: string }) => (
+      <Menu.Item
+        key={model.id}
+        className={model.id === modelInfo?.currentModelId ? 'bg-2!' : ''}
+        onClick={() => handleSelectModel(model.id)}
+      >
+        <div className='flex items-center gap-8px w-full'>
+          {healthDot(model.id)}
+          <span>{model.label}</span>
+        </div>
+      </Menu.Item>
+    );
     return (
       <Dropdown
         trigger='click'
@@ -533,20 +551,14 @@ const AcpModelSelector: React.FC<{
                   </Menu.Item>
                 ))}
               </Menu.ItemGroup>
+              {byokModels.length > 0 && (
+                <Menu.ItemGroup title={t('conversation.welcome.byokModelsGroupLabel')}>
+                  {byokModels.map(renderModelItem)}
+                </Menu.ItemGroup>
+              )}
               {nativeModels.length > 0 && (
                 <Menu.ItemGroup title={t('conversation.welcome.nativeModelsGroupLabel')}>
-                  {nativeModels.map((model) => (
-                    <Menu.Item
-                      key={model.id}
-                      className={model.id === modelInfo?.currentModelId ? 'bg-2!' : ''}
-                      onClick={() => handleSelectModel(model.id)}
-                    >
-                      <div className='flex items-center gap-8px w-full'>
-                        {healthDot(model.id)}
-                        <span>{model.label}</span>
-                      </div>
-                    </Menu.Item>
-                  ))}
+                  {nativeModels.map(renderModelItem)}
                 </Menu.ItemGroup>
               )}
             </Menu>

--- a/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/src/renderer/services/i18n/i18n-keys.d.ts
@@ -760,6 +760,7 @@ export type I18nKey =
   | 'conversation.welcome.bugReportChooser'
   | 'conversation.welcome.bugReportNoScreenshot'
   | 'conversation.welcome.bugReportScreenshotCopied'
+  | 'conversation.welcome.byokModelsGroupLabel'
   | 'conversation.welcome.clearWorkspace'
   | 'conversation.welcome.currentWorkspace'
   | 'conversation.welcome.fluxGroupLabel'

--- a/src/renderer/services/i18n/locales/de-DE/conversation.json
+++ b/src/renderer/services/i18n/locales/de-DE/conversation.json
@@ -12,6 +12,7 @@
     "modelLoading": "Modelle werden geladen…",
     "fluxGroupLabel": "Flux",
     "nativeModelsGroupLabel": "Agentenmodelle",
+    "byokModelsGroupLabel": "Your API keys",
     "specifyWorkspace": "Im Ordner chatten",
     "currentWorkspace": "Aktueller Arbeitsbereich",
     "clearWorkspace": "Ordner entfernen",

--- a/src/renderer/services/i18n/locales/en-US/conversation.json
+++ b/src/renderer/services/i18n/locales/en-US/conversation.json
@@ -12,6 +12,7 @@
     "modelLoading": "Loading models…",
     "fluxGroupLabel": "Flux",
     "nativeModelsGroupLabel": "Agent models",
+    "byokModelsGroupLabel": "Your API keys",
     "specifyWorkspace": "Chat in Folder",
     "currentWorkspace": "Current Workspace",
     "clearWorkspace": "Remove folder",

--- a/src/renderer/services/i18n/locales/es-ES/conversation.json
+++ b/src/renderer/services/i18n/locales/es-ES/conversation.json
@@ -12,6 +12,7 @@
     "modelLoading": "Cargando modelos…",
     "fluxGroupLabel": "Flux",
     "nativeModelsGroupLabel": "Modelos del agente",
+    "byokModelsGroupLabel": "Your API keys",
     "specifyWorkspace": "Chatear en carpeta",
     "currentWorkspace": "Espacio de trabajo actual",
     "clearWorkspace": "Quitar carpeta",

--- a/src/renderer/services/i18n/locales/fr-FR/conversation.json
+++ b/src/renderer/services/i18n/locales/fr-FR/conversation.json
@@ -12,6 +12,7 @@
     "modelLoading": "Chargement des modèles…",
     "fluxGroupLabel": "Flux",
     "nativeModelsGroupLabel": "Modèles de l'agent",
+    "byokModelsGroupLabel": "Your API keys",
     "specifyWorkspace": "Discuter dans un dossier",
     "currentWorkspace": "Espace de travail actuel",
     "clearWorkspace": "Retirer le dossier",

--- a/src/renderer/services/i18n/locales/ja-JP/conversation.json
+++ b/src/renderer/services/i18n/locales/ja-JP/conversation.json
@@ -12,6 +12,7 @@
     "modelLoading": "モデルを読み込み中…",
     "fluxGroupLabel": "Flux",
     "nativeModelsGroupLabel": "エージェントのモデル",
+    "byokModelsGroupLabel": "Your API keys",
     "specifyWorkspace": "フォルダーでチャット",
     "currentWorkspace": "現在のワークスペース",
     "clearWorkspace": "フォルダーを解除",

--- a/src/renderer/services/i18n/locales/ko-KR/conversation.json
+++ b/src/renderer/services/i18n/locales/ko-KR/conversation.json
@@ -12,6 +12,7 @@
     "modelLoading": "모델 불러오는 중…",
     "fluxGroupLabel": "Flux",
     "nativeModelsGroupLabel": "에이전트 모델",
+    "byokModelsGroupLabel": "Your API keys",
     "specifyWorkspace": "폴더에서 채팅",
     "currentWorkspace": "현재 워크스페이스",
     "clearWorkspace": "폴더 제거",

--- a/src/renderer/services/i18n/locales/pt-BR/conversation.json
+++ b/src/renderer/services/i18n/locales/pt-BR/conversation.json
@@ -12,6 +12,7 @@
     "modelLoading": "Carregando modelos…",
     "fluxGroupLabel": "Flux",
     "nativeModelsGroupLabel": "Modelos do agente",
+    "byokModelsGroupLabel": "Your API keys",
     "specifyWorkspace": "Conversar na pasta",
     "currentWorkspace": "Espaço de trabalho atual",
     "clearWorkspace": "Remover pasta",

--- a/src/renderer/services/i18n/locales/ru-RU/conversation.json
+++ b/src/renderer/services/i18n/locales/ru-RU/conversation.json
@@ -12,6 +12,7 @@
     "modelLoading": "Загрузка моделей…",
     "fluxGroupLabel": "Flux",
     "nativeModelsGroupLabel": "Модели агента",
+    "byokModelsGroupLabel": "Your API keys",
     "specifyWorkspace": "Чат в папке",
     "currentWorkspace": "Текущая рабочая область",
     "clearWorkspace": "Удалить папку",

--- a/src/renderer/services/i18n/locales/tr-TR/conversation.json
+++ b/src/renderer/services/i18n/locales/tr-TR/conversation.json
@@ -12,6 +12,7 @@
     "modelLoading": "Modeller yükleniyor…",
     "fluxGroupLabel": "Flux",
     "nativeModelsGroupLabel": "Ajan modelleri",
+    "byokModelsGroupLabel": "Your API keys",
     "specifyWorkspace": "Klasörde Sohbet Et",
     "currentWorkspace": "Mevcut Çalışma Alanı",
     "clearWorkspace": "Klasörü kaldır",

--- a/src/renderer/services/i18n/locales/uk-UA/conversation.json
+++ b/src/renderer/services/i18n/locales/uk-UA/conversation.json
@@ -12,6 +12,7 @@
     "modelLoading": "Завантаження моделей…",
     "fluxGroupLabel": "Flux",
     "nativeModelsGroupLabel": "Моделі агента",
+    "byokModelsGroupLabel": "Your API keys",
     "specifyWorkspace": "Чат у папці",
     "currentWorkspace": "Поточна робоча область",
     "clearWorkspace": "Видалити папку",

--- a/src/renderer/services/i18n/locales/zh-CN/conversation.json
+++ b/src/renderer/services/i18n/locales/zh-CN/conversation.json
@@ -12,6 +12,7 @@
     "modelLoading": "正在加载模型…",
     "fluxGroupLabel": "Flux",
     "nativeModelsGroupLabel": "智能体模型",
+    "byokModelsGroupLabel": "Your API keys",
     "specifyWorkspace": "关联文件夹",
     "currentWorkspace": "当前工作空间",
     "clearWorkspace": "移除已选文件夹",

--- a/src/renderer/services/i18n/locales/zh-TW/conversation.json
+++ b/src/renderer/services/i18n/locales/zh-TW/conversation.json
@@ -12,6 +12,7 @@
     "modelLoading": "正在載入模型…",
     "fluxGroupLabel": "Flux",
     "nativeModelsGroupLabel": "代理模型",
+    "byokModelsGroupLabel": "Your API keys",
     "specifyWorkspace": "關聯資料夾",
     "currentWorkspace": "目前工作空間",
     "clearWorkspace": "移除資料夾",

--- a/tests/unit/fuigo/byokProviders.test.ts
+++ b/tests/unit/fuigo/byokProviders.test.ts
@@ -1,0 +1,162 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Desktop provider rows → Fuigo `[model.byok/…]` entries. Fuigo under Desktop
+ * authenticates with the Flux key alone, so before this every Fuigo chat was
+ * Flux-only; a user's Anthropic / OpenAI / OpenAI-compatible key had nothing
+ * to attach to. The key must never reach the TOML on disk.
+ */
+import { describe, expect, it } from 'vitest';
+import type { IProvider } from '@/common/config/storage';
+import { fuigoByokProvidersFromRows } from '@process/agent/fuigo/byok';
+import { FUIGO_MANAGED_CONFIG, buildFuigoManagedConfig } from '@process/agent/fuigo/launch';
+
+const row = (over: Partial<IProvider> & Record<string, unknown>): IProvider =>
+  ({
+    id: 'row-1',
+    platform: 'openai',
+    name: 'OpenAI',
+    baseUrl: '',
+    apiKey: 'sk-openai-secret',
+    model: ['gpt-4o'],
+    ...over,
+  }) as IProvider;
+
+const OPENAI = row({ __waylandModelRegistryBridge: 'v2:openai' });
+const ANTHROPIC = row({
+  id: 'row-2',
+  platform: 'anthropic',
+  name: 'Anthropic',
+  baseUrl: 'https://api.anthropic.com',
+  apiKey: 'sk-ant-secret',
+  model: ['claude-sonnet-4-5', 'claude-haiku-4-5'],
+  __waylandModelRegistryBridge: 'v2:anthropic',
+});
+const FLUX = row({
+  id: 'row-flux',
+  platform: 'openai-compatible',
+  name: 'FluxRouter',
+  baseUrl: '',
+  apiKey: 'sk-flux',
+  model: ['flux-auto', 'flux-fast'],
+  __waylandModelRegistryBridge: 'v2:flux-router',
+});
+
+describe('fuigoByokProvidersFromRows', () => {
+  it('yields nothing for no rows', () => {
+    expect(fuigoByokProvidersFromRows([])).toEqual([]);
+    expect(buildFuigoManagedConfig([])).toBe(FUIGO_MANAGED_CONFIG);
+  });
+
+  it('maps one OpenAI row to chat_completions entries keyed by a provider env var', () => {
+    const [p] = fuigoByokProvidersFromRows([OPENAI]);
+    expect(p).toMatchObject({ envKey: 'WAYLAND_BYOK_OPENAI_API_KEY', apiKey: 'sk-openai-secret' });
+    expect(p.entries).toEqual([
+      {
+        id: 'byok/openai/gpt-4o',
+        name: 'gpt-4o · OpenAI',
+        model: 'gpt-4o',
+        baseUrl: 'https://api.openai.com/v1',
+        apiBackend: 'chat_completions',
+        envKey: 'WAYLAND_BYOK_OPENAI_API_KEY',
+      },
+    ]);
+  });
+
+  it('maps an Anthropic row to the messages surface with a /v1 base', () => {
+    const [p] = fuigoByokProvidersFromRows([ANTHROPIC]);
+    expect(p.envKey).toBe('WAYLAND_BYOK_ANTHROPIC_API_KEY');
+    expect(p.entries.map((e) => e.id)).toEqual(['byok/anthropic/claude-sonnet-4-5', 'byok/anthropic/claude-haiku-4-5']);
+    expect(p.entries[0]).toMatchObject({ apiBackend: 'messages', baseUrl: 'https://api.anthropic.com/v1' });
+  });
+
+  it('keeps two providers apart and excludes the Flux row', () => {
+    const providers = fuigoByokProvidersFromRows([FLUX, OPENAI, ANTHROPIC]);
+    expect(providers.map((p) => p.envKey)).toEqual(['WAYLAND_BYOK_OPENAI_API_KEY', 'WAYLAND_BYOK_ANTHROPIC_API_KEY']);
+    const ids = providers.flatMap((p) => p.entries.map((e) => e.id));
+    expect(ids).not.toContainEqual(expect.stringContaining('flux'));
+    expect(ids).toHaveLength(3);
+  });
+
+  it('skips disabled rows, keyless rows, unsupported platforms and non-key registry providers', () => {
+    const rows = [
+      row({ enabled: false }),
+      row({ id: 'r-nokey', apiKey: '   ' }),
+      row({ id: 'r-gem', platform: 'gemini', name: 'Gemini' }),
+      row({ id: 'r-bed', platform: 'bedrock', name: 'Bedrock' }),
+      row({
+        id: 'r-chatgpt',
+        platform: 'openai-compatible',
+        name: 'ChatGPT',
+        baseUrl: 'https://x/v1',
+        __waylandModelRegistryBridge: 'v2:chatgpt-subscription',
+      }),
+      row({ id: 'r-compat-nourl', platform: 'openai-compatible', name: 'No URL', baseUrl: '' }),
+      row({ id: 'r-nomodels', model: [] }),
+    ];
+    expect(fuigoByokProvidersFromRows(rows)).toEqual([]);
+  });
+
+  it('honours per-model disables and drops duplicate model ids', () => {
+    const [p] = fuigoByokProvidersFromRows([
+      row({ model: ['gpt-4o', 'gpt-4o', 'o3-mini'], modelEnabled: { 'o3-mini': false } }),
+    ]);
+    expect(p.entries.map((e) => e.model)).toEqual(['gpt-4o']);
+  });
+
+  it('accepts a custom OpenAI-compatible endpoint and strips the trailing slash', () => {
+    const [p] = fuigoByokProvidersFromRows([
+      row({
+        platform: 'openai-compatible',
+        name: 'Groq Cloud',
+        baseUrl: 'https://api.groq.com/openai/v1/',
+        model: ['llama-3.3-70b'],
+        contextLimit: 131072,
+      }),
+    ]);
+    expect(p.envKey).toBe('WAYLAND_BYOK_GROQ_CLOUD_API_KEY');
+    expect(p.entries[0]).toMatchObject({
+      id: 'byok/groq-cloud/llama-3.3-70b',
+      baseUrl: 'https://api.groq.com/openai/v1',
+      contextWindow: 131072,
+    });
+  });
+});
+
+describe('buildFuigoManagedConfig', () => {
+  it('writes one [model.<id>] block per entry, with env_key and never the key', () => {
+    const providers = fuigoByokProvidersFromRows([OPENAI, ANTHROPIC]);
+    const toml = buildFuigoManagedConfig(providers.flatMap((p) => p.entries));
+    expect(toml.startsWith(FUIGO_MANAGED_CONFIG)).toBe(true);
+    expect(toml).toContain(
+      '[model."byok/openai/gpt-4o"]\nmodel = "gpt-4o"\nname = "gpt-4o · OpenAI"\nbase_url = "https://api.openai.com/v1"\napi_backend = "chat_completions"\nenv_key = "WAYLAND_BYOK_OPENAI_API_KEY"\n'
+    );
+    expect(toml).toContain('[model."byok/anthropic/claude-sonnet-4-5"]');
+    expect(toml).toContain(
+      'api_backend = "messages"\nenv_key = "WAYLAND_BYOK_ANTHROPIC_API_KEY"\nauth_scheme = "x_api_key"\nextra_headers = { "anthropic-version" = "2023-06-01" }\n'
+    );
+    expect(toml.match(/^\[model\./gm)).toHaveLength(3);
+    expect(toml).not.toContain('sk-openai-secret');
+    expect(toml).not.toContain('sk-ant-secret');
+    expect(toml).not.toMatch(/^api_key\s*=/m);
+  });
+
+  it('escapes TOML string content', () => {
+    const toml = buildFuigoManagedConfig([
+      {
+        id: 'byok/x/a"b\\c',
+        name: 'tab\there',
+        model: 'a"b\\c',
+        baseUrl: 'https://h/v1',
+        apiBackend: 'chat_completions',
+        envKey: 'K',
+      },
+    ]);
+    expect(toml).toContain('[model."byok/x/a\\"b\\\\c"]');
+    expect(toml).toContain('name = "tab\\u0009here"');
+  });
+});

--- a/tests/unit/fuigo/byokProviders.test.ts
+++ b/tests/unit/fuigo/byokProviders.test.ts
@@ -108,6 +108,22 @@ describe('fuigoByokProvidersFromRows', () => {
     expect(p.entries.map((e) => e.model)).toEqual(['gpt-4o']);
   });
 
+  it('fills a registry-mirrored OpenAI-compatible row with its canonical chat base', () => {
+    const [groq, hand] = fuigoByokProvidersFromRows([
+      row({
+        id: 'r-groq',
+        platform: 'openai-compatible',
+        name: 'Groq',
+        baseUrl: '',
+        model: ['llama-3.3-70b'],
+        __waylandModelRegistryBridge: 'v2:groq',
+      }),
+      row({ id: 'r-hand', platform: 'openai-compatible', name: 'Hand added', baseUrl: '', model: ['x'] }),
+    ]);
+    expect(groq.entries[0]).toMatchObject({ id: 'byok/groq/llama-3.3-70b', baseUrl: 'https://api.groq.com/openai/v1' });
+    expect(hand).toBeUndefined();
+  });
+
   it('accepts a custom OpenAI-compatible endpoint and strips the trailing slash', () => {
     const [p] = fuigoByokProvidersFromRows([
       row({

--- a/tests/unit/fuigo/launchContract.test.ts
+++ b/tests/unit/fuigo/launchContract.test.ts
@@ -165,6 +165,12 @@ describe('launch helpers', () => {
     expect(buildFuigoAcpArgs({ trusted: false })).toEqual(['--permission-mode', 'default', 'agent', 'stdio']);
   });
 
+  it('never requests a kernel sandbox: MCP children inherit it and lose $HOME writes (npx connectors)', () => {
+    for (const trusted of [true, false]) {
+      expect(buildFuigoAcpArgs({ trusted, maxTurns: 8 })).not.toContain('--sandbox');
+    }
+  });
+
   it('passes a positive integer maxTurns as a global --max-turns flag, before the agent subcommand', () => {
     expect(buildFuigoAcpArgs({ trusted: true, maxTurns: 25 })).toEqual([
       '--permission-mode',

--- a/tests/unit/fuigo/launchContract.test.ts
+++ b/tests/unit/fuigo/launchContract.test.ts
@@ -371,7 +371,7 @@ describe('AcpAgentManager Fuigo spawn contract', () => {
       FUIGO_MANAGED_BY_NPM: '1',
       ...fuigoCompatIsolationEnv(),
     });
-    expect(ensureFuigoHomeMock).toHaveBeenCalledWith(join('/tmp/userData', 'fuigo'));
+    expect(ensureFuigoHomeMock).toHaveBeenCalledWith(join('/tmp/userData', 'fuigo'), FUIGO_MANAGED_CONFIG);
   });
 
   it('caps an unattended run with both Fuigo process budgets and leaves a user chat uncapped', async () => {
@@ -386,6 +386,57 @@ describe('AcpAgentManager Fuigo spawn contract', () => {
     const chat = await resolve({});
     expect(chat.customEnv).not.toHaveProperty('FUIGO_MAX_MODEL_CALLS');
     expect(chat.customEnv).not.toHaveProperty('FUIGO_MAX_RUNTIME_SECS');
+  });
+
+  it('writes connected non-Flux providers into the managed config and carries each key only in env', async () => {
+    mockGet.mockImplementation(async (key: string) =>
+      key === 'model.config'
+        ? [
+            {
+              id: 'p-flux',
+              platform: 'openai-compatible',
+              name: 'FluxRouter',
+              baseUrl: '',
+              apiKey: 'sk-flux-row',
+              model: ['flux-auto'],
+              __waylandModelRegistryBridge: 'v2:flux-router',
+            },
+            {
+              id: 'p-oai',
+              platform: 'openai',
+              name: 'OpenAI',
+              baseUrl: '',
+              apiKey: 'sk-openai-secret',
+              model: ['gpt-4o'],
+              __waylandModelRegistryBridge: 'v2:openai',
+            },
+            {
+              id: 'p-ant',
+              platform: 'anthropic',
+              name: 'Anthropic',
+              baseUrl: 'https://api.anthropic.com',
+              apiKey: 'sk-ant-secret',
+              model: ['claude-sonnet-4-5'],
+              __waylandModelRegistryBridge: 'v2:anthropic',
+            },
+          ]
+        : undefined
+    );
+    const res = await resolve({});
+    expect(res.customEnv).toMatchObject({
+      FUIGO_API_KEY: 'sk-flux-test',
+      WAYLAND_BYOK_OPENAI_API_KEY: 'sk-openai-secret',
+      WAYLAND_BYOK_ANTHROPIC_API_KEY: 'sk-ant-secret',
+    });
+    const [, config] = ensureFuigoHomeMock.mock.calls.at(-1) as [string, string];
+    expect(config).toContain('[model."byok/openai/gpt-4o"]');
+    expect(config).toContain('env_key = "WAYLAND_BYOK_OPENAI_API_KEY"');
+    expect(config).toContain('[model."byok/anthropic/claude-sonnet-4-5"]');
+    expect(config).toContain('api_backend = "messages"');
+    expect(config).not.toContain('flux');
+    expect(config).not.toContain('sk-openai-secret');
+    expect(config).not.toContain('sk-ant-secret');
+    expect(config).not.toContain('sk-flux');
   });
 
   it('marks only unattended runs nonInteractive on the session request', async () => {

--- a/tests/unit/fuigo/launchContract.test.ts
+++ b/tests/unit/fuigo/launchContract.test.ts
@@ -134,9 +134,13 @@ vi.mock('@/common/chat/chatLib', () => ({ transformMessage: vi.fn(), uuid: vi.fn
 import AcpAgentManager from '../../../src/process/task/AcpAgentManager';
 import {
   FUIGO_MANAGED_CONFIG,
+  FUIGO_UNATTENDED_MAX_MODEL_CALLS,
+  FUIGO_UNATTENDED_MAX_RUNTIME_SECS,
   buildFuigoAcpArgs,
   buildFuigoSessionMetadata,
+  describeFuigoBudgetStop,
   extractFuigoPromptUsage,
+  fuigoBudgetEnv,
   fuigoCompatIsolationEnv,
   fuigoHomeDir,
   fuigoPluginDirs,
@@ -227,6 +231,28 @@ describe('launch helpers', () => {
       mkdirSync(join(ws, '.wayland'));
       expect(fuigoPluginDirs(ws)).toEqual([]);
     });
+  });
+
+  it('sets both process budgets for unattended runs only', () => {
+    expect(fuigoBudgetEnv({ unattended: true })).toEqual({
+      FUIGO_MAX_MODEL_CALLS: '200',
+      FUIGO_MAX_RUNTIME_SECS: '3600',
+    });
+    expect(fuigoBudgetEnv({ unattended: false })).toEqual({});
+  });
+
+  it('recognises the two Fuigo budget-stop error shapes and nothing else', () => {
+    const receipt = { partial: true, reason: 'Execution stopped with bounded capacity or unresolved work. …' };
+    expect(describeFuigoBudgetStop({ data: receipt })).toMatch(/^Stopped by the run budget: .*200 of its model calls/);
+    expect(describeFuigoBudgetStop({ cause: { data: receipt } })).toMatch(/^Stopped by the run budget/);
+    expect(describeFuigoBudgetStop({ data: 'execution budget: wall deadline exhausted' })).toMatch(/60-minute limit/);
+    expect(describeFuigoBudgetStop({ data: 'execution budget: model dispatch limit exhausted' })).toMatch(
+      /200 of its model calls/
+    );
+    expect(describeFuigoBudgetStop({ data: { partial: false, reason: 'Turn returned normally' } })).toBeNull();
+    expect(describeFuigoBudgetStop({ data: 'Execution state unavailable' })).toBeNull();
+    expect(describeFuigoBudgetStop(new Error('boom'))).toBeNull();
+    expect(describeFuigoBudgetStop(null)).toBeNull();
   });
 
   it('shares one engine home across conversations', () => {
@@ -340,6 +366,20 @@ describe('AcpAgentManager Fuigo spawn contract', () => {
       ...fuigoCompatIsolationEnv(),
     });
     expect(ensureFuigoHomeMock).toHaveBeenCalledWith(join('/tmp/userData', 'fuigo'));
+  });
+
+  it('caps an unattended run with both Fuigo process budgets and leaves a user chat uncapped', async () => {
+    const cron = await resolve({ unattendedHoldDeadlineMs: 60_000 });
+    expect(cron.customEnv).toMatchObject({
+      FUIGO_MAX_MODEL_CALLS: String(FUIGO_UNATTENDED_MAX_MODEL_CALLS),
+      FUIGO_MAX_RUNTIME_SECS: String(FUIGO_UNATTENDED_MAX_RUNTIME_SECS),
+    });
+    expect(cron.customEnv!.FUIGO_MAX_MODEL_CALLS).toBe('200');
+    expect(cron.customEnv!.FUIGO_MAX_RUNTIME_SECS).toBe('3600');
+
+    const chat = await resolve({});
+    expect(chat.customEnv).not.toHaveProperty('FUIGO_MAX_MODEL_CALLS');
+    expect(chat.customEnv).not.toHaveProperty('FUIGO_MAX_RUNTIME_SECS');
   });
 
   it('marks only unattended runs nonInteractive on the session request', async () => {

--- a/tests/unit/process/acp/session/PromptExecutor.fuigoBudget.test.ts
+++ b/tests/unit/process/acp/session/PromptExecutor.fuigoBudget.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2026 Ferrox Labs
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * A Fuigo process budget (FUIGO_MAX_MODEL_CALLS / FUIGO_MAX_RUNTIME_SECS, set
+ * for unattended runs) ends the prompt with a JSON-RPC error, not a stop
+ * reason — captured on the staged 1.0.15 over stdio:
+ *   calls: `-32603 Internal error`, data = the execution receipt
+ *          `{partial: true, reason: "Execution stopped with bounded capacity …"}`
+ *   wall:  `-32602 Invalid params`, data = "execution budget: wall deadline exhausted"
+ * Without the mapping the chat shows "Internal error: {receipt json}" and, for
+ * -32603, offers a recoverable retry against a process with nothing left.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { RequestError } from '@agentclientprotocol/sdk';
+import { PromptExecutor, type PromptHost } from '@process/acp/session/PromptExecutor';
+import type { PromptContent } from '@process/acp/types';
+import { FUIGO_UNATTENDED_MAX_MODEL_CALLS } from '@process/agent/fuigo/launch';
+
+const RETRY = { attempts: 1, backoff: { initialMs: 0, maxMs: 0, factor: 1, jitter: 0 } };
+const CONTENT = [{ type: 'text', text: 'hi' }] as unknown as PromptContent;
+
+const RECEIPT = {
+  id: '7fa1c5ff',
+  execution_id: 'b93083bf',
+  partial: true,
+  pending_attempts: [],
+  reason:
+    'Execution stopped with bounded capacity or unresolved work. Consult persisted conversation and tool results; pending attempts must not be replayed automatically.',
+  promptUsage: { modelCalls: 2 },
+};
+
+function createHost(backend: string) {
+  const prompt = vi.fn();
+  const host = {
+    status: 'active',
+    lifecycle: {
+      client: { prompt, cancel: vi.fn().mockResolvedValue(undefined) },
+      sessionId: 'sess-1',
+      reassertConfig: vi.fn().mockResolvedValue(undefined),
+      setAuthPendingForPrompt: vi.fn(),
+      teardown: vi.fn().mockResolvedValue(undefined),
+    },
+    messageTranslator: { onTurnStart: vi.fn(), onTurnEnd: vi.fn() },
+    authNegotiator: { buildAuthRequiredData: vi.fn().mockReturnValue({}) },
+    callbacks: { onSignal: vi.fn(), onContextUsage: vi.fn() },
+    metrics: { recordError: vi.fn() },
+    agentConfig: { agentBackend: backend },
+    setStatus: vi.fn((s: string) => {
+      host.status = s;
+    }),
+    enterError: vi.fn(),
+  } as unknown as PromptHost & { status: string };
+  return { host, prompt };
+}
+
+describe('PromptExecutor - Fuigo process budget stops', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('shows a model-call budget stop for the execution receipt, not a retryable internal error', async () => {
+    const { host, prompt } = createHost('fuigo');
+    prompt.mockRejectedValueOnce(new RequestError(-32603, 'Internal error', RECEIPT));
+
+    await expect(new PromptExecutor(host, 60_000, RETRY).execute(CONTENT)).rejects.toMatchObject({
+      retryable: false,
+      message: expect.stringContaining(`${FUIGO_UNATTENDED_MAX_MODEL_CALLS} of its model calls`),
+    });
+    expect(host.enterError).toHaveBeenCalledTimes(1);
+    const shown = (host.enterError as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(shown).toMatch(/^Stopped by the run budget/);
+    expect(shown).not.toContain('Internal error');
+    expect(shown).not.toContain('execution_id');
+    // Not the "recoverable, stay active" branch a bare -32603 takes.
+    expect(host.callbacks.onSignal).not.toHaveBeenCalledWith(expect.objectContaining({ recoverable: true }));
+  });
+
+  it('shows a runtime budget stop for the wall-deadline error', async () => {
+    const { host, prompt } = createHost('fuigo');
+    prompt.mockRejectedValueOnce(
+      new RequestError(-32602, 'Invalid params', 'execution budget: wall deadline exhausted')
+    );
+
+    await expect(new PromptExecutor(host, 60_000, RETRY).execute(CONTENT)).rejects.toMatchObject({ retryable: false });
+    const shown = (host.enterError as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(shown).toMatch(/^Stopped by the run budget: this run passed its 60-minute limit/);
+  });
+
+  it('leaves an unrelated internal error on the generic path', async () => {
+    const { host, prompt } = createHost('fuigo');
+    prompt.mockRejectedValueOnce(new RequestError(-32603, 'Internal error', 'Execution state unavailable'));
+
+    await expect(new PromptExecutor(host, 60_000, RETRY).execute(CONTENT)).rejects.toMatchObject({ retryable: true });
+    expect(host.enterError).not.toHaveBeenCalled();
+    expect(host.callbacks.onSignal).toHaveBeenCalledWith(expect.objectContaining({ type: 'error', recoverable: true }));
+  });
+
+  it('does not rewrite the same receipt for another backend', async () => {
+    const { host, prompt } = createHost('qwen');
+    prompt.mockRejectedValueOnce(new RequestError(-32603, 'Internal error', RECEIPT));
+    await expect(new PromptExecutor(host, 60_000, RETRY).execute(CONTENT)).rejects.toBeTruthy();
+    expect(host.enterError).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/renderer/acpModelSelectorFlux.dom.test.tsx
+++ b/tests/unit/renderer/acpModelSelectorFlux.dom.test.tsx
@@ -172,6 +172,52 @@ describe('AcpModelSelector - Flux models in the ACP picker', () => {
     expect(screen.queryByText('Flux Auto')).toBeNull();
   });
 
+  it('lists Fuigo BYOK entries under their own group and sends the byok id on select', async () => {
+    ipcMock.getModelInfo.mockResolvedValue({
+      success: true,
+      data: {
+        modelInfo: {
+          currentModelId: 'flux-auto',
+          currentModelLabel: 'Flux Auto',
+          availableModels: [
+            { id: 'byok/openai/gpt-4o', label: 'gpt-4o · OpenAI' },
+            { id: 'claude-haiku-4-5', label: 'claude-haiku-4-5' },
+          ],
+          canSwitch: true,
+          source: 'models',
+          sourceDetail: 'acp-models',
+        },
+      },
+    });
+    ipcMock.registryList.mockResolvedValue([{ providerId: 'flux-router' }]);
+
+    renderSelector(<AcpModelSelector conversationId='conv-5' backend='fuigo' />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Flux Auto').length).toBeGreaterThan(0);
+    });
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(screen.getByText('gpt-4o · OpenAI')).toBeTruthy();
+    });
+    // The i18n mock renders keys: the BYOK heading precedes the engine-catalog heading.
+    const byokHeading = screen.getByText('conversation.welcome.byokModelsGroupLabel');
+    const nativeHeading = screen.getByText('conversation.welcome.nativeModelsGroupLabel');
+    expect(byokHeading.compareDocumentPosition(nativeHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(
+      byokHeading.compareDocumentPosition(screen.getByText('gpt-4o · OpenAI')) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    expect(
+      screen.getByText('gpt-4o · OpenAI').compareDocumentPosition(nativeHeading) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByText('gpt-4o · OpenAI'));
+    await waitFor(() => {
+      expect(ipcMock.setModel).toHaveBeenCalledWith({ conversationId: 'conv-5', modelId: 'byok/openai/gpt-4o' });
+    });
+  });
+
   it('selecting a Flux model sets the chat model id to the flux id', async () => {
     ipcMock.getModelInfo.mockResolvedValue(NATIVE_INFO);
     ipcMock.registryList.mockResolvedValue([{ providerId: 'flux-router' }]);


### PR DESCRIPTION
Closes the two never-landed cutover items (plan Phase 1 items 7 and 8; scope audit rows M5, M6). Three commits, one per part.

## 1. Process budgets for unattended runs (M5, engine-side hard stop)

Fuigo honours `FUIGO_MAX_MODEL_CALLS` / `FUIGO_MAX_RUNTIME_SECS` (`fuigo-sampler/src/execution_budget.rs`: positive integers, read once per process, aggregate across sessions/subagents/side calls, wall clock from process init). Both are now set on the spawn env for unattended runs only (routines / team runs, the path that already sets `startupHints.nonInteractive`); user chats stay uncapped. Core kept no persisted keys for these (its stops were fixed thresholds), so the defaults live in `launch.ts`: 200 calls / 3600 s. Nothing new in the UI.

Verified on the staged 1.0.15 over stdio: calls cap -> the engine reserves the last call for a final answer, then the prompt returns `-32603` with the execution receipt (`partial: true, reason: "Execution stopped with bounded capacity ..."`); wall cap -> `-32602 "execution budget: wall deadline exhausted"`; process stays alive. `PromptExecutor` maps both to a "Stopped by the run budget" message and ends the turn instead of showing `Internal error: {receipt}` with a retry.

## 2. `--sandbox workspace`: measured, deliberately NOT wired (M5, sandbox half)

The "Desktop sandbox policy" the plan keyed on was Core's own config.toml profile, deleted with the WCoreConfig pane; Desktop has no engine sandbox setting left. Measured on darwin under `--sandbox workspace` from inside an MCP server Fuigo spawned on `session/new` (Seatbelt is process-wide, so every MCP child inherits it): loopback HTTP to 127.0.0.1 OK, `node -e` subprocess OK, temp-dir write OK, **`$HOME` write EPERM, `~/.npm/_npx` write EPERM** -> every npx-launched connector (incl. the TC-TIDE brief's TVControl fallback) breaks. Recorded in a comment next to `buildFuigoAcpArgs` and pinned by a test that no `--sandbox` is requested. Windows has no kernel sandbox in Fuigo at all.

## 3. BYOK providers in Fuigo chats (M6)

Desktop's connected non-Flux providers (`model.config` rows: Anthropic, OpenAI, OpenAI-compatible; Bedrock/Vertex/Azure/ChatGPT-subscription/Gemini skipped) become `[model."byok/<provider>/<model>"]` entries in the managed `$FUIGO_HOME/config.toml`, rebuilt before every spawn. Schema verified against `fuigo-shell/src/agent/config.rs` `ConfigModelOverride` and `docs/user-guide/11-custom-models.md` (`model`, `base_url`, `name`, `api_backend` `chat_completions|messages`, `env_key`, `auth_scheme = "x_api_key"` + `anthropic-version` header for Anthropic, `context_window`). Keys are never written: each provider gets a `WAYLAND_BYOK_<SLUG>_API_KEY` env var on the spawn. Ids are namespaced so `isFluxModelId` is false (set_model goes on the wire) and a user's `claude-*` key can never shadow the same id on the Flux route. The picker groups them under "Your API keys" above the engine catalog.

Live on the staged binary through `buildFuigoManagedConfig`, FluxRouter's two surfaces standing in for a BYOK provider: OpenAI-shaped (`/v1`, chat_completions) and Anthropic-shaped (`/anthropic/v1`, messages + x_api_key) both advertised the entry, accepted `session/set_model byok/probe/flux-fast`, answered, `_meta.modelId = flux-fast`. Negative control: a bogus per-entry key 401'd while `FUIGO_API_KEY` stayed valid, so `env_key` is load-bearing. Note: `_meta.modelId` names the underlying `model`, not the entry id.

In-app (dev Electron from this worktree, cloned `Wayland-fuigo-verify` profile, a loopback reverse proxy to FluxRouter registered as an OpenAI-compatible provider row): the Fuigo chat picker shows groups `Flux / Your API keys / Agent models`; selecting `flux-fast · Local BYOK Proxy` put `session/set_model {"modelId":"byok/local-byok-proxy/flux-fast"}` on the wire and the proxy logged 3x `POST /v1/chat/completions -> 200` during that turn (reply rendered); switching back to Flux Fast sent `modelId: flux-fast`, replied, proxy saw no further traffic. `<userData>/fuigo/config.toml` carried 28 `[model."byok/…"]` blocks and zero key material. Screenshots: `~/dev/wayland-worktrees/fuigo-verify-shots/byok-0{0..4}-*.png`. The verify also caught that registry-mirrored rows have an empty `baseUrl` (Groq/DeepSeek/… were dropped) -> fixed in the 4th commit via `CHAT_START_BASE_URL`.

Known cosmetic follow-up: the composer badge still reads "Routing via Flux" while a BYOK model is selected. Fuigo-side note: the picker only shows BYOK entries once the engine has advertised them (first spawn); `_meta.modelId` names the underlying model, not the entry id.

## Gates

- `bun run typecheck` 0 errors
- `bunx vitest run tests/unit/fuigo tests/unit/process/acp` + picker DOM tests: 40 files / 464 tests green; the 14 new cases fail without the change (verified by reverting the source)
- `bunx oxfmt --check` + `bunx oxlint` on touched files: clean
- `bun run test:bun` 294 pass / 0 fail
- `prek run --from-ref ferrox/main --to-ref HEAD` all hooks pass
- `node scripts/check-public-counts.mjs` match

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvuJEwapJMLSJ7BCaSbeuW
