### PR TITLE
ci(release): poll protected observer runs every 60 s, not 3 s

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -513,7 +513,7 @@ jobs:
             sleep 10
           done
           [[ "$run_id" =~ ^[0-9]+$ ]]
-          gh run watch "$run_id" --repo "$GITHUB_REPOSITORY" --exit-status
+          gh run watch "$run_id" --repo "$GITHUB_REPOSITORY" --exit-status --interval 60
           run="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/$run_id")"
           test "$(jq -r .display_title <<<"$run")" = "$EXPECTED_TITLE"
           test "$(jq -r .head_branch <<<"$run")" = 'release-trust-v1'
@@ -607,7 +607,7 @@ jobs:
             sleep 10
           done
           [[ "$run_id" =~ ^[0-9]+$ ]]
-          gh run watch "$run_id" --repo "$GITHUB_REPOSITORY" --exit-status
+          gh run watch "$run_id" --repo "$GITHUB_REPOSITORY" --exit-status --interval 60
           run="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/$run_id")"
           test "$(jq -r .display_title <<<"$run")" = "$EXPECTED_TITLE"
           test "$(jq -r .head_branch <<<"$run")" = 'release-trust-v1'
@@ -755,7 +755,7 @@ jobs:
             sleep 10
           done
           [[ "$run_id" =~ ^[0-9]+$ ]] || exit 1
-          gh run watch "$run_id" --repo "$GITHUB_REPOSITORY" --exit-status
+          gh run watch "$run_id" --repo "$GITHUB_REPOSITORY" --exit-status --interval 60
           echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
 
       - name: Download exact accepted receipt


### PR DESCRIPTION
v0.13.0-rehearsal-2 attempt 2: the producer job Exercise protected updater journeys failed with failed to get run: HTTP 403: API rate limit exceeded for installation after 25 minutes of gh run watch at its default 3 s refresh, while the observer run (34736257531) was still in progress with 5 of 6 targets already green. Three gh run watch calls in build-and-release.yml now pass --interval 60. No other change.

After merge: re-pin trust root to the new tip and cut v0.13.0-rehearsal-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvuJEwapJMLSJ7BCaSbeuW