### PR TITLE
fix(masterclass): stop Fuigo dropping Wayland-published connectors

### DIFF
--- a/src/process/agent/fuigo/launch.ts
+++ b/src/process/agent/fuigo/launch.ts
@@ -34,10 +34,20 @@ export function fuigoHomeDir(userDataDir: string): string {
  * switch for it, unlike the vendor-compat surfaces. Seen live on the ACP
  * stdio path: 9 worker spawns per session against the user's hosted Notion,
  * Supabase, Stripe, HF, Asana, Slack and Vercel connectors, each failing OAuth.
+ *
+ * `[claude_compat] imported = true` is Fuigo's "Claude import complete" marker.
+ * With it set, every `~/.claude.json` MCP loader returns empty, so Desktop can
+ * leave `FUIGO_CLAUDE_MCPS_ENABLED` ON (see `fuigoCompatIsolationEnv`) without
+ * Fuigo dialling the user's own Claude Code servers. Both halves are needed:
+ * the marker alone does not stop the kill-switch attribution described there,
+ * and the env switch alone re-imports every user server.
  */
 export const FUIGO_MANAGED_CONFIG = `# Managed by Wayland Desktop. Rewritten at every engine start; edits do not persist.
 [plugins]
 auto_discover = false
+
+[claude_compat]
+imported = true
 `;
 
 /**
@@ -233,6 +243,18 @@ export function fuigoCompatIsolationEnv(): Record<string, string> {
   // 1.0.14/1.0.15 (every session listed the user's ~200 personal skills on top
   // of the workspace ones); 1.0.16 gates it behind this cell (fuigo#16).
   env.FUIGO_AGENTS_SKILLS_ENABLED = '0';
+  // CLAUDE/MCPS stays ON, on purpose. With the switch OFF, Fuigo's
+  // `admit_client_mcp_servers` treats every name in the user's `~/.claude.json`
+  // as a "Claude-sourced" server and silently drops any client-forwarded stdio
+  // server with the same name — and Wayland's own Library publication writes
+  // its connectors into `~/.claude.json` (`com-ferroxlabs-tvcontrol`, ...).
+  // Net effect on 1.0.15/1.0.16: TVControl vanished from every Fuigo session
+  // on a machine with Claude Code installed, with no log line. The managed
+  // `[claude_compat] imported = true` marker (FUIGO_MANAGED_CONFIG) is what
+  // keeps the user's servers out when this is ON. Measured on the staged
+  // binary: OFF -> 4 of Desktop's 5 servers admitted; ON without marker -> 8
+  // (user's github/supabase/dev servers dialled); ON + marker -> exactly 5.
+  env.FUIGO_CLAUDE_MCPS_ENABLED = '1';
   return env;
 }
 

--- a/tests/integration/fuigoAcpEndToEnd.test.ts
+++ b/tests/integration/fuigoAcpEndToEnd.test.ts
@@ -30,7 +30,16 @@
  *      trust forward has become load-bearing.
  */
 import { spawn, type ChildProcess } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, describe, expect, it } from 'vitest';
@@ -170,6 +179,103 @@ async function runTurn(opts: { trusted: boolean; key: string; prompt: string; st
   }
 }
 
