### PR TITLE
ci(release): preflight no longer references the deleted Core engine tag

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -91,7 +91,7 @@ jobs:
             echo "Preflight refused the release. Nothing was built." >&2
             exit 1
           fi
-          echo "Preflight passed: observers registered, trust root current, engine $core_tag complete."
+          echo "Preflight passed: observers registered, trust root current, engine fuigo $(node -p "require('./scripts/fuigo/authority.json').version") complete."
 
   build-pipeline:
     name: Build Pipeline


### PR DESCRIPTION
Rehearsal tag v0.13.0-rehearsal-1 (run 34732557707) passed every preflight precondition and then failed at the success echo with core_tag: unbound variable (set -u). The variable came from the Wayland Core pin check that #1367 replaced with the scripts/fuigo/authority.json check. Print the Fuigo version from authority.json instead. One line in .github/workflows/build-and-release.yml.

After merge: move release-trust-v1 + WAYLAND_RELEASE_TRUST_ROOT_SHA to the new main tip and cut v0.13.0-rehearsal-2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvuJEwapJMLSJ7BCaSbeuW