+/**
+ * Fuigo's own record of which client-forwarded MCP servers survived admission.
+ * `mcp_config_resolved` is written to `<FUIGO_HOME>/sessions/<cwd>/<sid>/events.jsonl`
+ * right after `session/new`; a server missing from it never gets a worker and
+ * never appears in the tool catalogue — with no log line either way.
+ */
+function readAdmittedMcpServerNames(home: string): string[] | null {
+  const walk = (dir: string): string[] =>
+    readdirSync(dir).flatMap((name) => {
+      const full = join(dir, name);
+      return statSync(full).isDirectory() ? walk(full) : [full];
+    });
+  const sessions = join(home, 'sessions');
+  if (!existsSync(sessions)) return null;
+  for (const file of walk(sessions).filter((f) => f.endsWith('events.jsonl'))) {
+    for (const line of readFileSync(file, 'utf8').split('\n')) {
+      if (!line.trim()) continue;
+      const event = JSON.parse(line) as { type?: string; servers?: Array<{ name: string }> };
+      if (event.type === 'mcp_config_resolved') return (event.servers ?? []).map((server) => server.name);
+    }
+  }
+  return null;
+}
+
+/**
+ * Open a session with `mcpServers` forwarded exactly as Desktop forwards them,
+ * against a throwaway $HOME whose `~/.claude.json` declares `claudeJsonServers`.
+ * Returns the names Fuigo admitted. No prompt is sent, so this costs no tokens.
+ */
+async function resolveMcpAdmission(opts: {
+  key: string;
+  mcpServers: Array<{ name: string; command: string; args: string[] }>;
+  claudeJsonServers: Record<string, { command: string; args: string[] }>;
+}): Promise<string[] | null> {
+  const workspace = mkdtempSync(join(tmpdir(), 'fuigo-e2e-ws-'));
+  const home = mkdtempSync(join(tmpdir(), 'fuigo-e2e-home-'));
+  const userHome = mkdtempSync(join(tmpdir(), 'fuigo-e2e-user-home-'));
+  for (const dir of [workspace, home, userHome]) cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+  writeFileSync(join(userHome, '.claude.json'), JSON.stringify({ mcpServers: opts.claudeJsonServers }));
+  ensureFuigoHome(home);
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    ...fuigoCompatIsolationEnv(),
+    HOME: userHome,
+    FUIGO_HOME: home,
+    FUIGO_API_KEY: opts.key,
+    FUIGO_MANAGED_BY_NPM: '1',
+  };
+  for (const k of ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'XAI_API_KEY']) delete env[k];
+  const child: ChildProcess = spawn(ENGINE, buildFuigoAcpArgs({ trusted: true }), {
+    cwd: workspace,
+    env,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  child.stderr?.resume();
+  cleanups.push(() => {
+    if (child.exitCode === null) child.kill('SIGKILL');
+  });
+  const conn = new ClientSideConnection(
+    (): Client => ({
+      sessionUpdate: async () => {},
+      requestPermission: async (params) => {
+        const allow = params.options.find((o) => o.kind === 'allow_once') ?? params.options[0];
+        return { outcome: { outcome: 'selected', optionId: allow.optionId } };
+      },
+      readTextFile: async () => ({ content: '' }),
+      writeTextFile: async () => ({}),
+    }),
+    NdjsonTransport.fromChildProcess(child)
+  );
+  try {
+    await conn.initialize({
+      protocolVersion: PROTOCOL_VERSION,
+      clientCapabilities: { fs: { readTextFile: true, writeTextFile: true } },
+      _meta: { clientIdentifier: 'wayland-desktop', clientType: 'desktop' },
+    });
+    await conn.authenticate({ methodId: 'fuigo.api_key' });
+    const session = await conn.newSession({
+      cwd: workspace,
+      mcpServers: opts.mcpServers.map((server) => ({ ...server, env: [] })),
+      _meta: buildFuigoSessionMetadata({ nonInteractive: true, pluginDirs: [] }),
+    });
+    expect(session.sessionId).toBeTruthy();
+    // The event lands within the MCP init window (measured 40-460 ms).
+    const deadline = Date.now() + 5_000;
+    const poll = async (): Promise<string[] | null> => {
+      const admitted = readAdmittedMcpServerNames(home);
+      if (admitted || Date.now() > deadline) return admitted;
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      return poll();
+    };
+    return await poll();
+  } finally {
+    child.kill('SIGTERM');
+  }
+}
+
 describe.skipIf(!ENABLED)('Fuigo ACP end-to-end (staged binary, real FluxRouter)', () => {
   const key = readKey();
 
@@ -227,6 +333,29 @@ describe.skipIf(!ENABLED)('Fuigo ACP end-to-end (staged binary, real FluxRouter)
     },
     180_000
   );
+
+  // A Wayland connector is published into the user's ~/.claude.json under the
+  // same name Desktop forwards on session/new. With FUIGO_CLAUDE_MCPS_ENABLED=0
+  // Fuigo attributes that name to Claude and drops the forwarded server without
+  // a log line (TVControl vanished from every Fuigo chat on a machine with
+  // Claude Code). The managed marker + switch ON must admit exactly what
+  // Desktop forwarded and dial nothing else from ~/.claude.json.
+  it('admits a forwarded stdio server whose name Wayland also published to ~/.claude.json, and no other', async () => {
+    const stub = { command: process.execPath, args: ['-e', 'setTimeout(() => {}, 5000)'] };
+    const admitted = await resolveMcpAdmission({
+      key: key!,
+      mcpServers: [
+        { name: 'wayland-search-skills', ...stub },
+        { name: 'com.ferroxlabs-tvcontrol', ...stub },
+      ],
+      claudeJsonServers: {
+        'com-ferroxlabs-tvcontrol': stub, // what Wayland's Library publication writes
+        'users-own-private-server': stub, // must never be dialled from a Desktop session
+      },
+    });
+    expect(admitted).not.toBeNull();
+    expect(admitted!.toSorted()).toEqual(['com-ferroxlabs-tvcontrol', 'wayland-search-skills']);
+  }, 60_000);
 
   // Fuigo defect: the shipped 1.0.13 loads project instructions for an
   // untrusted cwd on the headless/stdio path. When this starts failing, the

--- a/tests/unit/fuigo/launchContract.test.ts
+++ b/tests/unit/fuigo/launchContract.test.ts
@@ -269,10 +269,20 @@ describe('launch helpers', () => {
     const env = fuigoCompatIsolationEnv();
     expect(Object.keys(env)).toHaveLength(19);
     for (const vendor of ['CLAUDE', 'CURSOR', 'CODEX'])
-      for (const surface of ['SKILLS', 'RULES', 'AGENTS', 'MCPS', 'HOOKS', 'SESSIONS'])
-        expect(env[`FUIGO_${vendor}_${surface}_ENABLED`]).toBe('0');
+      for (const surface of ['SKILLS', 'RULES', 'AGENTS', 'MCPS', 'HOOKS', 'SESSIONS']) {
+        // CLAUDE/MCPS is the one exception: OFF makes Fuigo drop any
+        // client-forwarded server whose name is also in ~/.claude.json, which
+        // is exactly where Wayland publishes its own connectors. The managed
+        // config marker keeps the user's servers out instead.
+        const expected = vendor === 'CLAUDE' && surface === 'MCPS' ? '1' : '0';
+        expect(env[`FUIGO_${vendor}_${surface}_ENABLED`]).toBe(expected);
+      }
     // 1.0.16: the ~/.agents/skills scan has its own cell outside the vendor grid.
     expect(env.FUIGO_AGENTS_SKILLS_ENABLED).toBe('0');
+  });
+
+  it('keeps Claude MCP scanning ON so Wayland-published connector names are not attributed to Claude', () => {
+    expect(fuigoCompatIsolationEnv().FUIGO_CLAUDE_MCPS_ENABLED).toBe('1');
   });
 
   describe('ensureFuigoHome', () => {
@@ -294,6 +304,9 @@ describe('launch helpers', () => {
       const config = readFileSync(join(home, 'config.toml'), 'utf8');
       expect(config).toBe(FUIGO_MANAGED_CONFIG);
       expect(config).toMatch(/^\[plugins\]\nauto_discover = false$/m);
+      // The import marker is what stops Fuigo reading ~/.claude.json while
+      // FUIGO_CLAUDE_MCPS_ENABLED is on; without it every user server is dialled.
+      expect(config).toMatch(/^\[claude_compat\]\nimported = true$/m);
       // POSIX modes only: Windows reports 0o666 for every file.
       if (process.platform !== 'win32') expect(statSync(join(home, 'config.toml')).mode & 0o777).toBe(0o600);
     });


### PR DESCRIPTION
## Description

On a machine with Claude Code installed, TVControl vanished from every Fuigo chat. Wayland's MCP Library publication writes each connector into the user's ~/.claude.json (com-ferroxlabs-tvcontrol, ...). Desktop launches Fuigo with FUIGO_CLAUDE_MCPS_ENABLED=0 so it does not dial the user's Claude MCP servers; with that switch off, Fuigo's admit_client_mcp_servers treats every name in ~/.claude.json as Claude-sourced and silently drops any client-forwarded stdio server carrying the same name. Fuigo writes no log line; its own mcp_config_resolved event lists 4 of the 5 servers Desktop forwarded on session/new. The tvcontrol-setup skill then searched the catalogue, found nothing, and the masterclass report path was dead before it started (run 1 evidence in the verify summary).

Fix: keep FUIGO_CLAUDE_MCPS_ENABLED on and set Fuigo's Claude-import marker ([claude_compat] imported = true) in the managed FUIGO_HOME config.toml Desktop already rewrites at every spawn. The marker makes every ~/.claude.json loader return empty, so the user's own servers are still never dialled, while the kill-switch attribution no longer runs. Measured on the staged 1.0.15 binary with a real ~/.claude.json: switch OFF -> 4 of 5 admitted; switch ON without marker -> 8 (user's github/supabase/dev servers dialled); switch ON + marker -> exactly Desktop's 5.

## Related Issues

- Masterclass-on-Fuigo tag gate for 0.13.0 (PR #1346 deferred Fuigo report testing). Summary: wayland-worktrees/MASTERCLASS-ON-FUIGO-VERIFY-2026-09-13.md

## Type of Change

- [x] Bug fix

## Testing

- [x] tests/unit/fuigo/launchContract.test.ts pins both halves (CLAUDE/MCPS = 1, marker in managed config); 3 cases red on the old contract, 19/19 green now.
- [x] tests/integration/fuigoAcpEndToEnd.test.ts (FUIGO_ACP_E2E=1) new case forwards a server whose name is also in a throwaway ~/.claude.json next to a private user server and asserts Fuigo admits the forwarded one and nothing else: red on the old contract (com-ferroxlabs-tvcontrol dropped), green now; the other 4 live cases unchanged (5 passed, 1 expected fail).
- [x] Packaged signed mac build (dist:verify:mac), fresh profile, CDP-driven as a user: Library install shows 113 tools, Smart Trader chat calls tv_health_check live (NASDAQ:SBUX 1D, TradingView 3.4.1), Fuigo journal mcp_init_completed total_servers 5 / total_tools 141, Skipping MCP tool with invalid name = 0.
- [x] Full masterclass report on the rebuilt package: 74 substantive panels, 74 matching ticker stamps, 0 unread, chart-only quotes, 52 KB HTML in artifacts/chat, rendered in the Artifacts pane, chart restored (SBUX 1D, same studies), same-conversation reopen shows message + card; idle reaper (exit 143) then session/load resume with chart_get_state live.
- [x] tsc --noEmit clean; oxfmt/oxlint clean on the three files.

## Additional Context

Two further findings from the same verify run, not fixed here: (1) a Library install can end with enabled = false when the background staleness re-probe fails right after the install probe succeeded and revokes the publication (1 of 2 runs; the detail page also renders Off immediately after install even when the record is enabled); (2) the Library install publishes the connector into the user's real ~/.claude.json, ~/.codex/config.toml and ~/.gemini/settings.json even from an E2E profile, and Archive removes them again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvuJEwapJMLSJ7BCaSbeuW
